### PR TITLE
Add Interface for Events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All Changes without a GitHub Username in brackets are from the core team: @Apoll
     * Added FabricScopedAttributeServer which gets and sets the value based on the provided fabric
     * Updated ClusterServerObj and ClusterClientObj typings to respect these Attribute types
     * Updated all Cluster definitions that use such attribute types
+    * Add Interface for Events which requires to define the supported events when creating a ClusterServer (Event Logic WIP in separate PR)
   * Enhance: Splitted up and corrected PowerSource and PressureMeasurement Cluster based on Matter 1.1 Specs
   * Fix: Added missing PulseWidthModulationLevelControlCluster to AllCLusters
   * Fix Typing of Commands in ClusterClient if no commands were present

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All Changes without a GitHub Username in brackets are from the core team: @Apoll
   * Fix Typing of Commands in ClusterClient if no commands were present
   * Fix: Fix equality checks in Attribute servers to check deeper then just === (and introduce new util method isDeepEqual)
   * Fix: Make sure an error received from sending subscription seed data reports is not bubbling up and activate subscription after successful seeding
+  * Fix: Allows Node.js Buffer objects to be persisted to storage as a Uint8Arrays that they subclass
 * matter.js API:
   * Breaking: Adjusted some constructors of the new API and remove the option to pass an array of clusters to be added initially because this was no longer compatible to the strong typing in some places. Use addClusterServer and addClusterClient methods
   * Deprecation: The classes MatterDevice and MatterController are deprecated to be used externally to the library and will be removed in later versions.

--- a/packages/matter-node.js/test/IntegrationTest.ts
+++ b/packages/matter-node.js/test/IntegrationTest.ts
@@ -213,19 +213,19 @@ describe("Integration Test", () => {
                 { endpointId: 2 }, // 2 / * /* - will be discarded in results!
             ]);
 
-            assert.equal(response.length, 39);
+            assert.equal(response.length, 42);
             assert.equal(response.filter(({
                 path: {
                     endpointId,
                     clusterId
                 }
-            }) => endpointId === 0 && clusterId === DescriptorCluster.id).length, 9);
+            }) => endpointId === 0 && clusterId === DescriptorCluster.id).length, 10);
             assert.equal(response.filter(({
                 path: {
                     endpointId,
                     clusterId
                 }
-            }) => endpointId === 1 && clusterId === DescriptorCluster.id).length, 9);
+            }) => endpointId === 1 && clusterId === DescriptorCluster.id).length, 10);
 
             const descriptorServerListData = response.find(({
                 path: {
@@ -249,7 +249,7 @@ describe("Integration Test", () => {
                     endpointId,
                     clusterId
                 }
-            }) => endpointId === 0 && clusterId === BasicInformationCluster.id).length, 20);
+            }) => endpointId === 0 && clusterId === BasicInformationCluster.id).length, 21);
             const softwareVersionStringData = response.find(({
                 path: {
                     endpointId,

--- a/packages/matter-node.js/test/cluster/ClusterServerTestingUtil.ts
+++ b/packages/matter-node.js/test/cluster/ClusterServerTestingUtil.ts
@@ -10,11 +10,11 @@ import { Message } from "@project-chip/matter.js/codec";
 import { Fabric } from "@project-chip/matter.js/fabric";
 import { FabricIndex, VendorId, FabricId, NodeId } from "@project-chip/matter.js/datatype";
 import { ByteArray } from "@project-chip/matter.js/util";
-import { Attributes, ClusterServerObj, Commands } from "@project-chip/matter.js/cluster";
+import { Attributes, ClusterServerObj, Commands, Events } from "@project-chip/matter.js/cluster";
 import { Endpoint } from "@project-chip/matter.js/device";
 
 // TODO make that nicer
-export async function callCommandOnClusterServer<A extends Attributes, C extends Commands>(clusterServer: ClusterServerObj<A, C>, commandName: string, args: any, endpoint: Endpoint, session?: SecureSession<any>, message?: Message): Promise<{ code: StatusCode, responseId: number, response: any }> {
+export async function callCommandOnClusterServer<A extends Attributes, C extends Commands, E extends Events>(clusterServer: ClusterServerObj<A, C, E>, commandName: string, args: any, endpoint: Endpoint, session?: SecureSession<any>, message?: Message): Promise<{ code: StatusCode, responseId: number, response: any }> {
     const command = (clusterServer._commands as any)[commandName];
     if (command === undefined) throw new Error(`Command ${commandName} not found`);
     const { code, responseId, response } = await command.invoke(session ?? {} as SecureSession<any>, command.requestSchema.encodeTlv(args), message ?? {} as Message, endpoint);

--- a/packages/matter-node.js/test/cluster/GroupsServerTest.ts
+++ b/packages/matter-node.js/test/cluster/GroupsServerTest.ts
@@ -20,7 +20,7 @@ import { ClusterServer, StatusCode } from "@project-chip/matter.js/interaction";
 import { SecureSession } from "@project-chip/matter.js/session";
 import { Fabric, FabricJsonObject } from "@project-chip/matter.js/fabric";
 import {
-    ClusterServerObj, GroupsCluster, GroupsClusterHandler, IdentifyCluster, ClusterServerHandlers, IdentifyType
+    ClusterServerObjForCluster, GroupsCluster, GroupsClusterHandler, IdentifyCluster, ClusterServerHandlers, IdentifyType
 } from "@project-chip/matter.js/cluster";
 import { GroupId } from "@project-chip/matter.js/datatype";
 import { getPromiseResolver } from "@project-chip/matter.js/util";
@@ -29,7 +29,7 @@ import { callCommandOnClusterServer, createTestSessionWithFabric } from "./Clust
 import { Endpoint, DeviceTypes } from "@project-chip/matter.js/device";
 
 describe("Groups Server test", () => {
-    let groupsServer: ClusterServerObj<typeof GroupsCluster.attributes, typeof GroupsCluster.commands> | undefined;
+    let groupsServer: ClusterServerObjForCluster<typeof GroupsCluster> | undefined;
     let testFabric: Fabric | undefined;
     let testSession: SecureSession<any> | undefined
     let endpoint: Endpoint | undefined;

--- a/packages/matter-node.js/test/cluster/ScenesServerTest.ts
+++ b/packages/matter-node.js/test/cluster/ScenesServerTest.ts
@@ -21,7 +21,7 @@ import { SecureSession } from "@project-chip/matter.js/session";
 import { Fabric, FabricJsonObject } from "@project-chip/matter.js/fabric";
 import {
     GroupsCluster, GroupsClusterHandler, ScenesCluster, ScenesClusterHandler, OnOffCluster, OnOffClusterHandler,
-    ClusterServerObj
+    ClusterServerObjForCluster
 } from "@project-chip/matter.js/cluster";
 import { GroupId, AttributeId, ClusterId } from "@project-chip/matter.js/datatype";
 import { getPromiseResolver } from "@project-chip/matter.js/util";
@@ -31,9 +31,9 @@ import { TlvBoolean } from "@project-chip/matter.js/tlv";
 import { Endpoint, DeviceTypes } from "@project-chip/matter.js/device";
 
 describe("Scenes Server test", () => {
-    let groupsServer: ClusterServerObj<typeof GroupsCluster.attributes, typeof GroupsCluster.commands> | undefined;
-    let scenesServer: ClusterServerObj<typeof ScenesCluster.attributes, typeof ScenesCluster.commands> | undefined;
-    let onOffServer: ClusterServerObj<typeof OnOffCluster.attributes, typeof OnOffCluster.commands> | undefined;
+    let groupsServer: ClusterServerObjForCluster<typeof GroupsCluster> | undefined;
+    let scenesServer: ClusterServerObjForCluster<typeof ScenesCluster> | undefined;
+    let onOffServer: ClusterServerObjForCluster<typeof OnOffCluster> | undefined;
     let testFabric: Fabric | undefined;
     let testSession: SecureSession<any> | undefined
     let endpoint: Endpoint | undefined;

--- a/packages/matter-node.js/test/interaction/InteractionProtocolTest.ts
+++ b/packages/matter-node.js/test/interaction/InteractionProtocolTest.ts
@@ -252,7 +252,9 @@ describe("InteractionProtocol", () => {
                     caseSessionsPerFabric: 100,
                     subscriptionsPerFabric: 100,
                 },
-            }, {}));
+            }, {}, {
+                startUp: true
+            }));
             const interactionProtocol = new InteractionServer(storageManager)
                 .setRootEndpoint(endpoint);
 
@@ -281,7 +283,9 @@ describe("InteractionProtocol", () => {
                     caseSessionsPerFabric: 100,
                     subscriptionsPerFabric: 100,
                 },
-            }, {});
+            }, {}, {
+                startUp: true
+            });
 
             const storageManager = new StorageManager(new StorageBackendMemory());
             await storageManager.initialize();
@@ -303,7 +307,10 @@ describe("InteractionProtocol", () => {
                 subjectsPerAccessControlEntry: 4,
                 targetsPerAccessControlEntry: 4,
                 accessControlEntriesPerFabric: 3
-            }, {});
+            }, {}, {
+                accessControlEntryChanged: true,
+                accessControlExtensionChanged: true,
+            });
 
             const storageManager = new StorageManager(new StorageBackendMemory());
             await storageManager.initialize();
