### PR TITLE
Improve Command Invoke Logging

### DIFF
--- a/packages/matter.js/src/protocol/interaction/InteractionServer.ts
+++ b/packages/matter.js/src/protocol/interaction/InteractionServer.ts
@@ -13,7 +13,7 @@ import {
 } from "./InteractionMessenger.js";
 import { Attributes, Cluster, Commands, Events, TlvNoResponse } from "../../cluster/Cluster.js";
 import {
-    StatusCode, TlvAttributePath, TlvAttributeReport, TlvInvokeResponseData, TlvSubscribeResponse
+    StatusCode, TlvAttributePath, TlvAttributeReport, TlvCommandPath, TlvInvokeResponseData, TlvSubscribeResponse
 } from "./InteractionProtocol.js"
 import { BitSchema, TypeFromBitSchema } from "../../schema/BitmapSchema.js";
 import { TypeFromSchema } from "../../tlv/TlvSchema.js";
@@ -451,7 +451,7 @@ export class InteractionServer implements ProtocolHandler<MatterDevice> {
     }
 
     async handleInvokeRequest(exchange: MessageExchange<MatterDevice>, { invokeRequests }: InvokeRequest, message: Message): Promise<InvokeResponse> {
-        logger.debug(`Received invoke request from ${exchange.channel.getName()}: ${invokeRequests.map(({ commandPath: { endpointId, clusterId, commandId } }) => `${toHex(endpointId)}/${toHex(clusterId)}/${toHex(commandId)}`).join(", ")}`);
+        logger.debug(`Received invoke request from ${exchange.channel.getName()}: ${invokeRequests.map(({ commandPath: { endpointId, clusterId, commandId } }) => this.resolveCommandName({ endpointId, clusterId, commandId})).join(", ")}`);
 
         const invokeResponses: TypeFromSchema<typeof TlvInvokeResponseData>[] = [];
 
@@ -530,6 +530,33 @@ export class InteractionServer implements ProtocolHandler<MatterDevice> {
         }
         const attribute = this.attributes.get(attributePathToId({ endpointId, clusterId, attributeId }));
         const attributeName = `${attribute?.name ?? "unknown"}(${toHex(attributeId)})`;
+        return `${endpointName}/${clusterName}/${attributeName}`;
+    }
+
+    private resolveCommandName({ endpointId, clusterId, commandId }: TypeFromSchema<typeof TlvCommandPath>) {
+        if (endpointId === undefined) {
+            return `*/${toHex(clusterId)}/${toHex(commandId)}`;
+        }
+        const endpoint = this.endpoints.get(endpointId);
+        if (endpoint === undefined) {
+            return `unknown(${toHex(endpointId)})/${toHex(clusterId)}/${toHex(commandId)}`;
+        }
+        const endpointName = `${endpoint.name}(${toHex(endpointId)})`;
+
+        if (clusterId === undefined) {
+            return `${endpointName}/*/${toHex(commandId)}`;
+        }
+        const cluster = endpoint.getClusterServerById(clusterId);
+        if (cluster === undefined) {
+            return `${endpointName}/unknown(${toHex(clusterId)})/${toHex(commandId)}`;
+        }
+        const clusterName = `${cluster.name}(${toHex(clusterId)})`;
+
+        if (commandId === undefined) {
+            return `${endpointName}/${clusterName}/*`;
+        }
+        const command = this.commands.get(commandPathToId({ endpointId, clusterId, commandId }));
+        const attributeName = `${command?.name ?? "unknown"}(${toHex(commandId)})`;
         return `${endpointName}/${clusterName}/${attributeName}`;
     }
 


### PR DESCRIPTION
This PR improves logging of command invokes to more easy see whcih cluster and whcih endpoint.

Logging will be now

> ... InteractionProtocol Received invoke request from udp://192.168.200.2:5540 on session secure/4464: MA-rootdevice(0x0)/OperationalCredentials(0x3e)/removeFabric(0xa)

instead of just

> ... InteractionProtocol Received invoke request from udp://192.168.200.2:5540 on session secure/4464: 0x0/0x3e/0xa

