### PR TITLE
Enhance persistence Json to also support Maps

### DIFF
--- a/packages/matter-node.js/src/persistence/JsonConverter.ts
+++ b/packages/matter-node.js/src/persistence/JsonConverter.ts
@@ -1,0 +1,51 @@
+/**
+ * @license
+ * Copyright 2022-2023 Project CHIP Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/** Special Magic key to identify special object types with custom encoding in JSON. */
+const JSON_SPECIAL_KEY_TYPE = "__object__";
+
+/** Special Magic key to identify the valöue of the customly encoded objects in JSON. */
+const JSON_SPECIAL_KEY_VALUE = "__value__";
+
+export function toJson(object: any): string {
+    return JSON.stringify(object, (_key, value) => {
+        if (typeof value === 'bigint') {
+            return `{"${JSON_SPECIAL_KEY_TYPE}":"BigInt","${JSON_SPECIAL_KEY_VALUE}":"${value.toString()}"}`;
+        }
+        if (typeof value === 'object' && value !== null && value.type === 'Buffer' && Array.isArray(value.data)) {
+            return `{"${JSON_SPECIAL_KEY_TYPE}":"Buffer","${JSON_SPECIAL_KEY_VALUE}":"${Buffer.from(value.data).toString('base64')}"}`;
+        }
+        if (value instanceof Uint8Array) {
+            return `{"${JSON_SPECIAL_KEY_TYPE}":"Uint8Array","${JSON_SPECIAL_KEY_VALUE}":"${Buffer.from(value).toString('base64')}"}`;
+        }
+        if (value instanceof Map) {
+            return `{"${JSON_SPECIAL_KEY_TYPE}":"Map","${JSON_SPECIAL_KEY_VALUE}":${JSON.stringify(toJson(Array.from(value.entries())))}}`;
+        }
+        return value;
+    });
+}
+
+export function fromJson(json: string): any {
+    return JSON.parse(json, (_key, value) => {
+        if (typeof value === "string" && value.startsWith(`{"${JSON_SPECIAL_KEY_TYPE}":"`) && value.endsWith('"}')) {
+            const data = JSON.parse(value);
+            const object = data[JSON_SPECIAL_KEY_TYPE];
+            switch (object) {
+                case "BigInt":
+                    return BigInt(data[JSON_SPECIAL_KEY_VALUE]);
+                case "Buffer":
+                    return Buffer.from(data[JSON_SPECIAL_KEY_VALUE], 'base64');
+                case "Uint8Array":
+                    return new Uint8Array(Buffer.from(data[JSON_SPECIAL_KEY_VALUE], 'base64'));
+                case "Map":
+                    return new Map(fromJson(data[JSON_SPECIAL_KEY_VALUE]));
+                default:
+                    throw new Error(`Unknown object type: ${object}`);
+            }
+        }
+        return value;
+    });
+}

--- a/packages/matter-node.js/src/persistence/StorageNode.ts
+++ b/packages/matter-node.js/src/persistence/StorageNode.ts
@@ -7,6 +7,7 @@
 import { Time } from "../time/Time";
 import { readFile, writeFile } from "fs/promises";
 import { StorageInMemory } from "./StorageInMemory";
+import { fromJson, toJson } from "./JsonConverter";
 
 /** We store changes 1s after a value was set to the storage, but not more often than every 1s. */
 const COMMIT_DELAY = 1000 /* 1s */;