@@ -345,7 +352,9 @@ describe("InteractionProtocol", () => {
                     caseSessionsPerFabric: 100,
                     subscriptionsPerFabric: 100,
                 },
-            }, {});
+            }, {}, {
+                startUp: true
+            });
 
             const storageManager = new StorageManager(new StorageBackendMemory());
             await storageManager.initialize();

--- a/packages/matter.js/src/CommissioningController.ts
+++ b/packages/matter.js/src/CommissioningController.ts
@@ -173,7 +173,7 @@ export class CommissioningController extends MatterNode {
      */
     async getRootClusterClientWithNewInteractionClient<F extends BitSchema, SF extends TypeFromBitSchema<F>, A extends Attributes, C extends Commands, E extends Events>(
         cluster: Cluster<F, SF, A, C, E>
-    ): Promise<ClusterClientObj<A, C> | undefined> {
+    ): Promise<ClusterClientObj<A, C, E> | undefined> {
         return super.getRootClusterClient(cluster, await this.createInteractionClient());
     }
 
@@ -284,7 +284,7 @@ export class CommissioningController extends MatterNode {
             throw new Error("No device type found for endpoint");
         }
 
-        const endpointClusters = Array<ClusterServerObj<Attributes, Commands> | ClusterClientObj<Attributes, Commands>>();
+        const endpointClusters = Array<ClusterServerObj<Attributes, Commands, Events> | ClusterClientObj<Attributes, Commands, Events>>();
 
         // Add ClusterClients for all server clusters of the device
         for (const clusterId of descriptorData.serverList) {
@@ -306,7 +306,8 @@ export class CommissioningController extends MatterNode {
                 continue;
             }
             const clusterData = (data[clusterId.id] ?? {}) as AttributeInitialValues<Attributes>; // TODO correct typing
-            endpointClusters.push(ClusterServer(cluster, /*clusterData.featureMap,*/ clusterData, {}) as ClusterServerObj<Attributes, Commands>); // TODO Add Default handler!
+            // Todo add logic for Events
+            endpointClusters.push(ClusterServer(cluster, /*clusterData.featureMap,*/ clusterData, {}) as ClusterServerObj<Attributes, Commands, Events>); // TODO Add Default handler!
         }
 
         if (endpointId === 0) {

--- a/packages/matter.js/src/MatterNode.ts
+++ b/packages/matter.js/src/MatterNode.ts
@@ -23,7 +23,7 @@ export abstract class MatterNode {
      *
      * @param cluster ClusterServer object to add
      */
-    addRootClusterServer<A extends Attributes, C extends Commands>(cluster: ClusterServerObj<A, C>) {
+    addRootClusterServer<A extends Attributes, C extends Commands, E extends Events>(cluster: ClusterServerObj<A, C, E>) {
         this.rootEndpoint.addClusterServer(cluster);
     }
 
@@ -34,7 +34,7 @@ export abstract class MatterNode {
      */
     getRootClusterServer<F extends BitSchema, SF extends TypeFromBitSchema<F>, A extends Attributes, C extends Commands, E extends Events>(
         cluster: Cluster<F, SF, A, C, E>
-    ): ClusterServerObj<A, C> | undefined {
+    ): ClusterServerObj<A, C, E> | undefined {
         return this.rootEndpoint.getClusterServer(cluster);
     }
 
@@ -43,7 +43,7 @@ export abstract class MatterNode {
      *
      * @param cluster ClusterClient object to add
      */
-    addRootClusterClient<A extends Attributes, C extends Commands>(cluster: ClusterClientObj<A, C>) {
+    addRootClusterClient<A extends Attributes, C extends Commands, E extends Events>(cluster: ClusterClientObj<A, C, E>) {
         this.rootEndpoint.addClusterClient(cluster);
     }
 
@@ -57,7 +57,7 @@ export abstract class MatterNode {
     getRootClusterClient<F extends BitSchema, SF extends TypeFromBitSchema<F>, A extends Attributes, C extends Commands, E extends Events>(
         cluster: Cluster<F, SF, A, C, E>,
         interactionClient?: InteractionClient
-    ): ClusterClientObj<A, C> | undefined {
+    ): ClusterClientObj<A, C, E> | undefined {
         return this.rootEndpoint.getClusterClient(cluster, interactionClient);
     }
 

--- a/packages/matter.js/src/cluster/Cluster.ts
+++ b/packages/matter.js/src/cluster/Cluster.ts
@@ -60,11 +60,15 @@ export const OptionalCommand = <RequestT, ResponseT>(requestId: number, requestS
 export const enum EventPriority {
     Critical,
     Info,
+    Debug,
 }
 export interface Event<T> { id: number, schema: TlvSchema<T>, priority: EventPriority, optional: boolean }
 export interface OptionalEvent<T> extends Event<T> { optional: true }
 export const Event = <FT extends TlvFields>(id: number, priority: EventPriority, data: FT = <FT>{}): Event<TypeFromFields<FT>> => ({ id, schema: TlvObject(data), priority, optional: false });
-export const OptionalEvent = <FT extends TlvFields>(id: number, priority: EventPriority, data: FT = <FT>{}): Event<TypeFromFields<FT>> => ({ id, schema: TlvObject(data), priority, optional: true });
+export const OptionalEvent = <FT extends TlvFields>(id: number, priority: EventPriority, data: FT = <FT>{}): OptionalEvent<TypeFromFields<FT>> => ({ id, schema: TlvObject(data), priority, optional: true });
+export type EventType<T extends Event<any>> = T extends OptionalEvent<infer EventT> ? EventT : (T extends Event<infer EventT> ? EventT : never);
+export type MandatoryEventNames<E extends Events> = { [K in keyof E]: E[K] extends OptionalEvent<any> ? never : K }[keyof E];
+export type OptionalEventNames<E extends Events> = { [K in keyof E]: E[K] extends OptionalEvent<any> ? K : never }[keyof E];
 
 /* Interfaces and helper methods to define a cluster */
 export interface Attributes { [key: string]: Attribute<any> }

--- a/packages/matter.js/src/cluster/IdentifyCluster.ts
+++ b/packages/matter.js/src/cluster/IdentifyCluster.ts
@@ -73,7 +73,7 @@ export const IdentifyCluster = Cluster({
         identifyTime: WritableAttribute(0, TlvUInt16, { default: 0 }), /* unit: seconds */
 
         /** Specifies how the identification state is presented to the user. */
-        identifyType: Attribute(1, TlvEnum<IdentifyType>(), { default: 0 }),
+        identifyType: Attribute(1, TlvEnum<IdentifyType>(), { default: IdentifyType.None }),
     },
 
     /** @see {@link MatterApplicationClusterSpecificationV1_0} § 1.2.6 */

--- a/packages/matter.js/src/cluster/client/AttributeClient.ts
+++ b/packages/matter.js/src/cluster/client/AttributeClient.ts
@@ -53,6 +53,7 @@ export class AttributeClient<T> {
         }
         return await interactionClient.getWithVersion(this.endpointId, this.clusterId, this.attribute, alwaysRequestFromRemote);
     }
+
     async subscribe(minIntervalS: number, maxIntervalS: number) {
         const interactionClient = await this.getInteractionClientCallback();
         if (interactionClient === undefined) {

--- a/packages/matter.js/src/cluster/client/ClusterClient.ts
+++ b/packages/matter.js/src/cluster/client/ClusterClient.ts
@@ -5,14 +5,18 @@
  */
 import {
     Attribute, AttributeJsType, Attributes, Command, Commands, OptionalAttribute, OptionalWritableAttribute,
-    RequestType, ResponseType, WritableAttribute, MandatoryAttributeNames, OptionalAttributeNames
+    RequestType, ResponseType, WritableAttribute, MandatoryAttributeNames, OptionalAttributeNames,
+    EventType, Events, MandatoryEventNames, OptionalEventNames, Cluster
 } from "../Cluster.js";
 import { AttributeClient } from "./AttributeClient.js";
 import { Merge } from "../../util/Type.js";
 import { InteractionClient } from "../../protocol/interaction/InteractionClient.js";
 import { ClusterServerObj } from "../server/ClusterServer.js";
+import { EventClient } from "./EventClient.js";
 
 export type AttributeClients<A extends Attributes> = Merge<{ [P in MandatoryAttributeNames<A>]: AttributeClient<AttributeJsType<A[P]>> }, { [P in OptionalAttributeNames<A>]: AttributeClient<AttributeJsType<A[P]> | undefined> }>;
+
+export type EventClients<E extends Events> = Merge<{ [P in MandatoryEventNames<E>]: EventClient<EventType<E[P]>> }, { [P in OptionalEventNames<E>]: EventClient<EventType<E[P]> | undefined> }>;
 
 export type SignatureFromCommandSpec<C extends Command<any, any>> = (request: RequestType<C>) => Promise<ResponseType<C>>;
 type GetterTypeFromSpec<A extends Attribute<any>> = A extends OptionalAttribute<infer T> ? (T | undefined) : AttributeJsType<A>;
@@ -23,23 +27,31 @@ type ClientAttributeSubscribers<A extends Attributes> = { [P in keyof A as `subs
 
 type CommandServers<C extends Commands> = { [P in keyof C]: SignatureFromCommandSpec<C[P]> };
 
+type ClientEventGetters<E extends Events> = { [P in keyof E as `get${Capitalize<string & P>}Event`]: () => Promise<EventType<E[P]>> };
+type ClientEventSubscribers<E extends Events> = { [P in keyof E as `subscribe${Capitalize<string & P>}Event`]: (listener: (value: EventType<E[P]>) => void, minIntervalS: number, maxIntervalS: number) => Promise<void> };
+
+export type ClusterClientObjForCluster<C extends Cluster<any, any, any, any, any>> = ClusterClientObj<C["attributes"], C["commands"], C["events"]>;
+
 /** Strongly typed interface of a cluster client */
-export type ClusterClientObj<A extends Attributes, C extends Commands> =
+export type ClusterClientObj<A extends Attributes, C extends Commands, E extends Events> =
     {
         id: number;
         _type: "ClusterClient";
         name: string;
         endpointId: number;
         attributes: AttributeClients<A>;
+        events: EventClients<E>;
         commands: CommandServers<C>;
         subscriptAllAttributes: (minIntervalFloorSeconds: number, maxIntervalCeilingSeconds: number) => Promise<void>;
-        _clone: (newInteractionClient?: InteractionClient) => ClusterClientObj<A, C>;
+        _clone: (newInteractionClient?: InteractionClient) => ClusterClientObj<A, C, E>;
     }
     & ClientAttributeGetters<A>
     & ClientAttributeSetters<A>
     & ClientAttributeSubscribers<A>
-    & CommandServers<C>;
+    & CommandServers<C>
+    & ClientEventGetters<E>
+    & ClientEventSubscribers<E>;
 
-export function isClusterClient<A extends Attributes, C extends Commands>(obj: ClusterClientObj<A, C> | ClusterServerObj<A, C>): obj is ClusterClientObj<A, C> {
+export function isClusterClient<A extends Attributes, C extends Commands, E extends Events>(obj: ClusterClientObj<A, C, E> | ClusterServerObj<A, C, E>): obj is ClusterClientObj<A, C, E> {
     return obj._type === "ClusterClient";
 }

--- a/packages/matter.js/src/cluster/client/EventClient.ts
+++ b/packages/matter.js/src/cluster/client/EventClient.ts
@@ -1,0 +1,54 @@
+/**
+ * @license
+ * Copyright 2022-2023 Project CHIP Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { InteractionClient } from "../../protocol/interaction/InteractionClient.js";
+import { Event } from "../Cluster.js";
+
+export class EventClient<T> {
+    private readonly listeners = new Array<(event: T/*, oldValue: T*/) => void>();
+
+    constructor(
+        readonly event: Event<T>,
+        readonly name: string,
+        readonly endpointId: number,
+        readonly clusterId: number,
+        private getInteractionClientCallback: () => Promise<InteractionClient>,
+    ) { }
+
+    async get(_alwaysRequestFromRemote = false) {
+        const interactionClient = await this.getInteractionClientCallback();
+        if (interactionClient === undefined) {
+            throw new Error("No InteractionClient available");
+        }
+        throw new Error("Not yet implemented");
+        /*
+        return await interactionClient.get(this.endpointId, this.clusterId, this.event, alwaysRequestFromRemote);*/
+        // TODO: implement
+    }
+
+    async subscribe(_minIntervalS: number, _maxIntervalS: number) {
+        const interactionClient = await this.getInteractionClientCallback();
+        if (interactionClient === undefined) {
+            throw new Error("No InteractionClient available");
+        }
+        throw new Error("Not yet implemented");
+        /*
+        return await interactionClient.subscribe(this.endpointId, this.clusterId, this.attribute, minIntervalS, maxIntervalS, this.update.bind(this));*/
+        // TODO implement
+    }
+
+    setInteractionClientRequestorCallback(callback: () => Promise<InteractionClient>) {
+        this.getInteractionClientCallback = callback;
+    }
+
+    addListener(listener: (newValue: T/*, oldValue: T*/) => void) {
+        this.listeners.push(listener);
+    }
+
+    removeListener(listener: (newValue: T/*, oldValue: T*/) => void) {
+        this.listeners.splice(this.listeners.findIndex(item => item === listener), 1);
+    }
+}

--- a/packages/matter.js/src/cluster/server/EventServer.ts
+++ b/packages/matter.js/src/cluster/server/EventServer.ts
@@ -1,0 +1,53 @@
+/**
+ * @license
+ * Copyright 2022-2023 Project CHIP Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { TlvSchema } from "../../tlv/TlvSchema.js";
+import { Endpoint } from "../../device/Endpoint.js";
+import { Time } from "../../time/index.js";
+import { EventPriority } from "../Cluster.js";
+import { EventData } from "../../protocol/interaction/EventHandler.js";
+
+export class EventServer<T> {
+    private eventList = new Array<EventData<T>>();
+    private readonly listeners = new Array<(event: EventData<T>) => void>();
+    protected endpoint?: Endpoint;
+
+    constructor(
+        readonly eventId: number,
+        readonly clusterId: number,
+        readonly name: string,
+        readonly schema: TlvSchema<T>,
+        readonly priority: EventPriority,
+    ) { }
+
+    assignToEndpoint(endpoint: Endpoint) {
+        this.endpoint = endpoint;
+    }
+
+    triggerEvent(value: T) {
+        if (this.endpoint === undefined || this.endpoint.id === undefined) {
+            throw new Error("Endpoint not assigned");
+        }
+        const event: EventData<T> = {
+            eventId: this.eventId,
+            clusterId: this.clusterId,
+            endpointId: this.endpoint.id,
+            timestamp: Time.nowMs(),
+            priority: this.priority,
+            value,
+        };
+        this.eventList.push(event);
+        this.listeners.forEach(listener => listener(event));
+    }
+
+    addListener(listener: (event: EventData<T>) => void) {
+        this.listeners.push(listener);
+    }
+
+    removeListener(listener: (event: EventData<T>) => void) {
+        this.listeners.splice(this.listeners.findIndex(item => item === listener), 1);
+    }
+}

--- a/packages/matter.js/src/cluster/server/GroupsServer.ts
+++ b/packages/matter.js/src/cluster/server/GroupsServer.ts
@@ -168,7 +168,6 @@ export const GroupsClusterHandler: () => ClusterServerHandlers<typeof GroupsClus
             }
 
             const identifyCluster = endpoint.getClusterServer(IdentifyCluster);
-            console.log(identifyCluster?.attributes.identifyTime.getLocal());
             if (identifyCluster) {
                 if (identifyCluster.attributes.identifyTime.getLocal() > 0) { // We identify ourself currently
                     addGroupLogic(groupId, groupName, sessionType, (session as SecureSession<MatterDevice>).getAccessingFabric(), endpoint.getId());

--- a/packages/matter.js/src/device/Aggregator.ts
+++ b/packages/matter.js/src/device/Aggregator.ts
@@ -53,7 +53,14 @@ export class Aggregator extends ComposedDevice {
             device.setDeviceTypes(deviceTypes);
         }
         if (bridgedBasicInformation !== undefined) {
-            device.addClusterServer(ClusterServer(BridgedDeviceBasicInformationCluster, bridgedBasicInformation, {}));
+            device.addClusterServer(ClusterServer(
+                BridgedDeviceBasicInformationCluster,
+                bridgedBasicInformation,
+                {},
+                {
+                    reachableChanged: true
+                }
+            ));
         } else {
             if (!device.hasClusterServer(BridgedDeviceBasicInformationCluster)) {
                 throw new Error("BridgedDeviceBasicInformationCluster is required for bridged devices. Please add yourself or provide as second parameter");

--- a/packages/matter.js/src/device/Device.ts
+++ b/packages/matter.js/src/device/Device.ts
@@ -30,7 +30,7 @@ export class PairedDevice extends Endpoint {
      */
     constructor(
         definition: AtLeastOne<DeviceTypeDefinition>,
-        clusters: (ClusterServerObj<Attributes, Commands> | ClusterClientObj<Attributes, Commands>)[] = [],
+        clusters: (ClusterServerObj<Attributes, Commands, Events> | ClusterClientObj<Attributes, Commands, Events>)[] = [],
         endpointId: number
     ) {
         super(definition, endpointId);
@@ -48,7 +48,7 @@ export class PairedDevice extends Endpoint {
     /**
      * @deprecated PairedDevice does not support adding additional clusters
      */
-    override addClusterServer<A extends Attributes, C extends Commands>(cluster: ClusterServerObj<A, C>) {
+    override addClusterServer<A extends Attributes, C extends Commands, E extends Events>(cluster: ClusterServerObj<A, C, E>) {
         if (this.declineAddingMoreClusters) {
             throw new Error("PairedDevice does not support adding additional clusters");
         }
@@ -58,7 +58,7 @@ export class PairedDevice extends Endpoint {
     /**
      * @deprecated PairedDevice does not support adding additional clusters
      */
-    override addClusterClient<A extends Attributes, C extends Commands>(cluster: ClusterClientObj<A, C>) {
+    override addClusterClient<A extends Attributes, C extends Commands, E extends Events>(cluster: ClusterClientObj<A, C, E>) {
         if (this.declineAddingMoreClusters) {
             throw new Error("PairedDevice does not support adding additional clusters");
         }
@@ -153,17 +153,17 @@ export class Device extends Endpoint {
         return await this.commandHandler.executeHandler(command, ...args);
     }
 
-    protected createOptionalClusterServer<F extends BitSchema, SF extends TypeFromBitSchema<F>, A extends Attributes, C extends Commands, E extends Events>(_cluster: Cluster<F, SF, A, C, E>): ClusterServerObj<A, C> {
+    protected createOptionalClusterServer<F extends BitSchema, SF extends TypeFromBitSchema<F>, A extends Attributes, C extends Commands, E extends Events>(_cluster: Cluster<F, SF, A, C, E>): ClusterServerObj<A, C, E> {
         // TODO: Implement this in upper classes to add optional clusters on the fly
         throw new Error("createOptionalClusterServer needs to be implemented by derived classes");
     }
 
-    protected createOptionalClusterClient<F extends BitSchema, SF extends TypeFromBitSchema<F>, A extends Attributes, C extends Commands, E extends Events>(_cluster: Cluster<F, SF, A, C, E>): ClusterClientObj<A, C> {
+    protected createOptionalClusterClient<F extends BitSchema, SF extends TypeFromBitSchema<F>, A extends Attributes, C extends Commands, E extends Events>(_cluster: Cluster<F, SF, A, C, E>): ClusterClientObj<A, C, E> {
         // TODO: Implement this in upper classes to add optional clusters on the fly
         throw new Error("createOptionalClusterClient needs to be implemented by derived classes");
     }
 
-    override getClusterServer<F extends BitSchema, SF extends TypeFromBitSchema<F>, A extends Attributes, C extends Commands, E extends Events>(cluster: Cluster<F, SF, A, C, E>): ClusterServerObj<A, C> | undefined {
+    override getClusterServer<F extends BitSchema, SF extends TypeFromBitSchema<F>, A extends Attributes, C extends Commands, E extends Events>(cluster: Cluster<F, SF, A, C, E>): ClusterServerObj<A, C, E> | undefined {
         const clusterServer = super.getClusterServer(cluster);
         if (clusterServer !== undefined) {
             return clusterServer;
@@ -177,7 +177,7 @@ export class Device extends Endpoint {
         }
     }
 
-    override getClusterClient<F extends BitSchema, SF extends TypeFromBitSchema<F>, A extends Attributes, C extends Commands, E extends Events>(cluster: Cluster<F, SF, A, C, E>): ClusterClientObj<A, C> | undefined {
+    override getClusterClient<F extends BitSchema, SF extends TypeFromBitSchema<F>, A extends Attributes, C extends Commands, E extends Events>(cluster: Cluster<F, SF, A, C, E>): ClusterClientObj<A, C, E> | undefined {
         const clusterClient = super.getClusterClient(cluster);
         if (clusterClient !== undefined) {
             return clusterClient;

--- a/packages/matter.js/src/device/OnOffDevices.ts
+++ b/packages/matter.js/src/device/OnOffDevices.ts
@@ -9,7 +9,7 @@ import { createDefaultOnOffClusterServer } from "../cluster/server/OnOffServer.j
 import { createDefaultGroupsClusterServer } from "../cluster/server/GroupsServer.js";
 import { createDefaultScenesClusterServer } from "../cluster/server/ScenesServer.js";
 import { createDefaultIdentifyClusterServer } from "../cluster/server/IdentifyServer.js";
-import { AttributeInitialValues, CommandHandler } from "../cluster/server/ClusterServer.js";
+import { AttributeInitialValues, ClusterServerHandlers } from "../cluster/server/ClusterServer.js";
 import { IdentifyCluster, } from "../cluster/IdentifyCluster.js";
 import { OnOffCluster } from "../cluster/OnOffCluster.js";
 import { extendPublicHandlerMethods } from "../util/NamedHandler.js";
@@ -17,9 +17,8 @@ import { BitSchema, TypeFromBitSchema } from "../schema/BitmapSchema.js";
 import { Attributes, Cluster, Commands, Events } from "../cluster/Cluster.js";
 
 type OnOffBaseDeviceCommands = {
-    identify: CommandHandler<typeof IdentifyCluster.commands.identify, any>;
+    identify: ClusterServerHandlers<typeof IdentifyCluster>["identify"];
 }
-
 
 /**
  * Utility function to get the initial attribute values for a cluster out of an object with initial attribute values

--- a/packages/matter.js/src/protocol/interaction/EventHandler.ts
+++ b/packages/matter.js/src/protocol/interaction/EventHandler.ts
@@ -1,0 +1,73 @@
+/**
+ * @license
+ * Copyright 2022-2023 Project CHIP Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { StorageContext } from "../../storage/StorageContext.js";
+import { StorageManager } from "../../storage/StorageManager.js";
+import { EventPriority } from "../../cluster/index.js";
+
+const MAX_EVENTS = 10_000;
+
+/**
+ * Data of one Event
+ */
+export interface EventData<T> {
+    endpointId: number;
+    clusterId: number;
+    eventId: number
+    timestamp: number;
+    priority: EventPriority;
+    value: T;
+}
+
+/**
+ * Data of an event which was triggered and stored internally
+ */
+interface EventStorageData<T> extends EventData<T> {
+    eventNumber: number;
+}
+
+/**
+ * Class that collects all triggered events up to a certain limit of events and handle logic
+ * to handle subscriptions (TBD)
+ */
+export class EventHandler {
+    private readonly eventStorage: StorageContext;
+    private eventNumber = 0;
+    private storedEventCount = 0;
+    private readonly events = {
+        [EventPriority.Critical]: new Array<EventStorageData<any>>(),
+        [EventPriority.Info]: new Array<EventStorageData<any>>(),
+        [EventPriority.Debug]: new Array<EventStorageData<any>>(),
+    }
+
+    constructor(storageManager: StorageManager) {
+        this.eventStorage = storageManager.createContext("EventHandler");
+        this.eventNumber = this.eventStorage.get("lastEventNumber", this.eventNumber);
+    }
+
+    pushEvent(event: EventData<any>) {
+        const eventData = {
+            eventNumber: ++this.eventNumber,
+            ...event,
+        };
+        this.events[event.priority].push(eventData);
+        this.storedEventCount++;
+        this.eventStorage.set("lastEventNumber", this.eventNumber);
+        this.cleanUpEvents();
+    }
+
+    cleanUpEvents() {
+        if (this.storedEventCount < MAX_EVENTS) return;
+        const eventsToDelete = this.storedEventCount - MAX_EVENTS; // should be always 1, but lets be sure
+        for (const priority of [EventPriority.Debug, EventPriority.Info, EventPriority.Critical]) {
+            const events = this.events[priority];
+            if (events.length > 0) {
+                events.splice(0, events.length - eventsToDelete);
+                return;
+            }
+        }
+    }
+}

--- a/packages/matter.js/test/cluster/ClusterServerTest.ts
+++ b/packages/matter.js/test/cluster/ClusterServerTest.ts
@@ -43,7 +43,9 @@ describe("ClusterServer structure", () => {
                         caseSessionsPerFabric: 3,
                         subscriptionsPerFabric: 3,
                     },
-                }, {});
+                }, {}, {
+                startUp: true
+            });
 
             // TS ignore to allow a check, remove to test typing)
 
@@ -99,7 +101,9 @@ describe("ClusterServer structure", () => {
                         caseSessionsPerFabric: 3,
                         subscriptionsPerFabric: 3,
                     },
-                }, {});
+                }, {}, {
+                startUp: true
+            });
 
             assert.equal(basic.attributes.nodeLabel.getLocal(), "");
             assert.ok(basic.attributes.nodeLabel instanceof AttributeServer);
@@ -144,7 +148,9 @@ describe("ClusterServer structure", () => {
                         subscriptionsPerFabric: 3,
                     },
                     manufacturingDate: "12345678"
-                }, {});
+                }, {}, {
+                startUp: true
+            });
 
             // TS ignore to allow a check, remove to test typing)
 
@@ -205,7 +211,9 @@ describe("ClusterServer structure", () => {
                         subscriptionsPerFabric: 3,
                     },
                     reachable: true
-                }, {});
+                }, {}, {
+                startUp: true
+            });
 
             // guard needed because as per types optional are potentially undefined
             assert.equal(basic.attributes.reachable?.getLocal(), true);
@@ -251,7 +259,9 @@ describe("ClusterServer structure", () => {
                         caseSessionsPerFabric: 3,
                         subscriptionsPerFabric: 3,
                     },
-                }, {});
+                }, {}, {
+                startUp: true
+            });
 
             // guard needed because as per types optional are potentially undefined
             assert.equal(basic.attributes.serialNumber, undefined);
@@ -301,7 +311,9 @@ describe("ClusterServer structure", () => {
                         caseSessionsPerFabric: 3,
                         subscriptionsPerFabric: 3,
                     },
-                }, {});
+                }, {}, {
+                startUp: true
+            });
 
             assert.equal(basic.attributes.localConfigDisabled, undefined);
             // guard needed because as per types optional are potentially undefined
@@ -381,9 +393,10 @@ describe("ClusterServer structure", () => {
             assert.ok(server);
             // as any is trick because these attributes are not officially exposed by typings
             assert.deepEqual((server.attributes as any).featureMap.get(), { basic: false });
-            assert.deepEqual((server.attributes as any).attributeList.get(), [new AttributeId(0), new AttributeId(1), new AttributeId(2), new AttributeId(65533), new AttributeId(65532), new AttributeId(65531), new AttributeId(65529), new AttributeId(65528)]);
+            assert.deepEqual((server.attributes as any).attributeList.get(), [new AttributeId(0), new AttributeId(1), new AttributeId(2), new AttributeId(65533), new AttributeId(65532), new AttributeId(65531), new AttributeId(65530), new AttributeId(65529), new AttributeId(65528)]);
             assert.deepEqual((server.attributes as any).acceptedCommandList.get(), [new CommandId(0), new CommandId(2)]);
             assert.deepEqual((server.attributes as any).generatedCommandList.get(), []);
+            assert.deepEqual((server.attributes as any).eventList.get(), []);
         });
 
         it("IdentifyCluster including optional commands", () => {
@@ -401,9 +414,10 @@ describe("ClusterServer structure", () => {
             assert.ok(server);
             // as any is trick because these attributes are not officially exposed by typings
             assert.deepEqual((server.attributes as any).featureMap.get(), {});
-            assert.deepEqual((server.attributes as any).attributeList.get(), [new AttributeId(0), new AttributeId(1), new AttributeId(65533), new AttributeId(65532), new AttributeId(65531), new AttributeId(65529), new AttributeId(65528)]);
+            assert.deepEqual((server.attributes as any).attributeList.get(), [new AttributeId(0), new AttributeId(1), new AttributeId(65533), new AttributeId(65532), new AttributeId(65531), new AttributeId(65530), new AttributeId(65529), new AttributeId(65528)]);
             assert.deepEqual((server.attributes as any).acceptedCommandList.get(), [new CommandId(0), new CommandId(0x40)]);
             assert.deepEqual((server.attributes as any).generatedCommandList.get(), []);
+            assert.deepEqual((server.attributes as any).eventList.get(), []);
         });
 
         it("IdentifyCluster including optional commands", () => {
@@ -421,9 +435,10 @@ describe("ClusterServer structure", () => {
             assert.ok(server);
             // as any is trick because these attributes are not officially exposed by typings
             assert.deepEqual((server.attributes as any).featureMap.get(), {});
-            assert.deepEqual((server.attributes as any).attributeList.get(), [new AttributeId(0), new AttributeId(1), new AttributeId(65533), new AttributeId(65532), new AttributeId(65531), new AttributeId(65529), new AttributeId(65528)]);
+            assert.deepEqual((server.attributes as any).attributeList.get(), [new AttributeId(0), new AttributeId(1), new AttributeId(65533), new AttributeId(65532), new AttributeId(65531), new AttributeId(65530), new AttributeId(65529), new AttributeId(65528)]);
             assert.deepEqual((server.attributes as any).acceptedCommandList.get(), [new CommandId(0), new CommandId(0x40)]);
             assert.deepEqual((server.attributes as any).generatedCommandList.get(), []);
+            assert.deepEqual((server.attributes as any).eventList.get(), []);
         });
 
         it("IdentifyCluster without optional commands", () => {
@@ -440,7 +455,7 @@ describe("ClusterServer structure", () => {
             assert.ok(server);
             // as any is trick because these attributes are not officially exposed by typings
             assert.deepEqual((server.attributes as any).featureMap.get(), {});
-            assert.deepEqual((server.attributes as any).attributeList.get(), [new AttributeId(0), new AttributeId(1), new AttributeId(65533), new AttributeId(65532), new AttributeId(65531), new AttributeId(65529), new AttributeId(65528)]);
+            assert.deepEqual((server.attributes as any).attributeList.get(), [new AttributeId(0), new AttributeId(1), new AttributeId(65533), new AttributeId(65532), new AttributeId(65531), new AttributeId(65530), new AttributeId(65529), new AttributeId(65528)]);
             assert.deepEqual((server.attributes as any).acceptedCommandList.get(), [new CommandId(0)]);
             assert.deepEqual((server.attributes as any).generatedCommandList.get(), []);
         });
@@ -463,9 +478,10 @@ describe("ClusterServer structure", () => {
             assert.ok(server);
             // as any is trick because these attributes are not officially exposed by typings
             assert.deepEqual((server.attributes as any).featureMap.get(), {});
-            assert.deepEqual((server.attributes as any).attributeList.get(), [new AttributeId(0), new AttributeId(65533), new AttributeId(65532), new AttributeId(65531), new AttributeId(65529), new AttributeId(65528)]);
+            assert.deepEqual((server.attributes as any).attributeList.get(), [new AttributeId(0), new AttributeId(65533), new AttributeId(65532), new AttributeId(65531), new AttributeId(65530), new AttributeId(65529), new AttributeId(65528)]);
             assert.deepEqual((server.attributes as any).acceptedCommandList.get(), [new CommandId(0), new CommandId(1), new CommandId(2), new CommandId(3), new CommandId(4), new CommandId(5)]);
             assert.deepEqual((server.attributes as any).generatedCommandList.get(), [new CommandId(0), new CommandId(1), new CommandId(2), new CommandId(3)]);
+            assert.deepEqual((server.attributes as any).eventList.get(), []);
         });
     });
 });

--- a/packages/matter.js/test/device/MatterNodeStructureTest.ts
+++ b/packages/matter.js/test/device/MatterNodeStructureTest.ts
@@ -83,7 +83,9 @@ function addRequiredRootClusters(node: MatterNode, includeAdminCommissioningClus
             },
             serialNumber: `node-matter-0000`
         },
-        {}
+        {}, {
+        startUp: true
+    }
     )
     );
 
@@ -149,7 +151,10 @@ function addRequiredRootClusters(node: MatterNode, includeAdminCommissioningClus
                 targetsPerAccessControlEntry: 4,
                 accessControlEntriesPerFabric: 4,
             },
-            {}
+            {}, {
+            accessControlEntryChanged: true,
+            accessControlExtensionChanged: true,
+        }
         )
     );
 
@@ -182,6 +187,9 @@ function addRequiredRootClusters(node: MatterNode, includeAdminCommissioningClus
             },
             {
                 testEventTrigger: async () => { /* ignore */ }
+            },
+            {
+                bootReason: true,
             }
         )
     );
@@ -247,7 +255,7 @@ describe("Endpoint Structures", () => {
             assert.ok(endpoints.get(0)?.hasClusterServer(GroupKeyManagementCluster));
             assert.ok(endpoints.get(0)?.hasClusterServer(GeneralCommissioningCluster));
 
-            assert.equal(attributePaths.length, 101);
+            assert.equal(attributePaths.length, 110);
             assert.equal(commandPaths.length, 18);
         });
 
@@ -295,7 +303,7 @@ describe("Endpoint Structures", () => {
             })) as AttributeServer<EndpointNumber[]>;
             assert.deepEqual(rootPartsListAttribute?.getLocal(), [new EndpointNumber(1)]);
 
-            assert.equal(attributePaths.length, 146);
+            assert.equal(attributePaths.length, 161);
             assert.equal(commandPaths.length, 38);
         });
     });
@@ -368,7 +376,7 @@ describe("Endpoint Structures", () => {
             })) as AttributeServer<EndpointNumber[]>;
             assert.deepEqual(composedPartsListAttribute?.getLocal(), [new EndpointNumber(2), new EndpointNumber(3)]);
 
-            assert.equal(attributePaths.length, 200);
+            assert.equal(attributePaths.length, 222);
             assert.equal(commandPaths.length, 58);
         });
     });
@@ -384,7 +392,9 @@ describe("Endpoint Structures", () => {
             onoffLightDevice.addClusterServer(ClusterServer(BridgedDeviceBasicInformationCluster, {
                 nodeLabel: "Socket 1",
                 reachable: true
-            }, {}))
+            }, {}, {
+                reachableChanged: true
+            }))
 
             aggregator.addBridgedDevice(onoffLightDevice);
             node.addEndpoint(aggregator);
@@ -437,7 +447,7 @@ describe("Endpoint Structures", () => {
             const deviceTypeListAttribute = attributes.get(attributePathToId({ endpointId: 11, clusterId: DescriptorCluster.id, attributeId: DescriptorCluster.attributes.deviceTypeList.id })) as AttributeServer<EndpointNumber[]>;
             assert.deepEqual(deviceTypeListAttribute?.getLocal(), [{ deviceType: new DeviceTypeId(DeviceTypes.ON_OFF_LIGHT.code), revision: 2 }, { deviceType: new DeviceTypeId(DeviceTypes.BRIDGED_NODE.code), revision: 1 }]);
 
-            assert.equal(attributePaths.length, 162);
+            assert.equal(attributePaths.length, 179);
             assert.equal(commandPaths.length, 38);
         });
 
@@ -511,7 +521,7 @@ describe("Endpoint Structures", () => {
             const deviceTypeListAttribute = attributes.get(attributePathToId({ endpointId: 11, clusterId: DescriptorCluster.id, attributeId: DescriptorCluster.attributes.deviceTypeList.id })) as AttributeServer<EndpointNumber[]>;
             assert.deepEqual(deviceTypeListAttribute?.getLocal(), [{ deviceType: new DeviceTypeId(DeviceTypes.ON_OFF_LIGHT.code), revision: 2 }, { deviceType: new DeviceTypeId(DeviceTypes.BRIDGED_NODE.code), revision: 1 }]);
 
-            assert.equal(attributePaths.length, 214);
+            assert.equal(attributePaths.length, 238);
             assert.equal(commandPaths.length, 58);
         });
 
@@ -631,7 +641,7 @@ describe("Endpoint Structures", () => {
             const rootPartsListAttribute = attributes.get(attributePathToId({ endpointId: 0, clusterId: DescriptorCluster.id, attributeId: DescriptorCluster.attributes.partsList.id })) as AttributeServer<EndpointNumber[]>;
             assert.deepEqual(rootPartsListAttribute?.getLocal(), [new EndpointNumber(1), new EndpointNumber(11), new EndpointNumber(12), new EndpointNumber(2), new EndpointNumber(21), new EndpointNumber(22)]);
 
-            assert.equal(attributePaths.length, 339);
+            assert.equal(attributePaths.length, 380);
             assert.equal(commandPaths.length, 98);
         });
 
@@ -748,7 +758,7 @@ describe("Endpoint Structures", () => {
             const rootPartsListAttribute = attributes.get(attributePathToId({ endpointId: 0, clusterId: DescriptorCluster.id, attributeId: DescriptorCluster.attributes.partsList.id })) as AttributeServer<EndpointNumber[]>;
             assert.deepEqual(rootPartsListAttribute?.getLocal(), [new EndpointNumber(1), new EndpointNumber(2), new EndpointNumber(3), new EndpointNumber(4), new EndpointNumber(5), new EndpointNumber(6)]);
 
-            assert.equal(attributePaths.length, 339);
+            assert.equal(attributePaths.length, 380);
             assert.equal(commandPaths.length, 98);
         });
 
@@ -870,7 +880,7 @@ describe("Endpoint Structures", () => {
             const rootPartsListAttribute = attributes.get(attributePathToId({ endpointId: 0, clusterId: DescriptorCluster.id, attributeId: DescriptorCluster.attributes.partsList.id })) as AttributeServer<EndpointNumber[]>;
             assert.deepEqual(rootPartsListAttribute?.getLocal(), [new EndpointNumber(37), new EndpointNumber(3), new EndpointNumber(38), new EndpointNumber(39), new EndpointNumber(40), new EndpointNumber(18)]);
 
-            assert.equal(attributePaths.length, 339);
+            assert.equal(attributePaths.length, 380);
             assert.equal(commandPaths.length, 98);
         });
 


### PR DESCRIPTION
This PR adds the first step for Event support. This means the basic ClusterSeverr/ClusterClient interface and typing is added.

I decided for now that for CLusterServer the full list of Events needs to be provided, which means that also the mandatory ones are needed to be provided - mainly that the Dev on this level "knows" that he needs to support this. We could discuss if we only want to have the optional ones being specified, but so it matches for me to the current level of string typing in ClusterServer.

The user will interact with EventServer and EventClient instances - in fact the same concept as alreayd used for Attributes. And we have convenient named methods to trigger an event (Server) or read/subscribe for events (Client).

Internally because of the way Events needs to be managed according to specs I added an EventManager class which will hold all events in a list based on priority and holds the events up to a certain number (se to 10k for now). The final implemntation shere and all logic to read, subscribe to events will be added in a later PR because it is internally without big interface changes.