### PR TITLE
Consolidate and Rename Interaction Protocol Types

### DIFF
--- a/packages/matter-node.js/test/interaction/InteractionProtocolTest.ts
+++ b/packages/matter-node.js/test/interaction/InteractionProtocolTest.ts
@@ -30,7 +30,7 @@ import { Message } from "@project-chip/matter.js/codec";
 const READ_REQUEST: ReadRequest = {
     interactionModelRevision: 1,
     isFabricFiltered: true,
-    attributes: [
+    attributeRequests: [
         { endpointId: 0, clusterId: 0x28, attributeId: 2 },
         { endpointId: 0, clusterId: 0x28, attributeId: 4 },
     ],
@@ -39,16 +39,16 @@ const READ_REQUEST: ReadRequest = {
 const READ_RESPONSE: DataReport = {
     interactionModelRevision: 1,
     suppressResponse: false,
-    values: [
+    attributeReports: [
         {
-            value: {
+            attributeData: {
                 path: { endpointId: 0, clusterId: 0x28, attributeId: 2 },
                 data: TlvUInt8.encodeTlv(1),
                 dataVersion: 0,
             }
         },
         {
-            value: {
+            attributeData: {
                 path: { endpointId: 0, clusterId: 0x28, attributeId: 4 },
                 data: TlvUInt8.encodeTlv(2),
                 dataVersion: 0,
@@ -161,14 +161,14 @@ const INVOKE_COMMAND_REQUEST_WITH_EMPTY_ARGS: InvokeRequest = {
     interactionModelRevision: 1,
     suppressResponse: false,
     timedRequest: false,
-    invokes: [
+    invokeRequests: [
         {
-            path: {
+            commandPath: {
                 endpointId: 0,
                 clusterId: 6,
                 commandId: 1,
             },
-            args: TlvNoArguments.encodeTlv(undefined),
+            commandFields: TlvNoArguments.encodeTlv(undefined),
         }
     ]
 };
@@ -177,9 +177,9 @@ const INVOKE_COMMAND_REQUEST_WITH_NO_ARGS: InvokeRequest = {
     interactionModelRevision: 1,
     suppressResponse: false,
     timedRequest: false,
-    invokes: [
+    invokeRequests: [
         {
-            path: { endpointId: 0, clusterId: 6, commandId: 1 },
+            commandPath: { endpointId: 0, clusterId: 6, commandId: 1 },
         }
     ]
 };
@@ -187,10 +187,10 @@ const INVOKE_COMMAND_REQUEST_WITH_NO_ARGS: InvokeRequest = {
 const INVOKE_COMMAND_RESPONSE: InvokeResponse = {
     interactionModelRevision: 1,
     suppressResponse: false,
-    responses: [
+    invokeResponses: [
         {
-            result: {
-                path: { clusterId: 6, commandId: 1, endpointId: 0 }, result: { code: 0 }
+            status: {
+                commandPath: { clusterId: 6, commandId: 1, endpointId: 0 }, status: { status: 0 }
             }
         }
     ]

--- a/packages/matter.js/src/cluster/GroupsCluster.ts
+++ b/packages/matter.js/src/cluster/GroupsCluster.ts
@@ -5,7 +5,7 @@
  */
 
 import { TlvGroupId } from "../datatype/GroupId.js";
-import { InteractionProtocolStatusCode as StatusCode } from "../protocol/interaction/InteractionProtocol.js";
+import { StatusCode } from "../protocol/interaction/InteractionProtocol.js";
 import { BitFlag } from "../schema/BitmapSchema.js";
 import { Attribute, Cluster, Command, TlvNoResponse } from "./Cluster.js";
 import { TlvField, TlvObject } from "../tlv/TlvObject.js";

--- a/packages/matter.js/src/cluster/ScenesCluster.ts
+++ b/packages/matter.js/src/cluster/ScenesCluster.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { InteractionProtocolStatusCode as StatusCode } from "../protocol/interaction/InteractionProtocol.js";
+import { StatusCode } from "../protocol/interaction/InteractionProtocol.js";
 import { BitFlag } from "../schema/BitmapSchema.js";
 import { Attribute, Cluster, Command, OptionalAttribute, OptionalCommand, TlvNoResponse } from "./Cluster.js";
 import { TlvAttributeId } from "../datatype/AttributeId.js";

--- a/packages/matter.js/src/cluster/server/CommandServer.ts
+++ b/packages/matter.js/src/cluster/server/CommandServer.ts
@@ -9,12 +9,9 @@ import { Session } from "../../session/Session.js";
 import { TlvSchema, TlvStream } from "../../tlv/TlvSchema.js";
 import { Message } from "../../codec/MessageCodec.js";
 import { Logger } from "../../log/Logger.js";
+import { StatusCode } from "../../protocol/interaction/index.js";
 
 const logger = Logger.get("CommandServer");
-
-export const enum ResultCode {
-    Success = 0x00,
-}
 
 export class CommandServer<RequestT, ResponseT> {
     constructor(
@@ -26,11 +23,11 @@ export class CommandServer<RequestT, ResponseT> {
         protected readonly handler: (request: RequestT, session: Session<MatterDevice>, message: Message) => Promise<ResponseT> | ResponseT,
     ) { }
 
-    async invoke(session: Session<MatterDevice>, args: TlvStream, message: Message): Promise<{ code: ResultCode, responseId: number, response: TlvStream }> {
+    async invoke(session: Session<MatterDevice>, args: TlvStream, message: Message): Promise<{ code: StatusCode, responseId: number, response: TlvStream }> {
         const request = this.requestSchema.decodeTlv(args);
         logger.debug(`Invoke ${this.name} with data ${Logger.toJSON(request)}`);
         const response = await this.handler(request, session, message);
         logger.debug(`Invoke ${this.name} response : ${Logger.toJSON(response)}`);
-        return { code: ResultCode.Success, responseId: this.responseId, response: this.responseSchema.encodeTlv(response) };
+        return { code: StatusCode.Success, responseId: this.responseId, response: this.responseSchema.encodeTlv(response) };
     }
 }

--- a/packages/matter.js/src/cluster/server/GroupsServer.ts
+++ b/packages/matter.js/src/cluster/server/GroupsServer.ts
@@ -6,7 +6,7 @@
 
 import { GroupsCluster } from "../GroupsCluster.js";
 import { GroupId } from "../../datatype/GroupId.js";
-import { InteractionProtocolStatusCode as StatusCode } from "../../protocol/interaction/InteractionProtocol.js";
+import { StatusCode } from "../../protocol/interaction/InteractionProtocol.js";
 import { ClusterServerHandlers } from "./ClusterServer.js";
 import { MatterDevice } from "../../MatterDevice.js";
 import { SecureSession } from "../../session/SecureSession.js";

--- a/packages/matter.js/src/protocol/interaction/AttributeDataDecoder.ts
+++ b/packages/matter.js/src/protocol/interaction/AttributeDataDecoder.ts
@@ -41,7 +41,7 @@ export interface DecodedAttributeValue {
 
 export function normalizeAndDecodeReadAttributeReport(data: TypeFromSchema<typeof TlvAttributeReport>[]): DecodedAttributeReportValue[] {
     // TODO Decide how to handle the attribute report status field, right now we ignore it
-    const dataValues = data.flatMap(({ value }) => value !== undefined ? value : []);
+    const dataValues = data.flatMap(({ attributeData }) => attributeData !== undefined ? attributeData : []);
 
     return normalizeAndDecodeAttributeData(dataValues) as DecodedAttributeReportValue[]; // dataVersion existing in incoming data, so must also in outgoing data
 }

--- a/packages/matter.js/src/protocol/interaction/InteractionProtocol.ts
+++ b/packages/matter.js/src/protocol/interaction/InteractionProtocol.ts
@@ -14,7 +14,7 @@ import { TlvField, TlvList, TlvObject, TlvOptionalField } from "../../tlv/TlvObj
 import { MatterCoreSpecificationV1_0 } from "../../spec/Specifications.js";
 
 /** @see {@link MatterCoreSpecificationV1_0}, section 8.10 */
-export const enum InteractionProtocolStatusCode {
+export const enum StatusCode {
     Success = 0x00,
     Failure = 0x01,
     InvalidSubscription = 0x7d,
@@ -98,8 +98,8 @@ export const TlvDataVersionFilter = TlvObject({ // DataVersionFilterIB
 
 /** @see {@link MatterCoreSpecificationV1_0}, section 10.5.17 */
 export const TlvStatus = TlvObject({ // StatusIB
-    status: TlvOptionalField(0, TlvEnum<InteractionProtocolStatusCode>()),
-    clusterStatus: TlvOptionalField(1, TlvEnum<InteractionProtocolStatusCode>()),
+    status: TlvOptionalField(0, TlvEnum<StatusCode>()),
+    clusterStatus: TlvOptionalField(1, TlvEnum<StatusCode>()),
 });
 
 /** @see {@link MatterCoreSpecificationV1_0}, section 10.5.16 */
@@ -124,7 +124,7 @@ export const TlvAttributeReportData = TlvObject({ // AttributeDataIB version for
 /** @see {@link MatterCoreSpecificationV1_0}, section 10.5.5 */
 export const TlvAttributeReport = TlvObject({ // AttributeReportIB
     attributeStatus: TlvOptionalField(0, TlvAttributeStatus),
-    value: TlvOptionalField(1, TlvAttributeReportData), // AttributeDataIB, TODO rename to attributeData
+    attributeData: TlvOptionalField(1, TlvAttributeReportData),
 });
 
 /** @see {@link MatterCoreSpecificationV1_0}, section 10.5.15 */
@@ -141,45 +141,40 @@ export const TlvEventReport = TlvObject({ // EventReportIB
 
 /** @see {@link MatterCoreSpecificationV1_0}, section 10.5.11 */
 export const TlvCommandPath = TlvList({ // CommandPathIB
-    endpointId: TlvField(0, TlvUInt16), // TODO Formally Optional
+    endpointId: TlvOptionalField(0, TlvUInt16),
     clusterId: TlvField(1, TlvUInt32),
     commandId: TlvField(2, TlvUInt32),
 });
 
 /** @see {@link MatterCoreSpecificationV1_0}, section 10.5.12 */
 export const TlvCommandData = TlvObject({ // CommandDataIB
-    path: TlvField(0, TlvCommandPath), // TODO rename to commandPath
-    args: TlvOptionalField(1, TlvAny), // TODO rename to commandFields
+    commandPath: TlvField(0, TlvCommandPath),
+    commandFields: TlvOptionalField(1, TlvAny),
 });
 
 /** @see {@link MatterCoreSpecificationV1_0}, section 10.5.14 */
 export const TlvCommandStatus = TlvObject({ // CommandStatusIB
-    path: TlvField(0, TlvCommandPath), // TODO rename to commandPath
-    result: TlvField(1, TlvObject({ // StatusIB, TODO consolidate and rename to status
-        code: TlvField(0, TlvUInt16),
-    })),
+    commandPath: TlvField(0, TlvCommandPath),
+    status: TlvField(1, TlvStatus),
 });
 
 /** @see {@link MatterCoreSpecificationV1_0}, section 10.5.13 */
 export const TlvInvokeResponseData = TlvObject({ // InvokeResponseIB
-    response: TlvOptionalField(0, TlvObject({ // CommandDataIB, TODO consolidate with types! Rename to command
-        path: TlvField(0, TlvCommandPath),
-        response: TlvField(1, TlvAny),
-    })),
-    result: TlvOptionalField(1, TlvCommandStatus), // TODO rename to status
+    command: TlvOptionalField(0, TlvCommandData),
+    status: TlvOptionalField(1, TlvCommandStatus),
 });
 
 // Request/Response Messages
 
 /** @see {@link MatterCoreSpecificationV1_0}, section 10.6.1 */
 export const TlvStatusResponse = TlvObject({
-    status: TlvField(0, TlvEnum<InteractionProtocolStatusCode>()),
+    status: TlvField(0, TlvEnum<StatusCode>()),
     interactionModelRevision: TlvField(0xFF, TlvUInt8),
 });
 
 /** @see {@link MatterCoreSpecificationV1_0}, section 10.6.2 */
 export const TlvReadRequest = TlvObject({
-    attributes: TlvField(0, TlvArray(TlvAttributePath)), // TODO rename to attributeRequests, formally optional
+    attributeRequests: TlvOptionalField(0, TlvArray(TlvAttributePath)),
     eventRequests: TlvOptionalField(1, TlvArray(TlvEventPath)),
     eventFilters: TlvOptionalField(2, TlvArray(TlvEventFilter)),
     isFabricFiltered: TlvField(3, TlvBoolean),
@@ -190,7 +185,7 @@ export const TlvReadRequest = TlvObject({
 /** @see {@link MatterCoreSpecificationV1_0}, section 10.6.3 */
 export const TlvDataReport = TlvObject({
     subscriptionId: TlvOptionalField(0, TlvUInt32),
-    values: TlvOptionalField(1, TlvArray(TlvAttributeReport)), // TODO: rename to attributeReports
+    attributeReports: TlvOptionalField(1, TlvArray(TlvAttributeReport)),
     eventReports: TlvOptionalField(2, TlvArray(TlvEventReport)),
     moreChunkedMessages: TlvOptionalField(3, TlvBoolean),
     suppressResponse: TlvOptionalField(4, TlvBoolean),
@@ -220,14 +215,14 @@ export const TlvSubscribeResponse = TlvObject({
 export const TlvInvokeRequest = TlvObject({
     suppressResponse: TlvField(0, TlvBoolean),
     timedRequest: TlvField(1, TlvBoolean),
-    invokes: TlvField(2, TlvArray(TlvCommandData)), // TODO: rename to invokeRequests
+    invokeRequests: TlvField(2, TlvArray(TlvCommandData)),
     interactionModelRevision: TlvField(0xFF, TlvUInt8),
 });
 
 /** @see {@link MatterCoreSpecificationV1_0}, section 10.6.10 */
 export const TlvInvokeResponse = TlvObject({
     suppressResponse: TlvField(0, TlvBoolean),
-    responses: TlvField(1, TlvArray(TlvInvokeResponseData)), // TODO: rename to invokeResponses
+    invokeResponses: TlvField(1, TlvArray(TlvInvokeResponseData)),
     interactionModelRevision: TlvField(0xFF, TlvUInt8),
 });
 

--- a/packages/matter.js/src/protocol/interaction/SubscriptionHandler.ts
+++ b/packages/matter.js/src/protocol/interaction/SubscriptionHandler.ts
@@ -11,9 +11,7 @@ import { AttributeWithPath, INTERACTION_PROTOCOL_ID, attributePathToId } from ".
 import { Logger } from "../../log/Logger.js";
 import { Time, Timer } from "../../time/Time.js";
 import { NodeId } from "../../datatype/NodeId.js";
-import {
-    InteractionProtocolStatusCode as StatusCode, TlvAttributePath,
-} from "./InteractionProtocol.js";
+import { StatusCode, TlvAttributePath } from "./InteractionProtocol.js";
 import { tryCatchAsync } from "../../common/TryCatchHandler.js";
 import { SecureSession } from "../../session/SecureSession.js";
 import { TlvSchema, TypeFromSchema } from "../../tlv/TlvSchema.js";
@@ -127,8 +125,8 @@ export class SubscriptionHandler {
             suppressResponse: false,
             subscriptionId: this.subscriptionId,
             interactionModelRevision: 1,
-            values: values.map(({ path, schema, value, version }) => ({
-                value: {
+            attributeReports: values.map(({ path, schema, value, version }) => ({
+                attributeData: {
                     path,
                     dataVersion: version,
                     data: schema.encodeTlv(value),
@@ -168,8 +166,8 @@ export class SubscriptionHandler {
                     suppressResponse: !values.length, // suppressResponse ok for empty DataReports
                     subscriptionId: this.subscriptionId,
                     interactionModelRevision: 1,
-                    values: values.map(({ path, schema, value, version }) => ({
-                        value: {
+                    attributeReports: values.map(({ path, schema, value, version }) => ({
+                        attributeData: {
                             path,
                             dataVersion: version,
                             data: schema.encodeTlv(value),

--- a/packages/matter.js/test/protocol/interaction/AttributeDataDecoderTest.ts
+++ b/packages/matter.js/test/protocol/interaction/AttributeDataDecoderTest.ts
@@ -3,8 +3,8 @@
  * Copyright 2022-2023 Project CHIP Authors
  * SPDX-License-Identifier: Apache-2.0
  */
-
-
+import { Time } from "../../../src/time/Time.js";
+import { TimeFake } from "../../../src/time/TimeFake.js";
 import { normalizeAndDecodeReadAttributeReport, normalizeAttributeData } from "../../../src/protocol/interaction/AttributeDataDecoder.js";
 import * as assert from "assert";
 import { TlvField, TlvObject } from "../../../src/tlv/TlvObject.js";
@@ -12,7 +12,11 @@ import { TlvUInt8 } from "../../../src/tlv/TlvNumber.js";
 import { TlvNullable } from "../../../src/tlv/TlvNullable.js";
 import { TlvArray } from "../../../src/tlv/TlvArray.js";
 import { ByteArray } from "../../../src/util/ByteArray.js";
-import { TlvAttributeData, TlvDataReport } from "../../../src/protocol/interaction/InteractionProtocol.js";
+import {
+    TlvAttributeData,
+    TlvAttributeReport,
+    TlvDataReport
+} from "../../../src/protocol/interaction/InteractionProtocol.js";
 import { ClusterId } from "../../../src/datatype/ClusterId.js";
 import { VendorId } from "../../../src/datatype/VendorId.js";
 import { AttributeId } from "../../../src/datatype/AttributeId.js";
@@ -26,20 +30,26 @@ const TlvAclTestSchema = TlvObject({
     targets: TlvField(4, TlvNullable(TlvUInt8)),
 });
 
+const fakeTime = new TimeFake(0);
+
 describe("DataReportDecoder", () => {
+
+    beforeAll(() => {
+        Time.get = () => fakeTime;
+    });
 
     describe("decode chunked array using raw data from chip-tool", () => {
         it("decode chunked array with two elements", () => {
-            const data = [
+            const data: TypeFromSchema<typeof TlvAttributeReport>[] = [
                 {
-                    value: {
+                    attributeData: {
                         path: { endpointId: 0, clusterId: 0x1f, attributeId: 0 },
                         data: TlvArray(TlvAclTestSchema).encodeTlv([]),
                         dataVersion: 0,
                     }
                 },
                 {
-                    value: {
+                    attributeData: {
                         path: { endpointId: 0, clusterId: 0x1f, attributeId: 0, listIndex: null },
                         data: TlvAclTestSchema.encodeTlv({
                             privilege: 1,
@@ -51,7 +61,7 @@ describe("DataReportDecoder", () => {
                     }
                 },
                 {
-                    value: {
+                    attributeData: {
                         path: { endpointId: 0, clusterId: 0x1f, attributeId: 0, listIndex: null },
                         data: TlvAclTestSchema.encodeTlv({
                             privilege: 2,
@@ -90,16 +100,16 @@ describe("DataReportDecoder", () => {
         });
 
         it("decode chunked array with indexed adding", () => {
-            const data = [
+            const data: TypeFromSchema<typeof TlvAttributeReport>[] = [
                 {
-                    value: {
+                    attributeData: {
                         path: { endpointId: 0, clusterId: 0x1f, attributeId: 0 },
                         data: TlvArray(TlvAclTestSchema).encodeTlv([]),
                         dataVersion: 0,
                     }
                 },
                 {
-                    value: {
+                    attributeData: {
                         path: { endpointId: 0, clusterId: 0x1f, attributeId: 0, listIndex: 0 },
                         data: TlvAclTestSchema.encodeTlv({
                             privilege: 1,
@@ -111,7 +121,7 @@ describe("DataReportDecoder", () => {
                     }
                 },
                 {
-                    value: {
+                    attributeData: {
                         path: { endpointId: 0, clusterId: 0x1f, attributeId: 0, listIndex: 1 },
                         data: TlvAclTestSchema.encodeTlv({
                             privilege: 2,
@@ -150,16 +160,16 @@ describe("DataReportDecoder", () => {
         });
 
         it("decode chunked array with indexed deletion", () => {
-            const data = [
+            const data: TypeFromSchema<typeof TlvAttributeReport>[] = [
                 {
-                    value: {
+                    attributeData: {
                         path: { endpointId: 0, clusterId: 0x1f, attributeId: 0 },
                         data: TlvArray(TlvAclTestSchema).encodeTlv([]),
                         dataVersion: 0,
                     }
                 },
                 {
-                    value: {
+                    attributeData: {
                         path: { endpointId: 0, clusterId: 0x1f, attributeId: 0, listIndex: 0 },
                         data: TlvAclTestSchema.encodeTlv({
                             privilege: 1,
@@ -171,7 +181,7 @@ describe("DataReportDecoder", () => {
                     }
                 },
                 {
-                    value: {
+                    attributeData: {
                         path: { endpointId: 0, clusterId: 0x1f, attributeId: 0, listIndex: 1 },
                         data: TlvAclTestSchema.encodeTlv({
                             privilege: 2,
@@ -183,7 +193,7 @@ describe("DataReportDecoder", () => {
                     }
                 },
                 {
-                    value: {
+                    attributeData: {
                         path: { endpointId: 0, clusterId: 0x1f, attributeId: 0, listIndex: 2 },
                         data: TlvAclTestSchema.encodeTlv({
                             privilege: 3,
@@ -195,7 +205,7 @@ describe("DataReportDecoder", () => {
                     }
                 },
                 {
-                    value: {
+                    attributeData: {
                         path: { endpointId: 0, clusterId: 0x1f, attributeId: 0, listIndex: 1 },
                         data: TlvNullable(TlvAclTestSchema).encodeTlv(null),
                         dataVersion: 0,
@@ -228,16 +238,16 @@ describe("DataReportDecoder", () => {
         });
 
         it("decode chunked array with indexed modify", () => {
-            const data = [
+            const data: TypeFromSchema<typeof TlvAttributeReport>[] = [
                 {
-                    value: {
+                    attributeData: {
                         path: { endpointId: 0, clusterId: 0x1f, attributeId: 0 },
                         data: TlvArray(TlvAclTestSchema).encodeTlv([]),
                         dataVersion: 0,
                     }
                 },
                 {
-                    value: {
+                    attributeData: {
                         path: { endpointId: 0, clusterId: 0x1f, attributeId: 0, listIndex: 0 },
                         data: TlvAclTestSchema.encodeTlv({
                             privilege: 1,
@@ -249,7 +259,7 @@ describe("DataReportDecoder", () => {
                     }
                 },
                 {
-                    value: {
+                    attributeData: {
                         path: { endpointId: 0, clusterId: 0x1f, attributeId: 0, listIndex: 1 },
                         data: TlvAclTestSchema.encodeTlv({
                             privilege: 2,
@@ -261,7 +271,7 @@ describe("DataReportDecoder", () => {
                     }
                 },
                 {
-                    value: {
+                    attributeData: {
                         path: { endpointId: 0, clusterId: 0x1f, attributeId: 0, listIndex: 2 },
                         data: TlvAclTestSchema.encodeTlv({
                             privilege: 3,
@@ -273,7 +283,7 @@ describe("DataReportDecoder", () => {
                     }
                 },
                 {
-                    value: {
+                    attributeData: {
                         path: { endpointId: 0, clusterId: 0x1f, attributeId: 0, listIndex: 1 },
                         data: TlvAclTestSchema.encodeTlv({
                             privilege: 4,
@@ -326,9 +336,9 @@ describe("DataReportDecoder", () => {
             const decodedData = TlvDataReport.decode(tlvData);
 
             assert.ok(decodedData);
-            assert.ok(Array.isArray(decodedData.values));
+            assert.ok(Array.isArray(decodedData.attributeReports));
 
-            const normalizedData = normalizeAndDecodeReadAttributeReport(decodedData.values);
+            const normalizedData = normalizeAndDecodeReadAttributeReport(decodedData.attributeReports);
 
             assert.equal(normalizedData.length, 1);
             assert.deepEqual(normalizedData[0].path, {
@@ -354,9 +364,9 @@ describe("DataReportDecoder", () => {
             const decodedData = TlvDataReport.decode(tlvData);
 
             assert.ok(decodedData);
-            assert.ok(Array.isArray(decodedData.values));
+            assert.ok(Array.isArray(decodedData.attributeReports));
 
-            const normalizedData = normalizeAndDecodeReadAttributeReport(decodedData.values);
+            const normalizedData = normalizeAndDecodeReadAttributeReport(decodedData.attributeReports);
 
             assert.equal(normalizedData.length, 1);
             assert.deepEqual(normalizedData[0].path, {
@@ -376,9 +386,9 @@ describe("DataReportDecoder", () => {
             const decodedData = TlvDataReport.decode(tlvData);
 
             assert.ok(decodedData);
-            assert.ok(Array.isArray(decodedData.values));
+            assert.ok(Array.isArray(decodedData.attributeReports));
 
-            const normalizedData = normalizeAndDecodeReadAttributeReport(decodedData.values);
+            const normalizedData = normalizeAndDecodeReadAttributeReport(decodedData.attributeReports);
 
             assert.deepEqual(normalizedData, [
                 {


### PR DESCRIPTION
This PR is solving some planned renamings to consolidate the Interaction Protocol datatypes and Objects to have the same naming as in the specs and also renames "InteractionProtocolStaticCode" back to "StatucCode" now that the new export structure prevents conflicts here.