### PR TITLE
Implements ManualPairingCodeSchema.decodeInternal()

### DIFF
--- a/packages/matter-node.js/README.md
+++ b/packages/matter-node.js/README.md
@@ -149,7 +149,7 @@ The following parameters are available:
 * -ip: the IP address of the device to commission
 * -discriminator: the discriminator to use for pairing (default: 3840)
 * -pin: the pin to use for pairing (default: 20202021)
-* -code: code to use for pairing (-discriminator and -pin will be ignored)
+* -pairingcode: code to use for pairing (-discriminator and -pin will be ignored)
 * -store: the storage location (directory) to use for storing the pairing information (default: controller-node). Delete the directory or provide an alternative name to reset the controller
 
 ## Modifying the server (DeviceNode) behavior

--- a/packages/matter-node.js/README.md
+++ b/packages/matter-node.js/README.md
@@ -149,6 +149,7 @@ The following parameters are available:
 * -ip: the IP address of the device to commission
 * -discriminator: the discriminator to use for pairing (default: 3840)
 * -pin: the pin to use for pairing (default: 20202021)
+* -code: code to use for pairing (-discriminator and -pin will be ignored)
 * -store: the storage location (directory) to use for storing the pairing information (default: controller-node). Delete the directory or provide an alternative name to reset the controller
 
 ## Modifying the server (DeviceNode) behavior

--- a/packages/matter-node.js/README.md
+++ b/packages/matter-node.js/README.md
@@ -114,7 +114,7 @@ npm run matter -- -on "echo 255 > /sys/class/leds/led1/brightness" -off "echo 0 
 
 The following parameters are available:
 * -passcode: the passcode to use for pairing (default: 20202021)
-* -discriminator: the discriminator to use for pairing (default: 3840)
+* -discriminator: the discriminator to use for pairing (default: 3840, value between 0 and 4095)
 * -vendorid: the vendor ID as number to use for pairing (default: 65521 (0xFFF1))
 * -productid: the product ID as number to use for pairing (default: 32768 (0x8000))
 * -announceinterface: limit mdns announcements to the provided network interface, e.g. "en0" (default: all interfaces available)
@@ -147,7 +147,7 @@ This will commission a Matter device (for debugging purpose only for now).
 
 The following parameters are available:
 * -ip: the IP address of the device to commission
-* -discriminator: the discriminator to use for pairing (default: 3840)
+* -discriminator: the discriminator to use for pairing (default: 3840, value between 0 and 4095)
 * -pin: the pin to use for pairing (default: 20202021)
 * -pairingcode: code to use for pairing (-discriminator and -pin will be ignored)
 * -store: the storage location (directory) to use for storing the pairing information (default: controller-node). Delete the directory or provide an alternative name to reset the controller

--- a/packages/matter-node.js/src/ControllerNode.ts
+++ b/packages/matter-node.js/src/ControllerNode.ts
@@ -29,6 +29,7 @@ import { MdnsScanner } from "@project-chip/matter.js/mdns";
 import { ClusterClient } from "@project-chip/matter.js/interaction";
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { BasicInformationCluster, DescriptorCluster, OnOffCluster } from "@project-chip/matter.js/cluster";
+import { ManualPairingCodeCodec } from "@project-chip/matter-node.js/schema";
 
 import { getIntParameter, getParameter } from "./util/CommandLine";
 import { StorageBackendDisk } from "./storage/StorageBackendDisk";
