### PR TITLE
Correct TCP advertisement because not supported

### DIFF
--- a/packages/matter.js/src/mdns/MdnsBroadcaster.ts
+++ b/packages/matter.js/src/mdns/MdnsBroadcaster.ts
@@ -67,7 +67,7 @@ export class MdnsBroadcaster implements Broadcaster {
                     `DN=${deviceName}`,             /* Device Name */
                     "SII=5000",                     /* Sleepy Idle Interval */
                     "SAI=300",                      /* Sleepy Active Interval */
-                    "T=1",                          /* TCP supported */
+                    "T=0",                          /* TCP not supported */
                     `D=${discriminator}`,           /* Discriminator */
                     `CM=${mode}`,                   /* Commission Mode */
                     "PH=33",                        /* Pairing Hint */


### PR DESCRIPTION
We do ot support TCP (and even when noone seems to use it at all), so we should also not advertise it.

PS: tested it with Apple afterwards ... no change in behavior