### PR TITLE
Standardize environmental logic

### DIFF
--- a/packages/matter-node.js/src/util/MatterEnvironment.ts
+++ b/packages/matter-node.js/src/util/MatterEnvironment.ts
@@ -1,0 +1,152 @@
+/**
+ * @license
+ * Copyright 2022-2023 Project CHIP Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { requireMinNodeVersion } from "./Node";
+requireMinNodeVersion(16);
+
+import { singleton } from "@project-chip/matter.js/util";
+import { Time } from "@project-chip/matter.js/time";
+import { TimeNode } from "../time/TimeNode";
+Time.get = singleton(() => new TimeNode());
+
+import { Network } from "@project-chip/matter.js/net";
+import { NetworkNode } from "../net/NetworkNode";
+Network.get = singleton(() => new NetworkNode());
+
+import { Crypto } from "@project-chip/matter.js/crypto";
+import { CryptoNode } from "../crypto/CryptoNode";
+Crypto.get = singleton(() => new CryptoNode());
+
+import { Logger, Format } from "@project-chip/matter.js/log";
+
+import { StorageManager } from "@project-chip/matter.js/storage";
+import { StorageBackendDisk } from "../storage";
+
+const logger = Logger.get("MatterEnvironment");
+let initialized = false;
+
+let shutdownOK: (value: any) => void;
+let shutdownError: (reason?: Error) => void;
+
+async function interrupt() {
+    await MatterEnvironment.shutdown();
+}
+
+function interruptHandler() {
+    interrupt().catch((reason) => {
+        console.error("Internal error handling interrupt:", reason);
+    });
+}
+
+/**
+ * Implements default configuration of matter.js and matter-node.js.
+ */
+export class MatterEnvironment {
+    static session: Promise<void>;
+
+    /**
+     * Initialize the matter environment.
+     * 
+     * @param name default the name of the application
+     */
+    static async startup(name: string) {
+        if (initialized) {
+            throw new Error("Environment is already started");
+        }
+
+        logger.info(`Startup of ${name}`);
+        await configureDefaultStorage(name);
+
+        this.session = new Promise((resolve, reject) => {
+            shutdownOK = resolve;
+            shutdownError = reject;
+        });
+
+        initialized = true;
+
+        process.on("SIGINT", interruptHandler);
+    }
+
+    /**
+     * Return matter environment to uninitialized state.
+     */
+    static async shutdown(reason?: any) {
+        if (!initialized) {
+            throw new Error("Environment is not started");
+        }
+
+        try {
+            await closeStorage();
+            process.off("SIGINT", interruptHandler);
+        } catch (e) {
+            logger.error(e);
+        }
+
+        initialized = false;
+        logger.info("Shutdown");
+
+        if (reason) {
+            shutdownError(reason);
+        } else {
+            shutdownOK(undefined);
+        }
+    }
+
+    /**
+     * Execute logic with automatic environment management.
+     */
+    static async run(name: string, fn: () => Promise<void>) {
+        await this.startup(name);
+
+        try {
+            await fn();
+        } catch (e) {
+            await this.shutdown(e);
+        }
+
+        await this.session;
+    }
+
+    /**
+     * Execute logic with automatic environment and process management.
+     */
+    static exec(name: string, fn: () => Promise<void>) {
+        this.run(name, fn).then(() => {
+            process.exit(0);
+        }).catch((reason) => {
+            logger.error(reason);
+            process.exit(1);
+        });
+    }
+}
+
+requireMinNodeVersion(16);
+
+// Make a best guess as to whether the environment supports ANSI escape codes
+if (process.stdout.isTTY || process.env.TERM_PROGRAM == "vscode" || process.env.VSCODE_INSPECTOR_OPTIONS) {
+    Logger.format = Format.ANSI;
+}
+
+let defaultStorageManager: StorageManager | undefined;
+
+async function configureDefaultStorage(name: string) {
+    if (defaultStorageManager) {
+        await closeStorage();
+    }
+
+    const backend = new StorageBackendDisk(name);
+    const manager = new StorageManager(backend);
+    await manager.initialize();
+
+    StorageManager.get = () => manager;
+}
+
+async function closeStorage() {
+    if (defaultStorageManager) {
+        await defaultStorageManager.close();
+        defaultStorageManager = undefined;
+    }
+}

--- a/packages/matter-node.js/src/util/index.ts
+++ b/packages/matter-node.js/src/util/index.ts
@@ -5,5 +5,6 @@
  */
 
 export * from "./CommandLine";
-export * from "./Node"
+export * from "./Node";
+export * from "./MatterEnvironment";
 export * from "@project-chip/matter.js/util";