@@ -52,8 +53,17 @@ class ControllerNode {
         const ip = getParameter("ip") ?? controllerStorage.get<string>("ip", "");
         if (ip === "") throw new Error("Please specify the IP of the device to commission with -ip");
         const port = getIntParameter("port") ?? controllerStorage.get("port", 5540);
-        const discriminator = getIntParameter("discriminator") ?? controllerStorage.get("discriminator", 3840);
-        const setupPin = getIntParameter("pin") ?? controllerStorage.get("pin", 20202021);
+
+        const code = getParameter("code");
+        let discriminator, setupPin;
+        if (code !== undefined) {
+            const pairingCode = ManualPairingCodeCodec.decode(code);
+            discriminator = pairingCode.discriminator;
+            setupPin = pairingCode.passcode;
+        } else {
+            discriminator = getIntParameter("discriminator") ?? controllerStorage.get("discriminator", 3840);
+            setupPin = getIntParameter("pin") ?? controllerStorage.get("pin", 20202021);
+        }
 
         controllerStorage.set("ip", ip);
         controllerStorage.set("port", port);

--- a/packages/matter-node.js/src/ControllerNode.ts
+++ b/packages/matter-node.js/src/ControllerNode.ts
@@ -54,14 +54,15 @@ class ControllerNode {
         if (ip === "") throw new Error("Please specify the IP of the device to commission with -ip");
         const port = getIntParameter("port") ?? controllerStorage.get("port", 5540);
 
-        const code = getParameter("code");
+        const pairingCode = getParameter("pairingcode");
         let discriminator, setupPin;
-        if (code !== undefined) {
-            const pairingCode = ManualPairingCodeCodec.decode(code);
-            discriminator = pairingCode.discriminator;
-            setupPin = pairingCode.passcode;
+        if (pairingCode !== undefined) {
+            const pairingCodeCodec = ManualPairingCodeCodec.decode(pairingCode);
+            discriminator = pairingCodeCodec.shortDiscriminator;
+            setupPin = pairingCodeCodec.passcode;
         } else {
             discriminator = getIntParameter("discriminator") ?? controllerStorage.get("discriminator", 3840);
+            if (discriminator > 4095) throw new Error("Discriminator value must be less than 4096");
             setupPin = getIntParameter("pin") ?? controllerStorage.get("pin", 20202021);
         }
 

--- a/packages/matter-node.js/src/DeviceNode.ts
+++ b/packages/matter-node.js/src/DeviceNode.ts
@@ -65,6 +65,7 @@ class DeviceNode {
         const vendorName = "matter-node.js";
         const passcode = getIntParameter("passcode") ?? deviceStorage.get("passcode", 20202021);
         const discriminator = getIntParameter("discriminator") ?? deviceStorage.get("discriminator", 3840);
+        if (discriminator > 4095) throw new Error("Discriminator value must be less than 4096");
         // product name / id and vendor id should match what is in the device certificate
         const vendorId = new VendorId(getIntParameter("vendorid") ?? deviceStorage.get("vendorid", 0xFFF1));
         const productName = "matter-node.js Test Product";

--- a/packages/matter.js/src/schema/PairingCodeSchema.ts
+++ b/packages/matter.js/src/schema/PairingCodeSchema.ts
@@ -87,7 +87,7 @@ class ManualPairingCodeSchema extends Schema<ManualPairingData, string> {
     }
 
     protected decodeInternal(encoded: string): ManualPairingData {
-        if(encoded.length < 10) throw new Error("Invalid pairing code");
+        if (encoded.length < 10) throw new Error("Invalid pairing code");
         const verhoeff = new Verhoeff();
         if (verhoeff.computeChecksum(encoded.slice(0, -1)) !== parseInt(encoded.slice(-1))) {
             throw new Error("Invalid checksum");

--- a/packages/matter.js/src/schema/PairingCodeSchema.ts
+++ b/packages/matter.js/src/schema/PairingCodeSchema.ts
@@ -90,7 +90,9 @@ class ManualPairingCodeSchema extends Schema<ManualPairingData, string> {
     }
 
     protected decodeInternal(encoded: string): ManualPairingData {
-        if (encoded.length !== 11 && encoded.length != 21) throw new Error("Invalid pairing code");
+        if (encoded.length !== 11 && encoded.length != 21) {
+            throw new Error("Invalid pairing code");
+        }
         if (new Verhoeff().computeChecksum(encoded.slice(0, -1)) !== parseInt(encoded.slice(-1))) {
             throw new Error("Invalid checksum");
         }

--- a/packages/matter.js/src/schema/PairingCodeSchema.ts
+++ b/packages/matter.js/src/schema/PairingCodeSchema.ts
@@ -64,15 +64,18 @@ class QrPairingCodeSchema extends Schema<QrCodeData, string> {
 export const QrPairingCodeCodec = new QrPairingCodeSchema();
 
 export type ManualPairingData = {
-    discriminator: number,
+    discriminator?: number,
+    shortDiscriminator?: number,
     passcode: number,
     vendorId?: number,
     productId?: number,
 };
 
-/** See {@link MatterCoreSpecificationV1_0} § 5.1.4.1 Table 39/40 */
+/** See {@link MatterCoreSpecificationV1_0} § 5.1.4.1 Table 38/39/40 */
 class ManualPairingCodeSchema extends Schema<ManualPairingData, string> {
     protected encodeInternal({ discriminator, passcode, vendorId, productId }: ManualPairingData): string {
+        if (discriminator === undefined) throw new Error("discriminator is required");
+        if (discriminator > 4095) throw new Error("discriminator value must be less than 4096");
         let result = "";
         const hasVendorProductIds = (vendorId !== undefined) && (productId !== undefined);
         result += ((discriminator >> 10) | (hasVendorProductIds ? (1 << 2) : 0));
@@ -87,21 +90,20 @@ class ManualPairingCodeSchema extends Schema<ManualPairingData, string> {
     }
 
     protected decodeInternal(encoded: string): ManualPairingData {
-        if (encoded.length < 10) throw new Error("Invalid pairing code");
-        const verhoeff = new Verhoeff();
-        if (verhoeff.computeChecksum(encoded.slice(0, -1)) !== parseInt(encoded.slice(-1))) {
+        if (encoded.length !== 11 && encoded.length != 21) throw new Error("Invalid pairing code");
+        if (new Verhoeff().computeChecksum(encoded.slice(0, -1)) !== parseInt(encoded.slice(-1))) {
             throw new Error("Invalid checksum");
         }
         const hasVendorProductIds = !!(parseInt(encoded[0]) & (1 << 2));
-        const discriminator = (parseInt(encoded[0]) & ~(1 << 2)) << 10 | (parseInt(encoded.slice(1, 6)) & 0x300) >> 6;
-        const passcode = (parseInt(encoded.slice(1, 6)) & 0x3FFF) | (parseInt(encoded.slice(6, 10)) << 14);
+        const shortDiscriminator = (parseInt(encoded[0]) & 0x03) << 2 | (parseInt(encoded.slice(1, 6)) >> 14) & 0x3
+        const passcode = parseInt(encoded.slice(1, 6)) & 0x3FFF | parseInt(encoded.slice(6, 10)) << 14;
         let vendorId: number | undefined;
         let productId: number | undefined;
         if (hasVendorProductIds) {
             vendorId = parseInt(encoded.slice(10, 15));
             productId = parseInt(encoded.slice(15, 20));
         }
-        return { discriminator, passcode, vendorId, productId };
+        return { shortDiscriminator, passcode, vendorId, productId };
     }
 }
 

--- a/packages/matter.js/test/schema/PairingCodeSchemaTest.ts
+++ b/packages/matter.js/test/schema/PairingCodeSchemaTest.ts
@@ -22,11 +22,37 @@ const QR_CODE_DATA: QrCodeData = {
     passcode: 34567890,
 };
 
-const MANUAL_PAIRING_CODE_DATA: ManualPairingData = {
-    discriminator: 2976,
-    passcode: 34567890,
-};
-const MANUAL_PAIRING_CODE = "26318621095";
+type MANUAL_PAIRING_DATA_CODE = {
+    data: ManualPairingData,
+    code: string
+}
+
+const MANUAL_PAIRING_DATA_CODES: Array<MANUAL_PAIRING_DATA_CODE> = [
+    {
+        data: {
+            discriminator: 2976,
+            shortDiscriminator: 11,
+            passcode: 34567890,
+        },
+        code: "26318621095"
+    },
+    {
+        data: {
+            discriminator: 10,
+            shortDiscriminator: 0,
+            passcode: 12345678,
+        },
+        code: "00852607537"
+    },
+    {
+        data: {
+            discriminator: 2001,
+            shortDiscriminator: 7,
+            passcode: 23456789,
+        },
+        code: "16043714310"
+    }
+];
 
 describe("QrPairingCodeCodec", () => {
     describe("encode", () => {
@@ -50,9 +76,20 @@ describe("QrPairingCodeCodec", () => {
 describe("ManualPairingCodeCodec", () => {
     describe("encode", () => {
         it("encodes the data", () => {
-            const result = ManualPairingCodeCodec.encode(MANUAL_PAIRING_CODE_DATA);
+            for (const pairingCode of MANUAL_PAIRING_DATA_CODES) {
+                const result = ManualPairingCodeCodec.encode(pairingCode.data);
 
-            assert.equal(result, MANUAL_PAIRING_CODE);
+                assert.equal(result, pairingCode.code);
+            }
+        });
+
+        it("decode the data", () => {
+            for (const dataCode of MANUAL_PAIRING_DATA_CODES) {
+                const result = ManualPairingCodeCodec.decode(dataCode.code);
+
+                assert.equal(result.shortDiscriminator, dataCode.data.shortDiscriminator);
+                assert.equal(result.passcode, dataCode.data.passcode);
+            }
         });
     });
 });


### PR DESCRIPTION
Implements the missing decode functionality for pairing codes and allows passing in a code to the `ControllerNode.ts` class.  Tested on a Philips Hue bridge, using the pairing code generated in their IOS app.   