### PR TITLE
Add Endpoint data to invoke parameters

### DIFF
--- a/packages/matter-node.js/test/IntegrationTest.ts
+++ b/packages/matter-node.js/test/IntegrationTest.ts
@@ -157,7 +157,7 @@ describe("Integration", () => {
                     }, {
                         nameSupport: { groupNames: true }
                     },
-                        GroupsClusterHandler(0x00)),
+                        GroupsClusterHandler()),
                 ])
                 .addEndpoint(0x01, DEVICE.ON_OFF_LIGHT, [onOffServer])
             );

--- a/packages/matter.js/src/cluster/server/ClusterServer.ts
+++ b/packages/matter.js/src/cluster/server/ClusterServer.ts
@@ -13,6 +13,7 @@ import { Message } from "../../codec/MessageCodec.js";
 import { Merge } from "../../util/Type.js";
 import { MatterDevice } from "../../MatterDevice.js";
 import { Session } from "../../session/Session.js";
+import { EndpointData } from "../../protocol/interaction/InteractionServer.js";
 
 type MandatoryAttributeNames<A extends Attributes> = { [K in keyof A]: A[K] extends OptionalAttribute<any> ? never : K }[keyof A];
 type OptionalAttributeNames<A extends Attributes> = { [K in keyof A]: A[K] extends OptionalAttribute<any> ? K : never }[keyof A];