@@ -25,7 +26,7 @@ export class StorageNode extends StorageInMemory {
     override async initialize() {
         if (this.initialized) throw new Error("Storage already initialized!");
         try {
-            this.store = this.fromJson(await readFile(this.path, "utf-8"));
+            this.store = fromJson(await readFile(this.path, "utf-8"));
         } catch (error: any) {
             // We accept that the file does not exist yet to initialize with an empty store.
             if (error.code !== "ENOENT") {
@@ -46,47 +47,12 @@ export class StorageNode extends StorageInMemory {
     private async commit() {
         if (!this.initialized || this.closed) return;
         this.waitForCommit = false;
-        await writeFile(this.path, this.toJson(this.store), "utf-8");
+        await writeFile(this.path, toJson(this.store), "utf-8");
     }
 
     override async close() {
         this.commitTimer.stop();
         await this.commit();
         this.closed = true;
-    }
-
-    private toJson(object: any): string {
-        return JSON.stringify(object, (_key, value) => {
-            if (typeof value === 'bigint') {
-                return `{"__object__":"BigInt","__value__":"${value.toString()}"}`;
-            }
-            if (typeof value === 'object' && value.type === 'Buffer' && Array.isArray(value.data)) {
-                return `{"__object__":"Buffer","__value__":"${Buffer.from(value.data).toString('base64')}"}`;
-            }
-            if (value instanceof Uint8Array) {
-                return `{"__object__":"Uint8Array","__value__":"${Buffer.from(value).toString('base64')}"}`;
-            }
-            return value;
-        }, " ");
-    }
-
-    private fromJson(json: string): any {
-        return JSON.parse(json, (_key, value) => {
-            if (typeof value === "string" && value.startsWith('{"__object__":"') && value.endsWith('"}')) {
-                const data = JSON.parse(value);
-                const object = data.__object__;
-                switch (object) {
-                    case "BigInt":
-                        return BigInt(data.__value__);
-                    case "Buffer":
-                        return Buffer.from(data.__value__, 'base64');
-                    case "Uint8Array":
-                        return new Uint8Array(Buffer.from(data.__value__, 'base64'));
-                    default:
-                        throw new Error(`Unknown object type: ${object}`);
-                }
-            }
-            return value;
-        });
     }
 }

--- a/packages/matter-node.js/test/persistence/JsonConverterTest.ts
+++ b/packages/matter-node.js/test/persistence/JsonConverterTest.ts
@@ -25,7 +25,7 @@ describe("JsonConverter", () => {
 
             const json = toJson(obj);
 
-            assert.equal(json, "{\"aNumber\":1,\"aNumberString\":\"2\",\"aString\":\"hello\",\"aBoolean\":true,\"aNull\":null,\"anObject\":{\"a\":1,\"b\":2,\"c\":3},\"anNumberArray\":[1,2,3],\"anStringArray\":[\"a\",\"b\",\"c\"],\"anObjectArray\":[{\"a\":1},{\"b\":2},{\"c\":3}]}");
+            assert.equal(json, `{"aNumber":1,"aNumberString":"2","aString":"hello","aBoolean":true,"aNull":null,"anObject":{"a":1,"b":2,"c":3},"anNumberArray":[1,2,3],"anStringArray":["a","b","c"],"anObjectArray":[{"a":1},{"b":2},{"c":3}]}`);
 
             const decodedObj = fromJson(json);
 
@@ -37,7 +37,7 @@ describe("JsonConverter", () => {
 
             const json = toJson(obj);
 
-            assert.equal(json, "\"{\\\"__object__\\\":\\\"BigInt\\\",\\\"__value__\\\":\\\"12345678901234567890\\\"}\"");
+            assert.equal(json, `"{\\"__object__\\":\\"BigInt\\",\\"__value__\\":\\"12345678901234567890\\"}"`);
 
             const decodedObj = fromJson(json);
 
@@ -50,7 +50,7 @@ describe("JsonConverter", () => {
 
             const json = toJson(obj);
 
-            assert.equal(json, "\"{\\\"__object__\\\":\\\"Buffer\\\",\\\"__value__\\\":\\\"aGVsbG8=\\\"}\"");
+            assert.equal(json, `"{\\"__object__\\":\\"Buffer\\",\\"__value__\\":\\"aGVsbG8=\\"}"`);
 
             const decodedObj = fromJson(json);
 
@@ -63,7 +63,7 @@ describe("JsonConverter", () => {
 
             const json = toJson(obj);
 
-            assert.equal(json, "\"{\\\"__object__\\\":\\\"Uint8Array\\\",\\\"__value__\\\":\\\"AQID\\\"}\"");
+            assert.equal(json, `"{\\"__object__\\":\\"Uint8Array\\",\\"__value__\\":\\"AQID\\"}"`);
 
             const decodedObj = fromJson(json);
 
@@ -76,7 +76,7 @@ describe("JsonConverter", () => {
 
             const json = toJson(obj);
 
-            assert.equal(json, "\"{\\\"__object__\\\":\\\"Map\\\",\\\"__value__\\\":\\\"[[\\\\\\\"a\\\\\\\",1],[\\\\\\\"b\\\\\\\",2],[\\\\\\\"c\\\\\\\",3]]\\\"}\"");
+            assert.equal(json, `"{\\"__object__\\":\\"Map\\",\\"__value__\\":\\"[[\\\\\\"a\\\\\\",1],[\\\\\\"b\\\\\\",2],[\\\\\\"c\\\\\\",3]]\\"}"`);
 
             const decodedObj = fromJson(json);
 
@@ -90,7 +90,7 @@ describe("JsonConverter", () => {
 
             const json = toJson(obj);
 
-            assert.equal(json, "\"{\\\"__object__\\\":\\\"Map\\\",\\\"__value__\\\":\\\"[[1,\\\\\\\"{\\\\\\\\\\\\\\\"__object__\\\\\\\\\\\\\\\":\\\\\\\\\\\\\\\"Map\\\\\\\\\\\\\\\",\\\\\\\\\\\\\\\"__value__\\\\\\\\\\\\\\\":\\\\\\\\\\\\\\\"[[\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\"a\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\",1]]\\\\\\\\\\\\\\\"}\\\\\\\"],[2,\\\\\\\"{\\\\\\\\\\\\\\\"__object__\\\\\\\\\\\\\\\":\\\\\\\\\\\\\\\"Map\\\\\\\\\\\\\\\",\\\\\\\\\\\\\\\"__value__\\\\\\\\\\\\\\\":\\\\\\\\\\\\\\\"[[\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\"b\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\",2]]\\\\\\\\\\\\\\\"}\\\\\\\"]]\\\"}\"");
+            assert.equal(json, `"{\\"__object__\\":\\"Map\\",\\"__value__\\":\\"[[1,\\\\\\"{\\\\\\\\\\\\\\"__object__\\\\\\\\\\\\\\":\\\\\\\\\\\\\\"Map\\\\\\\\\\\\\\",\\\\\\\\\\\\\\"__value__\\\\\\\\\\\\\\":\\\\\\\\\\\\\\"[[\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\"a\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\",1]]\\\\\\\\\\\\\\"}\\\\\\"],[2,\\\\\\"{\\\\\\\\\\\\\\"__object__\\\\\\\\\\\\\\":\\\\\\\\\\\\\\"Map\\\\\\\\\\\\\\",\\\\\\\\\\\\\\"__value__\\\\\\\\\\\\\\":\\\\\\\\\\\\\\"[[\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\"b\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\",2]]\\\\\\\\\\\\\\"}\\\\\\"]]\\"}"`);
 
             const decodedObj = fromJson(json);
 

--- a/packages/matter-node.js/test/persistence/JsonConverterTest.ts
+++ b/packages/matter-node.js/test/persistence/JsonConverterTest.ts
@@ -1,0 +1,106 @@
+/**
+ * @license
+ * Copyright 2022-2023 Project CHIP Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as assert from "assert";
+import { fromJson, toJson } from "../../src/persistence/JsonConverter";
+
+describe("JsonConverter", () => {
+
+    describe("encode/decode", () => {
+        it("encode/decode object with primitives", () => {
+            const obj = {
+                aNumber: 1,
+                aNumberString: "2",
+                aString: "hello",
+                aBoolean: true,
+                aNull: null,
+                anObject: { a: 1, b: 2, c: 3 },
+                anNumberArray: [1, 2, 3],
+                anStringArray: ["a", "b", "c"],
+                anObjectArray: [{ a: 1 }, { b: 2 }, { c: 3 }],
+            };
+
+            const json = toJson(obj);
+
+            assert.equal(json, "{\"aNumber\":1,\"aNumberString\":\"2\",\"aString\":\"hello\",\"aBoolean\":true,\"aNull\":null,\"anObject\":{\"a\":1,\"b\":2,\"c\":3},\"anNumberArray\":[1,2,3],\"anStringArray\":[\"a\",\"b\",\"c\"],\"anObjectArray\":[{\"a\":1},{\"b\":2},{\"c\":3}]}");
+
+            const decodedObj = fromJson(json);
+
+            assert.deepEqual(decodedObj, obj);
+        });
+
+        it("encode/decode BigInt", () => {
+            const obj = BigInt("12345678901234567890");
+
+            const json = toJson(obj);
+
+            assert.equal(json, "\"{\\\"__object__\\\":\\\"BigInt\\\",\\\"__value__\\\":\\\"12345678901234567890\\\"}\"");
+
+            const decodedObj = fromJson(json);
+
+            assert.deepEqual(decodedObj, obj);
+            assert.equal(typeof decodedObj, "bigint");
+        });
+
+        it("encode/decode Buffer", () => {
+            const obj = Buffer.from("hello");
+
+            const json = toJson(obj);
+
+            assert.equal(json, "\"{\\\"__object__\\\":\\\"Buffer\\\",\\\"__value__\\\":\\\"aGVsbG8=\\\"}\"");
+
+            const decodedObj = fromJson(json);
+
+            assert.deepEqual(decodedObj, obj);
+            assert.ok(decodedObj instanceof Buffer);
+        });
+
+        it("encode/decode Uint8Array", () => {
+            const obj = new Uint8Array([1, 2, 3]);
+
+            const json = toJson(obj);
+
+            assert.equal(json, "\"{\\\"__object__\\\":\\\"Uint8Array\\\",\\\"__value__\\\":\\\"AQID\\\"}\"");
+
+            const decodedObj = fromJson(json);
+
+            assert.deepEqual(decodedObj, obj);
+            assert.ok(decodedObj instanceof Uint8Array);
+        });
+
+        it("encode/decode Map", () => {
+            const obj = new Map([["a", 1], ["b", 2], ["c", 3]]);
+
+            const json = toJson(obj);
+
+            assert.equal(json, "\"{\\\"__object__\\\":\\\"Map\\\",\\\"__value__\\\":\\\"[[\\\\\\\"a\\\\\\\",1],[\\\\\\\"b\\\\\\\",2],[\\\\\\\"c\\\\\\\",3]]\\\"}\"");
+
+            const decodedObj = fromJson(json);
+
+            assert.deepEqual(decodedObj, obj);
+            assert.ok(decodedObj instanceof Map);
+            assert.equal(decodedObj.get("a"), 1);
+        });
+
+        it("encode/decide Map of Maps", () => {
+            const obj = new Map([[1, new Map([["a", 1]])], [2, new Map([["b", 2]])]]);
+
+            const json = toJson(obj);
+
+            assert.equal(json, "\"{\\\"__object__\\\":\\\"Map\\\",\\\"__value__\\\":\\\"[[1,\\\\\\\"{\\\\\\\\\\\\\\\"__object__\\\\\\\\\\\\\\\":\\\\\\\\\\\\\\\"Map\\\\\\\\\\\\\\\",\\\\\\\\\\\\\\\"__value__\\\\\\\\\\\\\\\":\\\\\\\\\\\\\\\"[[\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\"a\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\",1]]\\\\\\\\\\\\\\\"}\\\\\\\"],[2,\\\\\\\"{\\\\\\\\\\\\\\\"__object__\\\\\\\\\\\\\\\":\\\\\\\\\\\\\\\"Map\\\\\\\\\\\\\\\",\\\\\\\\\\\\\\\"__value__\\\\\\\\\\\\\\\":\\\\\\\\\\\\\\\"[[\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\"b\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\",2]]\\\\\\\\\\\\\\\"}\\\\\\\"]]\\\"}\"");
+
+            const decodedObj = fromJson(json);
+
+            assert.deepEqual(decodedObj, obj);
+
+            assert.ok(decodedObj instanceof Map);
+            assert.ok(decodedObj.get(1) instanceof Map);
+            assert.equal(decodedObj.get(1).get("a"), 1);
+            assert.ok(decodedObj.get(2) instanceof Map);
+            assert.equal(decodedObj.get(2).get("b"), 2);
+        });
+    });
+});


### PR DESCRIPTION
This PR does the following:
* Split out the custom JSON Converter methods into an own file so that they can also be used by other storage implementations
* Add support to alaps persist and restore "Map" objects
* Add Tests for the json converter