### PR TITLE
Cluster API enhancements

### DIFF
--- a/packages/matter-node.js/test/cluster/GroupsServerTest.ts
+++ b/packages/matter-node.js/test/cluster/GroupsServerTest.ts
@@ -20,7 +20,7 @@ import { ClusterServer, StatusCode } from "@project-chip/matter.js/interaction";
 import { SecureSession } from "@project-chip/matter.js/session";
 import { Fabric, FabricJsonObject } from "@project-chip/matter.js/fabric";
 import {
-    ClusterServerObj, GroupsCluster, GroupsClusterHandler, IdentifyCluster, ClusterServerHandlers, IdentifyType
+    ClusterServerObj, GroupsCluster, IdentifyCluster, ClusterServerHandlers, IdentifyType, ClusterServerFactory
 } from "@project-chip/matter.js/cluster";
 import { GroupId } from "@project-chip/matter.js/datatype";
 import { getPromiseResolver } from "@project-chip/matter.js/util";
@@ -37,7 +37,7 @@ describe("Groups Server test", () => {
 
     // TODO make that nicer and maybe  move to a "testing support library"
     async function initializeTestEnv() {
-        groupsServer = ClusterServer(GroupsCluster, { nameSupport: { groupNames: true } }, GroupsClusterHandler());
+        groupsServer = ClusterServerFactory.create(GroupsCluster);
         const identifyServer = ClusterServer(
             IdentifyCluster,
             {

--- a/packages/matter-node.js/test/cluster/ScenesServerTest.ts
+++ b/packages/matter-node.js/test/cluster/ScenesServerTest.ts
@@ -16,13 +16,10 @@ import { Time, TimeFake } from "@project-chip/matter.js/time";
 Time.get = () => new TimeFake(0);
 
 import * as assert from "assert";
-import { ClusterServer, StatusCode } from "@project-chip/matter.js/interaction";
+import { StatusCode } from "@project-chip/matter.js/interaction";
 import { SecureSession } from "@project-chip/matter.js/session";
 import { Fabric, FabricJsonObject } from "@project-chip/matter.js/fabric";
-import {
-    GroupsCluster, GroupsClusterHandler, ScenesCluster, ScenesClusterHandler, OnOffCluster, OnOffClusterHandler,
-    ClusterServerObj
-} from "@project-chip/matter.js/cluster";
+import { GroupsCluster, ScenesCluster, OnOffCluster, ClusterServerObj, ClusterServerFactory } from "@project-chip/matter.js/cluster";
 import { GroupId, AttributeId, ClusterId } from "@project-chip/matter.js/datatype";
 import { getPromiseResolver } from "@project-chip/matter.js/util";
 import { SessionType, Message } from "@project-chip/matter.js/codec";
@@ -40,16 +37,16 @@ describe("Scenes Server test", () => {
 
     // TODO make that nicer and maybe  move to a "testing support library"
     async function initializeTestEnv() {
-        groupsServer = ClusterServer(GroupsCluster, { nameSupport: { groupNames: true } }, GroupsClusterHandler());
-        scenesServer = ClusterServer(ScenesCluster, {
+        groupsServer = ClusterServerFactory.create(GroupsCluster, { nameSupport: { groupNames: true } });
+        scenesServer = ClusterServerFactory.create(ScenesCluster, {
             sceneCount: 0,
             currentScene: 0,
             currentGroup: new GroupId(0),
             sceneValid: false,
             nameSupport: { sceneNames: true },
             lastConfiguredBy: null
-        }, ScenesClusterHandler());
-        onOffServer = ClusterServer(OnOffCluster, { onOff: true }, OnOffClusterHandler());
+        });
+        onOffServer = ClusterServerFactory.create(OnOffCluster, { onOff: true });
         testSession = await createTestSessionWithFabric();
         testFabric = testSession.getFabric();
 

--- a/packages/matter.js/src/CommissioningController.ts
+++ b/packages/matter.js/src/CommissioningController.ts
@@ -23,7 +23,7 @@ import { Aggregator } from "./device/Aggregator.js";
 import { PairedDevice } from "./device/Device.js";
 import { ComposedDevice } from "./device/ComposedDevice.js";
 import { DescriptorCluster } from "./cluster/DescriptorCluster.js";
-import { AllClustersMap } from "./cluster/ClusterHelper.js";
+import { getClusterById } from "./cluster/ClusterHelper.js";
 import { ClusterClientObj, isClusterClient } from "./cluster/client/ClusterClient.js";
 import { BitSchema, TypeFromBitSchema } from "./schema/BitmapSchema.js";
 import { Attributes, Cluster, Commands, Events } from "./cluster/Cluster.js";
@@ -288,7 +288,7 @@ export class CommissioningController extends MatterNode {
 
         // Add ClusterClients for all server clusters of the device
         for (const clusterId of descriptorData.serverList) {
-            const cluster = AllClustersMap[clusterId.id];
+            const cluster = getClusterById(clusterId.id);
             if (cluster === undefined) {
                 logger.info(`Cluster with id ${clusterId} not known, ignore`);
                 continue;
@@ -300,7 +300,7 @@ export class CommissioningController extends MatterNode {
         // TODO use the attributes attributeList, acceptedCommands, generatedCommands to crate the ClusterClient/Server objects
         // Add ClusterServers for all client clusters of the device
         for (const clusterId of descriptorData.clientList) {
-            const cluster = AllClustersMap[clusterId.id];
+            const cluster = getClusterById(clusterId.id);
             if (cluster === undefined) {
                 logger.info(`Cluster with id ${clusterId.id} not known, ignore`);
                 continue;

--- a/packages/matter.js/src/CommissioningController.ts
+++ b/packages/matter.js/src/CommissioningController.ts
@@ -23,10 +23,10 @@ import { Aggregator } from "./device/Aggregator.js";
 import { PairedDevice } from "./device/Device.js";
 import { ComposedDevice } from "./device/ComposedDevice.js";
 import { DescriptorCluster } from "./cluster/DescriptorCluster.js";
-import { getClusterById } from "./cluster/ClusterHelper.js";
 import { ClusterClientObj, isClusterClient } from "./cluster/client/ClusterClient.js";
 import { BitSchema, TypeFromBitSchema } from "./schema/BitmapSchema.js";
 import { Attributes, Cluster, Commands, Events } from "./cluster/Cluster.js";
+import { ClusterFactory } from "./cluster/ClusterFactory.js";
 
 const logger = new Logger("CommissioningController");
 
@@ -288,7 +288,7 @@ export class CommissioningController extends MatterNode {
 
         // Add ClusterClients for all server clusters of the device
         for (const clusterId of descriptorData.serverList) {
-            const cluster = getClusterById(clusterId.id);
+            const cluster = ClusterFactory.get(clusterId.id);
             if (cluster === undefined) {
                 logger.info(`Cluster with id ${clusterId} not known, ignore`);
                 continue;
@@ -300,7 +300,7 @@ export class CommissioningController extends MatterNode {
         // TODO use the attributes attributeList, acceptedCommands, generatedCommands to crate the ClusterClient/Server objects
         // Add ClusterServers for all client clusters of the device
         for (const clusterId of descriptorData.clientList) {
-            const cluster = getClusterById(clusterId.id);
+            const cluster = ClusterFactory.get(clusterId.id);
             if (cluster === undefined) {
                 logger.info(`Cluster with id ${clusterId.id} not known, ignore`);
                 continue;

--- a/packages/matter.js/src/cluster/ClusterFactory.ts
+++ b/packages/matter.js/src/cluster/ClusterFactory.ts
@@ -1,0 +1,34 @@
+import { MatterError } from "../common/MatterError.js";
+import { Cluster } from "./Cluster.js";
+import { ClusterIdentifier } from "./ClusterIdentifier.js";
+import { BitSchema, BitmapSchema } from "../schema/BitmapSchema.js"
+
+// Ensure all clusters are registered before access
+import "./cluster.js";
+
+export class ClusterFactory {
+    private static clusterVariants = new Map<
+        ClusterIdentifier,
+        {
+            featureSchema: ReturnType<typeof BitmapSchema>,
+            clusters: Map<number, Cluster<any, any, any, any, any>>
+        }
+    >();
+
+    static get(clusterId: ClusterIdentifier, features?: BitSchema) {
+        const variants = this.clusterVariants.get(clusterId);
+
+        if (!variants) {
+            throw new MatterError(`No definition for cluster 0x${clusterId.toString(16).padStart(4, "0")}`);
+        }
+
+        if (features) {
+            const cluster = variants.clusters.get(variants.featureSchema.encode(features));
+            if (cluster) {
+                return cluster;
+            }
+        }
+
+        return variants.clusters.values().next().value;
+    }
+}

--- a/packages/matter.js/src/cluster/ClusterHelper.ts
+++ b/packages/matter.js/src/cluster/ClusterHelper.ts
@@ -3,67 +3,10 @@
  * Copyright 2022 The node-matter Authors
  * SPDX-License-Identifier: Apache-2.0
  */
-import { Attribute, Cluster } from "./Cluster.js";
-import { AccessControlCluster } from "./AccessControlCluster.js";
-import { ActionsCluster } from "./ActionsCluster.js";
-import { AdminCommissioningCluster } from "./AdminCommissioningCluster.js";
-import { BasicInformationCluster } from "./BasicInformationCluster.js";
-import { BindingCluster } from "./BindingCluster.js";
-import { BooleanStateCluster } from "./BooleanStateCluster.js";
-import { BridgedDeviceBasicInformationCluster } from "./BridgedDeviceBasicInformationCluster.js";
-import { DescriptorCluster } from "./DescriptorCluster.js";
-import { FlowMeasurementCluster } from "./FlowMeasurementCluster.js";
-import { GeneralCommissioningCluster } from "./GeneralCommissioningCluster.js";
-import { GroupsCluster } from "./GroupsCluster.js";
-import { IdentifyCluster } from "./IdentifyCluster.js";
-import { IlluminanceMeasurementCluster } from "./IlluminanceMeasurementCluster.js";
-import { UserLabelCluster, FixedLabelCluster } from "./LabelCluster.js";
-import { LevelControlCluster } from "./LevelControlCluster.js";
-import { WifiAndEthernetAndThreadNetworkCommissioningCluster } from "./NetworkCommissioningCluster.js";
-import { OccupancySensingCluster } from "./OccupancySensingCluster.js";
-import { OnOffCluster } from "./OnOffCluster.js";
-import { OperationalCredentialsCluster } from "./OperationalCredentialsCluster.js";
-import { PowerSourceCluster } from "./PowerSourceCluster.js";
-import { PowerSourceConfigurationCluster } from "./PowerSourceConfigurationCluster.js";
-import { PressureMeasurementCluster } from "./PressureMeasurementCluster.js";
-import { ScenesCluster } from "./ScenesCluster.js";
-import { TemperatureMeasurementCluster } from "./TemperatureMeasurementCluster.js";
-import { RelativeHumidityCluster, SoilMoistureMeasurementCluster, LeafWetnessMeasurementCluster } from "./WaterContentMeasurementCluster.js";
-import { GeneralDiagnosticsCluster } from "./GeneralDiagnosticsCluster.js";
-import { GroupKeyManagementCluster } from "./GroupKeyManagementCluster.js";
+import { Attribute, Cluster, BaseClustersMap } from "./Cluster.js";
 
-export const AllClustersMap: { [key: Cluster<any, any, any, any, any>["id"]]: Cluster<any, any, any, any, any> } = {
-    [AccessControlCluster.id]: AccessControlCluster,
-    [ActionsCluster.id]: ActionsCluster,
-    [AdminCommissioningCluster.id]: AdminCommissioningCluster,
-    [BasicInformationCluster.id]: BasicInformationCluster,
-    [BindingCluster.id]: BindingCluster,
-    [BooleanStateCluster.id]: BooleanStateCluster,
-    [BridgedDeviceBasicInformationCluster.id]: BridgedDeviceBasicInformationCluster,
-    [DescriptorCluster.id]: DescriptorCluster,
-    [FlowMeasurementCluster.id]: FlowMeasurementCluster,
-    [GeneralCommissioningCluster.id]: GeneralCommissioningCluster,
-    [GeneralDiagnosticsCluster.id]: GeneralDiagnosticsCluster,
-    [GroupKeyManagementCluster.id]: GroupKeyManagementCluster,
-    [GroupsCluster.id]: GroupsCluster,
-    [IdentifyCluster.id]: IdentifyCluster,
-    [IlluminanceMeasurementCluster.id]: IlluminanceMeasurementCluster,
-    [UserLabelCluster.id]: UserLabelCluster,
-    [FixedLabelCluster.id]: FixedLabelCluster,
-    [LevelControlCluster.id]: LevelControlCluster,
-    [WifiAndEthernetAndThreadNetworkCommissioningCluster.id]: WifiAndEthernetAndThreadNetworkCommissioningCluster,
-    [OccupancySensingCluster.id]: OccupancySensingCluster,
-    [OnOffCluster.id]: OnOffCluster,
-    [OperationalCredentialsCluster.id]: OperationalCredentialsCluster,
-    [PowerSourceCluster.id]: PowerSourceCluster,
-    [PowerSourceConfigurationCluster.id]: PowerSourceConfigurationCluster,
-    [PressureMeasurementCluster.id]: PressureMeasurementCluster,
-    [ScenesCluster.id]: ScenesCluster,
-    [TemperatureMeasurementCluster.id]: TemperatureMeasurementCluster,
-    [RelativeHumidityCluster.id]: RelativeHumidityCluster,
-    [LeafWetnessMeasurementCluster.id]: LeafWetnessMeasurementCluster,
-    [SoilMoistureMeasurementCluster.id]: SoilMoistureMeasurementCluster,
-};
+// Ensure all clusters are loaded so BaseClustersMap is fully populated
+import "./clusters.js";
 
 interface CachedAttributeInfo {
     attribute: Attribute<any>;
@@ -72,7 +15,7 @@ interface CachedAttributeInfo {
 const clusterAttributeCache = new Map<number, Map<number, CachedAttributeInfo>>();
 
 export function getClusterById(clusterId: number): Cluster<any, any, any, any, any> {
-    return AllClustersMap[clusterId];
+    return BaseClustersMap[clusterId];
 }
 
 export function getClusterAttributeById(clusterDef: Cluster<any, any, any, any, any>, attributeId: number): CachedAttributeInfo | undefined {

--- a/packages/matter.js/src/cluster/ClusterHelper.ts
+++ b/packages/matter.js/src/cluster/ClusterHelper.ts
@@ -3,7 +3,7 @@
  * Copyright 2022 The node-matter Authors
  * SPDX-License-Identifier: Apache-2.0
  */
-import { Attribute, Cluster, BaseClustersMap } from "./Cluster.js";
+import { Attribute, Cluster } from "./Cluster.js";
 
 // Ensure all clusters are loaded so BaseClustersMap is fully populated
 import "./clusters.js";
@@ -13,10 +13,6 @@ interface CachedAttributeInfo {
     name: string;
 }
 const clusterAttributeCache = new Map<number, Map<number, CachedAttributeInfo>>();
-
-export function getClusterById(clusterId: number): Cluster<any, any, any, any, any> {
-    return BaseClustersMap[clusterId];
-}
 
 export function getClusterAttributeById(clusterDef: Cluster<any, any, any, any, any>, attributeId: number): CachedAttributeInfo | undefined {
     if (!clusterAttributeCache.has(clusterDef.id)) {

--- a/packages/matter.js/src/cluster/ClusterIdentifier.ts
+++ b/packages/matter.js/src/cluster/ClusterIdentifier.ts
@@ -1,0 +1,17 @@
+/**
+ * @license
+ * Copyright 2022-2023 Project CHIP Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// There will be an enum here.  But should ClusterIdentifier be this enum?
+// During development of a new type of cluster you would not want to be
+// constrained by current IDs.
+
+// If we want to use "ClusterId" we should probably rename datatype/ClusterId.
+
+/**
+ * A numeric code from the Matter Application Cluster specification that
+ * uniquely identifies a cluster.
+ */
+export type ClusterIdentifier = number;

--- a/packages/matter.js/src/cluster/ClusterServerFactory.ts
+++ b/packages/matter.js/src/cluster/ClusterServerFactory.ts
@@ -1,0 +1,48 @@
+/**
+ * @license
+ * Copyright 2022-2023 Project CHIP Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ClusterServer } from "../protocol/interaction/index.js";
+import { BitSchema, TypeFromBitSchema } from "../schema/BitmapSchema.js";
+import { AttributeInitialValues, Attributes, Cluster, ClusterServerHandlers, Commands, Events } from "./index.js";
+
+type AnyCluster = Cluster<any, any, any, any, any>;
+
+function notImplemented() {
+    throw new Error("Not implemented");
+}
+
+export class ClusterServerFactory {
+    private static providers = new Map<AnyCluster, () => any>();
+
+    public static register<F extends BitSchema, SF extends TypeFromBitSchema<F>, A extends Attributes, C extends Commands, E extends Events>(cluster: Cluster<F, SF, A, C, E>, provider: () => ClusterServerHandlers<Cluster<F, SF, A, C, E>>) {
+        this.providers.set(cluster, provider);
+    }
+
+    public static create<F extends BitSchema, SF extends TypeFromBitSchema<F>, A extends Attributes, C extends Commands, E extends Events>(cluster: Cluster<F, SF, A, C, E>, attributeInitialValues?: AttributeInitialValues<A>, handlers?: ClusterServerHandlers<Cluster<F, SF, A, C, E>>) {
+        handlers = Object.assign({}, handlers);
+
+        const provider = this.providers.get(cluster);
+        if (provider) {
+            Object.assign(handlers, provider());
+        }
+
+        for (const command in cluster.commands) {
+            if (!(handlers as any)[command]) {
+                (handlers as any)[command] = notImplemented;
+            }
+        }
+
+        let attributes = {} as AttributeInitialValues<A>;
+        for (const attribute in cluster.attributes) {
+            if (cluster.attributes[attribute].default !== undefined) {
+                (attributes as any)[attribute] = cluster.attributes[attribute].default;
+            }
+        }
+        Object.assign(attributes, attributeInitialValues);
+
+        return ClusterServer(cluster, attributes, handlers);
+    }
+}

--- a/packages/matter.js/src/cluster/ClusterServerFactory.ts
+++ b/packages/matter.js/src/cluster/ClusterServerFactory.ts
@@ -6,25 +6,101 @@
 
 import { ClusterServer } from "../protocol/interaction/index.js";
 import { BitSchema, TypeFromBitSchema } from "../schema/BitmapSchema.js";
-import { AttributeInitialValues, Attributes, Cluster, ClusterServerHandlers, Commands, Events } from "./index.js";
+import { Attributes, Cluster, Commands, Events, GlobalAttributes, MandatoryLocalAttributeNames, OptionalAttributeNames } from "./Cluster.js";
+import { AttributeInitialValues, ClusterServerHandlers } from "./server/ClusterServer.js";
+import { UnsupportedCommandError } from "./server/CommandServer.js";
 
 type AnyCluster = Cluster<any, any, any, any, any>;
+const GLOBAL_ATTRIBUTES = new Set(Object.keys(GlobalAttributes({})));
 
-function notImplemented() {
-    throw new Error("Not implemented");
+export function notImplemented() {
+    // Command server will fail gracefully with the appropriate status code
+    // in response to this error
+    throw new UnsupportedCommandError();
 }
 
-export class ClusterServerFactory {
-    private static providers = new Map<AnyCluster, () => any>();
+function mandatoryLocalAttributeNames<A extends Attributes>(attributes: A) {
+    return Object.entries(attributes)
+        .filter(([_name, attr]) => !attr.optional)
+        .filter(([name]) => !GLOBAL_ATTRIBUTES.has(name))
+        .map(([name]) => name as MandatoryLocalAttributeNames<A>);
+}
 
-    public static register<F extends BitSchema, SF extends TypeFromBitSchema<F>, A extends Attributes, C extends Commands, E extends Events>(cluster: Cluster<F, SF, A, C, E>, provider: () => ClusterServerHandlers<Cluster<F, SF, A, C, E>>) {
-        this.providers.set(cluster, provider);
+function optionalAttributeNames<A extends Attributes>(attributes: A) {
+    return Object.entries(attributes)
+        .filter(([_name, attr]) => attr.optional)
+        .map(([name]) => name as OptionalAttributeNames<A>)
+}
+
+// Shortcut for cluster server implementers - create initial attribute map from
+// schema if not provided.  Could move into ClusterServer but then
+// attributeInitialValues argument would need to be optional.  Not sure if
+// that's desirable.  Also, this file is shorter than InteractionServer ;)
+function createDefaultAttributeInitialValues<F extends BitSchema, SF extends TypeFromBitSchema<F>, A extends Attributes, C extends Commands, E extends Events>(cluster: Cluster<F, SF, A, C, E>): AttributeInitialValues<A> {
+    const result = {} as AttributeInitialValues<A>;
+
+    mandatoryLocalAttributeNames(cluster.attributes).forEach((name) =>
+        (result as any)[name] = cluster.attributes[name].default);
+
+    // TODO - caller can override but should we make the set of optional
+    // attributes configurable?
+    optionalAttributeNames(cluster.attributes).forEach((name) => {
+        if (cluster.attributes[name] !== undefined) {
+            (result as any)[name] = cluster.attributes[name].default
+        }
+    });
+
+    return result;
+}
+
+/**
+ * This factory acts as a central registry for default cluster implementations.
+ */
+export class ClusterServerFactory {
+    private static defaultHandlerProviders = new Map<AnyCluster, () => any>();
+    private static defaultAttributeInitialValues = new Map<AnyCluster, any>;
+
+    /**
+     * Retrieve default values for attributes based on cluster schema.
+     */
+    public static getDefaultAttributeInitialValues<F extends BitSchema, SF extends TypeFromBitSchema<F>, A extends Attributes, C extends Commands, E extends Events>(cluster: Cluster<F, SF, A, C, E>) {
+        const aiv = this.defaultAttributeInitialValues.get(cluster) as AttributeInitialValues<A>;
+        if (aiv == undefined) {
+            return createDefaultAttributeInitialValues(cluster);
+        }
+        return aiv;
     }
 
+    /**
+     * Register the default implementation for a cluster.
+     * 
+     * @param cluster the cluster to configure
+     * @param defaultHandlerProvider a function that create the cluster handlers
+     * @param defaultAttributeInitialValues optional overrides for default attribute values
+     */
+    public static registerClusterDefaults<F extends BitSchema, SF extends TypeFromBitSchema<F>, A extends Attributes, C extends Commands, E extends Events>(
+        cluster: Cluster<F, SF, A, C, E>, defaultHandlerProvider: () => ClusterServerHandlers<Cluster<F, SF, A, C, E>>,
+        defaultAttributeInitialValues: AttributeInitialValues<A> = createDefaultAttributeInitialValues(cluster)
+    ) {
+        this.defaultHandlerProviders.set(cluster, defaultHandlerProvider);
+        this.defaultAttributeInitialValues.set(cluster, defaultAttributeInitialValues);
+
+        const x = this.defaultAttributeInitialValues.get(cluster);
+        if (x.sceneCount) console.log(x.sceneCount);
+    }
+
+    /**
+     * Create a new cluster server.
+     * 
+     * @param cluster the cluster for the server
+     * @param attributeInitialValues optional overrides for attribute values
+     * @param handlers optional overrides for cluster handlers
+     * @returns 
+     */
     public static create<F extends BitSchema, SF extends TypeFromBitSchema<F>, A extends Attributes, C extends Commands, E extends Events>(cluster: Cluster<F, SF, A, C, E>, attributeInitialValues?: AttributeInitialValues<A>, handlers?: ClusterServerHandlers<Cluster<F, SF, A, C, E>>) {
         handlers = Object.assign({}, handlers);
 
-        const provider = this.providers.get(cluster);
+        const provider = this.defaultHandlerProviders.get(cluster);
         if (provider) {
             Object.assign(handlers, provider());
         }
@@ -35,14 +111,12 @@ export class ClusterServerFactory {
             }
         }
 
-        let attributes = {} as AttributeInitialValues<A>;
-        for (const attribute in cluster.attributes) {
-            if (cluster.attributes[attribute].default !== undefined) {
-                (attributes as any)[attribute] = cluster.attributes[attribute].default;
-            }
-        }
-        Object.assign(attributes, attributeInitialValues);
+        // TODO - should we throw an error here if mandatory attributes do not
+        // have a value yet?
 
-        return ClusterServer(cluster, attributes, handlers);
+        return ClusterServer(
+            cluster,
+            Object.assign({}, this.getDefaultAttributeInitialValues(cluster), attributeInitialValues),
+            handlers);
     }
 }

--- a/packages/matter.js/src/cluster/clusters.ts
+++ b/packages/matter.js/src/cluster/clusters.ts
@@ -1,0 +1,38 @@
+/**
+ * @license
+ * Copyright 2022 The node-matter Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// All cluster implementations should appear here
+
+// Separate index for clusters so we can load the registry without circular
+// references
+
+export * from "./AccessControlCluster.js";
+export * from "./ActionsCluster.js";
+export * from "./AdminCommissioningCluster.js";
+export * from "./BasicInformationCluster.js";
+export * from "./BindingCluster.js";
+export * from "./BooleanStateCluster.js";
+export * from "./BridgedDeviceBasicInformationCluster.js";
+export * from "./DescriptorCluster.js";
+export * from "./FlowMeasurementCluster.js";
+export * from "./GeneralCommissioningCluster.js";
+export * from "./GeneralDiagnosticsCluster.js";
+export * from "./GroupKeyManagementCluster.js";
+export * from "./GroupsCluster.js";
+export * from "./IdentifyCluster.js";
+export * from "./IlluminanceMeasurementCluster.js";
+export * from "./LabelCluster.js";
+export * from "./LevelControlCluster.js";
+export * from "./NetworkCommissioningCluster.js";
+export * from "./OccupancySensingCluster.js";
+export * from "./OnOffCluster.js";
+export * from "./OperationalCredentialsCluster.js";
+export * from "./PowerSourceCluster.js";
+export * from "./PowerSourceConfigurationCluster.js";
+export * from "./PressureMeasurementCluster.js";
+export * from "./ScenesCluster.js";
+export * from "./TemperatureMeasurementCluster.js";
+export * from "./WaterContentMeasurementCluster.js";

--- a/packages/matter.js/src/cluster/index.ts
+++ b/packages/matter.js/src/cluster/index.ts
@@ -7,35 +7,10 @@
 // Export general Cluster specific types
 export * from "./Cluster.js";
 export * from "./ClusterHelper.js";
+export * from "./ClusterServerFactory.js";
 
 // Export all Cluster definitions
-export * from "./AccessControlCluster.js";
-export * from "./ActionsCluster.js";
-export * from "./AdminCommissioningCluster.js";
-export * from "./BasicInformationCluster.js";
-export * from "./BindingCluster.js";
-export * from "./BooleanStateCluster.js";
-export * from "./BridgedDeviceBasicInformationCluster.js";
-export * from "./DescriptorCluster.js";
-export * from "./FlowMeasurementCluster.js";
-export * from "./GeneralCommissioningCluster.js";
-export * from "./GeneralDiagnosticsCluster.js";
-export * from "./GroupKeyManagementCluster.js";
-export * from "./GroupsCluster.js";
-export * from "./IdentifyCluster.js";
-export * from "./IlluminanceMeasurementCluster.js";
-export * from "./LabelCluster.js";
-export * from "./LevelControlCluster.js";
-export * from "./NetworkCommissioningCluster.js";
-export * from "./OccupancySensingCluster.js";
-export * from "./OnOffCluster.js";
-export * from "./OperationalCredentialsCluster.js";
-export * from "./PowerSourceCluster.js";
-export * from "./PowerSourceConfigurationCluster.js";
-export * from "./PressureMeasurementCluster.js";
-export * from "./ScenesCluster.js";
-export * from "./TemperatureMeasurementCluster.js";
-export * from "./WaterContentMeasurementCluster.js";
+export * from "./clusters.js";
 
 // Export all Client classes
 export * from "./client/ClusterClient.js";
@@ -50,9 +25,11 @@ export * from "./server/AdminCommissioningServer.js";
 export * from "./server/GeneralCommissioningServer.js";
 export * from "./server/GroupKeyManagementServer.js";
 export * from "./server/GroupsServer.js";
-export * from "./server/IdentifyServer.js";
-export * from "./server/LevelControlServer.js";
 export * from "./server/NetworkCommissioningServer.js";
-export * from "./server/OnOffServer.js";
 export * from "./server/OperationalCredentialsServer.js";
 export * from "./server/ScenesServer.js";
+
+// Additional server handles export only via ClusterServerFactory
+import "./server/IdentifyServer.js";
+import "./server/LevelControlServer.js";
+import "./server/OnOffServer.js";

--- a/packages/matter.js/src/cluster/server/AdminCommissioningServer.ts
+++ b/packages/matter.js/src/cluster/server/AdminCommissioningServer.ts
@@ -8,6 +8,7 @@ import { AdminCommissioningCluster } from "../AdminCommissioningCluster.js"
 import { ClusterServerHandlers } from "./ClusterServer.js"
 import { PaseServer } from "../../session/pase/PaseServer.js";
 import { SecureChannelProtocol } from "../../protocol/securechannel/SecureChannelProtocol.js";
+import { UnsupportedCommandError } from "./CommandServer.js";
 
 export const AdminCommissioningHandler: (secureChannelProtocol: SecureChannelProtocol) => ClusterServerHandlers<typeof AdminCommissioningCluster> = (secureChannelProtocol) => ({
     openCommissioningWindow: async function({ request: { pakePasscodeVerifier: pakeVerifier, discriminator, iterations, salt, commissioningTimeout }, session, /* attributes: { windowStatus } */ }) {
@@ -17,11 +18,11 @@ export const AdminCommissioningHandler: (secureChannelProtocol: SecureChannelPro
     },
 
     openBasicCommissioningWindow: async function() {
-        throw new Error("Not implemented");
+        throw new UnsupportedCommandError();
     },
 
     revokeCommissioning: async function() {
         // TODO: implement this
-        throw new Error("Not implemented");
+        throw new UnsupportedCommandError();
     }
 });

--- a/packages/matter.js/src/cluster/server/ClusterServer.ts
+++ b/packages/matter.js/src/cluster/server/ClusterServer.ts
@@ -19,7 +19,7 @@ import {
     GlobalAttributes,
     MandatoryAttributeNames,
     OptionalAttributeNames,
-    RequestType, ResponseType,
+    RequestType, ResponseType, MandatoryLocalAttributeNames,
 } from "../Cluster.js";
 import { Message } from "../../codec/MessageCodec.js";
 import { Merge } from "../../util/Type.js";
@@ -36,7 +36,7 @@ import { Endpoint } from "../../device/Endpoint.js";
 export type AttributeServers<A extends Attributes> = Merge<Omit<{ [P in MandatoryAttributeNames<A>]: AttributeServer<AttributeJsType<A[P]>> }, keyof GlobalAttributes<any>>, { [P in OptionalAttributeNames<A>]?: AttributeServer<AttributeJsType<A[P]>> }>;
 
 /** Initial values for the cluster attribute */
-export type AttributeInitialValues<A extends Attributes> = Merge<Omit<{ [P in MandatoryAttributeNames<A>]: AttributeJsType<A[P]> }, keyof GlobalAttributes<any>>, { [P in OptionalAttributeNames<A>]?: AttributeJsType<A[P]> }>;
+export type AttributeInitialValues<A extends Attributes> = Merge<{ [P in MandatoryLocalAttributeNames<A>]: AttributeJsType<A[P]> }, { [P in OptionalAttributeNames<A>]?: AttributeJsType<A[P]> }>;
 export type AttributeServerValues<A extends Attributes> = Merge<{ [P in MandatoryAttributeNames<A>]: AttributeJsType<A[P]> }, { [P in OptionalAttributeNames<A>]?: AttributeJsType<A[P]> }>;
 
 type MandatoryCommandNames<C extends Commands> = { [K in keyof C]: C[K] extends OptionalCommand<any, any> ? never : K }[keyof C];

--- a/packages/matter.js/src/cluster/server/CommandServer.ts
+++ b/packages/matter.js/src/cluster/server/CommandServer.ts
@@ -14,6 +14,32 @@ import { Endpoint } from "../../device/Endpoint.js";
 
 const logger = Logger.get("CommandServer");
 
+/**
+ * This error type allows a command handler to communicate the appropriate
+ * status code to CommandServer by throwing an exception.
+ */
+export class CommandError extends Error {
+    constructor(message: string, public code: StatusCode) {
+        super(message);
+    }
+}
+
+/**
+ * Specialization of CommandError for handlers that are not implemented, either
+ * because we haven't gotten to it yet or because the library consumer needs to
+ * implement the handler.
+ * 
+ * TODO - maybe we should have a TodoCommandError to differentiate?
+ */
+export class UnsupportedCommandError extends CommandError {
+    constructor(message = "Not implemented") {
+        super(message, StatusCode.UnsupportedCommand);
+    }
+}
+
+/**
+ * A CommandServer handles invocation of a single command from the fabric.
+ */
 export class CommandServer<RequestT, ResponseT> {
     constructor(
         readonly invokeId: number,
@@ -27,8 +53,19 @@ export class CommandServer<RequestT, ResponseT> {
     async invoke(session: Session<MatterDevice>, args: TlvStream, message: Message, endpoint: Endpoint): Promise<{ code: StatusCode, responseId: number, response: TlvStream }> {
         const request = this.requestSchema.decodeTlv(args);
         logger.debug(`Invoke ${this.name} with data ${Logger.toJSON(request)}`);
-        const response = await this.handler(request, session, message, endpoint);
-        logger.debug(`Invoke ${this.name} response : ${Logger.toJSON(response)}`);
-        return { code: StatusCode.Success, responseId: this.responseId, response: this.responseSchema.encodeTlv(response) };
+        try {
+            const response = await this.handler(request, session, message, endpoint);
+            logger.debug(`Invoke ${this.name} response : ${Logger.toJSON(response)}`);
+            return { code: StatusCode.Success, responseId: this.responseId, response: this.responseSchema.encodeTlv(response) };
+        } catch (e) {
+            if (e instanceof CommandError) {
+                // Graceful command failure
+                logger.debug(`Invoke ${this.name} exception : ${e.message} (code ${e.code})`);
+                return { code: e.code, responseId: this.responseId, response: [] };
+            } else {
+                // Internal error
+                throw e;
+            }
+        }
     }
 }

--- a/packages/matter.js/src/cluster/server/GroupKeyManagementServer.ts
+++ b/packages/matter.js/src/cluster/server/GroupKeyManagementServer.ts
@@ -6,20 +6,21 @@
 
 import { ClusterServerHandlers } from "./ClusterServer.js";
 import { GroupKeyManagementCluster } from "../GroupKeyManagementCluster.js";
+import { UnsupportedCommandError } from "./CommandServer.js";
 
 // TODO: Implement this
 
 export const GroupKeyManagementClusterHandler: () => ClusterServerHandlers<typeof GroupKeyManagementCluster> = () => ({
     keySetWrite: async () => {
-        throw new Error("Not implemented");
+        throw new UnsupportedCommandError();
     },
     keySetRead: async () => {
-        throw new Error("Not implemented");
+        throw new UnsupportedCommandError();
     },
     keySetRemove: async () => {
-        throw new Error("Not implemented");
+        throw new UnsupportedCommandError();
     },
     keySetReadAllIndices: async () => {
-        throw new Error("Not implemented");
+        throw new UnsupportedCommandError();
     }
 });

--- a/packages/matter.js/src/cluster/server/GroupsServer.ts
+++ b/packages/matter.js/src/cluster/server/GroupsServer.ts
@@ -14,7 +14,7 @@ import { Fabric } from "../../fabric/Fabric.js";
 import { SessionType } from "../../codec/MessageCodec.js";
 import { ScenesManager } from "./ScenesServer.js";
 import { IdentifyCluster } from "../IdentifyCluster.js";
-import { ClusterServer } from "../../protocol/interaction/InteractionServer.js";
+import { ClusterServerFactory } from "../ClusterServerFactory.js";
 
 /*
 TODO: If the Scenes server cluster is implemented on the same endpoint, the following extension field SHALL
@@ -71,7 +71,7 @@ export class GroupsManager {
     }
 }
 
-export const GroupsClusterHandler: () => ClusterServerHandlers<typeof GroupsCluster> = () => {
+ClusterServerFactory.register(GroupsCluster, () => {
     const addGroupLogic = (groupId: GroupId, groupName: string, sessionType: SessionType, fabric: Fabric, endpointId: number) => {
         // TODO If the AddGroup command was received as a unicast, the server SHALL generate an AddGroupResponse
         //      command with the Status field set to the evaluated status. If the AddGroup command was received
@@ -189,15 +189,5 @@ export const GroupsClusterHandler: () => ClusterServerHandlers<typeof GroupsClus
             //      response is not suppressed, the server SHALL generate a response with the Status field set to the
             //      evaluated status.
         },
-    }
-};
-
-export const createDefaultGroupsClusterServer = () => ClusterServer(
-    GroupsCluster,
-    {
-        nameSupport: {
-            groupNames: true,
-        },
-    },
-    GroupsClusterHandler()
-);
+    } as ClusterServerHandlers<typeof GroupsCluster>
+});

--- a/packages/matter.js/src/cluster/server/GroupsServer.ts
+++ b/packages/matter.js/src/cluster/server/GroupsServer.ts
@@ -71,7 +71,7 @@ export class GroupsManager {
     }
 }
 
-ClusterServerFactory.register(GroupsCluster, () => {
+ClusterServerFactory.registerClusterDefaults(GroupsCluster, () => {
     const addGroupLogic = (groupId: GroupId, groupName: string, sessionType: SessionType, fabric: Fabric, endpointId: number) => {
         // TODO If the AddGroup command was received as a unicast, the server SHALL generate an AddGroupResponse
         //      command with the Status field set to the evaluated status. If the AddGroup command was received

--- a/packages/matter.js/src/cluster/server/IdentifyServer.ts
+++ b/packages/matter.js/src/cluster/server/IdentifyServer.ts
@@ -3,15 +3,5 @@
  * Copyright 2022 The node-matter Authors
  * SPDX-License-Identifier: Apache-2.0
  */
-import { ClusterServer } from "../../protocol/interaction/InteractionServer.js";
-import { IdentifyCluster, IdentifyType } from "../IdentifyCluster.js";
-import { ClusterServerHandlers } from "./ClusterServer.js";
 
-export const createDefaultIdentifyClusterServer = (handlers: ClusterServerHandlers<typeof IdentifyCluster>) => ClusterServer(
-    IdentifyCluster,
-    {
-        identifyTime: 0,
-        identifyType: IdentifyType.None,
-    },
-    handlers
-);
+// This file is a no-op, remove or leave with a comment?

--- a/packages/matter.js/src/cluster/server/LevelControlServer.ts
+++ b/packages/matter.js/src/cluster/server/LevelControlServer.ts
@@ -7,11 +7,12 @@
 import { ClusterServerFactory } from "../ClusterServerFactory.js";
 import { LevelControlCluster } from "../LevelControlCluster.js";
 import { ClusterServerHandlers } from "./ClusterServer.js";
+import { UnsupportedCommandError } from "./CommandServer.js";
 
 
 // TODO: Create temporary options based on mask and override. How to expose to user of the library?
 
-ClusterServerFactory.register(LevelControlCluster, () => ({
+ClusterServerFactory.registerClusterDefaults(LevelControlCluster, () => ({
     moveToLevel: async ({ request: { level }, attributes: { currentLevel } }) => {
         currentLevel.set(level);
     },
@@ -21,15 +22,15 @@ ClusterServerFactory.register(LevelControlCluster, () => ({
     // underlying hardware. But how to expose these paramters to the caller of the library? Callback with
     // temporary options?
     move: async () => {
-        throw new Error("Not implemented")
+        throw new UnsupportedCommandError()
     },
 
     step: async () => {
-        throw new Error("Not implemented")
+        throw new UnsupportedCommandError()
     },
 
     stop: async () => {
-        throw new Error("Not implemented")
+        throw new UnsupportedCommandError()
     },
 
     moveToLevelWithOnOff: async function({ request: { level }, attributes: { currentLevel } }) {
@@ -46,14 +47,14 @@ ClusterServerFactory.register(LevelControlCluster, () => ({
     },
 
     moveWithOnOff: async () => {
-        throw new Error("Not implemented")
+        throw new UnsupportedCommandError()
     },
 
     stepWithOnOff: async () => {
-        throw new Error("Not implemented")
+        throw new UnsupportedCommandError()
     },
 
     stopWithOnOff: async () => {
-        throw new Error("Not implemented")
+        throw new UnsupportedCommandError()
     },
 } as ClusterServerHandlers<typeof LevelControlCluster>));

--- a/packages/matter.js/src/cluster/server/LevelControlServer.ts
+++ b/packages/matter.js/src/cluster/server/LevelControlServer.ts
@@ -4,13 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { ClusterServerFactory } from "../ClusterServerFactory.js";
 import { LevelControlCluster } from "../LevelControlCluster.js";
 import { ClusterServerHandlers } from "./ClusterServer.js";
 
 
 // TODO: Create temporary options based on mask and override. How to expose to user of the library?
 
-export const LevelControlClusterHandler: () => ClusterServerHandlers<typeof LevelControlCluster> = () => ({
+ClusterServerFactory.register(LevelControlCluster, () => ({
     moveToLevel: async ({ request: { level }, attributes: { currentLevel } }) => {
         currentLevel.set(level);
     },
@@ -55,4 +56,4 @@ export const LevelControlClusterHandler: () => ClusterServerHandlers<typeof Leve
     stopWithOnOff: async () => {
         throw new Error("Not implemented")
     },
-});
+} as ClusterServerHandlers<typeof LevelControlCluster>));

--- a/packages/matter.js/src/cluster/server/NetworkCommissioningServer.ts
+++ b/packages/matter.js/src/cluster/server/NetworkCommissioningServer.ts
@@ -6,29 +6,30 @@
 
 import { EthernetNetworkCommissioningCluster } from "../NetworkCommissioningCluster.js"
 import { ClusterServerHandlers } from "./ClusterServer.js"
+import { UnsupportedCommandError } from "./CommandServer.js";
 
 export const NetworkCommissioningHandler: () => ClusterServerHandlers<typeof EthernetNetworkCommissioningCluster> = () => ({
     scanNetworks: async function() {
-        throw new Error("Not implemented");
+        throw new UnsupportedCommandError();
     },
 
     removeNetwork: async function() {
-        throw new Error("Not implemented");
+        throw new UnsupportedCommandError();
     },
 
     connectNetwork: async function() {
-        throw new Error("Not implemented");
+        throw new UnsupportedCommandError();
     },
 
     reorderNetwork: async function() {
-        throw new Error("Not implemented");
+        throw new UnsupportedCommandError();
     },
 
     addOrUpdateWiFiNetwork: async function() {
-        throw new Error("Not implemented");
+        throw new UnsupportedCommandError();
     },
 
     addOrUpdateThreadNetwork: async function() {
-        throw new Error("Not implemented");
+        throw new UnsupportedCommandError();
     }
 });

--- a/packages/matter.js/src/cluster/server/OnOffServer.ts
+++ b/packages/matter.js/src/cluster/server/OnOffServer.ts
@@ -5,8 +5,8 @@
  */
 
 import { OnOffCluster } from "../OnOffCluster.js";
-import { AttributeInitialValues, ClusterServerHandlers } from "./ClusterServer.js";
-import { ClusterServer } from "../../protocol/interaction/InteractionServer.js";
+import { ClusterServerHandlers } from "./ClusterServer.js";
+import { ClusterServerFactory } from "../ClusterServerFactory.js";
 
 /*
 TODO: Global Cluster fields needs to be added also here because, as discussed, based on the implementation.
@@ -22,7 +22,7 @@ TODO: Global Cluster fields needs to be added also here because, as discussed, b
 * FabricIndex: empty
  */
 
-export const OnOffClusterHandler: () => ClusterServerHandlers<typeof OnOffCluster> = () => ({
+ClusterServerFactory.register(OnOffCluster, () => ({
     on: async ({ attributes: { onOff } }) => {
         onOff.set(true);
     },
@@ -36,12 +36,4 @@ export const OnOffClusterHandler: () => ClusterServerHandlers<typeof OnOffCluste
             onOff.set(true);
         }
     },
-});
-
-export const createDefaultOnOffClusterServer = (attributeInitialValues?: AttributeInitialValues<typeof OnOffCluster.attributes>) => ClusterServer(
-    OnOffCluster,
-    attributeInitialValues ?? {
-        onOff: false,
-    },
-    OnOffClusterHandler()
-);
+} as ClusterServerHandlers<typeof OnOffCluster>));

--- a/packages/matter.js/src/cluster/server/OnOffServer.ts
+++ b/packages/matter.js/src/cluster/server/OnOffServer.ts
@@ -22,7 +22,7 @@ TODO: Global Cluster fields needs to be added also here because, as discussed, b
 * FabricIndex: empty
  */
 
-ClusterServerFactory.register(OnOffCluster, () => ({
+ClusterServerFactory.registerClusterDefaults(OnOffCluster, () => ({
     on: async ({ attributes: { onOff } }) => {
         onOff.set(true);
     },

--- a/packages/matter.js/src/cluster/server/OperationalCredentialsServer.ts
+++ b/packages/matter.js/src/cluster/server/OperationalCredentialsServer.ts
@@ -15,6 +15,7 @@ import {
 } from "../OperationalCredentialsCluster.js";
 import { FabricIndex } from "../../datatype/FabricIndex.js";
 import { ClusterServerHandlers } from "./ClusterServer.js";
+import { UnsupportedCommandError } from "./CommandServer.js";
 
 export interface OperationalCredentialsServerConf {
     devicePrivateKey: ByteArray,
@@ -88,7 +89,7 @@ export const OperationalCredentialsClusterHandler: (conf: OperationalCredentials
     },
 
     updateOperationalCert: async () => {
-        throw new Error("Not implemented");
+        throw new UnsupportedCommandError();
     },
 
     updateFabricLabel: async ({ request: { label }, session }) => {

--- a/packages/matter.js/src/cluster/server/ScenesServer.ts
+++ b/packages/matter.js/src/cluster/server/ScenesServer.ts
@@ -12,7 +12,7 @@ import { MatterDevice } from "../../MatterDevice.js";
 import { SecureSession } from "../../session/SecureSession.js";
 import { Fabric } from "../../fabric/Fabric.js";
 import { SessionType } from "../../codec/MessageCodec.js";
-import { StatusResponseError } from "../../protocol/interaction/InteractionMessenger.js";
+import { StatusResponseError } from "../../protocol/interaction/StatusResponseError.js";
 import { TypeFromSchema } from "../../tlv/TlvSchema.js";
 import { GroupsManager } from "./GroupsServer.js";
 import { ClusterId } from "../../datatype/ClusterId.js";

--- a/packages/matter.js/src/cluster/server/ScenesServer.ts
+++ b/packages/matter.js/src/cluster/server/ScenesServer.ts
@@ -16,7 +16,7 @@ import { StatusResponseError } from "../../protocol/interaction/InteractionMesse
 import { TypeFromSchema } from "../../tlv/TlvSchema.js";
 import { GroupsManager } from "./GroupsServer.js";
 import { ClusterId } from "../../datatype/ClusterId.js";
-import { ClusterServer } from "../../protocol/interaction/InteractionServer.js";
+import { ClusterServerFactory } from "../ClusterServerFactory.js";
 
 interface scenesTableEntry {
     /** The group identifier for which this scene applies, or 0 if the scene is not associated with a group. */
@@ -125,7 +125,7 @@ export class ScenesManager {
     }
 }
 
-export const ScenesClusterHandler: () => ClusterServerHandlers<typeof ScenesCluster> = () => {
+ClusterServerFactory.register(ScenesCluster, () => {
     const addSceneLogic = (endpointId: number, groupId: GroupId, sceneId: number, sceneTransitionTime: number, sceneName: string, extensionFieldSets: any, transitionTime100ms: number, fabric: Fabric) => {
 
         if (groupId.id !== 0 && !GroupsManager.hasGroup(fabric, endpointId, groupId)) {
@@ -433,20 +433,5 @@ export const ScenesClusterHandler: () => ClusterServerHandlers<typeof ScenesClus
             }
             return sceneCount;
         }
-    }
-};
-
-export const createDefaultScenesClusterServer = () => ClusterServer(
-    ScenesCluster,
-    {
-        sceneCount: 0,
-        currentScene: 0,
-        currentGroup: new GroupId(0),
-        sceneValid: false,
-        nameSupport: {
-            sceneNames: true,
-        },
-        lastConfiguredBy: null,
-    },
-    ScenesClusterHandler()
-);
+    } as ClusterServerHandlers<typeof ScenesCluster>
+});

--- a/packages/matter.js/src/cluster/server/ScenesServer.ts
+++ b/packages/matter.js/src/cluster/server/ScenesServer.ts
@@ -125,7 +125,7 @@ export class ScenesManager {
     }
 }
 
-ClusterServerFactory.register(ScenesCluster, () => {
+ClusterServerFactory.registerClusterDefaults(ScenesCluster, () => {
     const addSceneLogic = (endpointId: number, groupId: GroupId, sceneId: number, sceneTransitionTime: number, sceneName: string, extensionFieldSets: any, transitionTime100ms: number, fabric: Fabric) => {
 
         if (groupId.id !== 0 && !GroupsManager.hasGroup(fabric, endpointId, groupId)) {

--- a/packages/matter.js/src/device/OnOffDevices.ts
+++ b/packages/matter.js/src/device/OnOffDevices.ts
@@ -5,10 +5,6 @@
  */
 import { DeviceTypes, DeviceTypeDefinition } from "./DeviceTypes.js";
 import { Device } from "./Device.js";
-import { createDefaultOnOffClusterServer } from "../cluster/server/OnOffServer.js";
-import { createDefaultGroupsClusterServer } from "../cluster/server/GroupsServer.js";
-import { createDefaultScenesClusterServer } from "../cluster/server/ScenesServer.js";
-import { createDefaultIdentifyClusterServer } from "../cluster/server/IdentifyServer.js";
 import { AttributeInitialValues, ClusterServerHandlers, CommandHandler } from "../cluster/server/ClusterServer.js";
 import { IdentifyCluster, } from "../cluster/IdentifyCluster.js";
 import { OnOffCluster } from "../cluster/OnOffCluster.js";

--- a/packages/matter.js/src/device/OnOffDevices.ts
+++ b/packages/matter.js/src/device/OnOffDevices.ts
@@ -9,12 +9,15 @@ import { createDefaultOnOffClusterServer } from "../cluster/server/OnOffServer.j
 import { createDefaultGroupsClusterServer } from "../cluster/server/GroupsServer.js";
 import { createDefaultScenesClusterServer } from "../cluster/server/ScenesServer.js";
 import { createDefaultIdentifyClusterServer } from "../cluster/server/IdentifyServer.js";
-import { AttributeInitialValues, CommandHandler } from "../cluster/server/ClusterServer.js";
+import { AttributeInitialValues, ClusterServerHandlers, CommandHandler } from "../cluster/server/ClusterServer.js";
 import { IdentifyCluster, } from "../cluster/IdentifyCluster.js";
 import { OnOffCluster } from "../cluster/OnOffCluster.js";
 import { extendPublicHandlerMethods } from "../util/NamedHandler.js";
 import { BitSchema, TypeFromBitSchema } from "../schema/BitmapSchema.js";
 import { Attributes, Cluster, Commands, Events } from "../cluster/Cluster.js";
+import { ClusterServerFactory } from "../cluster/ClusterServerFactory.js";
+import { GroupsCluster } from "../cluster/GroupsCluster.js";
+import { ScenesCluster } from "../cluster/ScenesCluster.js";
 
 type OnOffBaseDeviceCommands = {
     identify: CommandHandler<typeof IdentifyCluster.commands.identify, any>;
@@ -59,12 +62,12 @@ abstract class OnOffBaseDevice extends extendPublicHandlerMethods<typeof Device,
      */
     protected addDeviceClusters(attributeInitialValues?: { [key: number]: AttributeInitialValues<any> }) {
         // TODO: Find a way to make this automated based on the required clusters?
-        this.addClusterServer(createDefaultIdentifyClusterServer({
+        this.addClusterServer(ClusterServerFactory.create(IdentifyCluster, undefined, {
             identify: async (data) => await this._executeHandler("identify", data)
-        }));
-        this.addClusterServer(createDefaultGroupsClusterServer());
-        this.addClusterServer(createDefaultScenesClusterServer());
-        this.addClusterServer(createDefaultOnOffClusterServer(getClusterInitialAttributeValues(attributeInitialValues, OnOffCluster)));
+        } as ClusterServerHandlers<typeof IdentifyCluster>));
+        this.addClusterServer(ClusterServerFactory.create(GroupsCluster));
+        this.addClusterServer(ClusterServerFactory.create(ScenesCluster));
+        this.addClusterServer(ClusterServerFactory.create(OnOffCluster, getClusterInitialAttributeValues(attributeInitialValues, OnOffCluster)));
     }
 
     /**

--- a/packages/matter.js/src/protocol/interaction/InteractionClient.ts
+++ b/packages/matter.js/src/protocol/interaction/InteractionClient.ts
@@ -12,8 +12,9 @@ import { Logger } from "../../log/Logger.js";
 import { StatusCode, TlvAttributeReport } from "./InteractionProtocol.js";
 import { TlvSchema, TypeFromSchema } from "../../tlv/TlvSchema.js";
 import {
-    DataReport, IncomingInteractionClientMessenger, InteractionClientMessenger, ReadRequest, StatusResponseError
+    DataReport, IncomingInteractionClientMessenger, InteractionClientMessenger, ReadRequest
 } from "./InteractionMessenger.js";
+import { StatusResponseError } from "./StatusResponseError.js";
 import { attributePathToId, INTERACTION_PROTOCOL_ID } from "./InteractionServer.js";
 import { DecodedAttributeReportValue, normalizeAndDecodeReadAttributeReport } from "./AttributeDataDecoder.js";
 import { NodeId } from "../../datatype/NodeId.js";

--- a/packages/matter.js/src/protocol/interaction/InteractionMessenger.ts
+++ b/packages/matter.js/src/protocol/interaction/InteractionMessenger.ts
@@ -7,7 +7,6 @@
 import { ByteArray } from "../../util/ByteArray.js";
 import { Logger } from "../../log/Logger.js";
 import { tryCatchAsync } from "../../common/TryCatchHandler.js";
-import { MatterError } from "../../common/MatterError.js";
 import { MessageExchange, UnexpectedMessageError, RetransmissionLimitReachedError } from "../../protocol/MessageExchange.js";
 import { ExchangeProvider } from "../../protocol/ExchangeManager.js";
 import { MatterController } from "../../MatterController.js";
@@ -18,6 +17,7 @@ import {
 } from "./InteractionProtocol.js";
 import { TlvSchema, TypeFromSchema } from "../../tlv/TlvSchema.js";
 import { Message } from "../../codec/MessageCodec.js";
+import { StatusResponseError } from "./StatusResponseError.js";
 
 export const enum MessageType {
     StatusResponse = 0x01,
@@ -41,18 +41,6 @@ export type InvokeResponse = TypeFromSchema<typeof TlvInvokeResponse>;
 export type TimedRequest = TypeFromSchema<typeof TlvTimedRequest>;
 export type WriteRequest = TypeFromSchema<typeof TlvWriteRequest>;
 export type WriteResponse = TypeFromSchema<typeof TlvWriteResponse>;
-
-/** Error base Class for all errors related to the status response messages. */
-export class StatusResponseError extends MatterError {
-    public constructor(
-        message: string,
-        public readonly code: StatusCode,
-    ) {
-        super();
-
-        this.message = `(${code}) ${message}`;
-    }
-}
 
 const MAX_SPDU_LENGTH = 1024;
 

--- a/packages/matter.js/src/protocol/interaction/InteractionServer.ts
+++ b/packages/matter.js/src/protocol/interaction/InteractionServer.ts
@@ -8,9 +8,10 @@ import { MatterDevice } from "../../MatterDevice.js";
 import { ProtocolHandler } from "../../protocol/ProtocolHandler.js";
 import { MessageExchange } from "../../protocol/MessageExchange.js";
 import {
-    DataReport, InteractionServerMessenger, InvokeRequest, InvokeResponse, MessageType, ReadRequest, StatusResponseError,
+    DataReport, InteractionServerMessenger, InvokeRequest, InvokeResponse, MessageType, ReadRequest,
     SubscribeRequest, TimedRequest, WriteRequest, WriteResponse
 } from "./InteractionMessenger.js";
+import { StatusResponseError } from "./StatusResponseError.js";
 import { Attributes, Cluster, Commands, Events, TlvNoResponse } from "../../cluster/Cluster.js";
 import {
     StatusCode, TlvAttributePath, TlvAttributeReport, TlvCommandPath, TlvInvokeResponseData, TlvSubscribeResponse

--- a/packages/matter.js/src/protocol/interaction/StatusResponseError.ts
+++ b/packages/matter.js/src/protocol/interaction/StatusResponseError.ts
@@ -1,0 +1,14 @@
+import { MatterError } from "../../common/MatterError.js";
+import { StatusCode } from "./InteractionProtocol.js";
+
+/** Error base Class for all errors related to the status response messages. */
+export class StatusResponseError extends MatterError {
+    public constructor(
+        message: string,
+        public readonly code: StatusCode
+    ) {
+        super();
+
+        this.message = `(${code}) ${message}`;
+    }
+}

--- a/packages/matter.js/src/protocol/interaction/SubscriptionHandler.ts
+++ b/packages/matter.js/src/protocol/interaction/SubscriptionHandler.ts
@@ -5,7 +5,8 @@
  */
 
 import { MatterDevice } from "../../MatterDevice.js";
-import { InteractionServerMessenger, StatusResponseError } from "./InteractionMessenger.js";
+import { InteractionServerMessenger } from "./InteractionMessenger.js";
+import { StatusResponseError } from "./StatusResponseError.js";
 import { Fabric } from "../../fabric/Fabric.js";
 import { AttributeWithPath, INTERACTION_PROTOCOL_ID, attributePathToId } from "./InteractionServer.js";
 import { Logger } from "../../log/Logger.js";

--- a/packages/matter.js/test/TypingIssueTest.ts
+++ b/packages/matter.js/test/TypingIssueTest.ts
@@ -6,23 +6,22 @@
 
 import * as assert from "assert";
 import { IdentifyCluster, IdentifyType } from "../src/cluster/IdentifyCluster.js";
-import { createDefaultIdentifyClusterServer } from "../src/cluster/server/IdentifyServer.js";
 import { ClusterServerHandlers } from "../src/cluster/server/ClusterServer.js";
 import { ClusterServer } from "../src/protocol/interaction/InteractionServer.js";
 import { DeviceTypes } from "../src/device/DeviceTypes.js";
 import { Endpoint } from "../src/device/Endpoint.js";
 import { GroupsCluster } from "../src/cluster/GroupsCluster.js";
-import { GroupsClusterHandler } from "../src/cluster/server/GroupsServer.js";
 import { BasicInformationCluster } from "../src/cluster/BasicInformationCluster.js";
 import { VendorId } from "../src/datatype/VendorId.js";
+import { ClusterServerFactory } from "../src/cluster/ClusterServerFactory.js";
 
 describe('Typing issue Test', () => {
 
     it("typing issue test", async () => {
-        const identifyServer = createDefaultIdentifyClusterServer({
+        const identifyServer = ClusterServerFactory.create(IdentifyCluster, undefined, {
             identify: async ({ request: { identifyTime } }) => { console.log(identifyTime); /* */ },
             triggerEffect: async () => { console.log("triggerEffect"); /* */ },
-        })
+        } as ClusterServerHandlers<typeof IdentifyCluster>)
 
         /* Issue 1: */
         /* the as ClusterServerHandlers<typeof IdentifyCluster> is needed ... in fact ok-ish */
@@ -33,7 +32,7 @@ describe('Typing issue Test', () => {
                 { identify: async ({ request: { identifyTime } }) => { console.log(identifyTime); } } as ClusterServerHandlers<typeof IdentifyCluster>
             );
 
-        const groupsServer = ClusterServer(GroupsCluster, { nameSupport: { groupNames: true } }, GroupsClusterHandler());
+        const groupsServer = ClusterServerFactory.create(GroupsCluster);
 
         /* Issue 2: */
         // adding the cluster in the array do not work - uncomment it to see it ... seems to be something that get weird because of the optional command which is not implemented

--- a/packages/matter.js/test/cluster/ClusterServerFactoryTest.ts
+++ b/packages/matter.js/test/cluster/ClusterServerFactoryTest.ts
@@ -33,8 +33,7 @@ describe("ClusterServerFactory", () => {
                 sceneValid: false,
                 nameSupport: {
                     sceneNames: true
-                },
-                lastConfiguredBy: null
+                }
             });
 
             itHasCorrectDefaultsFor(IdentifyCluster, {

--- a/packages/matter.js/test/cluster/ClusterServerFactoryTest.ts
+++ b/packages/matter.js/test/cluster/ClusterServerFactoryTest.ts
@@ -1,0 +1,56 @@
+import * as assert from "assert";
+import { ClusterServerFactory } from "../../src/cluster/ClusterServerFactory.js";
+import { Cluster, GroupsCluster, IdentifyCluster, IdentifyType, OnOffCluster, ScenesCluster } from "../../src/cluster/index.js";
+import { GroupId } from "../../src/datatype/GroupId.js";
+
+describe("ClusterServerFactory", () => {
+    // Violate encapsulation for testing
+    const defaultHandlerProviders = (ClusterServerFactory as any).defaultHandlerProviders;
+    const defaultAttributeInitialValues = (ClusterServerFactory as any).defaultAttributeInitialValues;
+
+    describe("register", () => {
+        it("registers all clusters", () => {
+            assert.ok(defaultHandlerProviders.size >= 4);
+        });
+
+        it("has defaults for every cluster", () => {
+            assert.equal(defaultHandlerProviders.size, defaultAttributeInitialValues.size);
+        });
+
+        describe("defaults", () => {
+            // We don't test defaults comprehensively, just attempt at a
+            // representative sample
+            function itHasCorrectDefaultsFor(cluster: Cluster<any, any, any, any, any>, defaults: any) {
+                it(`are correct for ${cluster.name}`, () =>
+                    assert.deepStrictEqual(ClusterServerFactory.getDefaultAttributeInitialValues(cluster), defaults)
+                );
+            }
+
+            itHasCorrectDefaultsFor(ScenesCluster, {
+                sceneCount: 0,
+                currentScene: 0,
+                currentGroup: new GroupId(0),
+                sceneValid: false,
+                nameSupport: {
+                    sceneNames: true
+                },
+                lastConfiguredBy: null
+            });
+
+            itHasCorrectDefaultsFor(IdentifyCluster, {
+                identifyTime: 0,
+                identifyType: IdentifyType.None
+            });
+
+            itHasCorrectDefaultsFor(GroupsCluster, {
+                nameSupport: {
+                    groupNames: true
+                }
+            });
+
+            itHasCorrectDefaultsFor(OnOffCluster, {
+                onOff: false
+            });
+        });
+    });
+});

--- a/packages/matter.js/test/cluster/server/CommandServerTest.ts
+++ b/packages/matter.js/test/cluster/server/CommandServerTest.ts
@@ -1,0 +1,47 @@
+import * as assert from "assert";
+import { CommandServer, UnsupportedCommandError } from "../../../src/cluster/index.js";
+import { TlvString } from "../../../src/tlv/index.js";
+import { MatterDevice } from "../../../src/MatterDevice.js";
+import { Session } from "../../../src/session/index.js";
+import { Message } from "../../../src/codec/index.js";
+import { Endpoint } from "../../../src/device/index.js";
+import { Time, TimeFake } from "../../../src/time/index.js";
+import { StatusCode } from "../../../src/protocol/interaction/index.js";
+
+describe("CommandServer", () => {
+    async function testInvoke(handler: (request: string) => Promise<any>) {
+        const cs = new CommandServer(4, 5, "test", TlvString, TlvString,
+            async (request, _message, _session, _endpoint) => await handler(request));
+        const result = await cs.invoke(
+            {} as unknown as Session<MatterDevice>,
+            TlvString.encodeTlv("hello"),
+            {} as Message,
+            {} as Endpoint
+        );
+        assert.equal(result.responseId, 5);
+        return result;
+    }
+
+    beforeAll(() => Time.get = () => new TimeFake(0));
+
+    describe("invoke", () => {
+        it("succeeds", async () => {
+            const result = await testInvoke(async (request) => `${request} world`);
+            assert.equal(result.code, StatusCode.Success);
+            assert.equal(TlvString.decodeTlv(result.response), "hello world");
+        })
+
+        it("fails gracefully", async () => {
+            const result = await testInvoke(async () => { throw new UnsupportedCommandError() });
+            assert.equal(result.code, StatusCode.UnsupportedCommand);
+            assert.deepEqual(result.response, []);
+        })
+
+        it("fails ungracefully", async () => {
+            await assert.rejects(
+                () => testInvoke(async () => { throw Error("oops") }),
+                Error,
+                "oops");
+        })
+    })
+})

--- a/packages/matter.js/test/device/MatterNodeStructureTest.ts
+++ b/packages/matter.js/test/device/MatterNodeStructureTest.ts
@@ -296,7 +296,7 @@ describe("Endpoint Structures", () => {
             assert.deepEqual(rootPartsListAttribute?.getLocal(), [new EndpointNumber(1)]);
 
             assert.equal(attributePaths.length, 146);
-            assert.equal(commandPaths.length, 38);
+            assert.equal(commandPaths.length, 39);
         });
     });
 
@@ -369,7 +369,7 @@ describe("Endpoint Structures", () => {
             assert.deepEqual(composedPartsListAttribute?.getLocal(), [new EndpointNumber(2), new EndpointNumber(3)]);
 
             assert.equal(attributePaths.length, 200);
-            assert.equal(commandPaths.length, 58);
+            assert.equal(commandPaths.length, 60);
         });
     });
 
@@ -438,7 +438,7 @@ describe("Endpoint Structures", () => {
             assert.deepEqual(deviceTypeListAttribute?.getLocal(), [{ deviceType: new DeviceTypeId(DeviceTypes.ON_OFF_LIGHT.code), revision: 2 }, { deviceType: new DeviceTypeId(DeviceTypes.BRIDGED_NODE.code), revision: 1 }]);
 
             assert.equal(attributePaths.length, 162);
-            assert.equal(commandPaths.length, 38);
+            assert.equal(commandPaths.length, 39);
         });
 
         it("Device Structure with one aggregator and two Light endpoints and defined endpoint IDs", () => {
@@ -512,7 +512,7 @@ describe("Endpoint Structures", () => {
             assert.deepEqual(deviceTypeListAttribute?.getLocal(), [{ deviceType: new DeviceTypeId(DeviceTypes.ON_OFF_LIGHT.code), revision: 2 }, { deviceType: new DeviceTypeId(DeviceTypes.BRIDGED_NODE.code), revision: 1 }]);
 
             assert.equal(attributePaths.length, 214);
-            assert.equal(commandPaths.length, 58);
+            assert.equal(commandPaths.length, 60);
         });
 
         it("Device Structure with two aggregators and two Light endpoints and defined endpoint IDs", () => {
@@ -632,7 +632,7 @@ describe("Endpoint Structures", () => {
             assert.deepEqual(rootPartsListAttribute?.getLocal(), [new EndpointNumber(1), new EndpointNumber(11), new EndpointNumber(12), new EndpointNumber(2), new EndpointNumber(21), new EndpointNumber(22)]);
 
             assert.equal(attributePaths.length, 339);
-            assert.equal(commandPaths.length, 98);
+            assert.equal(commandPaths.length, 102);
         });
 
         it("Device Structure with two aggregators and two Light endpoints and all auto-assigned endpoint IDs", () => {
@@ -749,7 +749,7 @@ describe("Endpoint Structures", () => {
             assert.deepEqual(rootPartsListAttribute?.getLocal(), [new EndpointNumber(1), new EndpointNumber(2), new EndpointNumber(3), new EndpointNumber(4), new EndpointNumber(5), new EndpointNumber(6)]);
 
             assert.equal(attributePaths.length, 339);
-            assert.equal(commandPaths.length, 98);
+            assert.equal(commandPaths.length, 102);
         });
 
         it("Device Structure with two aggregators and two Light endpoints and all partly autoassigned endpoint IDs", () => {
@@ -871,7 +871,7 @@ describe("Endpoint Structures", () => {
             assert.deepEqual(rootPartsListAttribute?.getLocal(), [new EndpointNumber(37), new EndpointNumber(3), new EndpointNumber(38), new EndpointNumber(39), new EndpointNumber(40), new EndpointNumber(18)]);
 
             assert.equal(attributePaths.length, 339);
-            assert.equal(commandPaths.length, 98);
+            assert.equal(commandPaths.length, 102);
         });
 
     });

--- a/packages/matter.js/test/device/MatterNodeStructureTest.ts
+++ b/packages/matter.js/test/device/MatterNodeStructureTest.ts
@@ -295,8 +295,8 @@ describe("Endpoint Structures", () => {
             }));
             assert.deepEqual(rootPartsListAttribute?.getLocal(), [new EndpointNumber(1)]);
 
-            assert.equal(attributePaths.length, 146);
-            assert.equal(commandPaths.length, 39);
+            assert.equal(attributePaths.length, 145);
+            assert.equal(commandPaths.length, 38);
         });
     });
 
@@ -368,8 +368,8 @@ describe("Endpoint Structures", () => {
             }));
             assert.deepEqual(composedPartsListAttribute?.getLocal(), [new EndpointNumber(2), new EndpointNumber(3)]);
 
-            assert.equal(attributePaths.length, 200);
-            assert.equal(commandPaths.length, 60);
+            assert.equal(attributePaths.length, 198);
+            assert.equal(commandPaths.length, 58);
         });
     });
 
@@ -437,8 +437,8 @@ describe("Endpoint Structures", () => {
             const deviceTypeListAttribute: AttributeServer<EndpointNumber[]> | undefined = attributes.get(attributePathToId({ endpointId: 11, clusterId: DescriptorCluster.id, attributeId: DescriptorCluster.attributes.deviceTypeList.id }));
             assert.deepEqual(deviceTypeListAttribute?.getLocal(), [{ deviceType: new DeviceTypeId(DeviceTypes.ON_OFF_LIGHT.code), revision: 2 }, { deviceType: new DeviceTypeId(DeviceTypes.BRIDGED_NODE.code), revision: 1 }]);
 
-            assert.equal(attributePaths.length, 162);
-            assert.equal(commandPaths.length, 39);
+            assert.equal(attributePaths.length, 161);
+            assert.equal(commandPaths.length, 38);
         });
 
         it("Device Structure with one aggregator and two Light endpoints and defined endpoint IDs", () => {
@@ -511,8 +511,8 @@ describe("Endpoint Structures", () => {
             const deviceTypeListAttribute: AttributeServer<EndpointNumber[]> | undefined = attributes.get(attributePathToId({ endpointId: 11, clusterId: DescriptorCluster.id, attributeId: DescriptorCluster.attributes.deviceTypeList.id }));
             assert.deepEqual(deviceTypeListAttribute?.getLocal(), [{ deviceType: new DeviceTypeId(DeviceTypes.ON_OFF_LIGHT.code), revision: 2 }, { deviceType: new DeviceTypeId(DeviceTypes.BRIDGED_NODE.code), revision: 1 }]);
 
-            assert.equal(attributePaths.length, 214);
-            assert.equal(commandPaths.length, 60);
+            assert.equal(attributePaths.length, 212);
+            assert.equal(commandPaths.length, 58);
         });
 
         it("Device Structure with two aggregators and two Light endpoints and defined endpoint IDs", () => {
@@ -631,8 +631,8 @@ describe("Endpoint Structures", () => {
             const rootPartsListAttribute: AttributeServer<EndpointNumber[]> | undefined = attributes.get(attributePathToId({ endpointId: 0, clusterId: DescriptorCluster.id, attributeId: DescriptorCluster.attributes.partsList.id }));
             assert.deepEqual(rootPartsListAttribute?.getLocal(), [new EndpointNumber(1), new EndpointNumber(11), new EndpointNumber(12), new EndpointNumber(2), new EndpointNumber(21), new EndpointNumber(22)]);
 
-            assert.equal(attributePaths.length, 339);
-            assert.equal(commandPaths.length, 102);
+            assert.equal(attributePaths.length, 335);
+            assert.equal(commandPaths.length, 98);
         });
 
         it("Device Structure with two aggregators and two Light endpoints and all auto-assigned endpoint IDs", () => {
@@ -748,8 +748,8 @@ describe("Endpoint Structures", () => {
             const rootPartsListAttribute: AttributeServer<EndpointNumber[]> | undefined = attributes.get(attributePathToId({ endpointId: 0, clusterId: DescriptorCluster.id, attributeId: DescriptorCluster.attributes.partsList.id }));
             assert.deepEqual(rootPartsListAttribute?.getLocal(), [new EndpointNumber(1), new EndpointNumber(2), new EndpointNumber(3), new EndpointNumber(4), new EndpointNumber(5), new EndpointNumber(6)]);
 
-            assert.equal(attributePaths.length, 339);
-            assert.equal(commandPaths.length, 102);
+            assert.equal(attributePaths.length, 335);
+            assert.equal(commandPaths.length, 98);
         });
 
         it("Device Structure with two aggregators and two Light endpoints and all partly autoassigned endpoint IDs", () => {
@@ -870,8 +870,8 @@ describe("Endpoint Structures", () => {
             const rootPartsListAttribute: AttributeServer<EndpointNumber[]> | undefined = attributes.get(attributePathToId({ endpointId: 0, clusterId: DescriptorCluster.id, attributeId: DescriptorCluster.attributes.partsList.id }));
             assert.deepEqual(rootPartsListAttribute?.getLocal(), [new EndpointNumber(37), new EndpointNumber(3), new EndpointNumber(38), new EndpointNumber(39), new EndpointNumber(40), new EndpointNumber(18)]);
 
-            assert.equal(attributePaths.length, 339);
-            assert.equal(commandPaths.length, 102);
+            assert.equal(attributePaths.length, 335);
+            assert.equal(commandPaths.length, 98);
         });
 
     });


### PR DESCRIPTION
Background:  While designing device-level API, a few small gaps in the cluster-level API were causing friction with implementation.  This is an attempt to address.

@Apollon77 - I *think* I covered all your asks here, see summary before you look at the code.  Definitely fixed the initial naive implementation once I actually ran it.  I didn't squash so you can see the differences.

Might be helpful to scan `ClusterServerFactoryTest.ts` and `CommandServerTest.ts` before looking at implementation.

Quick summary of scope:

---

**Problem:** It would be good to give the user a convenient mechanism for creating any cluster along the lines of `createDefaultScenesCluster()`.  Currently convenience is limited to clusters with hand-crafted server implementations.  This also made it difficult to automatically implement the clusters on the device.

**Proposal:** Implement generalized `ClusterServerFactory.create` that creates a `ClusterServer` for any cluster, regardless of whether we have better default handlers available.

**Side benefits:** The cluster server files can be a bit smaller as `ClusterServerFactory` handles more automatically.  Imports are smaller since there's only one factory method and it already knows about default handlers.  The default attribute values only use the schema as source-of-truth in this version.

---

**Problem:** Cluster definitions weren't available centrally.  `AllClustersMap` contained most clusters but it was keyed by ID so couldn't contain extended clusters which share an ID with their parent.  Previously I was scanning exports.  Worked but a bit icky.

**Proposal:** Create a central registry for clusters and extended clusters.  Populate the registry automatically when the cluster is defined.

**Side benefits:** Devs don't need to remember to update `AllClustersMap`.  Previously some handler exports accidentally didn't follow conventions; won't be an issue now.

---

**Problem:** It would be good to offer a mechanism for API users to invoke matter.js's "smart" handlers from within their own handlers.  There was a bit of an inversion of control issue here as `InteractionHandler` looks for the presence of a handler to understand if it should respond with `StatusCode.UnsupportedCommand`.

**Proposal:** Create an alternate path for handlers to convey status information to `CommandServer`.  In addition to the current approach (return value) create a specialized exception class that conveys a status code.

**Side benefits:** This pattern may make implementation a bit simpler because a handler can bail at any time with an exception.  Some of the current handlers threw exceptions that were effectively internal errors, now they'll just result in `StatusCode.UnsupportedCommand`.  Handlers could also use this to send other status codes though I'm not sure if that's desirable.  Finally, `CommandServer` has unit tests now. :)