### PR TITLE
Optimize Typings for node10 TS settings

### DIFF
--- a/packages/matter-node.js/package.json
+++ b/packages/matter-node.js/package.json
@@ -77,10 +77,6 @@
             "default": "./dist/index.js"
         },
         "./package.json": "./package.json",
-        "./*": {
-            "types": "./dist/*/index.d.ts",
-            "default": "./dist/*/index.js"
-        },
         "./certificate": {
             "types": "./dist/exports/certificate.d.ts",
             "default": "./dist/exports/certificate.js"
@@ -148,6 +144,71 @@
         "./tlv": {
             "types": "./dist/exports/tlv.d.ts",
             "default": "./dist/exports/tlv.js"
+        },
+        "./*": {
+            "types": "./dist/*/index.d.ts",
+            "default": "./dist/*/index.js"
+        }
+    },
+    "typesVersions": {
+        "*": {
+            "certificate": [
+                "/dist/exports/certificate.d.ts"
+            ],
+            "cluster": [
+                "/dist/exports/cluster.d.ts"
+            ],
+            "codec": [
+                "/dist/exports/codec.d.ts"
+            ],
+            "common": [
+                "/dist/exports/common.d.ts"
+            ],
+            "datatype": [
+                "/dist/exports/datatype.d.ts"
+            ],
+            "device": [
+                "/dist/exports/device.d.ts"
+            ],
+            "fabric": [
+                "/dist/exports/fabric.d.ts"
+            ],
+            "interaction": [
+                "/dist/exports/interaction.d.ts"
+            ],
+            "log": [
+                "/dist/exports/log.d.ts"
+            ],
+            "math": [
+                "/dist/exports/math.d.ts"
+            ],
+            "mdns": [
+                "/dist/exports/mdns.d.ts"
+            ],
+            "protocol": [
+                "/dist/exports/protocol.d.ts"
+            ],
+            "schema": [
+                "/dist/exports/schema.d.ts"
+            ],
+            "securechannel": [
+                "/dist/exports/securechannel.d.ts"
+            ],
+            "session": [
+                "/dist/exports/session.d.ts"
+            ],
+            "spec": [
+                "/dist/exports/spec.d.ts"
+            ],
+            "tlv": [
+                "/dist/exports/tlv.d.ts"
+            ],
+            ".": [
+                "/dist/index.d.ts"
+            ],
+            "*": [
+                "/dist/*/index.d.ts"
+            ]
         }
     },
     "publishConfig": {

--- a/packages/matter.js/package.json
+++ b/packages/matter.js/package.json
@@ -103,6 +103,22 @@
     }
   },
   "types": "dist/es/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "interaction": [
+        "/dist/cjs/protocol/interaction/index.d.ts"
+      ],
+      "securechannel": [
+        "/dist/cjs/protocol/securechannel/index.d.ts"
+      ],
+      ".": [
+        "/dist/cjs/index.d.ts"
+      ],
+      "*": [
+        "/dist/cjs/*/index.d.ts"
+      ]
+    }
+  },
   "publishConfig": {
     "access": "public"
   }


### PR DESCRIPTION
I was checking a bit deeper if we have all typing exports correct and using https://arethetypeswrong.github.io I stumbled over an "issue" when coming with TS standard "node10" mooduleResultuon setting.

matter.js results:

![2023-05-26 11 42 32](https://github.com/project-chip/matter.js/assets/11976694/0506cf21-667e-4d80-bc4d-ed01427a2e70)

matter-mnode.js looks same-ish. Reason is that node10 do not support the" "exports" fiel, but can be tweaked by using typesVersions

This PR addresses and fixes this