### PR TITLE
Adjust logic to validate once optionally after decoding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /dist
 /node_modules
 /out
+/coverage/

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "clean": "rm -rf dist; rm -rf out",
     "build": "npm run clean; tsc --project tsconfig.dist-es.json; tsc --project tsconfig.dist-cjs.json; tsc --project tsconfig.dist-dts.json",
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
-    "test-web": "karma start karma.conf.cjs"
+    "test-web": "karma start test/karma.conf.cjs"
   },
   "devDependencies": {
     "@types/jasmine": "^4.3.0",

--- a/src/schema/Schema.ts
+++ b/src/schema/Schema.ts
@@ -13,9 +13,11 @@ export abstract class Schema<T, E> {
     }
 
     /** Decodes the encoded data using the schema. */
-    decode(encoded: E): T {
+    decode(encoded: E, validate = true): T {
         const result = this.decodeInternal(encoded);
-        this.validate(result);
+        if (validate) {
+            this.validate(result);
+        }
         return result;
     }
 

--- a/src/tlv/TlvAny.ts
+++ b/src/tlv/TlvAny.ts
@@ -72,7 +72,7 @@ export class AnySchema extends TlvSchema<TlvStream> {
         if (!Array.isArray(tlvStream)) throw new Error(`Expected TlvStream, got ${typeof tlvStream}.`);
         tlvStream.forEach(({ typeLength }) => {
             if (!typeLength || typeof typeLength !== "object") throw new Error(`Expected typeLength properties in TlvStream, got ${typeof typeLength}.`);
-            if (!typeLength.type || typeof typeLength.type !== "number") throw new Error(`Expected typeLength.type properties in TlvStream, got ${typeof typeLength.type}.`);
+            if (typeof typeLength.type !== "number") throw new Error(`Expected typeLength.type as number in TlvStream, got ${typeof typeLength.type}.`);
         });
     }
 }

--- a/src/tlv/TlvAny.ts
+++ b/src/tlv/TlvAny.ts
@@ -24,7 +24,7 @@ export class AnySchema extends TlvSchema<TlvStream> {
                 case TlvType.EndOfContainer:
                     writer.writeTag(typeLength, tagAssigned ?? tag);
                     break;
-                case TlvType.UnsignedInt: 
+                case TlvType.UnsignedInt:
                 case TlvType.SignedInt:
                 case TlvType.Float:
                 case TlvType.Utf8String:
@@ -44,7 +44,7 @@ export class AnySchema extends TlvSchema<TlvStream> {
         switch (typeLength.type) {
             case TlvType.Null:
             case TlvType.Boolean:
-            case TlvType.UnsignedInt: 
+            case TlvType.UnsignedInt:
             case TlvType.SignedInt:
             case TlvType.Float:
             case TlvType.Utf8String:
@@ -67,6 +67,14 @@ export class AnySchema extends TlvSchema<TlvStream> {
         }
         return tlvStream;
     }
+
+    override validate(tlvStream: TlvStream): void {
+        if (!Array.isArray(tlvStream)) throw new Error(`Expected TlvStream, got ${typeof tlvStream}.`);
+        tlvStream.forEach(({ typeLength }) => {
+            if (!typeLength || typeof typeLength !== "object") throw new Error(`Expected typeLength properties in TlvStream, got ${typeof typeLength}.`);
+            if (!typeLength.type || typeof typeLength.type !== "number") throw new Error(`Expected typeLength.type properties in TlvStream, got ${typeof typeLength.type}.`);
+        });
+    }
 }
 
-export const TlvAny = new AnySchema(); 
+export const TlvAny = new AnySchema();

--- a/src/tlv/TlvArray.ts
+++ b/src/tlv/TlvArray.ts
@@ -47,6 +47,7 @@ export class ArraySchema<T> extends TlvSchema<T[]> {
     }
 
     override validate(data: T[]): void {
+        if (!Array.isArray(data)) throw new Error(`Expected array, got ${typeof data}.`);
         if (data.length > this.maxLength) throw new Error(`Array is too long: ${data.length}, max ${this.maxLength}.`);
         if (data.length < this.minLength) throw new Error(`Array is too short: ${data.length}, min ${this.minLength}.`);
         data.forEach(element => this.elementSchema.validate(element));

--- a/src/tlv/TlvArray.ts
+++ b/src/tlv/TlvArray.ts
@@ -21,7 +21,7 @@ type LengthConstraints = {
  */
 export class ArraySchema<T> extends TlvSchema<T[]> {
     constructor(
-        private readonly elementSchema: TlvSchema<T>,
+        readonly elementSchema: TlvSchema<T>,
         private readonly minLength: number = 0,
         private readonly maxLength: number = 1024,
     ) {

--- a/src/tlv/TlvArray.ts
+++ b/src/tlv/TlvArray.ts
@@ -6,7 +6,7 @@
 
 import { TlvType, TlvTag, TlvTypeLength } from "./TlvCodec.js";
 import { TlvReader, TlvSchema, TlvWriter } from "./TlvSchema.js";
-import { MatterCoreSpecificationV1_0 } from "../spec/Specifications.js"; 
+import { MatterCoreSpecificationV1_0 } from "../spec/Specifications.js";
 
 type LengthConstraints = {
     minLength?: number,
@@ -16,7 +16,7 @@ type LengthConstraints = {
 
 /**
  * Schema to encode an array or string in TLV.
- * 
+ *
  * @see {@link MatterCoreSpecificationV1_0} § A.11.2 and A.11.4
  */
 export class ArraySchema<T> extends TlvSchema<T[]> {
@@ -43,13 +43,13 @@ export class ArraySchema<T> extends TlvSchema<T[]> {
             if (elementTypeLength.type === TlvType.EndOfContainer) break;
             result.push(this.elementSchema.decodeTlvInternalValue(reader, elementTypeLength));
         }
-        this.validate(result);
         return result;
     }
 
-    override validate({ length }: T[]): void {
-        if (length > this.maxLength) throw new Error(`Array is too long: ${length}, max ${this.maxLength}.`);
-        if (length < this.minLength) throw new Error(`Array is too short: ${length}, min ${this.minLength}.`);
+    override validate(data: T[]): void {
+        if (data.length > this.maxLength) throw new Error(`Array is too long: ${data.length}, max ${this.maxLength}.`);
+        if (data.length < this.minLength) throw new Error(`Array is too short: ${data.length}, min ${this.minLength}.`);
+        data.forEach(element => this.elementSchema.validate(element));
     }
 }
 

--- a/src/tlv/TlvBoolean.ts
+++ b/src/tlv/TlvBoolean.ts
@@ -6,11 +6,11 @@
 
 import { TlvType, TlvTag, TlvTypeLength } from "./TlvCodec.js";
 import { TlvReader, TlvSchema, TlvWriter } from "./TlvSchema.js";
-import { MatterCoreSpecificationV1_0 } from "../spec/Specifications.js"; 
+import { MatterCoreSpecificationV1_0 } from "../spec/Specifications.js";
 
 /**
  * Schema to encode a boolean in TLV.
- * 
+ *
  * @see {@link MatterCoreSpecificationV1_0} § A.11.3
  */
 export class BooleanSchema extends TlvSchema<boolean> {

--- a/src/tlv/TlvBoolean.ts
+++ b/src/tlv/TlvBoolean.ts
@@ -22,6 +22,10 @@ export class BooleanSchema extends TlvSchema<boolean> {
         if (typeLength.type !== TlvType.Boolean) throw new Error(`Unexpected type ${typeLength.type}.`)
         return typeLength.value;
     }
+
+    override validate(value: boolean): void {
+        if (typeof value !== "boolean") throw new Error(`Expected boolean, got ${typeof value}.`);
+    }
 }
 
 /** Boolean TLV schema. */

--- a/src/tlv/TlvNumber.ts
+++ b/src/tlv/TlvNumber.ts
@@ -39,6 +39,10 @@ export class TlvNumericSchema<T extends bigint | number> extends TlvSchema<T> {
 
     override validate(value: T): void {
         if (typeof value !== "number" && typeof value !== 'bigint') throw new Error(`Expected number, got ${typeof value}.`);
+        this.validateBoundaries(value);
+    }
+
+    validateBoundaries(value: T): void {
         if (this.min !== undefined && value < this.min) throw new Error(`Invalid value: ${value} is below the minimum, ${this.min}.`);
         if (this.max !== undefined && value > this.max) throw new Error(`Invalid value: ${value} is above the maximum, ${this.max}.`);
     }
@@ -80,8 +84,7 @@ export class TlvNumberSchema extends TlvNumericSchema<number> {
 
     override validate(value: number): void {
         if (typeof value !== "number") throw new Error(`Expected number, got ${typeof value}.`);
-        if (this.min !== undefined && value < this.min) throw new Error(`Invalid value: ${value} is below the minimum, ${this.min}.`);
-        if (this.max !== undefined && value > this.max) throw new Error(`Invalid value: ${value} is above the maximum, ${this.max}.`);
+        this.validateBoundaries(value);
     }
 }
 

--- a/src/tlv/TlvNumber.ts
+++ b/src/tlv/TlvNumber.ts
@@ -77,6 +77,12 @@ export class TlvNumberSchema extends TlvNumericSchema<number> {
             minValue(max, this.max),
         );
     }
+
+    override validate(value: number): void {
+        if (typeof value !== "number") throw new Error(`Expected number, got ${typeof value}.`);
+        if (this.min !== undefined && value < this.min) throw new Error(`Invalid value: ${value} is below the minimum, ${this.min}.`);
+        if (this.max !== undefined && value > this.max) throw new Error(`Invalid value: ${value} is above the maximum, ${this.max}.`);
+    }
 }
 
 export const TlvLongNumberSchema = TlvNumericSchema<number | bigint>;

--- a/src/tlv/TlvNumber.ts
+++ b/src/tlv/TlvNumber.ts
@@ -12,7 +12,7 @@ import { BitmapSchema, BitSchema, TypeFromBitSchema } from "../schema/BitmapSche
 
 /**
  * Schema to encode an unsigned integer in TLV.
- * 
+ *
  * @see {@link MatterCoreSpecificationV1_0} § A.11.1
  */
 export class TlvNumericSchema<T extends bigint | number> extends TlvSchema<T> {
@@ -34,12 +34,10 @@ export class TlvNumericSchema<T extends bigint | number> extends TlvSchema<T> {
     override decodeTlvInternalValue(reader: TlvReader, typeLength: TlvTypeLength) {
         if (typeLength.type !== this.type) throw new Error(`Unexpected type ${typeLength.type}, was expecting ${this.type}.`);
         const value = reader.readPrimitive(typeLength) as T;
-        this.validate(value);
         return value;
     }
 
     override validate(value: T): void {
-        super.validate(value);
         if (this.min !== undefined && value < this.min) throw new Error(`Invalid value: ${value} is below the minimum, ${this.min}.`);
         if (this.max !== undefined && value > this.max) throw new Error(`Invalid value: ${value} is above the maximum, ${this.max}.`);
     }

--- a/src/tlv/TlvNumber.ts
+++ b/src/tlv/TlvNumber.ts
@@ -38,6 +38,7 @@ export class TlvNumericSchema<T extends bigint | number> extends TlvSchema<T> {
     }
 
     override validate(value: T): void {
+        if (typeof value !== "number" && typeof value !== 'bigint') throw new Error(`Expected number, got ${typeof value}.`);
         if (this.min !== undefined && value < this.min) throw new Error(`Invalid value: ${value} is below the minimum, ${this.min}.`);
         if (this.max !== undefined && value > this.max) throw new Error(`Invalid value: ${value} is above the maximum, ${this.max}.`);
     }

--- a/src/tlv/TlvObject.ts
+++ b/src/tlv/TlvObject.ts
@@ -85,9 +85,10 @@ export class ObjectSchema<F extends TlvFields> extends TlvSchema<TypeFromFields<
 
     override validate(value: TypeFromFields<F>): void {
         for (const name in this.fieldDefinitions) {
-            if (this.fieldDefinitions[name].optional && (value as any)[name] === undefined) continue;
-            if (!this.fieldDefinitions[name].optional && (value as any)[name] === undefined) throw new Error(`Missing mandatory field ${name}`);
-            this.fieldDefinitions[name].schema.validate((value as any)[name]);
+            const { optional, schema } = this.fieldDefinitions[name];
+            if (optional && (value as any)[name] === undefined) continue;
+            if (!optional && (value as any)[name] === undefined) throw new Error(`Missing mandatory field ${name}`);
+            schema.validate((value as any)[name]);
         }
     }
 }

--- a/src/tlv/TlvObject.ts
+++ b/src/tlv/TlvObject.ts
@@ -31,7 +31,7 @@ export type TypeFromFields<F extends TlvFields> = Merge<TypeForMandatoryFields<F
 
 /**
  * Schema to encode an object in TLV.
- * 
+ *
  * @see {@link MatterCoreSpecificationV1_0} § A.5.1 and § A.11.4
  */
 export class ObjectSchema<F extends TlvFields> extends TlvSchema<TypeFromFields<F>> {
@@ -80,13 +80,14 @@ export class ObjectSchema<F extends TlvFields> extends TlvSchema<TypeFromFields<
             const { field, name } = fieldName;
             result[name] = field.schema.decodeTlvInternalValue(reader, elementTypeLength);
         }
-        this.validate(result);
         return result as TypeFromFields<F>;
     }
 
     override validate(value: TypeFromFields<F>): void {
         for (const name in this.fieldDefinitions) {
+            if (this.fieldDefinitions[name].optional && (value as any)[name] === undefined) continue;
             if (!this.fieldDefinitions[name].optional && (value as any)[name] === undefined) throw new Error(`Missing mandatory field ${name}`);
+            this.fieldDefinitions[name].schema.validate((value as any)[name]);
         }
     }
 }

--- a/src/tlv/TlvString.ts
+++ b/src/tlv/TlvString.ts
@@ -42,9 +42,10 @@ export class StringSchema<T extends TlvType.ByteString | TlvType.Utf8String> ext
         return reader.readPrimitive(typeLength) as TlvToPrimitive[T];
     }
 
-    override validate({ length }: TlvToPrimitive[T]): void {
-        if (length > this.maxLength) throw new Error(`String is too long: ${length}, max ${this.maxLength}.`);
-        if (length < this.minLength) throw new Error(`String is too short: ${length}, min ${this.minLength}.`);
+    override validate(value: TlvToPrimitive[T]): void {
+        if (typeof value !== "string" && !(value instanceof Uint8Array) && !Buffer.isBuffer(value)) throw new Error(`Expected string, got ${typeof value}.`);
+        if (value.length > this.maxLength) throw new Error(`String is too long: ${value.length}, max ${this.maxLength}.`);
+        if (value.length < this.minLength) throw new Error(`String is too short: ${value.length}, min ${this.minLength}.`);
     }
 
     bound({ minLength, maxLength, length }: LengthConstraints) {

--- a/src/tlv/TlvString.ts
+++ b/src/tlv/TlvString.ts
@@ -17,7 +17,7 @@ type LengthConstraints = {
 
 /**
  * Schema to encode an byte string or an Utf8 string in TLV.
- * 
+ *
  * @see {@link MatterCoreSpecificationV1_0} § A.11.2
  */
 export class StringSchema<T extends TlvType.ByteString | TlvType.Utf8String> extends TlvSchema<TlvToPrimitive[T]> {

--- a/src/tlv/TlvString.ts
+++ b/src/tlv/TlvString.ts
@@ -43,7 +43,8 @@ export class StringSchema<T extends TlvType.ByteString | TlvType.Utf8String> ext
     }
 
     override validate(value: TlvToPrimitive[T]): void {
-        if (typeof value !== "string" && !(value instanceof Uint8Array) && !Buffer.isBuffer(value)) throw new Error(`Expected string, got ${typeof value}.`);
+        if (this.type === TlvType.Utf8String && typeof value !== "string") throw new Error(`Expected string, got ${typeof value}.`);
+        if (this.type === TlvType.ByteString && !(value instanceof Uint8Array)) throw new Error(`Expected Uint8Array, got ${typeof value}.`);
         if (value.length > this.maxLength) throw new Error(`String is too long: ${value.length}, max ${this.maxLength}.`);
         if (value.length < this.minLength) throw new Error(`String is too short: ${value.length}, min ${this.minLength}.`);
     }

--- a/src/tlv/TlvString.ts
+++ b/src/tlv/TlvString.ts
@@ -8,6 +8,7 @@ import { TlvType, TlvCodec, TlvTag, TlvTypeLength, TlvToPrimitive } from "./TlvC
 import { TlvReader, TlvSchema, TlvWriter } from "./TlvSchema.js";
 import { MatterCoreSpecificationV1_0 } from "../spec/Specifications.js";
 import { maxValue, minValue } from "../util/Number.js";
+import { ByteArray } from "../util/ByteArray";
 
 type LengthConstraints = {
     minLength?: number,
@@ -44,7 +45,7 @@ export class StringSchema<T extends TlvType.ByteString | TlvType.Utf8String> ext
 
     override validate(value: TlvToPrimitive[T]): void {
         if (this.type === TlvType.Utf8String && typeof value !== "string") throw new Error(`Expected string, got ${typeof value}.`);
-        if (this.type === TlvType.ByteString && !(value instanceof Uint8Array)) throw new Error(`Expected Uint8Array, got ${typeof value}.`);
+        if (this.type === TlvType.ByteString && !(value instanceof ByteArray)) throw new Error(`Expected ByteArray, got ${typeof value}.`);
         if (value.length > this.maxLength) throw new Error(`String is too long: ${value.length}, max ${this.maxLength}.`);
         if (value.length < this.minLength) throw new Error(`String is too short: ${value.length}, min ${this.minLength}.`);
     }

--- a/src/tlv/TlvVoid.ts
+++ b/src/tlv/TlvVoid.ts
@@ -23,6 +23,10 @@ export class VoidSchema extends TlvSchema<void> {
     override decodeTlvInternalValue(_reader: TlvReader, _typeLength: TlvTypeLength): void {
         throw new Error("decodeTlvInternalValue should never be called");
     }
+
+    override validate(data: void): void {
+        if (data !== undefined) throw new Error(`Expected void, got ${typeof data}.`);
+    }
 }
 
 /** Void TLV schema. */

--- a/test/tlv/TlvAnyTest.ts
+++ b/test/tlv/TlvAnyTest.ts
@@ -1,0 +1,63 @@
+/**
+ * @license
+ * Copyright 2022 Project CHIP Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ByteArray } from "../../src/util/ByteArray.js";
+import { TlvType } from "../../src/tlv/TlvCodec";
+import { TlvAny } from "../../src/tlv/TlvAny";
+
+type CodecVector<I, E> = {[valueDescription: string]: { encoded: I, decoded: E }};
+
+const testVector: CodecVector<string, any> = {
+    "null": { encoded: "14", decoded: [ { tag: undefined, typeLength: { type: TlvType.Null }, value: null} ] },
+    "array": { encoded: "1618", decoded: [
+            {
+                tag: undefined,
+                typeLength: {
+                    type: TlvType.Array
+                }
+            },
+            {
+                tag: undefined,
+                typeLength: {
+                    type: TlvType.EndOfContainer
+                }
+            }
+        ] },
+};
+
+describe("TlvAny", () => {
+
+    describe("encode", () => {
+        for (const valueDescription in testVector) {
+            const { encoded, decoded } = testVector[valueDescription];
+            it(`encodes ${valueDescription}`, () => {
+                expect(TlvAny.encode(decoded).toHex())
+                    .toBe(encoded);
+            });
+        }
+    });
+
+    describe("decode", () => {
+        for (const valueDescription in testVector) {
+            const { encoded, decoded } = testVector[valueDescription];
+            it(`decodes ${valueDescription}`, () => {
+                expect(TlvAny.decode(ByteArray.fromHex(encoded)))
+                    .toEqual(decoded);
+            });
+        }
+    });
+
+    describe("validation", () => {
+        it("throws an error if the value is not a boolean", () => {
+            expect(() => TlvAny.validate("a" as any))
+                .toThrowError("Expected TlvStream, got string.");
+        });
+
+        it("does not throw an error if the value is a boolean", () => {
+            expect(TlvAny.validate([ { typeLength: { type: TlvType.Null }} ])).toBe(undefined);
+        });
+    });
+});

--- a/test/tlv/TlvBooleanTest.ts
+++ b/test/tlv/TlvBooleanTest.ts
@@ -35,4 +35,15 @@ describe("TlvBoolean", () => {
             });
         }
     });
+
+    describe("validation", () => {
+        it("throws an error if the value is not a boolean", () => {
+            expect(() => TlvBoolean.validate("a" as any))
+                .toThrowError("Expected boolean, got string.");
+        });
+
+        it("does not throw an error if the value is a boolean", () => {
+            expect(TlvBoolean.validate(true)).toBe(undefined);
+        });
+    });
 });

--- a/test/tlv/TlvComplexTest.ts
+++ b/test/tlv/TlvComplexTest.ts
@@ -1,0 +1,145 @@
+/**
+ * @license
+ * Copyright 2022 Project CHIP Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { TlvObject, TlvField, TlvOptionalField } from "../../src/tlv/TlvObject.js";
+import { TypeFromSchema } from "../../src/tlv/TlvSchema.js";
+import { TlvByteString, TlvString } from "../../src/tlv/TlvString.js";
+import { TlvUInt8 } from "../../src/tlv/TlvNumber.js";
+import { ByteArray } from "../../src/util/ByteArray.js";
+import { TlvArray } from "../../src/tlv/TlvArray";
+import { TlvBoolean } from "../../src/tlv/TlvBoolean";
+import { TlvNullable } from "../../src/tlv/TlvNullable";
+
+const schema = TlvObject({
+    /** Mandatory field jsdoc */
+    arrayField: TlvField(1,
+        TlvArray(
+            TlvObject({
+                /** Mandatory array field jsdoc */
+                mandatoryNumber: TlvField(1, TlvUInt8),
+
+                /** Optional array field jsdoc */
+                optionalByteString: TlvOptionalField(2, TlvByteString.bound({ minLength: 3, maxLength: 3 })),
+            }), { minLength: 1, maxLength: 2 }
+        )
+    ),
+
+    /** Optional field jsdoc */
+    optionalString: TlvOptionalField(2, TlvString),
+
+    /** Nullable field jsdoc */
+    nullableBoolean: TlvField(3, TlvNullable(TlvBoolean)),
+});
+
+type CodecVector<I, E> = {[valueDescription: string]: { encoded: E, decoded: I }};
+type CodecErrorVector<I> = {[valueDescription: string]: { structure: I, expectedError?: string }};
+
+const codecVector: CodecVector<TypeFromSchema<typeof schema>, string> = {
+    "an object with all fields": {
+        decoded: {
+            arrayField: [
+                { mandatoryNumber: 1, optionalByteString: ByteArray.fromHex("000000") },
+                { mandatoryNumber: 2, optionalByteString: ByteArray.fromHex("999999") },
+            ],
+            optionalString: "test",
+            nullableBoolean: true,
+        },
+        encoded: "15360115240101300203000000181524010230020399999918182c020474657374290318"
+    },
+    "an object with minimum fields": {
+        decoded: {
+            arrayField: [
+                { mandatoryNumber: 1 },
+            ],
+            nullableBoolean: null,
+        },
+        encoded: "153601152401011818340318"
+    },
+};
+
+const codecErrorVector: CodecErrorVector<TypeFromSchema<typeof schema>> = {
+    "an object with no fields": {
+        // @ts-ignore - Disable TS Compiler checks to proper test validation logic
+        structure: {},
+        expectedError: "Missing mandatory field arrayField"
+    },
+    "an object with empty array": {
+        // @ts-ignore - Disable TS Compiler checks to proper test validation logic
+        structure: {
+            arrayField: [
+            ],
+        },
+        expectedError: "Array is too short: 0, min 1."
+    },
+    "an object with missing nullable value": {
+        // @ts-ignore - Disable TS Compiler checks to proper test validation logic
+        structure: {
+            arrayField: [
+                { mandatoryNumber: 1 },
+            ],
+        },
+        expectedError: "Missing mandatory field nullableBoolean"
+    },
+    "an object with invalid datatype in array": {
+        structure: {
+            arrayField: [
+                // @ts-ignore - Disable TS Compiler checks to proper test validation logic
+                { mandatoryNumber: "test" },
+            ],
+        },
+        expectedError: "Expected number, got string."
+    },
+    "an object with invalid datatype in array #2": {
+        structure: {
+            arrayField: [
+                {
+                    // @ts-ignore - Disable TS Compiler checks to proper test validation logic
+                    mandatoryNumber: [
+                        { mandatoryNumber: 1 },
+                    ]
+                },
+            ],
+        },
+        expectedError: "Expected number, got object."
+    },
+};
+
+describe("TlvObject", () => {
+
+    describe("encode", () => {
+        for (const valueDescription in codecVector) {
+            const { encoded, decoded } = codecVector[valueDescription];
+            it(`encodes ${valueDescription}`, () => {
+                expect(schema.encode(decoded).toHex())
+                    .toBe(encoded);
+            });
+        }
+    });
+
+    describe("decode", () => {
+        for (const valueDescription in codecVector) {
+            const { encoded, decoded } = codecVector[valueDescription];
+            it(`decodes ${valueDescription}`, () => {
+                expect(schema.decode(ByteArray.fromHex(encoded)))
+                    .toEqual(decoded);
+            });
+        }
+    });
+
+    describe("errors", () => {
+        for (const valueDescription in codecErrorVector) {
+            const { structure, expectedError } = codecErrorVector[valueDescription];
+            it(`checks ${valueDescription}`, () => {
+                try {
+                    schema.validate(structure);
+                } catch (error) {
+                    expect((error as Error).message).toBe(expectedError || '');
+                }
+            });
+        }
+    });
+
+});

--- a/test/tlv/TlvNumberTest.ts
+++ b/test/tlv/TlvNumberTest.ts
@@ -88,7 +88,7 @@ describe("TlvNumber", () => {
 
         it("throws an error if the value is not a bigint", () => {
             expect(() => TlvUInt32.validate(BigInt(12345678790) as any))
-                .toThrowError("Invalid value: 12345678790 is above the maximum, 4294967295.");
+                .toThrowError("Expected number, got bigint.");
         });
 
         it("does not throw an error if the value is a number", () => {

--- a/test/tlv/TlvNumberTest.ts
+++ b/test/tlv/TlvNumberTest.ts
@@ -59,7 +59,7 @@ describe("TlvNumber", () => {
         });
     });
 
-    describe("validate", () => {
+    describe("validate bound ranges", () => {
         const BoundedUint = TlvUInt32.bound({ min: 5, max: 10 });
 
         for (const testName in validateTestVector) {
@@ -73,5 +73,31 @@ describe("TlvNumber", () => {
                 }
             });
         }
+    });
+
+    describe("validate", () => {
+        it("throws an error if the value is not a number", () => {
+            expect(() => TlvUInt32.validate("a" as any))
+                .toThrowError("Expected number, got string.");
+        });
+
+        it("throws an error if the value is not a bigint", () => {
+            expect(() => TlvUInt64.validate("a" as any))
+                .toThrowError("Expected number, got string.");
+        });
+
+        it("throws an error if the value is not a bigint", () => {
+            expect(() => TlvUInt32.validate(BigInt(12345678790) as any))
+                .toThrowError("Invalid value: 12345678790 is above the maximum, 4294967295.");
+        });
+
+        it("does not throw an error if the value is a number", () => {
+            expect(TlvUInt64.validate(12345)).toBe(undefined);
+        });
+
+        it("does not throw an error if the value is a bigint", () => {
+            expect(TlvUInt64.validate(BigInt(12345678790))).toBe(undefined);
+        });
+
     });
 });

--- a/test/tlv/TlvStringTest.ts
+++ b/test/tlv/TlvStringTest.ts
@@ -93,7 +93,7 @@ describe("TlvByteString", () => {
     describe("validation", () => {
         it("throws an error if the value is not a ByteString", () => {
             expect(() => TlvByteString.validate(5 as any))
-                .toThrowError("Expected string, got number.");
+                .toThrowError("Expected Uint8Array, got number.");
         });
 
         it("throws an error if the value is not a String", () => {

--- a/test/tlv/TlvStringTest.ts
+++ b/test/tlv/TlvStringTest.ts
@@ -74,7 +74,7 @@ describe("TlvByteString", () => {
         });
     });
 
-    describe("validate", () => {
+    describe("validate ByteString", () => {
         const BoundedInt = TlvByteString.bound({ minLength: 4, maxLength: 6 });
 
         for (const testName in validateByteStringTestVector) {
@@ -89,4 +89,17 @@ describe("TlvByteString", () => {
             });
         }
     });
+
+    describe("validation", () => {
+        it("throws an error if the value is not a ByteString", () => {
+            expect(() => TlvByteString.validate(5 as any))
+                .toThrowError("Expected string, got number.");
+        });
+
+        it("throws an error if the value is not a String", () => {
+            expect(() => TlvString.validate(true as any))
+                .toThrowError("Expected string, got boolean.");
+        });
+    });
+
 });

--- a/test/tlv/TlvStringTest.ts
+++ b/test/tlv/TlvStringTest.ts
@@ -93,7 +93,7 @@ describe("TlvByteString", () => {
     describe("validation", () => {
         it("throws an error if the value is not a ByteString", () => {
             expect(() => TlvByteString.validate(5 as any))
-                .toThrowError("Expected Uint8Array, got number.");
+                .toThrowError("Expected ByteArray, got number.");
         });
 
         it("throws an error if the value is not a String", () => {

--- a/test/tlv/TlvVoidTest.ts
+++ b/test/tlv/TlvVoidTest.ts
@@ -1,0 +1,28 @@
+/**
+ * @license
+ * Copyright 2022 Project CHIP Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { TlvVoid } from "../../src/tlv/TlvVoid";
+
+describe("TlvVoid", () => {
+
+    describe("encode", () => {
+        it("encodes undefined", () => {
+            expect(TlvVoid.encode(undefined).toHex())
+                .toBe("");
+        });
+    });
+
+    describe("validation", () => {
+        it("throws an error if the value is not undefined", () => {
+            expect(() => TlvVoid.validate("a" as any))
+                .toThrowError("Expected void, got string.");
+        });
+
+        it("does not throw an error if the value is undefined", () => {
+            expect(TlvVoid.validate(undefined)).toBe(undefined);
+        });
+    });
+});


### PR DESCRIPTION
Ok, as discussed in https://github.com/project-chip/matter.js/pull/46/files#r1094125357 here is my PR to change the following:
* decoding is "just" doing decode and after the decoding we do a recursive validation
* the decode method has an option to skip te validation after decoding.

You could already have a look if you have time. I currently work to add a complex Object/Array/different type test