### PR TITLE
Bring back Crypto Static interface

### DIFF
--- a/packages/matter-node.js/src/DeviceNode.ts
+++ b/packages/matter-node.js/src/DeviceNode.ts
@@ -87,7 +87,7 @@ class DeviceNode {
         onOffClusterServer.attributes.onOff.addListener(on => commandExecutor(on ? "on" : "off")?.());
 
         const secureChannelProtocol = new SecureChannelProtocol(
-            await PaseServer.fromPin(passcode, { iterations: 1000, salt: Crypto.get().getRandomData(32) }),
+            await PaseServer.fromPin(passcode, { iterations: 1000, salt: Crypto.getRandomData(32) }),
             new CaseServer(),
         );
 

--- a/packages/matter-node.js/src/crypto/CryptoNode.ts
+++ b/packages/matter-node.js/src/crypto/CryptoNode.ts
@@ -8,13 +8,13 @@ import * as crypto from "crypto";
 import { ByteArray } from "@project-chip/matter.js/util";
 import {
     CRYPTO_AUTH_TAG_LENGTH, CRYPTO_EC_CURVE, CRYPTO_ENCRYPT_ALGORITHM, CRYPTO_HASH_ALGORITHM, CRYPTO_SYMMETRIC_KEY_LENGTH,
-    CryptoDsaEncoding, CryptoBase,
+    CryptoDsaEncoding, Crypto,
 } from "@project-chip/matter.js/crypto";
 
 const EC_PRIVATE_KEY_PKCS8_HEADER = ByteArray.fromHex("308141020100301306072a8648ce3d020106082a8648ce3d030107042730250201010420");
 const EC_PUBLIC_KEY_SPKI_HEADER = ByteArray.fromHex("3059301306072a8648ce3d020106082a8648ce3d030107034200");
 
-export class CryptoNode extends CryptoBase {
+export class CryptoNode extends Crypto {
     encrypt(key: ByteArray, data: ByteArray, nonce: ByteArray, aad?: ByteArray): ByteArray {
         const cipher = crypto.createCipheriv(CRYPTO_ENCRYPT_ALGORITHM, key, nonce, { authTagLength: CRYPTO_AUTH_TAG_LENGTH });
         if (aad !== undefined) {

--- a/packages/matter-node.js/test/IntegrationTest.ts
+++ b/packages/matter-node.js/test/IntegrationTest.ts
@@ -94,7 +94,7 @@ describe("Integration", () => {
             .addNetInterface(await UdpInterface.create(matterPort, "udp6", SERVER_IP))
             .addBroadcaster(await MdnsBroadcaster.create(matterPort))
             .addProtocolHandler(new SecureChannelProtocol(
-                await PaseServer.fromPin(setupPin, { iterations: 1000, salt: Crypto.get().getRandomData(32) }),
+                await PaseServer.fromPin(setupPin, { iterations: 1000, salt: Crypto.getRandomData(32) }),
                 new CaseServer(),
             ))
             .addProtocolHandler(new InteractionServer(serverStorageManager)

--- a/packages/matter-node.js/test/certificate/CertificateManagerTest.ts
+++ b/packages/matter-node.js/test/certificate/CertificateManagerTest.ts
@@ -63,7 +63,7 @@ describe("CertificateManager", () => {
             assert.deepEqual(DerCodec.encode(signatureAlgorithmNode), DerCodec.encode(EcdsaWithSHA256_X962));
             const requestBytes = DerCodec.encode(requestNode);
             assert.deepEqual(requestBytes, CSR_REQUEST_ASN1);
-            Crypto.get().verifySpki(PUBLIC_KEY, DerCodec.encode(requestNode), signatureNode[BYTES_KEY], "der");
+            Crypto.verifySpki(PUBLIC_KEY, DerCodec.encode(requestNode), signatureNode[BYTES_KEY], "der");
         });
     });
 

--- a/packages/matter-node.js/test/crypto/Spake2pTest.ts
+++ b/packages/matter-node.js/test/crypto/Spake2pTest.ts
@@ -69,7 +69,7 @@ describe("Spake2p", () => {
             context.push(ByteArray.fromHex("15300120b2901e92036f7bca007a3a1bf24bd71f18772105e83479c92b7a8af35e8182742502498d240300280435052501881325022c011818"));
             // PbkdfParamResponse bytes
             context.push(ByteArray.fromHex("15300120b2901e92036f7bca007a3a1bf24bd71f18772105e83479c92b7a8af35e81827430022008070f685f2077779b824adf91e4bab6253b9d1a3c0f6615c6d447780f0feef325039c8d35042501e803300220163f8501fbbc0e6a8f69a9b999d038ca388ecffccc18fe259c4253f26e494dda1835052501881325022c011818"));
-            const result = Crypto.get().hash(context);
+            const result = Crypto.hash(context);
 
             assert.equal(result.toHex(), "c49718b0275b6f81fd6a081f6c34c5833382b75b3bd997895d13a51c71a02855");
         });

--- a/packages/matter-node.js/test/fabric/FabricTest.ts
+++ b/packages/matter-node.js/test/fabric/FabricTest.ts
@@ -70,7 +70,7 @@ describe("Fabric", () => {
 
     describe("getDestinationId", () => {
         it("generates the correct destination ID", () => {
-            const fabric = new Fabric(TEST_FABRIC_INDEX, TEST_FABRIC_ID, TEST_NODE_ID, TEST_ROOT_NODE, Buffer.alloc(0), TEST_ROOT_PUBLIC_KEY, Crypto.get().createKeyPair(), new VendorId(0), Buffer.alloc(0), Buffer.alloc(0), TEST_IDENTITY_PROTECTION_KEY, undefined, Buffer.alloc(0), '');
+            const fabric = new Fabric(TEST_FABRIC_INDEX, TEST_FABRIC_ID, TEST_NODE_ID, TEST_ROOT_NODE, Buffer.alloc(0), TEST_ROOT_PUBLIC_KEY, Crypto.createKeyPair(), new VendorId(0), Buffer.alloc(0), Buffer.alloc(0), TEST_IDENTITY_PROTECTION_KEY, undefined, Buffer.alloc(0), '');
 
             const result = fabric.getDestinationId(TEST_NODE_ID, TEST_RANDOM);
 
@@ -92,7 +92,7 @@ describe("Fabric", () => {
         });
 
         it("generates the correct destination ID 3", () => {
-            const fabric = new Fabric(TEST_FABRIC_INDEX, TEST_FABRIC_ID_3, TEST_NODE_ID_3, TEST_ROOT_NODE, Buffer.alloc(0), TEST_ROOT_PUBLIC_KEY_3, Crypto.get().createKeyPair(), new VendorId(0), Buffer.alloc(0), Buffer.alloc(0), TEST_IDENTITY_PROTECTION_KEY_3, undefined, Buffer.alloc(0), "");
+            const fabric = new Fabric(TEST_FABRIC_INDEX, TEST_FABRIC_ID_3, TEST_NODE_ID_3, TEST_ROOT_NODE, Buffer.alloc(0), TEST_ROOT_PUBLIC_KEY_3, Crypto.createKeyPair(), new VendorId(0), Buffer.alloc(0), Buffer.alloc(0), TEST_IDENTITY_PROTECTION_KEY_3, undefined, Buffer.alloc(0), "");
 
             const result = fabric.getDestinationId(TEST_NODE_ID_3, TEST_RANDOM_3);
 

--- a/packages/matter.js/src/MatterController.ts
+++ b/packages/matter.js/src/MatterController.ts
@@ -40,7 +40,7 @@ export class MatterController {
     public static async create(scanner: Scanner, netInterfaceIpv4: NetInterface, netInterfaceIpv6: NetInterface, storageManager: StorageManager) {
         const certificateManager = new RootCertificateManager(storageManager);
 
-        const ipkValue = Crypto.get().getRandomData(16);
+        const ipkValue = Crypto.getRandomData(16);
         const fabricBuilder = new FabricBuilder(FABRIC_INDEX)
             .setRootCert(certificateManager.getRootCert())
             .setRootNodeId(CONTROLLER_NODE_ID)
@@ -105,16 +105,15 @@ export class MatterController {
         this.ensureSuccess(await generalCommissioningClusterClient.armFailSafe({ breadcrumb: BigInt(1), expiryLengthSeconds: 60 }));
         this.ensureSuccess(await generalCommissioningClusterClient.setRegulatoryConfig({ breadcrumb: BigInt(2), newRegulatoryConfig: RegulatoryLocationType.IndoorOutdoor, countryCode: "US" }));
 
-        const crypto = Crypto.get();
 
         const operationalCredentialsClusterClient = ClusterClient(interactionClient, 0, OperationalCredentialsCluster);
         const { certificate: deviceAttestation } = await operationalCredentialsClusterClient.requestCertChain({ type: CertificateChainType.DeviceAttestation });
         // TODO: extract device public key from deviceAttestation
         const { certificate: productAttestation } = await operationalCredentialsClusterClient.requestCertChain({ type: CertificateChainType.ProductAttestationIntermediate });
         // TODO: validate deviceAttestation and productAttestation
-        const { elements: attestationElements, signature: attestationSignature } = await operationalCredentialsClusterClient.requestAttestation({ attestationNonce: crypto.getRandomData(32) });
+        const { elements: attestationElements, signature: attestationSignature } = await operationalCredentialsClusterClient.requestAttestation({ attestationNonce: Crypto.getRandomData(32) });
         // TODO: validate attestationSignature using device public key
-        const { elements: csrElements, signature: csrSignature } = await operationalCredentialsClusterClient.requestCertSigning({ certSigningRequestNonce: crypto.getRandomData(32) });
+        const { elements: csrElements, signature: csrSignature } = await operationalCredentialsClusterClient.requestCertSigning({ certSigningRequestNonce: Crypto.getRandomData(32) });
         if (deviceAttestation.length === 0 || productAttestation.length === 0 || attestationElements.length === 0 || attestationSignature.length === 0 || csrElements.length === 0 || csrSignature.length === 0) {
             // TODO: validate the data really
             throw new Error("Invalid response from device");

--- a/packages/matter.js/src/certificate/AttestationCertificateManager.ts
+++ b/packages/matter.js/src/certificate/AttestationCertificateManager.ts
@@ -35,8 +35,8 @@ export class AttestationCertificateManager {
     };
     private readonly paaKeyIdentifier = TestCert_PAA_NoVID_SKID;
     private readonly paiCertId = BigInt(1);
-    private readonly paiKeyPair = Crypto.get().createKeyPair();
-    private readonly paiKeyIdentifier = Crypto.get().hash(this.paiKeyPair.publicKey).slice(0, 20);
+    private readonly paiKeyPair = Crypto.createKeyPair();
+    private readonly paiKeyIdentifier = Crypto.hash(this.paiKeyPair.publicKey).slice(0, 20);
     private readonly paiCertBytes;
     private nextCertificateId = 2;
 
@@ -51,7 +51,7 @@ export class AttestationCertificateManager {
     }
 
     getDACert(productId: number) {
-        const dacKeyPair = Crypto.get().createKeyPair();
+        const dacKeyPair = Crypto.createKeyPair();
         return {
             keyPair: dacKeyPair,
             dac: this.generateDaCert(dacKeyPair.publicKey, this.vendorId, productId)
@@ -148,7 +148,7 @@ export class AttestationCertificateManager {
                     isCa: false
                 },
                 keyUsage: 1,
-                subjectKeyIdentifier: Crypto.get().hash(publicKey).slice(0, 20),
+                subjectKeyIdentifier: Crypto.hash(publicKey).slice(0, 20),
                 authorityKeyIdentifier: this.paiKeyIdentifier,
             },
         };

--- a/packages/matter.js/src/certificate/CertificateManager.ts
+++ b/packages/matter.js/src/certificate/CertificateManager.ts
@@ -322,7 +322,7 @@ export class CertificateManager {
         return DerCodec.encode({
             certificate,
             signAlgorithm: EcdsaWithSHA256_X962,
-            signature: BitByteArray(Crypto.get().signPkcs8(keys.privateKey, DerCodec.encode(certificate), "der")),
+            signature: BitByteArray(Crypto.signPkcs8(keys.privateKey, DerCodec.encode(certificate), "der")),
         });
     }
 
@@ -358,7 +358,7 @@ export class CertificateManager {
         return DerCodec.encode({
             certificate,
             signAlgorithm: EcdsaWithSHA256_X962,
-            signature: BitByteArray(Crypto.get().signPkcs8(keys.privateKey, DerCodec.encode(certificate), "der")),
+            signature: BitByteArray(Crypto.signPkcs8(keys.privateKey, DerCodec.encode(certificate), "der")),
         });
     }
 
@@ -392,7 +392,7 @@ export class CertificateManager {
         return DerCodec.encode({
             certificate,
             signAlgorithm: EcdsaWithSHA256_X962,
-            signature: BitByteArray(Crypto.get().signPkcs8(keys.privateKey, DerCodec.encode(certificate), "der")),
+            signature: BitByteArray(Crypto.signPkcs8(keys.privateKey, DerCodec.encode(certificate), "der")),
         });
     }
 
@@ -406,7 +406,7 @@ export class CertificateManager {
                 subjectKeyIdentifier: ContextTaggedBytes(0, subjectKeyIdentifier),
                 digestAlgorithm: SHA256_CMS,
                 signatureAlgorithm: EcdsaWithSHA256_X962,
-                signature: Crypto.get().signSec1(privateKey, eContent, "der")
+                signature: Crypto.signSec1(privateKey, eContent, "der")
             }]
         };
 
@@ -414,11 +414,11 @@ export class CertificateManager {
     }
 
     static validateRootCertificate(rootCert: RootCertificate) {
-        Crypto.get().verifySpki(rootCert.ellipticCurvePublicKey, this.rootCertToAsn1(rootCert), rootCert.signature);
+        Crypto.verifySpki(rootCert.ellipticCurvePublicKey, this.rootCertToAsn1(rootCert), rootCert.signature);
     }
 
     static validateNocCertificate(rootCert: RootCertificate, nocCert: OperationalCertificate) {
-        Crypto.get().verifySpki(rootCert.ellipticCurvePublicKey, this.nocCertToAsn1(nocCert), nocCert.signature);
+        Crypto.verifySpki(rootCert.ellipticCurvePublicKey, this.nocCertToAsn1(nocCert), nocCert.signature);
     }
 
     static createCertificateSigningRequest(keys: KeyPair) {
@@ -432,7 +432,7 @@ export class CertificateManager {
         return DerCodec.encode({
             request,
             signAlgorithm: EcdsaWithSHA256_X962,
-            signature: BitByteArray(Crypto.get().signPkcs8(keys.privateKey, DerCodec.encode(request), "der")),
+            signature: BitByteArray(Crypto.signPkcs8(keys.privateKey, DerCodec.encode(request), "der")),
         });
     }
 
@@ -457,7 +457,7 @@ export class CertificateManager {
 
         // Verify the CSR signature
         if (!EcdsaWithSHA256_X962[OBJECT_ID_KEY][BYTES_KEY].equals(signAlgorithmNode[ELEMENTS_KEY]?.[0]?.[BYTES_KEY])) throw new Error("Unsupported signature type");
-        Crypto.get().verifySpki(publicKey, DerCodec.encode(requestNode), signatureNode[BYTES_KEY], "der");
+        Crypto.verifySpki(publicKey, DerCodec.encode(requestNode), signatureNode[BYTES_KEY], "der");
 
         return publicKey;
     }

--- a/packages/matter.js/src/certificate/RootCertificateManager.ts
+++ b/packages/matter.js/src/certificate/RootCertificateManager.ts
@@ -13,8 +13,8 @@ import { StorageManager } from "../storage/StorageManager.js";
 
 export class RootCertificateManager {
     private rootCertId = BigInt(0);
-    private rootKeyPair = Crypto.get().createKeyPair();
-    private rootKeyIdentifier = Crypto.get().hash(this.rootKeyPair.publicKey).slice(0, 20);
+    private rootKeyPair = Crypto.createKeyPair();
+    private rootKeyIdentifier = Crypto.hash(this.rootKeyPair.publicKey).slice(0, 20);
     private rootCertBytes = this.generateRootCert();
     private nextCertificateId = 1;
 
@@ -71,12 +71,11 @@ export class RootCertificateManager {
                 authorityKeyIdentifier: this.rootKeyIdentifier,
             },
         };
-        const signature = Crypto.get().signPkcs8(this.rootKeyPair.privateKey, CertificateManager.rootCertToAsn1(unsignedCertificate));
+        const signature = Crypto.signPkcs8(this.rootKeyPair.privateKey, CertificateManager.rootCertToAsn1(unsignedCertificate));
         return TlvRootCertificate.encode({ ...unsignedCertificate, signature });
     }
 
     generateNoc(publicKey: ByteArray, fabricId: bigint, nodeId: NodeId) {
-        const crypto = Crypto.get();
         const now = Time.get().now();
         const certId = this.nextCertificateId++;
         const unsignedCertificate = {
@@ -93,11 +92,11 @@ export class RootCertificateManager {
                 basicConstraints: { isCa: false },
                 keyUsage: 1,
                 extendedKeyUsage: [2, 1],
-                subjectKeyIdentifier: crypto.hash(publicKey).slice(0, 20),
+                subjectKeyIdentifier: Crypto.hash(publicKey).slice(0, 20),
                 authorityKeyIdentifier: this.rootKeyIdentifier,
             },
         };
-        const signature = crypto.signPkcs8(this.rootKeyPair.privateKey, CertificateManager.nocCertToAsn1(unsignedCertificate));
+        const signature = Crypto.signPkcs8(this.rootKeyPair.privateKey, CertificateManager.nocCertToAsn1(unsignedCertificate));
         return TlvOperationalCertificate.encode({ ...unsignedCertificate, signature });
     }
 }

--- a/packages/matter.js/src/cluster/server/OperationalCredentialsServer.ts
+++ b/packages/matter.js/src/cluster/server/OperationalCredentialsServer.ts
@@ -24,7 +24,7 @@ export interface OperationalCredentialsServerConf {
 }
 
 function signWithDeviceKey(conf: OperationalCredentialsServerConf, session: SecureSession<MatterDevice>, data: ByteArray) {
-    return Crypto.get().signPkcs8(conf.devicePrivateKey, [data, session.getAttestationChallengeKey()]);
+    return Crypto.signPkcs8(conf.devicePrivateKey, [data, session.getAttestationChallengeKey()]);
 }
 
 export const OperationalCredentialsClusterHandler: (conf: OperationalCredentialsServerConf) => ClusterServerHandlers<typeof OperationalCredentialsCluster> = (conf) => ({

--- a/packages/matter.js/src/crypto/Spake2p.ts
+++ b/packages/matter.js/src/crypto/Spake2p.ts
@@ -26,7 +26,7 @@ export class Spake2p {
     static async computeW0W1({ iterations, salt }: PbkdfParameters, pin: number) {
         const pinWriter = new DataWriter(Endian.Little);
         pinWriter.writeUInt32(pin);
-        const ws = await Crypto.get().pbkdf2(pinWriter.toByteArray(), salt, iterations, 80);
+        const ws = await Crypto.pbkdf2(pinWriter.toByteArray(), salt, iterations, 80);
         const w0 = new BN(ws.slice(0, 40)).mod(P256_CURVE.n);
         const w1 = new BN(ws.slice(40, 80)).mod(P256_CURVE.n);
         return { w0, w1 };
@@ -39,7 +39,7 @@ export class Spake2p {
     }
 
     static create(context: ByteArray, w0: BN) {
-        const random = Crypto.get().getRandomBN(32, P256_CURVE.p);
+        const random = Crypto.getRandomBN(32, P256_CURVE.p);
         return new Spake2p(context, random, w0);
     }
 
@@ -82,13 +82,12 @@ export class Spake2p {
         const Ka = TT_HASH.slice(0, 16);
         const Ke = TT_HASH.slice(16, 32);
 
-        const crypto = Crypto.get();
-        const KcAB = await crypto.hkdf(Ka, new ByteArray(0), ByteArray.fromString("ConfirmationKeys"), 32);
+        const KcAB = await Crypto.hkdf(Ka, new ByteArray(0), ByteArray.fromString("ConfirmationKeys"), 32);
         const KcA = KcAB.slice(0, 16);
         const KcB = KcAB.slice(16, 32);
 
-        const hAY = crypto.hmac(KcA, Y);
-        const hBX = crypto.hmac(KcB, X);
+        const hAY = Crypto.hmac(KcA, Y);
+        const hBX = Crypto.hmac(KcB, X);
 
         return { Ke, hAY, hBX };
     }
@@ -105,7 +104,7 @@ export class Spake2p {
         this.addToContext(TTwriter, Z);
         this.addToContext(TTwriter, V);
         this.addToContext(TTwriter, this.w0.toBuffer());
-        return Crypto.get().hash(TTwriter.toByteArray());
+        return Crypto.hash(TTwriter.toByteArray());
     }
 
     private addToContext(TTwriter: DataWriter<Endian.Little>, data: ByteArray) {

--- a/packages/matter.js/src/datatype/NodeId.ts
+++ b/packages/matter.js/src/datatype/NodeId.ts
@@ -33,7 +33,7 @@ export class NodeId {
 
     static getRandomOperationalNodeId() {
         while (true) {
-            const randomBigInt = BigInt('0x' + Crypto.get().getRandomData(8).toHex());
+            const randomBigInt = BigInt('0x' + Crypto.getRandomData(8).toHex());
             if (randomBigInt >= OPERATIONAL_NODE_MIN && randomBigInt <= OPERATIONAL_NODE_MAX) {
                 return new NodeId(randomBigInt);
             }

--- a/packages/matter.js/src/fabric/Fabric.ts
+++ b/packages/matter.js/src/fabric/Fabric.ts
@@ -117,7 +117,7 @@ export class Fabric {
     }
 
     sign(data: ByteArray) {
-        return Crypto.get().signPkcs8(this.keyPair.privateKey, data);
+        return Crypto.signPkcs8(this.keyPair.privateKey, data);
     }
 
     verifyCredentials(_operationalCert: ByteArray, _intermediateCACert: ByteArray | undefined) {
@@ -131,7 +131,7 @@ export class Fabric {
         writer.writeByteArray(this.rootPublicKey);
         writer.writeUInt64(this.fabricId.id);
         writer.writeUInt64(nodeId.id);
-        return Crypto.get().hmac(this.operationalIdentityProtectionKey, writer.toByteArray());
+        return Crypto.hmac(this.operationalIdentityProtectionKey, writer.toByteArray());
     }
 
     addSession(session: SecureSession<any>) {
@@ -204,7 +204,7 @@ export class Fabric {
 }
 
 export class FabricBuilder {
-    private keyPair = Crypto.get().createKeyPair();
+    private keyPair = Crypto.createKeyPair();
     private rootVendorId?: VendorId;
     private rootCert?: ByteArray;
     private intermediateCACert?: ByteArray;
@@ -268,10 +268,9 @@ export class FabricBuilder {
         if (this.identityProtectionKey === undefined) throw new Error("identityProtectionKey needs to be set");
         if (this.operationalCert === undefined || this.fabricId === undefined || this.nodeId === undefined) throw new Error("operationalCert needs to be set");
 
-        const crypto = Crypto.get();
         const saltWriter = new DataWriter(Endian.Big);
         saltWriter.writeUInt64(this.fabricId.id);
-        const operationalId = await crypto.hkdf(this.rootPublicKey.slice(1), saltWriter.toByteArray(), COMPRESSED_FABRIC_ID_INFO, 8);
+        const operationalId = await Crypto.hkdf(this.rootPublicKey.slice(1), saltWriter.toByteArray(), COMPRESSED_FABRIC_ID_INFO, 8);
 
         return new Fabric(
             this.fabricIndex,
@@ -284,7 +283,7 @@ export class FabricBuilder {
             this.rootVendorId,
             this.rootCert,
             this.identityProtectionKey,
-            await crypto.hkdf(this.identityProtectionKey, operationalId, GROUP_SECURITY_INFO, 16),
+            await Crypto.hkdf(this.identityProtectionKey, operationalId, GROUP_SECURITY_INFO, 16),
             this.intermediateCACert,
             this.operationalCert,
             "",

--- a/packages/matter.js/src/mdns/MdnsBroadcaster.ts
+++ b/packages/matter.js/src/mdns/MdnsBroadcaster.ts
@@ -33,7 +33,7 @@ export class MdnsBroadcaster implements Broadcaster {
         logger.debug(`announce commissioning mode ${mode} ${deviceName} ${deviceType} ${vendorId} ${productId} ${discriminator}`);
 
         const shortDiscriminator = (discriminator >> 8) & 0x0F;
-        const instanceId = Crypto.get().getRandomData(8).toHex().toUpperCase();
+        const instanceId = Crypto.getRandomData(8).toHex().toUpperCase();
         const vendorQname = `_V${vendorId.id}._sub.${MATTER_COMMISSION_SERVICE_QNAME}`;
         const deviceTypeQname = `_T${deviceType}._sub.${MATTER_COMMISSION_SERVICE_QNAME}`;
         const shortDiscriminatorQname = `_S${shortDiscriminator}._sub.${MATTER_COMMISSION_SERVICE_QNAME}`;

--- a/packages/matter.js/src/protocol/ExchangeManager.ts
+++ b/packages/matter.js/src/protocol/ExchangeManager.ts
@@ -108,7 +108,7 @@ export class ExchangeManager<ContextT> {
 }
 
 export class ExchangeCounter {
-    private exchangeCounter = Crypto.get().getRandomUInt16();
+    private exchangeCounter = Crypto.getRandomUInt16();
 
     getIncrementedCounter() {
         this.exchangeCounter++;
@@ -120,7 +120,7 @@ export class ExchangeCounter {
 }
 
 export class MessageCounter {
-    private messageCounter = Crypto.get().getRandomUInt32();
+    private messageCounter = Crypto.getRandomUInt32();
 
     getIncrementedCounter() {
         this.messageCounter++;

--- a/packages/matter.js/src/protocol/interaction/InteractionServer.ts
+++ b/packages/matter.js/src/protocol/interaction/InteractionServer.ts
@@ -142,7 +142,7 @@ export class InteractionServer implements ProtocolHandler<MatterDevice> {
     private readonly attributePaths = new Array<AttributePath>();
     private readonly commands = new Map<string, CommandServer<any, any>>();
     private readonly commandPaths = new Array<CommandPath>();
-    private nextSubscriptionId = Crypto.get().getRandomUInt32();
+    private nextSubscriptionId = Crypto.getRandomUInt32();
 
     constructor(
         private readonly storageManager: StorageManager

--- a/packages/matter.js/src/session/SessionManager.ts
+++ b/packages/matter.js/src/session/SessionManager.ts
@@ -36,7 +36,7 @@ type ResumptionStorageRecord = {
 export class SessionManager<ContextT> {
     private readonly unsecureSession: UnsecureSession<ContextT>;
     private readonly sessions = new Map<number, Session<ContextT>>();
-    private nextSessionId = Crypto.get().getRandomUInt16();
+    private nextSessionId = Crypto.getRandomUInt16();
     private resumptionRecords = new Map<bigint, ResumptionRecord>();
     private readonly sessionStorage: StorageContext;
 

--- a/packages/matter.js/src/session/case/CaseClient.ts
+++ b/packages/matter.js/src/session/case/CaseClient.ts
@@ -24,20 +24,19 @@ export class CaseClient {
     async pair(client: MatterController, exchange: MessageExchange<MatterController>, fabric: Fabric, peerNodeId: NodeId) {
         const messenger = new CaseClientMessenger(exchange);
 
-        const crypto = Crypto.get();
         // Generate pairing info
-        const random = crypto.getRandom();
+        const random = Crypto.getRandom();
         const sessionId = client.getNextAvailableSessionId();
         const { operationalIdentityProtectionKey, operationalCert: nodeOpCert, intermediateCACert } = fabric;
-        const { publicKey: ecdhPublicKey, ecdh } = crypto.ecdhGeneratePublicKey();
+        const { publicKey: ecdhPublicKey, ecdh } = Crypto.ecdhGeneratePublicKey();
 
         // Send sigma1
         let sigma1Bytes;
         let resumptionRecord = client.findResumptionRecordByNodeId(peerNodeId);
         if (resumptionRecord !== undefined) {
             const { sharedSecret, resumptionId } = resumptionRecord;
-            const resumeKey = await crypto.hkdf(sharedSecret, ByteArray.concat(random, resumptionId), KDFSR1_KEY_INFO);
-            const resumeMic = crypto.encrypt(resumeKey, new ByteArray(0), RESUME1_MIC_NONCE);
+            const resumeKey = await Crypto.hkdf(sharedSecret, ByteArray.concat(random, resumptionId), KDFSR1_KEY_INFO);
+            const resumeMic = Crypto.encrypt(resumeKey, new ByteArray(0), RESUME1_MIC_NONCE);
             sigma1Bytes = await messenger.sendSigma1({ sessionId, destinationId: fabric.getDestinationId(peerNodeId, random), ecdhPublicKey, random, resumptionId, resumeMic });
         } else {
             sigma1Bytes = await messenger.sendSigma1({ sessionId, destinationId: fabric.getDestinationId(peerNodeId, random), ecdhPublicKey, random });
@@ -52,8 +51,8 @@ export class CaseClient {
             const { sessionId: peerSessionId, resumptionId, resumeMic } = sigma2Resume;
 
             const resumeSalt = ByteArray.concat(random, resumptionId);
-            const resumeKey = await crypto.hkdf(sharedSecret, resumeSalt, KDFSR2_KEY_INFO);
-            crypto.decrypt(resumeKey, resumeMic, RESUME2_MIC_NONCE);
+            const resumeKey = await Crypto.hkdf(sharedSecret, resumeSalt, KDFSR2_KEY_INFO);
+            Crypto.decrypt(resumeKey, resumeMic, RESUME2_MIC_NONCE);
 
             const secureSessionSalt = ByteArray.concat(random, resumptionRecord.resumptionId);
             secureSession = await client.createSecureSession(sessionId, fabric, peerNodeId, peerSessionId, sharedSecret, secureSessionSalt, true, true);
@@ -64,28 +63,28 @@ export class CaseClient {
         } else {
             // Process sigma2
             const { ecdhPublicKey: peerEcdhPublicKey, encrypted: peerEncrypted, random: peerRandom, sessionId: peerSessionId } = sigma2;
-            const sharedSecret = crypto.ecdhGenerateSecret(peerEcdhPublicKey, ecdh);
-            const sigma2Salt = ByteArray.concat(operationalIdentityProtectionKey, peerRandom, peerEcdhPublicKey, crypto.hash(sigma1Bytes));
-            const sigma2Key = await crypto.hkdf(sharedSecret, sigma2Salt, KDFSR2_INFO);
-            const peerEncryptedData = crypto.decrypt(sigma2Key, peerEncrypted, TBE_DATA2_NONCE);
+            const sharedSecret = Crypto.ecdhGenerateSecret(peerEcdhPublicKey, ecdh);
+            const sigma2Salt = ByteArray.concat(operationalIdentityProtectionKey, peerRandom, peerEcdhPublicKey, Crypto.hash(sigma1Bytes));
+            const sigma2Key = await Crypto.hkdf(sharedSecret, sigma2Salt, KDFSR2_INFO);
+            const peerEncryptedData = Crypto.decrypt(sigma2Key, peerEncrypted, TBE_DATA2_NONCE);
             const { nodeOpCert: peerNewOpCert, intermediateCACert: peerIntermediateCACert, signature: peerSignature, resumptionId: peerResumptionId } = TlvEncryptedDataSigma2.decode(peerEncryptedData);
             const peerSignatureData = TlvSignedData.encode({ nodeOpCert: peerNewOpCert, intermediateCACert: peerIntermediateCACert, ecdhPublicKey: peerEcdhPublicKey, peerEcdhPublicKey: ecdhPublicKey });
             const { ellipticCurvePublicKey: peerPublicKey, subject: { nodeId: peerNodeIdCert } } = TlvOperationalCertificate.decode(peerNewOpCert);
             if (peerNodeIdCert.id !== peerNodeId.id) throw new Error("The node ID in the peer certificate doesn't match the expected peer node ID");
-            crypto.verifySpki(peerPublicKey, peerSignatureData, peerSignature);
+            Crypto.verifySpki(peerPublicKey, peerSignatureData, peerSignature);
 
             // Generate and send sigma3
-            const sigma3Salt = ByteArray.concat(operationalIdentityProtectionKey, crypto.hash([sigma1Bytes, sigma2Bytes]));
-            const sigma3Key = await crypto.hkdf(sharedSecret, sigma3Salt, KDFSR3_INFO);
+            const sigma3Salt = ByteArray.concat(operationalIdentityProtectionKey, Crypto.hash([sigma1Bytes, sigma2Bytes]));
+            const sigma3Key = await Crypto.hkdf(sharedSecret, sigma3Salt, KDFSR3_INFO);
             const signatureData = TlvSignedData.encode({ nodeOpCert, intermediateCACert, ecdhPublicKey, peerEcdhPublicKey });
             const signature = fabric.sign(signatureData);
             const encryptedData = TlvEncryptedDataSigma3.encode({ nodeOpCert, intermediateCACert, signature });
-            const encrypted = crypto.encrypt(sigma3Key, encryptedData, TBE_DATA3_NONCE);
+            const encrypted = Crypto.encrypt(sigma3Key, encryptedData, TBE_DATA3_NONCE);
             const sigma3Bytes = await messenger.sendSigma3({ encrypted });
             await messenger.waitForSuccess();
 
             // All good! Create secure session
-            const secureSessionSalt = ByteArray.concat(operationalIdentityProtectionKey, crypto.hash([sigma1Bytes, sigma2Bytes, sigma3Bytes]));
+            const secureSessionSalt = ByteArray.concat(operationalIdentityProtectionKey, Crypto.hash([sigma1Bytes, sigma2Bytes, sigma3Bytes]));
             secureSession = await client.createSecureSession(sessionId, fabric, peerNodeId, peerSessionId, sharedSecret, secureSessionSalt, true, false);
             logger.info(`Case client: Paired succesfully with ${messenger.getChannelName()}`);
             resumptionRecord = { fabric, peerNodeId, sharedSecret, resumptionId: peerResumptionId };

--- a/packages/matter.js/src/session/case/CaseServer.ts
+++ b/packages/matter.js/src/session/case/CaseServer.ts
@@ -34,24 +34,23 @@ export class CaseServer implements ProtocolHandler<MatterDevice> {
 
     private async handleSigma1(server: MatterDevice, messenger: CaseServerMessenger) {
         logger.info(`Case server: Received pairing request from ${messenger.getChannelName()}`);
-        const crypto = Crypto.get();
         // Generate pairing info
         const sessionId = server.getNextAvailableSessionId();
-        const random = crypto.getRandom();
+        const random = Crypto.getRandom();
 
         // Read and process sigma 1
         const { sigma1Bytes, sigma1 } = await messenger.readSigma1();
         const { sessionId: peerSessionId, resumptionId: peerResumptionId, resumeMic: peerResumeMic, destinationId, random: peerRandom, ecdhPublicKey: peerEcdhPublicKey, mrpParams } = sigma1;
 
         // Try to resume a previous session
-        const resumptionId = crypto.getRandomData(16);
+        const resumptionId = Crypto.getRandomData(16);
         let resumptionRecord;
 
         // We try to resume the session
         if (peerResumptionId !== undefined && peerResumeMic !== undefined && (resumptionRecord = server.findResumptionRecordById(peerResumptionId)) !== undefined) {
             const { sharedSecret, fabric, peerNodeId } = resumptionRecord;
-            const peerResumeKey = await crypto.hkdf(sharedSecret, ByteArray.concat(peerRandom, peerResumptionId), KDFSR1_KEY_INFO);
-            crypto.decrypt(peerResumeKey, peerResumeMic, RESUME1_MIC_NONCE);
+            const peerResumeKey = await Crypto.hkdf(sharedSecret, ByteArray.concat(peerRandom, peerResumptionId), KDFSR1_KEY_INFO);
+            Crypto.decrypt(peerResumeKey, peerResumeMic, RESUME1_MIC_NONCE);
 
             // All good! Create secure session
             const secureSessionSalt = ByteArray.concat(peerRandom, peerResumptionId);
@@ -59,8 +58,8 @@ export class CaseServer implements ProtocolHandler<MatterDevice> {
 
             // Generate sigma 2 resume
             const resumeSalt = ByteArray.concat(peerRandom, resumptionId);
-            const resumeKey = await crypto.hkdf(sharedSecret, resumeSalt, KDFSR2_KEY_INFO);
-            const resumeMic = crypto.encrypt(resumeKey, new ByteArray(0), RESUME2_MIC_NONCE);
+            const resumeKey = await Crypto.hkdf(sharedSecret, resumeSalt, KDFSR2_KEY_INFO);
+            const resumeMic = Crypto.encrypt(resumeKey, new ByteArray(0), RESUME2_MIC_NONCE);
             try {
                 await messenger.sendSigma2Resume({ resumptionId, resumeMic, sessionId });
             } catch (error) {
@@ -81,28 +80,28 @@ export class CaseServer implements ProtocolHandler<MatterDevice> {
             // Generate sigma 2
             const fabric = server.findFabricFromDestinationId(destinationId, peerRandom);
             const { operationalCert: nodeOpCert, intermediateCACert, operationalIdentityProtectionKey } = fabric;
-            const { publicKey: ecdhPublicKey, sharedSecret } = crypto.ecdhGeneratePublicKeyAndSecret(peerEcdhPublicKey);
-            const sigma2Salt = ByteArray.concat(operationalIdentityProtectionKey, random, ecdhPublicKey, crypto.hash(sigma1Bytes));
-            const sigma2Key = await crypto.hkdf(sharedSecret, sigma2Salt, KDFSR2_INFO);
+            const { publicKey: ecdhPublicKey, sharedSecret } = Crypto.ecdhGeneratePublicKeyAndSecret(peerEcdhPublicKey);
+            const sigma2Salt = ByteArray.concat(operationalIdentityProtectionKey, random, ecdhPublicKey, Crypto.hash(sigma1Bytes));
+            const sigma2Key = await Crypto.hkdf(sharedSecret, sigma2Salt, KDFSR2_INFO);
             const signatureData = TlvSignedData.encode({ nodeOpCert, intermediateCACert, ecdhPublicKey, peerEcdhPublicKey });
             const signature = fabric.sign(signatureData);
             const encryptedData = TlvEncryptedDataSigma2.encode({ nodeOpCert, intermediateCACert, signature, resumptionId });
-            const encrypted = crypto.encrypt(sigma2Key, encryptedData, TBE_DATA2_NONCE);
+            const encrypted = Crypto.encrypt(sigma2Key, encryptedData, TBE_DATA2_NONCE);
             const sigma2Bytes = await messenger.sendSigma2({ random, sessionId, ecdhPublicKey, encrypted, mrpParams });
 
             // Read and process sigma 3
             const { sigma3Bytes, sigma3: { encrypted: peerEncrypted } } = await messenger.readSigma3();
-            const sigma3Salt = ByteArray.concat(operationalIdentityProtectionKey, crypto.hash([sigma1Bytes, sigma2Bytes]));
-            const sigma3Key = await crypto.hkdf(sharedSecret, sigma3Salt, KDFSR3_INFO);
-            const peerEncryptedData = crypto.decrypt(sigma3Key, peerEncrypted, TBE_DATA3_NONCE);
+            const sigma3Salt = ByteArray.concat(operationalIdentityProtectionKey, Crypto.hash([sigma1Bytes, sigma2Bytes]));
+            const sigma3Key = await Crypto.hkdf(sharedSecret, sigma3Salt, KDFSR3_INFO);
+            const peerEncryptedData = Crypto.decrypt(sigma3Key, peerEncrypted, TBE_DATA3_NONCE);
             const { nodeOpCert: peerNewOpCert, intermediateCACert: peerIntermediateCACert, signature: peerSignature } = TlvEncryptedDataSigma3.decode(peerEncryptedData);
             fabric.verifyCredentials(peerNewOpCert, peerIntermediateCACert);
             const peerSignatureData = TlvSignedData.encode({ nodeOpCert: peerNewOpCert, intermediateCACert: peerIntermediateCACert, ecdhPublicKey: peerEcdhPublicKey, peerEcdhPublicKey: ecdhPublicKey });
             const { ellipticCurvePublicKey: peerPublicKey, subject: { nodeId: peerNodeId } } = TlvOperationalCertificate.decode(peerNewOpCert);
-            crypto.verifySpki(peerPublicKey, peerSignatureData, peerSignature);
+            Crypto.verifySpki(peerPublicKey, peerSignatureData, peerSignature);
 
             // All good! Create secure session
-            const secureSessionSalt = ByteArray.concat(operationalIdentityProtectionKey, crypto.hash([sigma1Bytes, sigma2Bytes, sigma3Bytes]));
+            const secureSessionSalt = ByteArray.concat(operationalIdentityProtectionKey, Crypto.hash([sigma1Bytes, sigma2Bytes, sigma3Bytes]));
             const secureSession = await server.createSecureSession(sessionId, fabric, peerNodeId, peerSessionId, sharedSecret, secureSessionSalt, false, false, mrpParams?.idleRetransTimeoutMs, mrpParams?.activeRetransTimeoutMs);
             logger.info(`Case server: session ${secureSession.getId()} created with ${messenger.getChannelName()}`);
             await messenger.sendSuccess();

--- a/packages/matter.js/src/session/pase/PaseClient.ts
+++ b/packages/matter.js/src/session/pase/PaseClient.ts
@@ -19,8 +19,7 @@ const logger = Logger.get("PaseClient");
 export class PaseClient {
     async pair(client: MatterController, exchange: MessageExchange<MatterController>, setupPin: number) {
         const messenger = new PaseClientMessenger(exchange);
-        const crypto = Crypto.get();
-        const random = crypto.getRandom();
+        const random = Crypto.getRandom();
         const sessionId = client.getNextAvailableSessionId();
 
         // Send pbkdRequest and Read pbkdResponse
@@ -30,7 +29,7 @@ export class PaseClient {
 
         // Compute pake1 and read pake2
         const { w0, w1 } = await Spake2p.computeW0W1(pbkdfParameters, setupPin);
-        const spake2p = Spake2p.create(crypto.hash([SPAKE_CONTEXT, requestPayload, responsePayload]), w0);
+        const spake2p = Spake2p.create(Crypto.hash([SPAKE_CONTEXT, requestPayload, responsePayload]), w0);
         const X = spake2p.computeX();
         await messenger.sendPasePake1({ x: X });
 

--- a/packages/matter.js/src/session/pase/PaseServer.ts
+++ b/packages/matter.js/src/session/pase/PaseServer.ts
@@ -54,8 +54,7 @@ export class PaseServer implements ProtocolHandler<MatterDevice> {
     private async handlePairingRequest(server: MatterDevice, messenger: PaseServerMessenger) {
         logger.info(`Pase server: Received pairing request from ${messenger.getChannelName()}`);
         const sessionId = server.getNextAvailableSessionId();
-        const crypto = Crypto.get();
-        const random = crypto.getRandom();
+        const random = Crypto.getRandom();
 
         // Read pbkdRequest and send pbkdResponse
         const { requestPayload, request: { random: peerRandom, mrpParameters, passcodeId, hasPbkdfParameters, sessionId: peerSessionId } } = await messenger.readPbkdfParamRequest();
@@ -63,7 +62,7 @@ export class PaseServer implements ProtocolHandler<MatterDevice> {
         const responsePayload = await messenger.sendPbkdfParamResponse({ peerRandom, random, sessionId, mrpParameters, pbkdfParameters: hasPbkdfParameters ? undefined : this.pbkdfParameters });
 
         // Process pake1 and send pake2
-        const spake2p = Spake2p.create(crypto.hash([SPAKE_CONTEXT, requestPayload, responsePayload]), this.w0);
+        const spake2p = Spake2p.create(Crypto.hash([SPAKE_CONTEXT, requestPayload, responsePayload]), this.w0);
         const { x: X } = await messenger.readPasePake1();
         const Y = spake2p.computeY();
         const { Ke, hAY, hBX } = await spake2p.computeSecretAndVerifiersFromX(this.L, X, Y);


### PR DESCRIPTION
This PR adjusts the crypto abstraction back to an interface that can be used as static methods. Additionally it removed the kast "Buffer" usages from the code