### PR TITLE
Add ByteArrayBitmap schema

### DIFF
--- a/src/schema/BitmapSchema.ts
+++ b/src/schema/BitmapSchema.ts
@@ -4,15 +4,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Schema } from "./Schema.js";
+import { ByteArray } from "../util/ByteArray";
+import { Schema } from "./Schema";
 
 const enum BitRangeType {
     Flag,
     Number,
     Enum,
 }
-type BitRange<T> = { type: BitRangeType, offset: number, mask: number };
-const BitRange = <T>(type: BitRangeType, offset: number, length: number) => ({ type, mask: ((1 << length) - 1) << offset, offset } as BitRange<T>);
+
+type BitRange<T> = { type: BitRangeType, offset: number, length: number };
+const BitRange = <T>(type: BitRangeType, offset: number, length: number ) => ({ type, offset, length } as BitRange<T>);
 
 /** Defines the bit position of a boolean flag. */
 export interface BitFlag extends BitRange<boolean> { type: BitRangeType.Flag }
@@ -20,7 +22,7 @@ export const BitFlag = (offset: number) => BitRange(BitRangeType.Flag, offset, 1
 
 /** Defines the bit position and bit length of a numeric value. */
 export interface BitField extends BitRange<number> { type: BitRangeType.Number }
-export const BitField = (offset: number, length: number) => BitRange(BitRangeType.Number, offset, length) as BitField;
+export const BitField = (offset: number, length: number ) => BitRange(BitRangeType.Number, offset, length) as BitField;
 
 /** Defines the bit position and bit length of an enum flag. */
 export interface BitFieldEnum<E extends number> extends BitRange<E> { type: BitRangeType.Enum }
@@ -28,21 +30,33 @@ export const BitFieldEnum = <E extends number>(offset: number, length: number) =
 
 export type BitSchema = {[key: string]: BitFlag | BitField | BitFieldEnum<any> };
 export type TypeFromBitSchema<T extends BitSchema> = {[K in keyof T]: T[K] extends BitFieldEnum<infer E> ? E : (T[K] extends BitField ? number : boolean )};
+type MaskFromBitSchema<T extends BitSchema> = {[K in keyof T]: number };
+type MaskOffsetFromBitSchema<T extends BitSchema> = {[K in keyof T]: { mask: number, byteOffset: number, bitOffset: number }};
 
 class BitmapSchemaInternal<T extends BitSchema> extends Schema<TypeFromBitSchema<T>, number> {
-    constructor(readonly bitSchemas: T) {
+    private readonly masks: MaskFromBitSchema<T>;
+
+    constructor(
+        private readonly bitSchemas: T,
+    ) {
         super();
 
+        const masks = <MaskFromBitSchema<T>>{};
+        for (const name in this.bitSchemas) {
+            const { offset, length } = this.bitSchemas[name];
+            masks[name] = ((1 << length) - 1) << offset;
+        }
+        this.masks = masks;
         // TODO: validate that bitSchemas is coherent
     }
 
     override encodeInternal(value: TypeFromBitSchema<T>) {
         let result = 0;
         for (const name in this.bitSchemas) {
-            const { type, offset, mask } = this.bitSchemas[name];
+            const { type, offset } = this.bitSchemas[name];
             switch (type) {
                 case BitRangeType.Flag:
-                    if (value[name]) result |= mask;
+                    if (value[name]) result |= this.masks[name];
                     break;
                 case BitRangeType.Enum:
                 case BitRangeType.Number:
@@ -55,7 +69,8 @@ class BitmapSchemaInternal<T extends BitSchema> extends Schema<TypeFromBitSchema
     override decodeInternal(bitmap: number) {
         const result = {} as any;
         for (const name in this.bitSchemas) {
-            const { type, offset, mask } = this.bitSchemas[name];
+            const { type, offset } = this.bitSchemas[name];
+            const mask = this.masks[name];
             if (type === BitRangeType.Flag) {
                 result[name] = (bitmap & mask) !== 0;
             } else {
@@ -66,5 +81,80 @@ class BitmapSchemaInternal<T extends BitSchema> extends Schema<TypeFromBitSchema
     }
 }
 
+class ByteArrayBitmapSchemaInternal<T extends BitSchema> extends Schema<TypeFromBitSchema<T>, ByteArray> {
+    private readonly byteArrayLength: number;
+    private readonly maskOffset: MaskOffsetFromBitSchema<T>;
+
+    constructor(
+        private readonly bitSchemas: T,
+    ) {
+        super();
+
+        let maxBitLength = 0;
+        const maskOffset = <MaskOffsetFromBitSchema<T>>{};
+        for (const name in this.bitSchemas) {
+            const { offset, length } = this.bitSchemas[name];
+            const bitOffset = offset % 8;
+            const byteOffset = (offset - bitOffset) / 8;
+            const mask = ((1 << length) - 1) << bitOffset;
+            maskOffset[name] = { bitOffset, byteOffset, mask };
+            maxBitLength = Math.max(maxBitLength, offset + length);
+        }
+        this.byteArrayLength = Math.ceil(maxBitLength / 8);
+        this.maskOffset = maskOffset;
+    }
+
+    override encodeInternal(value: TypeFromBitSchema<T>) {
+        let result = new ByteArray(this.byteArrayLength);
+        for (const name in this.bitSchemas) {
+            const { type } = this.bitSchemas[name];
+            let { mask, bitOffset, byteOffset } = this.maskOffset[name];
+            switch (type) {
+                case BitRangeType.Flag:
+                    if (value[name]) result[byteOffset] |= mask;
+                    break;
+                case BitRangeType.Enum:
+                case BitRangeType.Number:
+                    let numValue = value[name] as number;
+                    while (mask !== 0) {
+                        result[byteOffset++] |= ((numValue & mask) << bitOffset) & 0xFF;
+                        const bitWritten = 8 - bitOffset;
+                        bitOffset = 0;
+                        numValue = numValue >> bitWritten;
+                        mask = mask >> 8;
+                    }
+            }
+        }
+        return result;
+    }
+
+    override decodeInternal(bitmap: ByteArray) {
+        if (bitmap.length !== this.byteArrayLength) throw new Error(`Unexpected length: ${bitmap.length}. Expected ${this.byteArrayLength}`);
+        const result = {} as any;
+        for (const name in this.bitSchemas) {
+            const { type } = this.bitSchemas[name];
+            let { mask, bitOffset, byteOffset } = this.maskOffset[name];
+            if (type === BitRangeType.Flag) {
+                result[name] = (bitmap[byteOffset] & mask) !== 0;
+            } else {
+                let value = 0;
+                let valueBitOffset = 0;
+                while (mask !== 0) {
+                    value |= ((bitmap[byteOffset++] & mask) >> bitOffset ) << valueBitOffset;
+                    const bitWritten = 8 - bitOffset;
+                    bitOffset = 0;
+                    valueBitOffset += bitWritten;
+                    mask = mask >> 8;
+                }
+                result[name] = value;
+            }
+        }
+        return result as TypeFromBitSchema<T>;
+    }
+}
+
 /** Declares a bitmap schema by indicating the bit position and their names. */
 export const BitmapSchema = <T extends BitSchema>(bitSchemas: T) => new BitmapSchemaInternal(bitSchemas);
+
+/** Declares a bitmap schema backed by a ByteArray by indicating the bit position and their names. */
+export const ByteArrayBitmapSchema = <T extends BitSchema>(bitSchemas: T) => new ByteArrayBitmapSchemaInternal(bitSchemas);

--- a/src/schema/BitmapSchema.ts
+++ b/src/schema/BitmapSchema.ts
@@ -22,7 +22,7 @@ export const BitFlag = (offset: number) => BitRange(BitRangeType.Flag, offset, 1
 
 /** Defines the bit position and bit length of a numeric value. */
 export interface BitField extends BitRange<number> { type: BitRangeType.Number }
-export const BitField = (offset: number, length: number ) => BitRange(BitRangeType.Number, offset, length) as BitField;
+export const BitField = (offset: number, length: number) => BitRange(BitRangeType.Number, offset, length) as BitField;
 
 /** Defines the bit position and bit length of an enum flag. */
 export interface BitFieldEnum<E extends number> extends BitRange<E> { type: BitRangeType.Enum }

--- a/test/schema/BitmapSchemaTest.ts
+++ b/test/schema/BitmapSchemaTest.ts
@@ -4,7 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { BitField, BitFieldEnum, BitFlag, BitmapSchema } from "../../src/schema/BitmapSchema.js";
+import { ByteArray } from "../../src/matter.js";
+import { BitField, BitFieldEnum, BitFlag, BitmapSchema, ByteArrayBitmapSchema } from "../../src/schema/BitmapSchema.js";
 
 describe("BitmapSchema", () => {
     const enum EnumTest {
@@ -48,6 +49,43 @@ describe("BitmapSchema", () => {
                 flag2: true,
                 enumTest: EnumTest.VALUE_1,
                 numberTest: 1,
+            });
+        });
+    });
+});
+
+describe("ByteArrayBitmapSchema", () => {
+    const TestByteArrayBitmapSchema = ByteArrayBitmapSchema({
+        /** flag1 jsdoc */
+        flag1: BitFlag(0),
+
+        /** number jsdoc */
+        number: BitField(1, 14),
+
+        /** flag2 jsdoc */
+        flag2: BitFlag(15),
+    });
+
+    describe("encode", () => {
+        it("encodes a bitmap using the schema", () => {
+            const result = TestByteArrayBitmapSchema.encode({
+                flag1: true,
+                flag2: true,
+                number: 0X2000,
+            });
+
+            expect(result.toHex()).toBe("01c0");
+        });
+    });
+
+    describe("decode", () => {
+        it("decodes a bitmap using the schema", () => {
+            const result = TestByteArrayBitmapSchema.decode(ByteArray.fromHex("01c0"));
+
+            expect(result).toEqual({
+                flag1: true,
+                flag2: true,
+                number: 0X2000,
             });
         });
     });


### PR DESCRIPTION
It uses the same syntax as Bitmap schema but the result is stored in a ByteArray rather than a number.
This is made to support cases where bitmap is longer than 32 bits.
I need this for the QR pairing code data in node-matter...