### PR TITLE
Adjust logging for non-errors on writes

### DIFF
--- a/packages/matter-node.js/src/matter/interaction/InteractionServer.ts
+++ b/packages/matter-node.js/src/matter/interaction/InteractionServer.ts
@@ -266,8 +266,8 @@ export class InteractionServer implements ProtocolHandler<MatterDevice> {
         });
 
         // TODO respect suppressResponse, potentially also needs adjustment in InteractionMessenger class!
-
-        logger.debug(`Write request from ${exchange.channel.getName()} done ${writeResults.length ? `with following errors: ${writeResults.map(({ path, statusCode }) => `${this.resolveAttributeName(path)}=${Logger.toJSON(statusCode)}`).join(", ")}` : "without errors"}`);
+        const errorResults = writeResults.filter(({ statusCode }) => statusCode !== StatusCode.Success);
+        logger.debug(`Write request from ${exchange.channel.getName()} done ${errorResults.length ? `with following errors: ${errorResults.map(({ path, statusCode }) => `${this.resolveAttributeName(path)}=${Logger.toJSON(statusCode)}`).join(", ")}` : "without errors"}`);
 
         return {
             interactionModelRevision: 1,


### PR DESCRIPTION
The logging was not updated to the fact that we now (because of Alexa requires it) return success on write, so logging migth be confusing now