### PR TITLE
Ignore unknown TLV object fields

### DIFF
--- a/src/tlv/TlvObject.ts
+++ b/src/tlv/TlvObject.ts
@@ -8,6 +8,7 @@ import { Merge } from "../util/Type.js";
 import { TlvType, TlvTag, TlvTypeLength } from "./TlvCodec.js";
 import { TlvReader, TlvSchema, TlvWriter } from "./TlvSchema.js";
 import { MatterCoreSpecificationV1_0 } from "../spec/Specifications.js";
+import { TlvAny } from "./TlvAny.js";
 
 export interface FieldType<T> {
     id: number,
@@ -71,8 +72,12 @@ export class ObjectSchema<F extends TlvFields> extends TlvSchema<TypeFromFields<
             if (profile !== undefined) throw new Error("Structure element tags should be context-specific.");
             if (id === undefined) throw new Error("Structure element tags should have an id.");
             const fieldName = this.fieldById[id];
-            if (fieldName === undefined) throw new Error(`Unknown field ${id}`);
-            const { field, name }= fieldName;
+            if (fieldName === undefined) {
+                // Ignore unknown field
+                TlvAny.decodeTlvInternalValue(reader, elementTypeLength);
+                continue;
+            }
+            const { field, name } = fieldName;
             result[name] = field.schema.decodeTlvInternalValue(reader, elementTypeLength);
         }
         this.validate(result);

--- a/src/tlv/TlvObject.ts
+++ b/src/tlv/TlvObject.ts
@@ -73,7 +73,7 @@ export class ObjectSchema<F extends TlvFields> extends TlvSchema<TypeFromFields<
             if (id === undefined) throw new Error("Structure element tags should have an id.");
             const fieldName = this.fieldById[id];
             if (fieldName === undefined) {
-                // Ignore unknown field
+                // Ignore unknown field by decoding it as raw TLV so we skip forward the proper length.
                 TlvAny.decodeTlvInternalValue(reader, elementTypeLength);
                 continue;
             }

--- a/test/tlv/TlvObjectTest.ts
+++ b/test/tlv/TlvObjectTest.ts
@@ -17,6 +17,10 @@ const schema = TlvObject({
     /** Optional field jsdoc */
     optionalField: TlvOptionalField(2, TlvString),
 });
+const schemaUnknownField1 = TlvObject({
+    /** Optional field jsdoc */
+    optionalField: TlvOptionalField(2, TlvString),
+});
 
 type CodecVector<I, E> = {[valueDescription: string]: { encoded: E, decoded: I }};
 
@@ -45,5 +49,11 @@ describe("TlvObject", () => {
                     .toEqual(decoded);
             });
         }
+
+        it("ignores unknown fields", () => {
+            const result = schemaUnknownField1.decode(schema.encode({ mandatoryField: 1, optionalField: "test" }));
+
+            expect(result).toEqual({ optionalField: "test" });
+        });
     });
 });


### PR DESCRIPTION
This crashes node-matter when using it with HA Matter plugin.