### PR TITLE
Add declaration map for .d.ts files

### DIFF
--- a/packages/matter.js/tsconfig.dist-dts.json
+++ b/packages/matter.js/tsconfig.dist-dts.json
@@ -5,6 +5,7 @@
     "moduleResolution": "node", // Required to correctly resolve Babel imports
     "outDir": "dist/dts",
     "declaration": true,
+    "declarationMap": true, // Link from type definition (.d.ts) to source .ts for code navigation
     "emitDeclarationOnly": true
   },
   "include": ["src/**/*.ts"],


### PR DESCRIPTION
Kind of trivial...  Allows you to click a symbol imported from matter.js in VS Code and go to the source .ts instead of the .d.ts file.