--- a/packages/matter.js/src/MatterController.ts
+++ b/packages/matter.js/src/MatterController.ts
@@ -37,7 +37,7 @@ const ADMIN_VENDOR_ID = new VendorId(752);
 const logger = Logger.get("MatterController");
 
 export class MatterController {
-    public static async create(scanner: Scanner, netInterfaceIpv4: NetInterface, netInterfaceIpv6: NetInterface, storageManager: StorageManager) {
+    public static async create(scanner: Scanner, netInterfaceIpv4: NetInterface, netInterfaceIpv6: NetInterface, storageManager = StorageManager.get()) {
         const certificateManager = new RootCertificateManager(storageManager);
 
         const ipkValue = Crypto.getRandomData(16);
@@ -71,7 +71,7 @@ export class MatterController {
         private readonly netInterfaceIpv6: NetInterface,
         private readonly certificateManager: RootCertificateManager,
         private readonly fabric: Fabric,
-        private readonly storageManager: StorageManager
+        private readonly storageManager = StorageManager.get()
     ) {
         this.controllerStorage = this.storageManager.createContext("MatterController");
 

--- a/packages/matter.js/src/MatterDevice.ts
+++ b/packages/matter.js/src/MatterDevice.ts
@@ -46,7 +46,7 @@ export class MatterDevice {
         private readonly vendorId: VendorId,
         private readonly productId: number,
         private readonly discriminator: number,
-        private readonly storageManager: StorageManager,
+        private readonly storageManager = StorageManager.get(),
     ) {
         this.fabricManager = new FabricManager(this.storageManager);
 

--- a/packages/matter.js/src/certificate/RootCertificateManager.ts
+++ b/packages/matter.js/src/certificate/RootCertificateManager.ts
@@ -18,7 +18,7 @@ export class RootCertificateManager {
     private rootCertBytes = this.generateRootCert();
     private nextCertificateId = 1;
 
-    constructor(storageManager: StorageManager) {
+    constructor(storageManager = StorageManager.get()) {
         const storage = storageManager.createContext("RootCertificateManager");
 
         // Read from storage if we have them stored, else store the just generated data

--- a/packages/matter.js/src/fabric/FabricManager.ts
+++ b/packages/matter.js/src/fabric/FabricManager.ts
@@ -20,7 +20,7 @@ export class FabricManager {
     private fabricBuilder?: FabricBuilder;
     private readonly fabricStorage: StorageContext;
 
-    constructor(storageManager: StorageManager) {
+    constructor(storageManager = StorageManager.get()) {
         this.fabricStorage = storageManager.createContext("FabricManager");
         const fabrics = this.fabricStorage.get<FabricJsonObject[]>("fabrics", []);
         fabrics.forEach(fabric => this.addFabric(Fabric.createFromStorageObject(fabric)));

--- a/packages/matter.js/src/mdns/MdnsBroadcaster.ts
+++ b/packages/matter.js/src/mdns/MdnsBroadcaster.ts
@@ -30,7 +30,13 @@ export class MdnsBroadcaster implements Broadcaster {
     ) { }
 
     setCommissionMode(mode: number, deviceName: string, deviceType: number, vendorId: VendorId, productId: number, discriminator: number) {
-        logger.debug(`announce commissioning mode ${mode} ${deviceName} ${deviceType} ${vendorId} ${productId} ${discriminator}`);
+        logger.debug("Announce commissioning", Logger.dict({
+            mode: mode,
+            device: `${deviceName} (type ${deviceType})`,
+            vendor: vendorId.id,
+            product: productId,
+            discriminator: discriminator
+        }));
 
         const shortDiscriminator = (discriminator >> 8) & 0x0F;
         const instanceId = Crypto.getRandomData(8).toHex().toUpperCase();

--- a/packages/matter.js/src/protocol/interaction/InteractionServer.ts
+++ b/packages/matter.js/src/protocol/interaction/InteractionServer.ts
@@ -158,7 +158,7 @@ export class InteractionServer implements ProtocolHandler<MatterDevice> {
     private nextSubscriptionId = Crypto.getRandomUInt32();
 
     constructor(
-        private readonly storageManager: StorageManager
+        private readonly storageManager = StorageManager.get()
     ) { }
 
     getId() {

--- a/packages/matter.js/src/session/SessionManager.ts
+++ b/packages/matter.js/src/session/SessionManager.ts
@@ -42,7 +42,7 @@ export class SessionManager<ContextT> {
 
     constructor(
         private readonly context: ContextT,
-        storageManager: StorageManager,
+        storageManager = StorageManager.get(),
     ) {
         this.sessionStorage = storageManager.createContext("SessionManager")
         this.unsecureSession = new UnsecureSession(context);

--- a/packages/matter.js/src/storage/StorageManager.ts
+++ b/packages/matter.js/src/storage/StorageManager.ts
@@ -8,6 +8,8 @@ import { StorageContext } from "./StorageContext.js";
 import { Storage } from "./Storage.js";
 
 export class StorageManager {
+    static get: () => StorageManager = () => { throw new Error("No provider configured"); };
+
     private initialized = false;
 
     constructor(


### PR DESCRIPTION
This is a proposal relating to the conversation from #129.  Goals:

- Streamline usage of the public API
- Create a central place for recommended initialization logic
- Do not limit flexibility (library users can still initialize themselves if they want)

Note that I implemented a new `StorageManager.get()` but StorageManager isn't a singleton.  The `get()` instance just allows for  default argument to the classes that utilize StorageManager.

I have a more ambitious branch that standardizes configuration but probably that's best to left to a separate conversation/PR.