@@ -24,7 +25,7 @@ export type AttributeInitialValues<A extends Attributes> = Merge<Omit<{ [P in Ma
 type MandatoryCommandNames<C extends Commands> = { [K in keyof C]: C[K] extends OptionalCommand<any, any> ? never : K }[keyof C];
 type OptionalCommandNames<C extends Commands> = { [K in keyof C]: C[K] extends OptionalCommand<any, any> ? K : never }[keyof C];
 type AttributeGetters<A extends Attributes> = { [P in keyof A as `get${Capitalize<string & P>}`]?: (session?: Session<MatterDevice>) => AttributeJsType<A[P]> };
-type CommandHandler<C extends Command<any, any>, A extends AttributeServers<any>> = C extends Command<infer RequestT, infer ResponseT> ? (args: { request: RequestT, attributes: A, session: Session<MatterDevice>, message: Message }) => Promise<ResponseT> : never;
+type CommandHandler<C extends Command<any, any>, A extends AttributeServers<any>> = C extends Command<infer RequestT, infer ResponseT> ? (args: { request: RequestT, attributes: A, session: Session<MatterDevice>, message: Message, endpoint: EndpointData }) => Promise<ResponseT> : never;
 type CommandHandlers<T extends Commands, A extends AttributeServers<any>> = Merge<{ [P in MandatoryCommandNames<T>]: CommandHandler<T[P], A> }, { [P in OptionalCommandNames<T>]?: CommandHandler<T[P], A> }>;
 
 /** Handlers to process cluster commands */

--- a/packages/matter.js/src/cluster/server/CommandServer.ts
+++ b/packages/matter.js/src/cluster/server/CommandServer.ts
@@ -9,7 +9,7 @@ import { Session } from "../../session/Session.js";
 import { TlvSchema, TlvStream } from "../../tlv/TlvSchema.js";
 import { Message } from "../../codec/MessageCodec.js";
 import { Logger } from "../../log/Logger.js";
-import { StatusCode } from "../../protocol/interaction/index.js";
+import { EndpointData, StatusCode } from "../../protocol/interaction/index.js";
 
 const logger = Logger.get("CommandServer");
 
@@ -20,13 +20,13 @@ export class CommandServer<RequestT, ResponseT> {
         readonly name: string,
         protected readonly requestSchema: TlvSchema<RequestT>,
         protected readonly responseSchema: TlvSchema<ResponseT>,
-        protected readonly handler: (request: RequestT, session: Session<MatterDevice>, message: Message) => Promise<ResponseT> | ResponseT,
+        protected readonly handler: (request: RequestT, session: Session<MatterDevice>, message: Message, endpoint: EndpointData) => Promise<ResponseT> | ResponseT,
     ) { }
 
-    async invoke(session: Session<MatterDevice>, args: TlvStream, message: Message): Promise<{ code: StatusCode, responseId: number, response: TlvStream }> {
+    async invoke(session: Session<MatterDevice>, args: TlvStream, message: Message, endpoint: EndpointData): Promise<{ code: StatusCode, responseId: number, response: TlvStream }> {
         const request = this.requestSchema.decodeTlv(args);
         logger.debug(`Invoke ${this.name} with data ${Logger.toJSON(request)}`);
-        const response = await this.handler(request, session, message);
+        const response = await this.handler(request, session, message, endpoint);
         logger.debug(`Invoke ${this.name} response : ${Logger.toJSON(response)}`);
         return { code: StatusCode.Success, responseId: this.responseId, response: this.responseSchema.encodeTlv(response) };
     }

--- a/packages/matter.js/src/cluster/server/GroupsServer.ts
+++ b/packages/matter.js/src/cluster/server/GroupsServer.ts
@@ -28,8 +28,8 @@ const getFabricFromSession = (session: SecureSession<MatterDevice>): Fabric => {
     return fabric;
 }
 
-export const GroupsClusterHandler: (endpointId: number) => ClusterServerHandlers<typeof GroupsCluster> = (endpointId: number) => {
-    const addGroupLogic = (groupId: GroupId, groupName: string, sessionType: SessionType, fabric: Fabric) => {
+export const GroupsClusterHandler: () => ClusterServerHandlers<typeof GroupsCluster> = () => {
+    const addGroupLogic = (groupId: GroupId, groupName: string, sessionType: SessionType, fabric: Fabric, endpointId: number) => {
         // TODO If the AddGroup command was received as a unicast, the server SHALL generate an AddGroupResponse
         //      command with the Status field set to the evaluated status. If the AddGroup command was received
         //      as a groupcast, the server SHALL NOT generate an AddGroupResponse command.
@@ -55,11 +55,11 @@ export const GroupsClusterHandler: (endpointId: number) => ClusterServerHandlers
     }
 
     return {
-        addGroup: async ({ request: { groupId, groupName }, session, message: { packetHeader: { sessionType } } }) => {
-            return addGroupLogic(groupId, groupName, sessionType, getFabricFromSession(session as SecureSession<MatterDevice>));
+        addGroup: async ({ request: { groupId, groupName }, session, message: { packetHeader: { sessionType } }, endpoint }) => {
+            return addGroupLogic(groupId, groupName, sessionType, getFabricFromSession(session as SecureSession<MatterDevice>), endpoint.id);
         },
 
-        viewGroup: async ({ request: { groupId }, session, message: { packetHeader: { sessionType } } }) => {
+        viewGroup: async ({ request: { groupId }, session, message: { packetHeader: { sessionType } }, endpoint }) => {
             // TODO If the ViewGroup command was received as a unicast, the server SHALL generate an ViewGroupResponse
             //      command with the Status field set to the evaluated status. If the ViewGroup command was received
             //      as a groupcast, the server SHALL NOT generate an ViewGroupResponse command.
@@ -71,7 +71,7 @@ export const GroupsClusterHandler: (endpointId: number) => ClusterServerHandlers
             }
 
             const fabric = getFabricFromSession(session as SecureSession<MatterDevice>);
-            const endpointGroups = fabric.getScopedClusterDataValue<Map<number, string>>(GroupsCluster, endpointId.toString());
+            const endpointGroups = fabric.getScopedClusterDataValue<Map<number, string>>(GroupsCluster, endpoint.id.toString());
             if (endpointGroups !== undefined) {
                 const groupName = endpointGroups.get(groupId.id);
                 if (groupName !== undefined) {
@@ -81,7 +81,7 @@ export const GroupsClusterHandler: (endpointId: number) => ClusterServerHandlers
             return { status: StatusCode.NotFound, groupId, groupName: '' };
         },
 
-        getGroupMembership: async ({ request: { groupList }, session, message: { packetHeader: { sessionType } } }) => {
+        getGroupMembership: async ({ request: { groupList }, session, message: { packetHeader: { sessionType } }, endpoint }) => {
             // TODO Later:
             //  Zigbee: If the total number of groups will cause the maximum payload length of a frame to be exceeded,
             //  then the GroupList field SHALL contain only as many groups as will fit.
@@ -92,7 +92,7 @@ export const GroupsClusterHandler: (endpointId: number) => ClusterServerHandlers
             }
 
             const fabric = getFabricFromSession(session as SecureSession<MatterDevice>)
-            const endpointGroups = fabric.getScopedClusterDataValue<Map<number, string>>(GroupsCluster, endpointId.toString()) ?? new Map<number, string>();
+            const endpointGroups = fabric.getScopedClusterDataValue<Map<number, string>>(GroupsCluster, endpoint.id.toString()) ?? new Map<number, string>();
             const fabricGroupsList = endpointGroups !== undefined ? Array.from(endpointGroups.keys()) : [];
             const capacity = fabricGroupsList.length < 0xff ? 0xfe - fabricGroupsList.length : 0;
             if (groupList.length === 0) {
@@ -106,7 +106,7 @@ export const GroupsClusterHandler: (endpointId: number) => ClusterServerHandlers
             return { capacity, groupList: filteredGroupsList };
         },
 
-        removeGroup: async ({ request: { groupId }, session, message: { packetHeader: { sessionType } } }) => {
+        removeGroup: async ({ request: { groupId }, session, message: { packetHeader: { sessionType } }, endpoint }) => {
             // TODO If the RemoveGroup command was received as a unicast, the server SHALL generate a RemoveGroupResponse
             //      command with the Status field set to the evaluated status. If the RemoveGroup command was received as
             //      a groupcast, the server SHALL NOT generate a RemoveGroupResponse command.
@@ -119,7 +119,7 @@ export const GroupsClusterHandler: (endpointId: number) => ClusterServerHandlers
             }
 
             const fabric = getFabricFromSession(session as SecureSession<MatterDevice>)
-            const endpointGroups = fabric.getScopedClusterDataValue<Map<number, string>>(GroupsCluster, endpointId.toString());
+            const endpointGroups = fabric.getScopedClusterDataValue<Map<number, string>>(GroupsCluster, endpoint.id.toString());
             if (endpointGroups !== undefined) {
                 if (endpointGroups.has(groupId.id)) {
                     endpointGroups.delete(groupId.id);
@@ -130,7 +130,7 @@ export const GroupsClusterHandler: (endpointId: number) => ClusterServerHandlers
             return { status: StatusCode.NotFound, groupId };
         },
 
-        removeAllGroups: async ({ session, message: { packetHeader: { sessionType } } }) => {
+        removeAllGroups: async ({ session, message: { packetHeader: { sessionType } }, endpoint }) => {
             // TODO Additionally, if the Scenes cluster is supported on the same endpoint, all scenes, except for scenes
             //      associated with group ID 0, SHALL be removed on that endpoint.
 
@@ -140,12 +140,12 @@ export const GroupsClusterHandler: (endpointId: number) => ClusterServerHandlers
             }
 
             const fabric = getFabricFromSession(session as SecureSession<MatterDevice>)
-            fabric.deleteScopedClusterDataValue(GroupsCluster, endpointId.toString());
+            fabric.deleteScopedClusterDataValue(GroupsCluster, endpoint.id.toString());
 
             throw new StatusResponseError("Return Status", StatusCode.Success);
         },
 
-        addGroupIfIdentifying: async ({ request: { groupId, groupName }, session, message: { packetHeader: { sessionType } } }) => {
+        addGroupIfIdentifying: async ({ request: { groupId, groupName }, session, message: { packetHeader: { sessionType } }, endpoint }) => {
             // TODO The server verifies that it is currently identifying itself. If the server it not currently identifying
             //      itself, the status SHALL be SUCCESS
             // return {status: AdminCommissioningStatusCode.Success, groupId};
@@ -154,7 +154,7 @@ export const GroupsClusterHandler: (endpointId: number) => ClusterServerHandlers
             //      if the AddGroupIfIdentifying command was received as unicast and the evaluated status is SUCCESS and a
             //      response is not suppressed, the server SHALL generate a response with the Status field set to the
             //      evaluated status.
-            const { status } = addGroupLogic(groupId, groupName, sessionType, getFabricFromSession(session as SecureSession<MatterDevice>));
+            const { status } = addGroupLogic(groupId, groupName, sessionType, getFabricFromSession(session as SecureSession<MatterDevice>), endpoint.id);
             throw new StatusResponseError("Return Status", status);
         },
     }


### PR DESCRIPTION
Some cluster logic requires details from the endpoint and later also access to other clusters on the endpoint. This PR introduces this in a minimalistic way - it will get refactored once again when new API is fully in place. But it also helps the use for GroupsCluster and allows in parallel Cluster logic development (e.g. Lighting control for onoff or scenes) - even with a refactoring later.