### PR TITLE
add tips about how to run matter-controller

### DIFF
--- a/packages/matter-node.js/README.md
+++ b/packages/matter-node.js/README.md
@@ -87,6 +87,11 @@ To run directly from Typescript files with on the fly compilation:
 ```bash
 npm run matter-controller
 ```
+with IP:
+
+```bash
+npm run matter-controller -- -ip [IP address of device to commission]
+```
 
 This will commission a Matter device (for debugging purpose only for now).
 

--- a/packages/matter-node.js/README.md
+++ b/packages/matter-node.js/README.md
@@ -85,11 +85,6 @@ matter-controller -ip [IP address of device to commission]
 To run directly from Typescript files with on the fly compilation:
 
 ```bash
-npm run matter-controller
-```
-with IP:
-
-```bash
 npm run matter-controller -- -ip [IP address of device to commission]
 ```
 


### PR DESCRIPTION
I try to use npm run "matter-controller -ip 127.0.0.1" but it fails.
I think there should be a tip about how to run it with IP.