### PR TITLE
Refactor Endpoint/Fabric aware Attributes with Getter functions

### DIFF
--- a/packages/matter-node.js/test/cluster/ScenesServerTest.ts
+++ b/packages/matter-node.js/test/cluster/ScenesServerTest.ts
@@ -54,8 +54,7 @@ describe("Scenes Server test", () => {
         testSession = await createTestSessionWithFabric();
         testFabric = testSession.getFabric();
 
-        endpoint = new Endpoint([DeviceTypes.ON_OFF_LIGHT], [groupsServer, /*scenesServer,*/ onOffServer], 1);
-        endpoint.addClusterServer(scenesServer);
+        endpoint = new Endpoint([DeviceTypes.ON_OFF_LIGHT], [groupsServer, scenesServer, onOffServer], 1);
     }
 
     describe("Basic scenes logic", () => {
@@ -89,7 +88,7 @@ describe("Scenes Server test", () => {
             assert.ok(scenesData);
             assert.deepEqual(scenesData, new Map([["1", new Map([[1, new Map([[1, { "extensionFieldSets": [{ "attributeValueList": [{ "attributeId": { "id": 0 }, "attributeValue": [{ "tag": undefined, "typeLength": { "type": 8, "value": true }, "value": undefined }] }], "clusterId": { "id": 6 } }], "sceneId": 1, "sceneName": "Scene 1", "sceneTransitionTime": 10, "scenesGroupId": 1, "transitionTime100ms": 0 }]])]])]]));
 
-            assert.equal(scenesServer!.attributes.sceneCount.get(testSession, endpoint), 1);
+            assert.equal(scenesServer!.attributes.sceneCount.get(testSession), 1);
         });
 
         it("add another scene on group 1 and verify storage", async () => {
@@ -114,7 +113,7 @@ describe("Scenes Server test", () => {
             const scenesData = persistedData.scopedClusterData.get(ScenesCluster.id);
             assert.ok(scenesData);
             assert.deepEqual(scenesData, new Map([["1", new Map([[1, new Map([[1, { "extensionFieldSets": [{ "attributeValueList": [{ "attributeId": { "id": 0 }, "attributeValue": [{ "tag": undefined, "typeLength": { "type": 8, "value": true }, "value": undefined }] }], "clusterId": { "id": 6 } }], "sceneId": 1, "sceneName": "Scene 1", "sceneTransitionTime": 10, "scenesGroupId": 1, "transitionTime100ms": 0 }], [2, { "extensionFieldSets": [{ "attributeValueList": [{ "attributeId": { "id": 0 }, "attributeValue": [{ "tag": undefined, "typeLength": { "type": 8, "value": false }, "value": undefined }] }], "clusterId": { "id": 6 } }], "sceneId": 2, "sceneName": "Scene 2", "sceneTransitionTime": 10, "scenesGroupId": 1, "transitionTime100ms": 0 }]])]])]]));
-            assert.equal(scenesServer!.attributes.sceneCount.get(testSession, endpoint), 2);
+            assert.equal(scenesServer!.attributes.sceneCount.get(testSession), 2);
         });
 
         it("add another new group and scene and verify storage", async () => {
@@ -142,7 +141,7 @@ describe("Scenes Server test", () => {
             const scenesData = persistedData.scopedClusterData.get(ScenesCluster.id);
             assert.ok(scenesData);
             assert.deepEqual(scenesData, new Map([["1", new Map([[1, new Map([[1, { "extensionFieldSets": [{ "attributeValueList": [{ "attributeId": { "id": 0 }, "attributeValue": [{ "tag": undefined, "typeLength": { "type": 8, "value": true }, "value": undefined }] }], "clusterId": { "id": 6 } }], "sceneId": 1, "sceneName": "Scene 1", "sceneTransitionTime": 10, "scenesGroupId": 1, "transitionTime100ms": 0 }], [2, { "extensionFieldSets": [{ "attributeValueList": [{ "attributeId": { "id": 0 }, "attributeValue": [{ "tag": undefined, "typeLength": { "type": 8, "value": false }, "value": undefined }] }], "clusterId": { "id": 6 } }], "sceneId": 2, "sceneName": "Scene 2", "sceneTransitionTime": 10, "scenesGroupId": 1, "transitionTime100ms": 0 }]])], [2, new Map([[3, { "extensionFieldSets": [{ "attributeValueList": [{ "attributeId": { "id": 0 }, "attributeValue": [{ "tag": undefined, "typeLength": { "type": 8, "value": true }, "value": undefined }] }], "clusterId": { "id": 6 } }], "sceneId": 3, "sceneName": "Scene 3", "sceneTransitionTime": 10, "scenesGroupId": 2, "transitionTime100ms": 0 }]])]])]]));
-            assert.equal(scenesServer!.attributes.sceneCount.get(testSession, endpoint), 3);
+            assert.equal(scenesServer!.attributes.sceneCount.get(testSession), 3);
         });
 
         it("get scene data", async () => {
@@ -171,7 +170,7 @@ describe("Scenes Server test", () => {
             const scenesData = persistedData.scopedClusterData.get(ScenesCluster.id);
             assert.ok(scenesData);
             assert.deepEqual(scenesData, new Map([["1", new Map([[1, new Map([[1, { "extensionFieldSets": [{ "attributeValueList": [{ "attributeId": { "id": 0 }, "attributeValue": [{ "tag": undefined, "typeLength": { "type": 8, "value": true }, "value": undefined }] }], "clusterId": { "id": 6 } }], "sceneId": 1, "sceneName": "Scene 1", "sceneTransitionTime": 10, "scenesGroupId": 1, "transitionTime100ms": 0 }]])], [2, new Map([[3, { "extensionFieldSets": [{ "attributeValueList": [{ "attributeId": { "id": 0 }, "attributeValue": [{ "tag": undefined, "typeLength": { "type": 8, "value": true }, "value": undefined }] }], "clusterId": { "id": 6 } }], "sceneId": 3, "sceneName": "Scene 3", "sceneTransitionTime": 10, "scenesGroupId": 2, "transitionTime100ms": 0 }]])]])]]));
-            assert.equal(scenesServer!.attributes.sceneCount.get(testSession, endpoint), 2);
+            assert.equal(scenesServer!.attributes.sceneCount.get(testSession), 2);
         });
 
         it("delete all scenes on one group and verify storage", async () => {
@@ -188,7 +187,7 @@ describe("Scenes Server test", () => {
             const scenesData = persistedData.scopedClusterData.get(ScenesCluster.id);
             assert.ok(scenesData);
             assert.deepEqual(scenesData, new Map([["1", new Map([[2, new Map([[3, { "extensionFieldSets": [{ "attributeValueList": [{ "attributeId": { "id": 0 }, "attributeValue": [{ "tag": undefined, "typeLength": { "type": 8, "value": true }, "value": undefined }] }], "clusterId": { "id": 6 } }], "sceneId": 3, "sceneName": "Scene 3", "sceneTransitionTime": 10, "scenesGroupId": 2, "transitionTime100ms": 0 }]])]])]]));
-            assert.equal(scenesServer!.attributes.sceneCount.get(testSession, endpoint), 1);
+            assert.equal(scenesServer!.attributes.sceneCount.get(testSession), 1);
         });
 
         it("delete one group and verify storage", async () => {
@@ -205,7 +204,7 @@ describe("Scenes Server test", () => {
             const scenesData = persistedData.scopedClusterData.get(ScenesCluster.id);
             assert.ok(scenesData);
             assert.deepEqual(scenesData, new Map([["1", new Map([])]]));
-            assert.equal(scenesServer!.attributes.sceneCount.get(testSession, endpoint), 0);
+            assert.equal(scenesServer!.attributes.sceneCount.get(testSession), 0);
         });
     });
 
@@ -315,7 +314,7 @@ describe("Scenes Server test", () => {
             assert.ok(scenesData);
             assert.deepEqual(scenesData, new Map([["1", new Map([[1, new Map([[1, { "extensionFieldSets": [{ "attributeValueList": [{ "attributeId": { "id": 0 }, "attributeValue": [{ "tag": undefined, "typeLength": { "type": 8, "value": true } }] }], "clusterId": { "id": 6 } }], "sceneId": 1, "sceneName": "", "sceneTransitionTime": 0, "scenesGroupId": 1, "transitionTime100ms": 0 }]])]])]]));
 
-            assert.equal(scenesServer?.attributes.sceneValid.get(testSession, endpoint), true);
+            assert.equal(scenesServer?.attributes.sceneValid.get(testSession), true);
             assert.equal(scenesServer?.attributes.currentScene.get(), 1);
             assert.deepEqual(scenesServer?.attributes.currentGroup.get(), new GroupId(1));
         });
@@ -413,7 +412,7 @@ describe("Scenes Server test", () => {
             assert.deepEqual(scenesServer?.attributes.currentGroup.get(), new GroupId(1));
             assert.equal(scenesServer?.attributes.currentScene.get(), 1);
 
-            assert.equal(scenesServer?.attributes.sceneValid.get(testSession, endpoint), false);
+            assert.equal(scenesServer?.attributes.sceneValid.get(testSession), false);
 
             const result = await callCommandOnClusterServer(scenesServer!, "recallScene", {
                 groupId: new GroupId(3),
@@ -424,7 +423,7 @@ describe("Scenes Server test", () => {
             assert.equal(onOffServer?.attributes.onOff.get(), true);
             assert.deepEqual(scenesServer?.attributes.currentGroup.get(), new GroupId(3));
             assert.equal(scenesServer?.attributes.currentScene.get(), 2);
-            assert.equal(scenesServer?.attributes.sceneValid.get(testSession, endpoint), true);
+            assert.equal(scenesServer?.attributes.sceneValid.get(testSession), true);
         });
 
         it("delete all groups and verify storage", async () => {

--- a/packages/matter.js/src/cluster/server/AttributeServer.ts
+++ b/packages/matter.js/src/cluster/server/AttributeServer.ts
@@ -15,6 +15,7 @@ export class AttributeServer<T> {
     private version = 0;
     private readonly matterListeners = new Array<(value: T, version: number) => void>();
     private readonly listeners = new Array<(newValue: T, oldValue: T) => void>();
+    protected endpoint?: Endpoint;
 
     constructor(
         readonly id: number,
@@ -26,6 +27,10 @@ export class AttributeServer<T> {
     ) {
         validator(defaultValue, name);
         this.value = defaultValue;
+    }
+
+    assignToEndpoint(endpoint: Endpoint) {
+        this.endpoint = endpoint;
     }
 
     set(value: T, _session?: Session<MatterDevice>) {
@@ -52,14 +57,14 @@ export class AttributeServer<T> {
         this.value = value;
     }
 
-    get(_session?: Session<MatterDevice>, _endpoint?: Endpoint): T {
+    get(_session?: Session<MatterDevice>): T {
         // TODO: check ACL
 
         return this.getLocal();
     }
 
-    getWithVersion(session?: Session<MatterDevice>, endpoint?: Endpoint) {
-        return { version: this.version, value: this.get(session, endpoint) };
+    getWithVersion(session?: Session<MatterDevice>) {
+        return { version: this.version, value: this.get(session) };
     }
 
     getLocal(): T {
@@ -105,9 +110,9 @@ export class AttributeGetterServer<T> extends AttributeServer<T> {
         throw new Error("Setter is not supported on attribute defined by a getter");
     }
 
-    override get(session?: SecureSession<MatterDevice>, endpoint?: Endpoint): T {
+    override get(session?: SecureSession<MatterDevice>): T {
         // TODO: check ACL
         // TODO handle "version" for getter
-        return this.getter(session, endpoint);
+        return this.getter(session, this.endpoint);
     }
 }

--- a/packages/matter.js/src/cluster/server/ClusterServer.ts
+++ b/packages/matter.js/src/cluster/server/ClusterServer.ts
@@ -96,7 +96,15 @@ export type ClusterServerObj<A extends Attributes, C extends Commands> =
         _commands: CommandServers<C>;
 
         /**
-         * Set Storage context sed by this cluster
+         * Assign this cluster to a specific endpoint
+         * @private
+         *
+         * @param endpoint Endpoint to assign to
+         */
+        _assignToEndpoint: (endpoint: Endpoint) => void;
+
+        /**
+         * Set Storage context used by this cluster
          * @private
          */
         _setStorage: (storageContext: StorageContext) => void;

--- a/packages/matter.js/src/device/Endpoint.ts
+++ b/packages/matter.js/src/device/Endpoint.ts
@@ -98,6 +98,7 @@ export class Endpoint {
     }
 
     addClusterServer<A extends Attributes, C extends Commands>(cluster: ClusterServerObj<A, C>) {
+        cluster._assignToEndpoint(this);
         if (cluster.id === DescriptorCluster.id) {
             this.descriptorCluster = cluster as unknown as ClusterServerObj<typeof DescriptorCluster.attributes, typeof DescriptorCluster.commands>;
         }

--- a/packages/matter.js/src/fabric/Fabric.ts
+++ b/packages/matter.js/src/fabric/Fabric.ts
@@ -63,7 +63,6 @@ export class Fabric {
         readonly operationalCert: ByteArray,
         public label: string,
         scopedClusterData?: Map<number, Map<string, SupportedStorageTypes>>
-
     ) {
         this.scopedClusterData = scopedClusterData ?? new Map<number, Map<string, SupportedStorageTypes>>();
     }


### PR DESCRIPTION
This PR fixes an issue where an error happend when trying to subscribe to an attribute that uses a getter function and is Fabric-and-Endpoint aware.