### PR TITLE
Groups Cluster Handler and Fabric Scoped storage

### DIFF
--- a/packages/matter-node.js/src/matter/cluster/server/ClusterServer.ts
+++ b/packages/matter-node.js/src/matter/cluster/server/ClusterServer.ts
@@ -9,6 +9,7 @@ import { MatterDevice } from "../../MatterDevice";
 import { Session } from "../../session/Session";
 import { Cluster, Command, Commands, AttributeJsType, Attributes, Attribute, OptionalAttribute, OptionalCommand, OptionalWritableAttribute, WritableAttribute, GlobalAttributes } from "@project-chip/matter.js";
 import { AttributeServer } from "./AttributeServer";
+import { Message } from "../../../codec/MessageCodec";
 
 type MandatoryAttributeNames<A extends Attributes> = { [K in keyof A]: A[K] extends OptionalAttribute<any> ? never : K }[keyof A];
 type OptionalAttributeNames<A extends Attributes> = { [K in keyof A]: A[K] extends OptionalAttribute<any> ? K : never }[keyof A];
@@ -20,7 +21,7 @@ export type AttributeInitialValues<A extends Attributes> = Merge<Omit<{ [P in Ma
 type MandatoryCommandNames<C extends Commands> = { [K in keyof C]: C[K] extends OptionalCommand<any, any> ? never : K }[keyof C];
 type OptionalCommandNames<C extends Commands> = { [K in keyof C]: C[K] extends OptionalCommand<any, any> ? K : never }[keyof C];
 type AttributeGetters<A extends Attributes> = { [P in keyof A as `get${Capitalize<string & P>}`]?: (session?: Session<MatterDevice>) => AttributeJsType<A[P]> };
-type CommandHandler<C extends Command<any, any>, A extends AttributeServers<any>> = C extends Command<infer RequestT, infer ResponseT> ? (args: { request: RequestT, attributes: A, session: Session<MatterDevice> }) => Promise<ResponseT> : never;
+type CommandHandler<C extends Command<any, any>, A extends AttributeServers<any>> = C extends Command<infer RequestT, infer ResponseT> ? (args: { request: RequestT, attributes: A, session: Session<MatterDevice>, message: Message }) => Promise<ResponseT> : never;
 type CommandHandlers<T extends Commands, A extends AttributeServers<any>> = Merge<{ [P in MandatoryCommandNames<T>]: CommandHandler<T[P], A> }, { [P in OptionalCommandNames<T>]?: CommandHandler<T[P], A> }>;
 
 /** Handlers to process cluster commands */

--- a/packages/matter-node.js/src/matter/cluster/server/GroupsServer.ts
+++ b/packages/matter-node.js/src/matter/cluster/server/GroupsServer.ts
@@ -73,7 +73,7 @@ export const GroupsClusterHandler: (endpointId: number) => ClusterServerHandlers
             if (endpointGroups !== undefined) {
                 const groupName = endpointGroups.get(groupId.id);
                 if (groupName !== undefined) {
-                    return {status: InteractionProtocolStatusCode.Success, groupId, groupName: groupName};
+                    return { status: InteractionProtocolStatusCode.Success, groupId, groupName: groupName };
                 }
             }
             return { status: InteractionProtocolStatusCode.NotFound, groupId, groupName: '' };

--- a/packages/matter-node.js/src/matter/cluster/server/GroupsServer.ts
+++ b/packages/matter-node.js/src/matter/cluster/server/GroupsServer.ts
@@ -1,0 +1,161 @@
+/**
+ * @license
+ * Copyright 2022 The node-matter Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { GroupsCluster, GroupId, InteractionProtocolStatusCode } from "@project-chip/matter.js";
+import { ClusterServerHandlers } from "./ClusterServer";
+import { SessionType } from "../../../codec/MessageCodec";
+import { StatusResponseError } from "../../interaction/InteractionMessenger";
+import { MatterDevice } from "../../MatterDevice";
+import { SecureSession } from "../../session/SecureSession";
+import { Fabric } from "../../fabric/Fabric";
+
+/*
+TODO: If the Scenes server cluster is implemented on the same endpoint, the following extension field SHALL
+      be added to the Scene Table:
+      * OnOff
+ */
+
+// TODO Put in a more central place once used by other clusters
+const getFabricFromSession = (session: SecureSession<MatterDevice>): Fabric => {
+    if (!session.isSecure()) throw new Error("Session needs to be a secure session");
+    const fabric = session.getFabric();
+    if (fabric === undefined) throw new Error("Session needs to have an associated Fabric");
+    return fabric;
+}
+
+export const GroupsClusterHandler: () => ClusterServerHandlers<typeof GroupsCluster> = () => {
+    const addGroupLogic = (groupId: GroupId, groupName: string, sessionType: SessionType, fabric: Fabric) => {
+        // TODO If the AddGroup command was received as a unicast, the server SHALL generate an AddGroupResponse
+        //      command with the Status field set to the evaluated status. If the AddGroup command was received
+        //      as a groupcast, the server SHALL NOT generate an AddGroupResponse command.
+        if (sessionType !== SessionType.Unicast) {
+            throw new Error("Groupcast not supported");
+        }
+        if (groupId.id < 1) {
+            return { status: InteractionProtocolStatusCode.ConstraintError, groupId };
+        }
+        if (groupName.length > 16) {
+            return { status: InteractionProtocolStatusCode.ConstraintError, groupId };
+        }
+
+        let fabricGroups = fabric.getScopedClusterDataInstance<Map<number, string>>(GroupsCluster.id);
+        if (fabricGroups === undefined) {
+            fabricGroups = new Map();
+            fabric.setScopedClusterDataInstance(GroupsCluster.id, fabricGroups);
+        }
+
+        fabricGroups.set(groupId.id, groupName || '');
+
+        return { status: InteractionProtocolStatusCode.Success, groupId };
+    }
+
+    return {
+        addGroup: async ({ request: { groupId, groupName }, session, message: { packetHeader: { sessionType } } }) => {
+            return addGroupLogic(groupId, groupName, sessionType, getFabricFromSession(session as SecureSession<MatterDevice>));
+        },
+
+        viewGroup: async ({ request: { groupId }, session, message: { packetHeader: { sessionType } } }) => {
+            // TODO If the ViewGroup command was received as a unicast, the server SHALL generate an ViewGroupResponse
+            //      command with the Status field set to the evaluated status. If the ViewGroup command was received
+            //      as a groupcast, the server SHALL NOT generate an ViewGroupResponse command.
+            if (sessionType !== SessionType.Unicast) {
+                throw new Error("Groupcast not supported");
+            }
+            if (groupId.id < 1) {
+                return { status: InteractionProtocolStatusCode.ConstraintError, groupId, groupName: '' };
+            }
+
+            const fabric = getFabricFromSession(session as SecureSession<MatterDevice>)
+            const fabricGroups = fabric.getScopedClusterDataInstance<Map<number, string>>(GroupsCluster.id);
+            if (fabricGroups !== undefined && fabricGroups.has(groupId.id)) {
+                return { status: InteractionProtocolStatusCode.Success, groupId, groupName: fabricGroups.get(groupId.id) || '' };
+            }
+            return { status: InteractionProtocolStatusCode.NotFound, groupId, groupName: '' };
+        },
+
+        getGroupMembership: async ({ request: { groupList }, session, message: { packetHeader: { sessionType } } }) => {
+            // TODO Later:
+            //  Zigbee: If the total number of groups will cause the maximum payload length of a frame to be exceeded,
+            //  then the GroupList field SHALL contain only as many groups as will fit.
+
+            // TODO the server SHALL only respond in this case if the command is unicast.
+            if (sessionType !== SessionType.Unicast) {
+                throw new Error("Groupcast not supported");
+            }
+
+            const fabric = getFabricFromSession(session as SecureSession<MatterDevice>)
+            const fabricGroups = fabric.getScopedClusterDataInstance<Map<number, string>>(GroupsCluster.id);
+            if (fabricGroups !== undefined) {
+                const allGroupsList = Array.from(fabricGroups.keys());
+                const capacity = allGroupsList.length < 0xff ? 0xff - allGroupsList.length : 0xfe;
+                if (groupList.length === 0) {
+                    return { capacity, groupList: allGroupsList.map(id => new GroupId(id)) };
+                }
+                const filteredGroupsList = groupList.filter(groupId => fabricGroups.has(groupId.id));
+                if (filteredGroupsList.length === 0) {
+                    return { capacity, groupList: [] };
+                } else {
+                    return { capacity, groupList: filteredGroupsList };
+                }
+            } else {
+                return { capacity: 0xff, groupList: [] };
+            }
+        },
+
+        removeGroup: async ({ request: { groupId }, session, message: { packetHeader: { sessionType } } }) => {
+            // TODO If the RemoveGroup command was received as a unicast, the server SHALL generate a RemoveGroupResponse
+            //      command with the Status field set to the evaluated status. If the RemoveGroup command was received as
+            //      a groupcast, the server SHALL NOT generate a RemoveGroupResponse command.
+            if (sessionType !== SessionType.Unicast) {
+                throw new Error("Groupcast not supported");
+            }
+
+            if (groupId.id < 1) {
+                return { status: InteractionProtocolStatusCode.ConstraintError, groupId };
+            }
+
+            const fabric = getFabricFromSession(session as SecureSession<MatterDevice>)
+            const fabricGroups = fabric.getScopedClusterDataInstance<Map<number, string>>(GroupsCluster.id);
+
+            if (fabricGroups !== undefined && fabricGroups.has(groupId.id)) {
+                fabricGroups.delete(groupId.id);
+                return { status: InteractionProtocolStatusCode.Success, groupId };
+            }
+            return { status: InteractionProtocolStatusCode.NotFound, groupId };
+        },
+
+        removeAllGroups: async ({ session, message: { packetHeader: { sessionType } } }) => {
+            // TODO Additionally, if the Scenes cluster is supported on the same endpoint, all scenes, except for scenes
+            //      associated with group ID 0, SHALL be removed on that endpoint.
+
+            // TODO If the RemoveAllGroups command was received as unicast and a response is not suppressed ... return Success
+            if (sessionType !== SessionType.Unicast) {
+                throw new Error("Groupcast not supported");
+            }
+
+            const fabric = getFabricFromSession(session as SecureSession<MatterDevice>)
+            const fabricGroups = fabric.getScopedClusterDataInstance<Map<number, string>>(GroupsCluster.id);
+            if (fabricGroups !== undefined) {
+                fabricGroups.clear();
+            }
+
+            throw new StatusResponseError("Return Status", InteractionProtocolStatusCode.Success);
+        },
+
+        addGroupIfIdentifying: async ({ request: { groupId, groupName }, session, message: { packetHeader: { sessionType } } }) => {
+            // TODO The server verifies that it is currently identifying itself. If the server it not currently identifying
+            //      itself, the status SHALL be SUCCESS
+            // return {status: AdminCommissioningStatusCode.Success, groupId};
+
+            // TODO If the AddGroupIfIdentifying command was received as unicast and the evaluated status is not SUCCESS, or
+            //      if the AddGroupIfIdentifying command was received as unicast and the evaluated status is SUCCESS and a
+            //      response is not suppressed, the server SHALL generate a response with the Status field set to the
+            //      evaluated status.
+            const { status } = addGroupLogic(groupId, groupName, sessionType, getFabricFromSession(session as SecureSession<MatterDevice>));
+            throw new StatusResponseError("Return Status", status);
+        },
+    }
+};

--- a/packages/matter-node.js/src/matter/fabric/Fabric.ts
+++ b/packages/matter-node.js/src/matter/fabric/Fabric.ts
@@ -28,11 +28,14 @@ export type FabricJsonObject = {
     intermediateCACert: ByteArray | undefined;
     operationalCert: ByteArray;
     label: string;
+    scopedClusterData: Map<number, any>
 }
 
 export class Fabric {
 
     private readonly sessions = new Array<SecureSession<any>>();
+
+    private readonly scopedClusterData: Map<number, any>;
 
     private removeCallback: (() => void) | undefined;
     private persistCallback: (() => void) | undefined;
@@ -52,7 +55,11 @@ export class Fabric {
         readonly intermediateCACert: ByteArray | undefined,
         readonly operationalCert: ByteArray,
         public label: string,
-    ) { }
+        scopedClusterData?: Map<number, any>
+
+    ) {
+        this.scopedClusterData = scopedClusterData ?? new Map<number, any>();
+    }
 
     toStorageObject(): FabricJsonObject {
         return {
@@ -70,6 +77,7 @@ export class Fabric {
             intermediateCACert: this.intermediateCACert,
             operationalCert: this.operationalCert,
             label: this.label,
+            scopedClusterData: this.scopedClusterData
         };
     }
 
@@ -145,6 +153,14 @@ export class Fabric {
 
     persist() {
         this.persistCallback?.();
+    }
+
+    getScopedClusterDataInstance<T>(clusterId: number): T | undefined {
+        return this.scopedClusterData.get(clusterId);
+    }
+
+    setScopedClusterDataInstance<T>(clusterId: number, instance: T) {
+        this.scopedClusterData.set(clusterId, instance);
     }
 }
 

--- a/packages/matter-node.js/src/matter/fabric/Fabric.ts
+++ b/packages/matter-node.js/src/matter/fabric/Fabric.ts
@@ -7,8 +7,9 @@
 import { Crypto, KeyPair } from "../../crypto/Crypto";
 import { CertificateManager, TlvOperationalCertificate, TlvRootCertificate } from "../certificate/CertificateManager";
 import { NodeId } from "../common/NodeId";
-import { ByteArray, DataWriter, Endian, toBigInt, VendorId, FabricId, FabricIndex } from "@project-chip/matter.js";
+import { ByteArray, DataWriter, Endian, toBigInt, VendorId, FabricId, FabricIndex, Cluster } from "@project-chip/matter.js";
 import { SecureSession } from "../session/SecureSession";
+import { SupportedStorageTypes } from "../../storage/StringifyTools";
 
 const COMPRESSED_FABRIC_ID_INFO = ByteArray.fromString("CompressedFabric");
 const GROUP_SECURITY_INFO = ByteArray.fromString("GroupKey v1.0");
@@ -28,7 +29,7 @@ export type FabricJsonObject = {
     intermediateCACert: ByteArray | undefined;
     operationalCert: ByteArray;
     label: string;
-    scopedClusterData: Map<number, any>
+    scopedClusterData: Map<number, Map<string, SupportedStorageTypes>>
 }
 
 export class Fabric {
@@ -55,10 +56,10 @@ export class Fabric {
         readonly intermediateCACert: ByteArray | undefined,
         readonly operationalCert: ByteArray,
         public label: string,
-        scopedClusterData?: Map<number, any>
+        scopedClusterData?: Map<number, Map<string, SupportedStorageTypes>>
 
     ) {
-        this.scopedClusterData = scopedClusterData ?? new Map<number, any>();
+        this.scopedClusterData = scopedClusterData ?? new Map<number, Map<string, SupportedStorageTypes>>();
     }
 
     toStorageObject(): FabricJsonObject {
@@ -155,12 +156,44 @@ export class Fabric {
         this.persistCallback?.();
     }
 
-    getScopedClusterDataInstance<T>(clusterId: number): T | undefined {
-        return this.scopedClusterData.get(clusterId);
+    getScopedClusterDataValue<T>(cluster: Cluster<any, any, any, any>, clusterDataKey: string): T | undefined {
+        const dataMap = this.scopedClusterData.get(cluster.id);
+        if (dataMap === undefined) {
+            return undefined;
+        }
+        return dataMap.get(clusterDataKey);
     }
 
-    setScopedClusterDataInstance<T>(clusterId: number, instance: T) {
-        this.scopedClusterData.set(clusterId, instance);
+    setScopedClusterDataValue<T>(cluster: Cluster<any, any, any, any>, clusterDataKey: string, value: T) {
+        if (!this.scopedClusterData.has(cluster.id)) {
+            this.scopedClusterData.set(cluster.id, new Map<string, SupportedStorageTypes>());
+        }
+        this.scopedClusterData.get(cluster.id).set(clusterDataKey, value);
+        this.persist();
+    }
+
+    deleteScopedClusterDataValue(cluster: Cluster<any, any, any, any>, clusterDataKey: string) {
+        if (!this.scopedClusterData.has(cluster.id)) {
+            return;
+        }
+        this.scopedClusterData.get(cluster.id).delete(clusterDataKey);
+        this.persist();
+    }
+
+    hasScopedClusterDataValue(cluster: Cluster<any, any, any, any>, clusterDataKey: string) {
+        return this.scopedClusterData.has(cluster.id) && this.scopedClusterData.get(cluster.id).has(clusterDataKey);
+    }
+
+    deleteScopedClusterData(cluster: Cluster<any, any, any, any>) {
+        this.scopedClusterData.delete(cluster.id);
+        this.persist();
+    }
+
+    getScopedClusterDataKeys(cluster: Cluster<any, any, any, any>): string[] {
+        if (!this.scopedClusterData.has(cluster.id)) {
+            return [];
+        }
+        return Array.from(this.scopedClusterData.get(cluster.id).keys());
     }
 }
 

--- a/packages/matter-node.js/test/IntegrationTest.ts
+++ b/packages/matter-node.js/test/IntegrationTest.ts
@@ -245,7 +245,7 @@ describe("Integration", () => {
                     clusterId: DescriptorCluster.id,
                     attributeId: DescriptorCluster.attributes.serverList.id,
                     attributeName: "serverList"
-                }, value: [new ClusterId(40), new ClusterId(48), new ClusterId(62), new ClusterId(31), new ClusterId(29)], version: 1
+                }, value: [new ClusterId(40), new ClusterId(48), new ClusterId(62), new ClusterId(31), new ClusterId(4), new ClusterId(29)], version: 1
             })
 
             assert.equal(response.filter(({

--- a/packages/matter-node.js/test/IntegrationTest.ts
+++ b/packages/matter-node.js/test/IntegrationTest.ts
@@ -398,7 +398,7 @@ describe("Integration", () => {
 
     describe("Groups server fabric scoped storage", () => {
         it("set a group name", async () => {
-            const groupsCluster = ClusterClient(await client.connect(new NodeId(BigInt(1))), 0, GroupsCluster);
+            const groupsCluster = ClusterClient(await client.connect(client.getFabric().nodeId), 0, GroupsCluster);
             await groupsCluster.addGroup({ groupId: new GroupId(1), groupName: "Group 1" });
         });
     });

--- a/packages/matter-node.js/test/IntegrationTest.ts
+++ b/packages/matter-node.js/test/IntegrationTest.ts
@@ -155,7 +155,7 @@ describe("Integration", () => {
                     }, {
                         nameSupport: { groupNames: true }
                     },
-                        GroupsClusterHandler()),
+                        GroupsClusterHandler(0x00)),
                 ])
                 .addEndpoint(0x01, DEVICE.ON_OFF_LIGHT, [onOffServer])
             );
@@ -251,11 +251,13 @@ describe("Integration", () => {
             assert.equal(typeof firstFabric, "object");
             assert.equal(firstFabric.fabricIndex, 1);
             assert.equal(firstFabric.fabricId, 1);
-            assert.ok(firstFabric.scopedClusterData instanceof Map);
+            assert.ok(firstFabric.scopedClusterData);
             assert.equal(firstFabric.scopedClusterData.size, 1);
-            const groupsClusterData = firstFabric.scopedClusterData.get(GroupsCluster.id);
+            const groupsClusterEndpointMap = firstFabric.scopedClusterData.get(GroupsCluster.id);
+            assert.ok(groupsClusterEndpointMap);
+            assert.equal(groupsClusterEndpointMap.size, 1);
+            const groupsClusterData = groupsClusterEndpointMap.get("0");
             assert.ok(groupsClusterData instanceof Map);
-            assert.equal(groupsClusterData.size, 1);
             assert.equal(groupsClusterData.get(1), "Group 1");
 
             assert.equal(fakeServerStorage.get("FabricManager", "nextFabricIndex"), 2);


### PR DESCRIPTION
This PR does:
* it adds a missing "passing message to invoke handlers" part that was missed in a PR before but needed to work
* It adds a Groups Cluster Handler implementation that supports group names - Groups Multicast messages are still not supported!
* It adds a Fabric based Cluster data storage to store "Fabric scoped cluster data" (like the group names per endpoint in this case).
