### PR TITLE
Conditional ClusterSchemas and WindowCoveringCluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ All Changes without a GitHub Username in brackets are from the core team: @Apoll
   * Adjustment: Do not send empty arrays for empty subscription messages to further shorten the payload
   * Fix: Respond with Unsupported Command when a unknown command is received and log the error
   * Fix: Increase the array maximum size according to specs
-  * Fix: Fixed internal TlvTag representation to allow also decoding of the internal object format of a Tlv stream 
+  * Fix: Fixed internal TlvTag representation to allow also decoding of the internal object format of a Tlv stream
   * Fix: Adjust internal tag encoding to not use {} when empty
 * matter.js API:
   * Feature: Introduce new High level API, see [API.md](./packages/matter.js/API.md) for details!

--- a/packages/matter.js/src/CommissioningController.ts
+++ b/packages/matter.js/src/CommissioningController.ts
@@ -25,7 +25,7 @@ import { ComposedDevice } from "./device/ComposedDevice.js";
 import { DescriptorCluster } from "./cluster/DescriptorCluster.js";
 import { AllClustersMap } from "./cluster/ClusterHelper.js";
 import { ClusterClientObj, isClusterClient } from "./cluster/client/ClusterClient.js";
-import { BitSchema, TypeFromBitSchema } from "./schema/BitmapSchema.js";
+import { BitSchema, TypeFromPartialBitSchema } from "./schema/BitmapSchema.js";
 import { Attributes, Cluster, Commands, Events } from "./cluster/Cluster.js";
 
 const logger = new Logger("CommissioningController");
@@ -171,7 +171,7 @@ export class CommissioningController extends MatterNode {
      *
      * @param cluster The cluster to get the client for
      */
-    async getRootClusterClientWithNewInteractionClient<F extends BitSchema, SF extends TypeFromBitSchema<F>, A extends Attributes, C extends Commands, E extends Events>(
+    async getRootClusterClientWithNewInteractionClient<F extends BitSchema, SF extends TypeFromPartialBitSchema<F>, A extends Attributes, C extends Commands, E extends Events>(
         cluster: Cluster<F, SF, A, C, E>
     ): Promise<ClusterClientObj<A, C, E> | undefined> {
         return super.getRootClusterClient(cluster, await this.createInteractionClient());

--- a/packages/matter.js/src/MatterNode.ts
+++ b/packages/matter.js/src/MatterNode.ts
@@ -6,7 +6,7 @@
 
 import { RootEndpoint } from "./device/Device.js";
 import { Endpoint } from "./device/Endpoint.js";
-import { BitSchema, TypeFromBitSchema } from "./schema/BitmapSchema.js";
+import { BitSchema, TypeFromPartialBitSchema } from "./schema/BitmapSchema.js";
 import { Attributes, Cluster, Commands, Events } from "./cluster/Cluster.js";
 import { ClusterClientObj } from "./cluster/client/ClusterClient.js";
 import { ClusterServerObj } from "./cluster/server/ClusterServer.js";
@@ -32,7 +32,7 @@ export abstract class MatterNode {
      *
      * @param cluster ClusterServer to get or undefined if not existing
      */
-    getRootClusterServer<F extends BitSchema, SF extends TypeFromBitSchema<F>, A extends Attributes, C extends Commands, E extends Events>(
+    getRootClusterServer<F extends BitSchema, SF extends TypeFromPartialBitSchema<F>, A extends Attributes, C extends Commands, E extends Events>(
         cluster: Cluster<F, SF, A, C, E>
     ): ClusterServerObj<A, C, E> | undefined {
         return this.rootEndpoint.getClusterServer(cluster);
@@ -54,7 +54,7 @@ export abstract class MatterNode {
      * @param interactionClient Optional InteractionClient to use for the cluster client. If not provided, the default
      *                          InteractionClient of the root endpoint is used.
      */
-    getRootClusterClient<F extends BitSchema, SF extends TypeFromBitSchema<F>, A extends Attributes, C extends Commands, E extends Events>(
+    getRootClusterClient<F extends BitSchema, SF extends TypeFromPartialBitSchema<F>, A extends Attributes, C extends Commands, E extends Events>(
         cluster: Cluster<F, SF, A, C, E>,
         interactionClient?: InteractionClient
     ): ClusterClientObj<A, C, E> | undefined {

--- a/packages/matter.js/src/cluster/Cluster.ts
+++ b/packages/matter.js/src/cluster/Cluster.ts
@@ -5,7 +5,7 @@
  */
 
 import { Merge } from "../util/Type.js";
-import { BitSchema, TypeFromBitSchema } from "../schema/BitmapSchema.js";
+import { BitSchema, TypeFromPartialBitSchema } from "../schema/BitmapSchema.js";
 import { TlvSchema } from "../tlv/TlvSchema.js";
 import { TlvVoid } from "../tlv/TlvVoid.js";
 import { TlvFields, TlvObject, TypeFromFields } from "../tlv/TlvObject.js";
@@ -22,39 +22,414 @@ export const enum AccessLevel {
     Administer,
 }
 
+export type ConditionalFeatureList<F extends BitSchema> = TypeFromPartialBitSchema<F>[];
+
 /* Interfaces and helper methods to define a cluster attribute */
-export interface Attribute<T> { id: number, schema: TlvSchema<T>, optional: boolean, readAcl: AccessLevel, writable: boolean, scene: boolean, persistent: boolean, fixed: boolean, fabricScoped: boolean, omitChanges: boolean, writeAcl?: AccessLevel, default?: T }
+export interface Attribute<T> {
+    id: number,
+    schema: TlvSchema<T>,
+    optional: boolean,
+    readAcl: AccessLevel,
+    writable: boolean,
+    scene: boolean,
+    persistent: boolean,
+    fixed: boolean,
+    fabricScoped: boolean,
+    omitChanges: boolean,
+    writeAcl?: AccessLevel,
+    default?: T
+}
+
 export interface OptionalAttribute<T> extends Attribute<T> { optional: true }
+
+export interface ConditionalAttribute<T, F extends BitSchema> extends OptionalAttribute<T> {
+    optionalIf?: ConditionalFeatureList<F>,
+    mandatoryIf?: ConditionalFeatureList<F>,
+}
+
 export interface WritableAttribute<T> extends Attribute<T> { writable: true }
+
 export interface OptionalWritableAttribute<T> extends OptionalAttribute<T> { writable: true }
+
+export interface ConditionalWritableAttribute<T, F extends BitSchema> extends OptionalWritableAttribute<T> {
+    optionalIf?: ConditionalFeatureList<F>,
+    mandatoryIf?: ConditionalFeatureList<F>,
+}
+
 export interface WritableFabricScopedAttribute<T> extends WritableAttribute<T> { fabricScoped: true }
+
 export interface OptionalWritableFabricScopedAttribute<T> extends OptionalWritableAttribute<T> { fabricScoped: true }
+
+export interface ConditionalWritableFabricScopedAttribute<T, F extends BitSchema> extends OptionalWritableFabricScopedAttribute<T> {
+    optionalIf?: ConditionalFeatureList<F>,
+    mandatoryIf?: ConditionalFeatureList<F>,
+}
+
 export interface FixedAttribute<T> extends Attribute<T> { fixed: true }
+
 export interface OptionalFixedAttribute<T> extends OptionalAttribute<T> { fixed: true }
 
+export interface ConditionalFixedAttribute<T, F extends BitSchema> extends OptionalFixedAttribute<T> {
+    optionalIf?: ConditionalFeatureList<F>,
+    mandatoryIf?: ConditionalFeatureList<F>,
+}
+
 export type AttributeJsType<T extends Attribute<any>> = T extends Attribute<infer JsType> ? JsType : never;
-interface AttributeOptions<T> { scene?: boolean, persistent?: boolean, omitChanges?: boolean, default?: T, readAcl?: AccessLevel, writeAcl?: AccessLevel }
-export const Attribute = <T, V extends T>(id: number, schema: TlvSchema<T>, { scene = false, persistent = false, omitChanges = false, default: conformanceValue, readAcl = AccessLevel.View }: AttributeOptions<V> = {}): Attribute<T> => ({ id, schema, optional: false, writable: false, fixed: false, scene, persistent, fabricScoped: false, omitChanges, default: conformanceValue, readAcl });
-export const OptionalAttribute = <T, V extends T>(id: number, schema: TlvSchema<T>, { scene = false, persistent = false, omitChanges = false, default: conformanceValue, readAcl = AccessLevel.View }: AttributeOptions<V> = {}): OptionalAttribute<T> => ({ id, schema, optional: true, writable: false, fixed: false, scene, persistent, fabricScoped: false, omitChanges, default: conformanceValue, readAcl });
-export const WritableAttribute = <T, V extends T>(id: number, schema: TlvSchema<T>, { scene = false, persistent = true, omitChanges = false, default: conformanceValue, readAcl = AccessLevel.View, writeAcl = AccessLevel.View }: AttributeOptions<V> = {}): WritableAttribute<T> => ({ id, schema, optional: false, writable: true, fixed: false, scene, persistent, fabricScoped: false, omitChanges, default: conformanceValue, readAcl, writeAcl });
-export const OptionalWritableAttribute = <T, V extends T>(id: number, schema: TlvSchema<T>, { scene = false, persistent = true, omitChanges = false, default: conformanceValue, readAcl = AccessLevel.View, writeAcl = AccessLevel.View }: AttributeOptions<V> = {}): OptionalWritableAttribute<T> => ({ id, schema, optional: true, writable: true, fixed: false, scene, persistent, fabricScoped: false, omitChanges, default: conformanceValue, readAcl, writeAcl });
-export const WritableFabricScopedAttribute = <T, V extends T>(id: number, schema: TlvSchema<T>, { scene = false, persistent = true, omitChanges = false, default: conformanceValue, readAcl = AccessLevel.View, writeAcl = AccessLevel.View }: AttributeOptions<V> = {}): WritableFabricScopedAttribute<T> => ({ id, schema, optional: false, writable: true, fixed: false, scene, persistent, fabricScoped: true, omitChanges, default: conformanceValue, readAcl, writeAcl });
-export const OptionalWritableFabricScopedAttribute = <T, V extends T>(id: number, schema: TlvSchema<T>, { scene = false, persistent = true, omitChanges = false, default: conformanceValue, readAcl = AccessLevel.View, writeAcl = AccessLevel.View }: AttributeOptions<V> = {}): OptionalWritableFabricScopedAttribute<T> => ({ id, schema, optional: true, writable: true, fixed: false, scene, persistent, fabricScoped: true, omitChanges, default: conformanceValue, readAcl, writeAcl });
-export const FixedAttribute = <T, V extends T>(id: number, schema: TlvSchema<T>, { scene = false, persistent = false, omitChanges = false, default: conformanceValue, readAcl = AccessLevel.View }: AttributeOptions<V> = {}): FixedAttribute<T> => ({ id, schema, optional: false, writable: false, fixed: true, scene, persistent, fabricScoped: false, omitChanges, default: conformanceValue, readAcl });
-export const OptionalFixedAttribute = <T, V extends T>(id: number, schema: TlvSchema<T>, { scene = false, persistent = false, omitChanges = false, default: conformanceValue, readAcl = AccessLevel.View }: AttributeOptions<V> = {}): OptionalFixedAttribute<T> => ({ id, schema, optional: true, writable: false, fixed: true, scene, persistent, fabricScoped: false, omitChanges, default: conformanceValue, readAcl });
+
+interface AttributeOptions<T> {
+    scene?: boolean;
+    persistent?: boolean;
+    omitChanges?: boolean;
+    default?: T;
+    readAcl?: AccessLevel;
+    writeAcl?: AccessLevel;
+}
+
+interface ConditionalAttributeOptions<T, F extends BitSchema> extends AttributeOptions<T> {
+    optionalIf?: ConditionalFeatureList<F>,
+    mandatoryIf?: ConditionalFeatureList<F>,
+}
+
+export const Attribute = <T, V extends T>(id: number, schema: TlvSchema<T>, {
+    scene = false,
+    persistent = false,
+    omitChanges = false,
+    default: conformanceValue,
+    readAcl = AccessLevel.View,
+}: AttributeOptions<V> = {}): Attribute<T> => ({
+    id,
+    schema,
+    optional: false,
+    writable: false,
+    fixed: false,
+    scene,
+    persistent,
+    fabricScoped: false,
+    omitChanges,
+    default: conformanceValue,
+    readAcl
+});
+
+export const OptionalAttribute = <T, V extends T>(id: number, schema: TlvSchema<T>, {
+    scene = false,
+    persistent = false,
+    omitChanges = false,
+    default: conformanceValue,
+    readAcl = AccessLevel.View,
+}: AttributeOptions<V> = {}): OptionalAttribute<T> => ({
+    id,
+    schema,
+    optional: true,
+    writable: false,
+    fixed: false,
+    scene,
+    persistent,
+    fabricScoped: false,
+    omitChanges,
+    default: conformanceValue,
+    readAcl
+});
+
+export const ConditionalAttribute = <T, V extends T, F extends BitSchema>(id: number, schema: TlvSchema<T>, {
+    scene = false,
+    persistent = false,
+    omitChanges = false,
+    default: conformanceValue,
+    readAcl = AccessLevel.View,
+    optionalIf = [],
+    mandatoryIf = [],
+}: ConditionalAttributeOptions<V, F>): ConditionalAttribute<T, F> => ({
+    id,
+    schema,
+    optional: true,
+    optionalIf,
+    mandatoryIf,
+    writable: false,
+    fixed: false,
+    scene,
+    persistent,
+    fabricScoped: false,
+    omitChanges,
+    default: conformanceValue,
+    readAcl
+});
+
+export const WritableAttribute = <T, V extends T>(id: number, schema: TlvSchema<T>, {
+    scene = false,
+    persistent = true,
+    omitChanges = false,
+    default: conformanceValue,
+    readAcl = AccessLevel.View,
+    writeAcl = AccessLevel.View,
+}: AttributeOptions<V> = {}): WritableAttribute<T> => ({
+    id,
+    schema,
+    optional: false,
+    writable: true,
+    fixed: false,
+    scene,
+    persistent,
+    fabricScoped: false,
+    omitChanges,
+    default: conformanceValue,
+    readAcl,
+    writeAcl
+});
+
+export const OptionalWritableAttribute = <T, V extends T>(id: number, schema: TlvSchema<T>, {
+    scene = false,
+    persistent = true,
+    omitChanges = false,
+    default: conformanceValue,
+    readAcl = AccessLevel.View,
+    writeAcl = AccessLevel.View,
+}: AttributeOptions<V> = {}): OptionalWritableAttribute<T> => ({
+    id,
+    schema,
+    optional: true,
+    writable: true,
+    fixed: false,
+    scene,
+    persistent,
+    fabricScoped: false,
+    omitChanges,
+    default: conformanceValue,
+    readAcl,
+    writeAcl
+});
+
+export const ConditionalWritableAttribute = <T, V extends T, F extends BitSchema>(id: number, schema: TlvSchema<T>, {
+    scene = false,
+    persistent = true,
+    omitChanges = false,
+    default: conformanceValue,
+    readAcl = AccessLevel.View,
+    writeAcl = AccessLevel.View,
+    optionalIf = [],
+    mandatoryIf = [],
+}: ConditionalAttributeOptions<V, F>): ConditionalWritableAttribute<T, F> => ({
+    id,
+    schema,
+    optional: true,
+    optionalIf,
+    mandatoryIf,
+    writable: true,
+    fixed: false,
+    scene,
+    persistent,
+    fabricScoped: false,
+    omitChanges,
+    default: conformanceValue,
+    readAcl,
+    writeAcl
+});
+
+export const WritableFabricScopedAttribute = <T, V extends T>(id: number, schema: TlvSchema<T>, {
+    scene = false,
+    persistent = true,
+    omitChanges = false,
+    default: conformanceValue,
+    readAcl = AccessLevel.View,
+    writeAcl = AccessLevel.View,
+}: AttributeOptions<V> = {}): WritableFabricScopedAttribute<T> => ({
+    id,
+    schema,
+    optional: false,
+    writable: true,
+    fixed: false,
+    scene,
+    persistent,
+    fabricScoped: true,
+    omitChanges,
+    default: conformanceValue,
+    readAcl,
+    writeAcl
+});
+
+export const OptionalWritableFabricScopedAttribute = <T, V extends T>(id: number, schema: TlvSchema<T>, {
+    scene = false,
+    persistent = true,
+    omitChanges = false,
+    default: conformanceValue,
+    readAcl = AccessLevel.View,
+    writeAcl = AccessLevel.View,
+}: AttributeOptions<V> = {}): OptionalWritableFabricScopedAttribute<T> => ({
+    id,
+    schema,
+    optional: true,
+    writable: true,
+    fixed: false,
+    scene,
+    persistent,
+    fabricScoped: true,
+    omitChanges,
+    default: conformanceValue,
+    readAcl,
+    writeAcl
+});
+
+export const ConditionalWritableFabricScopedAttribute = <T, V extends T, F extends BitSchema>(id: number, schema: TlvSchema<T>, {
+    scene = false,
+    persistent = true,
+    omitChanges = false,
+    default: conformanceValue,
+    readAcl = AccessLevel.View,
+    writeAcl = AccessLevel.View,
+    optionalIf = [],
+    mandatoryIf = [],
+}: ConditionalAttributeOptions<V, F> = {}): ConditionalWritableFabricScopedAttribute<T, F> => ({
+    id,
+    schema,
+    optional: true,
+    optionalIf,
+    mandatoryIf,
+    writable: true,
+    fixed: false,
+    scene,
+    persistent,
+    fabricScoped: true,
+    omitChanges,
+    default: conformanceValue,
+    readAcl,
+    writeAcl
+});
+
+export const FixedAttribute = <T, V extends T>(id: number, schema: TlvSchema<T>, {
+    scene = false,
+    persistent = false,
+    omitChanges = false,
+    default: conformanceValue,
+    readAcl = AccessLevel.View,
+}: AttributeOptions<V> = {}): FixedAttribute<T> => ({
+    id,
+    schema,
+    optional: false,
+    writable: false,
+    fixed: true,
+    scene,
+    persistent,
+    fabricScoped: false,
+    omitChanges,
+    default: conformanceValue,
+    readAcl
+});
+
+export const OptionalFixedAttribute = <T, V extends T>(id: number, schema: TlvSchema<T>, {
+    scene = false,
+    persistent = false,
+    omitChanges = false,
+    default: conformanceValue,
+    readAcl = AccessLevel.View,
+}: AttributeOptions<V> = {}): OptionalFixedAttribute<T> => ({
+    id,
+    schema,
+    optional: true,
+    writable: false,
+    fixed: true,
+    scene,
+    persistent,
+    fabricScoped: false,
+    omitChanges,
+    default: conformanceValue,
+    readAcl
+});
+
+export const ConditionalFixedAttribute = <T, V extends T, F extends BitSchema>(id: number, schema: TlvSchema<T>, {
+    scene = false,
+    persistent = false,
+    omitChanges = false,
+    default: conformanceValue,
+    readAcl = AccessLevel.View,
+    optionalIf = [],
+    mandatoryIf = [],
+}: ConditionalAttributeOptions<V, F>): ConditionalFixedAttribute<T, F> => ({
+    id,
+    schema,
+    optional: true,
+    optionalIf,
+    mandatoryIf,
+    writable: false,
+    fixed: true,
+    scene,
+    persistent,
+    fabricScoped: false,
+    omitChanges,
+    default: conformanceValue,
+    readAcl
+});
 
 export type MandatoryAttributeNames<A extends Attributes> = { [K in keyof A]: A[K] extends OptionalAttribute<any> ? never : K }[keyof A];
 export type OptionalAttributeNames<A extends Attributes> = { [K in keyof A]: A[K] extends OptionalAttribute<any> ? K : never }[keyof A];
 
 /* Interfaces and helper methods to define a cluster command */
 export const TlvNoResponse = TlvVoid;
-export interface Command<RequestT, ResponseT> { optional: boolean, requestId: number, requestSchema: TlvSchema<RequestT>, responseId: number, responseSchema: TlvSchema<ResponseT> }
-export interface OptionalCommand<RequestT, ResponseT> extends Command<RequestT, ResponseT> { optional: true }
+
+export interface Command<RequestT, ResponseT> {
+    optional: boolean,
+    requestId: number,
+    requestSchema: TlvSchema<RequestT>,
+    responseId: number,
+    responseSchema: TlvSchema<ResponseT>
+}
+
+export interface OptionalCommand<RequestT, ResponseT> extends Command<RequestT, ResponseT> {
+    optional: true,
+}
+
+export interface ConditionalCommand<RequestT, ResponseT, F extends BitSchema> extends OptionalCommand<RequestT, ResponseT> {
+    mandatoryIf?: ConditionalFeatureList<F>,
+    optionalIf?: ConditionalFeatureList<F>
+}
+
 export type ResponseType<T extends Command<any, any>> = T extends OptionalCommand<any, infer ResponseT> ? ResponseT : (T extends Command<any, infer ResponseT> ? ResponseT : never);
 export type RequestType<T extends Command<any, any>> = T extends OptionalCommand<infer RequestT, any> ? RequestT : (T extends Command<infer RequestT, any> ? RequestT : never);
 
-export const Command = <RequestT, ResponseT>(requestId: number, requestSchema: TlvSchema<RequestT>, responseId: number, responseSchema: TlvSchema<ResponseT>): Command<RequestT, ResponseT> => ({ optional: false, requestId, requestSchema, responseId, responseSchema });
-export const OptionalCommand = <RequestT, ResponseT>(requestId: number, requestSchema: TlvSchema<RequestT>, responseId: number, responseSchema: TlvSchema<ResponseT>): OptionalCommand<RequestT, ResponseT> => ({ optional: true, requestId, requestSchema, responseId, responseSchema });
+interface ConditionalCommandOptions<F extends BitSchema> {
+    optionalIf?: ConditionalFeatureList<F>,
+    mandatoryIf?: ConditionalFeatureList<F>
+}
+
+export const Command = <RequestT, ResponseT>(
+    requestId: number,
+    requestSchema: TlvSchema<RequestT>,
+    responseId: number,
+    responseSchema: TlvSchema<ResponseT>
+): Command<RequestT, ResponseT> => ({
+    optional: false,
+    requestId,
+    requestSchema,
+    responseId,
+    responseSchema
+});
+
+export const OptionalCommand = <RequestT, ResponseT>(
+    requestId: number,
+    requestSchema: TlvSchema<RequestT>,
+    responseId: number,
+    responseSchema: TlvSchema<ResponseT>,
+): OptionalCommand<RequestT, ResponseT> => ({
+    optional: true,
+    requestId,
+    requestSchema,
+    responseId,
+    responseSchema
+});
+
+export const ConditionalCommand = <RequestT, ResponseT, F extends BitSchema>(
+    requestId: number,
+    requestSchema: TlvSchema<RequestT>,
+    responseId: number,
+    responseSchema: TlvSchema<ResponseT>,
+    { optionalIf, mandatoryIf }: ConditionalCommandOptions<F>
+): ConditionalCommand<RequestT, ResponseT, F> => ({
+    optional: true,
+    optionalIf,
+    mandatoryIf,
+    requestId,
+    requestSchema,
+    responseId,
+    responseSchema
+});
 
 /* Interfaces and helper methods to define a cluster event */
 export const enum EventPriority {
@@ -62,18 +437,72 @@ export const enum EventPriority {
     Info,
     Debug,
 }
-export interface Event<T> { id: number, schema: TlvSchema<T>, priority: EventPriority, optional: boolean }
-export interface OptionalEvent<T> extends Event<T> { optional: true }
-export const Event = <FT extends TlvFields>(id: number, priority: EventPriority, data: FT = <FT>{}): Event<TypeFromFields<FT>> => ({ id, schema: TlvObject(data), priority, optional: false });
-export const OptionalEvent = <FT extends TlvFields>(id: number, priority: EventPriority, data: FT = <FT>{}): OptionalEvent<TypeFromFields<FT>> => ({ id, schema: TlvObject(data), priority, optional: true });
+
+export interface Event<T> {
+    id: number,
+    schema: TlvSchema<T>,
+    priority: EventPriority,
+    optional: boolean
+}
+
+interface ConditionalEventOptions<F extends BitSchema> {
+    optionalIf?: ConditionalFeatureList<F>,
+    mandatoryIf?: ConditionalFeatureList<F>
+}
+
+export interface OptionalEvent<T> extends Event<T> {
+    optional: true
+}
+
+export interface ConditionalEvent<T, F extends BitSchema> extends OptionalEvent<T> {
+    mandatoryIf?: ConditionalFeatureList<F>,
+    optionalIf?: ConditionalFeatureList<F>
+}
+
+export const Event = <FT extends TlvFields>(id: number, priority: EventPriority, data: FT = <FT>{}): Event<TypeFromFields<FT>> => ({
+    id,
+    schema: TlvObject(data),
+    priority,
+    optional: false
+});
+
+export const OptionalEvent = <FT extends TlvFields>(id: number, priority: EventPriority, data: FT = <FT>{}): OptionalEvent<TypeFromFields<FT>> => ({
+    id,
+    schema: TlvObject(data),
+    priority,
+    optional: true
+});
+
+export const ConditionalEvent = <FT extends TlvFields, F extends BitSchema>(
+    id: number,
+    priority: EventPriority,
+    data: FT = <FT>{},
+    { optionalIf, mandatoryIf }: ConditionalEventOptions<F>
+): ConditionalEvent<TypeFromFields<FT>, F> => ({
+    id,
+    schema: TlvObject(data),
+    priority,
+    optional: true,
+    optionalIf,
+    mandatoryIf
+});
+
 export type EventType<T extends Event<any>> = T extends OptionalEvent<infer EventT> ? EventT : (T extends Event<infer EventT> ? EventT : never);
 export type MandatoryEventNames<E extends Events> = { [K in keyof E]: E[K] extends OptionalEvent<any> ? never : K }[keyof E];
 export type OptionalEventNames<E extends Events> = { [K in keyof E]: E[K] extends OptionalEvent<any> ? K : never }[keyof E];
 
 /* Interfaces and helper methods to define a cluster */
-export interface Attributes { [key: string]: Attribute<any> }
-export interface Commands { [key: string]: Command<any, any> }
-export interface Events { [key: string]: Event<any> }
+export interface Attributes {
+    [key: string]: Attribute<any>
+}
+
+export interface Commands {
+    [key: string]: Command<any, any>
+}
+
+export interface Events {
+    [key: string]: Event<any>
+}
 
 // TODO Adjust typing to be derived from the schema below
 /** @see {@link MatterCoreSpecificationV1_0} § 7.13 */
@@ -82,7 +511,7 @@ export type GlobalAttributes<F extends BitSchema> = {
     clusterRevision: Attribute<number>,
 
     /** Indicates whether the server supports zero or more optional cluster features. */
-    featureMap: Attribute<TypeFromBitSchema<F>>,
+    featureMap: Attribute<TypeFromPartialBitSchema<F>>,
 
     /** List of the attribute IDs of the attributes supported by the cluster instance. */
     attributeList: Attribute<AttributeId[]>,
@@ -106,7 +535,7 @@ export const GlobalAttributes = <F extends BitSchema>(features: F) => ({
     generatedCommandList: Attribute(0xFFF8, TlvArray(TlvCommandId)),
 } as GlobalAttributes<F>);
 
-export interface Cluster<F extends BitSchema, SF extends TypeFromBitSchema<F>, A extends Attributes, C extends Commands, E extends Events> {
+export interface Cluster<F extends BitSchema, SF extends TypeFromPartialBitSchema<F>, A extends Attributes, C extends Commands, E extends Events> {
     id: number,
     name: string,
     revision: number,
@@ -116,7 +545,8 @@ export interface Cluster<F extends BitSchema, SF extends TypeFromBitSchema<F>, A
     commands: C,
     events: E,
 }
-export const Cluster = <F extends BitSchema, SF extends TypeFromBitSchema<F>, A extends Attributes = {}, C extends Commands = {}, E extends Events = {}>({
+
+export const Cluster = <F extends BitSchema, SF extends TypeFromPartialBitSchema<F>, A extends Attributes = {}, C extends Commands = {}, E extends Events = {}>({
     id,
     name,
     revision,
@@ -145,7 +575,7 @@ export const Cluster = <F extends BitSchema, SF extends TypeFromBitSchema<F>, A 
     events,
 });
 
-type ClusterExtend<F extends BitSchema, SF extends TypeFromBitSchema<F>, A extends Attributes, C extends Commands, E extends Events> = {
+type ClusterExtend<F extends BitSchema, SF extends TypeFromPartialBitSchema<F>, A extends Attributes, C extends Commands, E extends Events> = {
     supportedFeatures: SF,
     attributes?: A,
     commands?: C,
@@ -157,8 +587,8 @@ type ClusterExtend<F extends BitSchema, SF extends TypeFromBitSchema<F>, A exten
 export const ClusterExtend =
     <
         F extends BitSchema,
-        SF_BASE extends TypeFromBitSchema<F>,
-        SF_EXTEND extends TypeFromBitSchema<F>,
+        SF_BASE extends TypeFromPartialBitSchema<F>,
+        SF_EXTEND extends TypeFromPartialBitSchema<F>,
         A_BASE extends Attributes = {},
         C_BASE extends Commands = {},
         E_BASE extends Events = {},
@@ -166,7 +596,16 @@ export const ClusterExtend =
         C_EXTEND extends Commands = {},
         E_EXTEND extends Events = {},
     >(
-        { id, name, revision, features, supportedFeatures, attributes, commands, events }: Cluster<F, SF_BASE, A_BASE, C_BASE, E_BASE>,
+        {
+            id,
+            name,
+            revision,
+            features,
+            supportedFeatures,
+            attributes,
+            commands,
+            events
+        }: Cluster<F, SF_BASE, A_BASE, C_BASE, E_BASE>,
         {
             supportedFeatures: supportedFeaturesExtend,
             attributes: attributesExtend = <A_EXTEND>{},

--- a/packages/matter.js/src/cluster/WindowCoveringCluster.ts
+++ b/packages/matter.js/src/cluster/WindowCoveringCluster.ts
@@ -1,0 +1,177 @@
+/**
+ * @license
+ * Copyright 2022 The matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { TlvEnum, TlvUInt16 } from "../tlv/TlvNumber.js";
+import { TlvObject, TlvOptionalField } from "../tlv/TlvObject.js";
+import { Attribute, ClusterExtend, Command, OptionalCommand, TlvNoResponse } from "./Cluster.js";
+import { ClusterServerObjForCluster } from "./server/ClusterServer.js";
+import { WindowCoveringClusterSchema } from "./schema/WindowCoveringCluster.js";
+import { MatterApplicationClusterSpecificationV1_0 } from "../spec/Specifications.js";
+
+/** alias for percentages expressed as 0 to 100.00 with 2 decimals */
+const WCPercent100ths = TlvUInt16.bound({ max: 10000 });
+
+/** @see {@link MatterApplicationClusterSpecificationV1_0} § 5.3.5.1 */
+export enum WindowCoveringType {
+    /** Lift Only */
+    RollerShade = 0x00,
+
+    /** Lift Only */
+    RollerShade2Motor = 0x01,
+
+    /** Lift Only */
+    RollerShadeExterior = 0x02,
+
+    /** Lift Only */
+    RollerShadeExterior2Motor = 0x03,
+
+    /** Lift Only */
+    Drapery = 0x04,
+
+    /** Lift Only */
+    Awning = 0x05,
+
+    /** Lift & Tilt */
+    Shutter = 0x06,
+
+    /** Tilt Only */
+    TiltOnlyBlind = 0x07,
+
+    /** Lift & Tilt */
+    LiftAndTiltBlind = 0x08,
+
+    /** Lift Only */
+    ProjectorScreen = 0x09,
+
+    Unknown = 0xff,
+}
+
+/** @see {@link MatterApplicationClusterSpecificationV1_0} § 5.3.5.15 */
+export enum WindowCoveringOperationalStatus {
+    Stopped = 0,
+    Opening = 1,
+    Closing = 2,
+}
+
+/** @see {@link MatterApplicationClusterSpecificationV1_0} § 5.3.6.5
+ - If the command includes LiftPercent100thsValue, then TargetPositionLiftPercent100ths attribute SHALL be set to
+   LiftPercent100thsValue. Otherwise the TargetPositionLiftPercent100ths attribute SHALL be set to
+   LiftPercentageValue * 100.
+ - If a client includes LiftPercent100thsValue in the command, the LiftPercentageValue SHALL be set to
+   LiftPercent100thsValue / 100, so a legacy server which only supports LiftPercentageValue (not LiftPercent100thsValue)
+   has a value to set the target position.
+ - If the server does not support the Position Aware feature, then a zero percentage SHALL be treated as a
+   UpOrOpen command and a non-zero percentage SHALL be treated as an DownOrClose command.
+   If the device is only a tilt control device, then the command SHOULD be ignored and a UNSUPPORTED_COMMAND status
+   SHOULD be returned.
+ */
+export const GotoLiftPercentParams = TlvObject({
+    /** Legacy Matter - still used by HomePod 16.3.2*/
+    percent: TlvOptionalField(0, WCPercent100ths), // TODO - clarify if this is correct and needs to be handled in WC Server
+    /** PREFERRED  */
+    percent100ths: TlvOptionalField(1, WCPercent100ths),
+});
+
+/** @see {@link MatterApplicationClusterSpecificationV1_0} § 5.3.6.7 */
+const GotoTiltPercentParams = GotoLiftPercentParams;
+
+// For now use the Schema cluster as basis for the cluster object temporary
+export const WindowCoveringCluster = WindowCoveringClusterSchema;
+
+////////////////////////////////// MIGHT GO AWAY
+
+const statusAttribute = {
+    operationalStatus: Attribute(
+        0x000a,
+        TlvEnum<WindowCoveringOperationalStatus>(),
+        {
+            default: WindowCoveringOperationalStatus.Stopped,
+        }
+    ),
+};
+
+/** PositionAwareLift */
+export const WCPositionAwareLiftCluster = ClusterExtend(WindowCoveringCluster, {
+    supportedFeatures: {
+        lift: true,
+        tilt: false,
+        positionAwareLift: true,
+        positionAwareTilt: false,
+        absolutePosition: false,
+    },
+    commands: {
+        gotoLiftPercent: Command(0x05, GotoLiftPercentParams, 5, TlvNoResponse),
+    },
+    attributes: {
+        type: Attribute(0x0000, TlvEnum<WindowCoveringType>(), {
+            default: WindowCoveringType.RollerShade,
+            persistent: true,
+        }),
+        ...statusAttribute,
+    },
+});
+
+/** PositionAware TiltCluster */
+export const WCPositionAwareTiltCluster = ClusterExtend(WindowCoveringCluster, {
+    supportedFeatures: {
+        lift: false,
+        tilt: true,
+        positionAwareLift: false,
+        positionAwareTilt: true,
+        absolutePosition: false,
+    },
+    commands: {
+        gotoTiltPercent: Command(0x08, GotoTiltPercentParams, 8, TlvNoResponse),
+    },
+    attributes: {
+        type: Attribute(0x0000, TlvEnum<WindowCoveringType>(), {
+            default: WindowCoveringType.TiltOnlyBlind,
+            persistent: true,
+        }),
+        ...statusAttribute,
+    },
+});
+
+/** Position Aware Lift & Tilt */
+export const WCPositionAwareLiftAndTiltCluster = ClusterExtend(
+    WindowCoveringCluster,
+    {
+        supportedFeatures: {
+            lift: true,
+            tilt: true,
+            positionAwareLift: true,
+            positionAwareTilt: true,
+            absolutePosition: false,
+        },
+        commands: {
+            gotoLiftPercent: OptionalCommand(
+                0x05,
+                GotoLiftPercentParams,
+                5,
+                TlvNoResponse
+            ),
+            gotoTiltPercent: OptionalCommand(
+                0x08,
+                GotoTiltPercentParams,
+                8,
+                TlvNoResponse
+            ),
+        },
+        attributes: {
+            ...statusAttribute,
+            type: Attribute(0x0000, TlvEnum<WindowCoveringType>(), {
+                default: WindowCoveringType.LiftAndTiltBlind,
+                persistent: true,
+            }),
+        },
+    }
+);
+
+/** convenience type */
+export type WindowCoveringClusterObj = ClusterServerObjForCluster<typeof WindowCoveringCluster>;
+export type WCPositionAwareLiftClusterObj = ClusterServerObjForCluster<typeof WCPositionAwareLiftCluster>;
+export type WCPositionAwareTiltClusterObj = ClusterServerObjForCluster<typeof WCPositionAwareTiltCluster>;
+export type WCPositionAwareLiftAndTiltClusterObj = ClusterServerObjForCluster<typeof WCPositionAwareLiftAndTiltCluster>;

--- a/packages/matter.js/src/cluster/schema/WindowCoveringCluster.ts
+++ b/packages/matter.js/src/cluster/schema/WindowCoveringCluster.ts
@@ -1,0 +1,478 @@
+/**
+ * @license
+ * Copyright 2022 The matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { BitFlag, TypeFromPartialBitSchema } from "../../schema/BitmapSchema.js";
+import { TlvNoArguments } from "../../tlv/TlvNoArguments.js";
+import { TlvBitmap, TlvEnum, TlvUInt16, TlvUInt8 } from "../../tlv/TlvNumber.js";
+import { TlvField, TlvObject, TlvOptionalField } from "../../tlv/TlvObject.js";
+import {
+    Attribute, Cluster, Command, ConditionalAttribute, ConditionalCommand, OptionalAttribute, TlvNoResponse,
+    WritableAttribute,
+} from "../Cluster.js";
+import { MatterApplicationClusterSpecificationV1_0 } from "../../spec/Specifications.js";
+
+
+/** alias for percentages expressed as 0 to 100 */
+const WCPercent = TlvUInt16.bound({ max: 100 });
+
+/** alias for percentages expressed as 0 to 100.00 with 2 decimals */
+const WCPercent100ths = TlvUInt16.bound({ max: 10000 });
+
+/** @see {@link MatterApplicationClusterSpecificationV1_0} § 5.3.4 */
+export const WindowCoveringFeatures = {
+    /**
+     * The Lift feature applies to window coverings that lift up and down (ex: for a roller shade, Up and Down is Lift
+     * Open and Close) or slide left to right (ex: for a sliding curtain, Left and Right is Lift Open and Close).
+     */
+    lift: BitFlag(0),
+
+    /** The Tilt feature applies to window coverings with vertical or horizontal strips. */
+
+    tilt: BitFlag(1),
+    /**
+     * Relative positioning with percent100ths (min step 0.01%) attribute is mandatory,
+     * E.g Max 10000 equals 100.00% and relative positioning with percent (min step 1%) attribute is for backward
+     * compatibility. The CurrentPosition attributes SHALL always reflects the physical position of an actuator and the
+     * TargetPosition attribute SHALL reflect the requested position of an actuator once a positioning command is received.
+     */
+    positionAwareLift: BitFlag(2),
+
+    /**
+     * The percentage attributes SHALL indicate the position as a percentage between the InstalledOpenLimits and
+     * InstalledClosedLimits attributes of the window covering starting at the open (0.00%).
+     * As a general rule, absolute positioning (in centimeters or tenth of a degrees) SHOULD NOT be supported for new
+     * implementations.
+     */
+    absolutePosition: BitFlag(3),
+
+    /** Position Aware tilt control is supported. */
+    positionAwareTilt: BitFlag(4),
+};
+
+/** @see {@link MatterApplicationClusterSpecificationV1_0} § 5.3.5.1 */
+export enum WindowCoveringType {
+    /** Lift Only */
+    RollerShade = 0x00,
+
+    /** Lift Only */
+    RollerShade2Motor = 0x01,
+
+    /** Lift Only */
+    RollerShadeExterior = 0x02,
+
+    /** Lift Only */
+    RollerShadeExterior2Motor = 0x03,
+
+    /** Lift Only */
+    Drapery = 0x04,
+
+    /** Lift Only */
+    Awning = 0x05,
+
+    /** Lift & Tilt */
+    Shutter = 0x06,
+
+    /** Tilt Only */
+    TiltOnlyBlind = 0x07,
+
+    /** Lift & Tilt */
+    LiftAndTiltBlind = 0x08,
+
+    /** Lift Only */
+    ProjectorScreen = 0x09,
+
+    Unknown = 0xff,
+}
+
+/** @see {@link MatterApplicationClusterSpecificationV1_0} § 5.3.5.16 */
+export enum WindowCoveringEndProductType {
+    RollerShade = 0x00,
+    RomanShade = 0x01,
+    BalloonShade = 0x02,
+    WovenWood = 0x03,
+    PleatedShade = 0x04,
+    CellularShade = 0x05,
+    LayeredShade = 0x06,
+    LayeredShade2D = 0x07,
+    SheerShade = 0x08,
+    TiltOnlyInteriorBlind = 0x09,
+    InteriorBlind = 0x0a,
+    VerticalBlindStripCurtain = 0x0b,
+    InteriorVenetianBlind = 0x0c,
+    ExteriorVenetianBlind = 0x0d,
+    LateralLeftCurtain = 0x0e,
+    LateralRightCurtain = 0x0f,
+    CentralCurtain = 0x10,
+    RollerShutter = 0x11,
+    ExteriorVerticalScreen = 0x12,
+    AwningTerrace = 0x13,
+    AwningVerticalScreen = 0x14,
+    TiltOnlyPergola = 0x15,
+    SwingingShutter = 0x16,
+    SlidingShutter = 0x17,
+    Unknown = 0xff,
+}
+
+/** @see {@link MatterApplicationClusterSpecificationV1_0} § 5.3.5.8 */
+export const WindowCoveringConfigStatus = {
+    /**
+     * Operational: This status bit defines if the Window Covering is operational.
+     * note: The SafetyStatus & Mode attributes might affect this bit
+     */
+    operational: BitFlag(0),
+
+    // reserved: BitFlag(1),
+    /**
+     * Reversal: This status bit identifies if the directions of the lift/slide movements have been
+     * reversed in order for commands (e.g: Open, Close, GoTos) to match the physical installation conditions
+     */
+    reversed: BitFlag(2), // LF
+
+    /**
+     * Control - Lift: This status bit identifies if the window covering supports the Position Aware
+     */
+    liftPositionAware: BitFlag(3), // LF
+
+    /**
+     * Control - Tilt: This status bit identifies if the window covering supports the Position Aware
+     */
+    tiltPositionAware: BitFlag(4), // LT
+
+    /**
+     * Encoder - Lift: This status bit identifies if a Position Aware Controlled Window Covering is employing an encoder for positioning the height of the window covering.
+     * 0 = Timer Controlled
+     * 1 = Encoder Controlled
+     */
+    liftPositionType: BitFlag(5), // LF & PA_LF
+
+    /**
+     * Encoder - Tilt: This status bit identifies if a Position Aware Controlled Window Covering is employing an encoder
+     * for tilting the window covering.
+     * 0 = Timer Controlled
+     * 1 = Encoder Controlled
+     */
+    tiltPositionType: BitFlag(6), // TL & PA_TL
+};
+
+/** @see {@link MatterApplicationClusterSpecificationV1_0} § 5.3.5.15 */
+export enum WindowCoveringOperationalStatus {
+    Stopped = 0,
+    Opening = 1,
+    Closing = 2,
+}
+
+/** @see {@link MatterApplicationClusterSpecificationV1_0} § 5.3.5.21 */
+export const WindowCoveringMode = {
+    reversed: BitFlag(0),
+    calibrateMode: BitFlag(1),
+    maintenanceMode: BitFlag(2),
+    ledFeedback: BitFlag(3),
+};
+
+/** @see {@link MatterApplicationClusterSpecificationV1_0} § 5.3.5.22 */
+export const WindowCoveringSafetyStatus = {
+    /** Movement commands are ignored (locked out). e.g. not granted authorization, outside some time/date range. */
+    remoteLockout: BitFlag(0),
+
+    /** Tampering detected on sensors or any other safety equipment. Ex: a device has been forcedly moved without its actuator(s). */
+    tamperDetection: BitFlag(1),
+
+    /** Communication failure to sensors or other safety equipment. */
+    failedCommunication: BitFlag(2),
+
+    /**
+     * Device has failed to reach the desired position. e.g. with Position Aware device, time expired before
+     * TargetPosition is reached.
+     */
+    positionFailure: BitFlag(3),
+
+    /** Motor(s) and/or electric circuit thermal protection activated. */
+    thermalProtection: BitFlag(4),
+
+    /** An obstacle is preventing actuator movement. */
+    obstacleDetected: BitFlag(5),
+
+    /**
+     * Device has power related issue or limitation e.g. device is running w/ the help of a backup battery or power
+     * might not be fully available at the moment.
+     */
+    powerIssue: BitFlag(6),
+
+    /** Local safety sensor (not a direct obstacle) is preventing movements (e.g. Safety EU Standard EN60335). */
+    stopInput: BitFlag(7),
+
+    /** Mechanical problem related to the motor(s) detected. */
+    motorJammed: BitFlag(8),
+
+    /** PCB, fuse and other electrics problems. */
+    hardwareFailure: BitFlag(9),
+
+    /** Actuator is manually operated and is preventing actuator movement (e.g. actuator is disengaged/decoupled). */
+    manualOperation: BitFlag(10),
+
+    /** Protection is activated. - wow so helpful */
+    protection: BitFlag(11),
+};
+
+/** @see {@link MatterApplicationClusterSpecificationV1_0} § 5.3.6.4 */
+const GoToLiftValueParams = TlvObject({
+    value: TlvField(0, TlvUInt16),
+});
+
+/** @see {@link MatterApplicationClusterSpecificationV1_0} § 5.3.6.5
+ - If the command includes LiftPercent100thsValue, then TargetPositionLiftPercent100ths attribute SHALL be set to
+   LiftPercent100thsValue. Otherwise the TargetPositionLiftPercent100ths attribute SHALL be set to
+   LiftPercentageValue * 100.
+ - If a client includes LiftPercent100thsValue in the command, the LiftPercentageValue SHALL be set to
+   LiftPercent100thsValue / 100, so a legacy server which only supports LiftPercentageValue (not LiftPercent100thsValue)
+   has a value to set the target position.
+ - If the server does not support the Position Aware feature, then a zero percentage SHALL be treated as a
+   UpOrOpen command and a non-zero percentage SHALL be treated as an DownOrClose command.
+   If the device is only a tilt control device, then the command SHOULD be ignored and a UNSUPPORTED_COMMAND status
+   SHOULD be returned.
+ */
+export const GotoLiftPercentParams = TlvObject({
+    /** Legacy Matter - still used by HomePod 16.3.2*/
+    percent: TlvOptionalField(0, WCPercent100ths), // TODO - clarify if this is correct and needs to be handled in WC Server
+    /** PREFERRED  */
+    percent100ths: TlvOptionalField(1, WCPercent100ths),
+});
+
+/** @see {@link MatterApplicationClusterSpecificationV1_0} § 5.3.6.6 */
+const GotoTiltValueParams = GoToLiftValueParams;
+
+/** @see {@link MatterApplicationClusterSpecificationV1_0} § 5.3.6.7 */
+const GotoTiltPercentParams = GotoLiftPercentParams;
+
+const LF: TypeFromPartialBitSchema<typeof WindowCoveringFeatures> = {
+    lift: true,
+};
+const LF_ABS: TypeFromPartialBitSchema<typeof WindowCoveringFeatures> = {
+    lift: true,
+    absolutePosition: true,
+};
+const LF_PALF: TypeFromPartialBitSchema<typeof WindowCoveringFeatures> = {
+    lift: true,
+    positionAwareLift: true,
+};
+const LF_PALF_ABS: TypeFromPartialBitSchema<typeof WindowCoveringFeatures> = {
+    lift: true,
+    positionAwareLift: true,
+};
+
+const TL: TypeFromPartialBitSchema<typeof WindowCoveringFeatures> = {
+    tilt: true,
+};
+/*const TL_ABS: TypeFromBitSchema<typeof WindowCoveringFeatures> = {
+  tilt: true,
+  absolutePosition: true,
+};*/
+const TL_PATL: TypeFromPartialBitSchema<typeof WindowCoveringFeatures> = {
+    tilt: true,
+    positionAwareTilt: true,
+};
+const TL_PATL_ABS: TypeFromPartialBitSchema<typeof WindowCoveringFeatures> = {
+    tilt: true,
+    positionAwareTilt: true,
+    absolutePosition: true,
+};
+
+/** @see {@link MatterApplicationClusterSpecificationV1_0} § 5.3 */
+export const WindowCoveringClusterSchema = Cluster({
+    id: 0x102,
+    name: "Window Covering",
+
+    /** @see {@link MatterApplicationClusterSpecificationV1_0} § 5.3.1 */
+    revision: 5,
+
+    /** At least ONE of the Lift and Tilt features SHALL be supported */
+    features: WindowCoveringFeatures,
+
+    /** NOTE: Unlike the most popular shading systems, ALL INTERNAL Percentages are percent OPEN, NOT percent light transmission */
+
+    /** @see {@link MatterApplicationClusterSpecificationV1_0} § 5.3.5 */
+    attributes: {
+        /** Note that the WindowCoveringType is associated with the Supported Features as well */
+        type: Attribute(0x0000, TlvEnum<WindowCoveringType>(), {
+            default: WindowCoveringType.RollerShade,
+            persistent: true,
+        }),
+        /** [LF & PA_LF & ABS] */
+        physicalClosedLimitLift: ConditionalAttribute(0x0001, TlvUInt16, {
+            optionalIf: [LF_PALF_ABS],
+            default: 0,
+        }),
+        /** [TL & PA_TL & ABS] */
+        physicalClosedLimitTilt: ConditionalAttribute(0x0002, TlvUInt16, {
+            optionalIf: [TL_PATL_ABS],
+            default: 0,
+        }),
+        /** [LF & PA_LF & ABS] */
+        currentPositionLift: ConditionalAttribute(0x0003, TlvUInt16, {
+            optionalIf: [LF_PALF_ABS],
+            scene: true,
+        }),
+        /** [TL & PA_TL & ABS] */
+        currentPositionTilt: ConditionalAttribute(0x0004, TlvUInt16, {
+            optionalIf: [TL_PATL_ABS],
+            scene: true,
+        }),
+        /** [LF] */
+        numOfActuationsLift: ConditionalAttribute(0x0005, TlvUInt16, {
+            optionalIf: [LF],
+            default: 0,
+        }),
+        /** [TL] */
+        numOfActuationsTilt: ConditionalAttribute(0x0006, TlvUInt16, {
+            optionalIf: [TL],
+            default: 0,
+        }),
+        /** M */
+        configStatus: Attribute(
+            0x0007,
+            TlvBitmap(TlvUInt8, WindowCoveringConfigStatus),
+            {
+                default: {
+                    liftPositionAware: false,
+                    operational: false,
+                    liftPositionType: false,
+                    reversed: false,
+                    tiltPositionAware: false,
+                    tiltPositionType: false,
+                },
+                persistent: true,
+            }
+        ),
+        /** [LF & PA_LF] */
+        currentPositionLiftPercent: ConditionalAttribute(0x0008, WCPercent, {
+            optionalIf: [LF_PALF],
+        }),
+        /** [TL & PA_TL] */
+        currentPositionTiltPercent: ConditionalAttribute(0x0009, WCPercent, {
+            optionalIf: [TL_PATL],
+        }),
+        /** M */
+        operationalStatus: Attribute(
+            0x000a,
+            TlvEnum<WindowCoveringOperationalStatus>(),
+            {
+                default: WindowCoveringOperationalStatus.Stopped,
+                persistent: true,
+            }
+        ),
+        /** LF & PA_LF */
+        targetPositionLiftPercent100ths: ConditionalAttribute(
+            0x000b,
+            WCPercent100ths,
+            {
+                mandatoryIf: [LF_PALF],
+                scene: true,
+            },
+        ),
+        /** TL & PA_TL */
+        targetPositionTiltPercent100ths: ConditionalAttribute(
+            0x000c,
+            WCPercent100ths,
+            {
+                mandatoryIf: [TL_PATL],
+                scene: true,
+            }
+        ),
+        /** M */
+        endProductType: WritableAttribute(
+            0x000d,
+            TlvEnum<WindowCoveringEndProductType>(),
+            {
+                default: 0,
+                persistent: true,
+            }
+        ),
+        /** LF & PA_LF */
+        currentPositionLiftPercent100ths: ConditionalAttribute(
+            0x000e,
+            WCPercent100ths,
+            { mandatoryIf: [LF_PALF] }
+        ),
+        /** TL & PA_TL */
+        currentPositionTiltPercent100ths: ConditionalAttribute(
+            0x000f,
+            WCPercent100ths,
+            { mandatoryIf: [TL_PATL] }
+        ),
+        /** LF & PA_LF & ABS */
+        installedOpenLimitLift: ConditionalAttribute(0x0010, TlvUInt16, {
+            mandatoryIf: [LF_PALF_ABS],
+            default: 0,
+        }),
+        /** LF & PA_LF & ABS */
+        installedClosedLimitLift: ConditionalAttribute(0x0011, TlvUInt16, {
+            mandatoryIf: [LF_PALF_ABS],
+        }),
+        /** TL & PA_TL & ABS */
+        installedOpenLimitTilt: ConditionalAttribute(0x0012, TlvUInt16, {
+            mandatoryIf: [TL_PATL_ABS],
+        }),
+        /** TL & PA_TL & ABS */
+        installedClosedLimitTilt: ConditionalAttribute(0x0013, TlvUInt16, {
+            mandatoryIf: [TL_PATL_ABS],
+        }),
+        // velocityLift:                  Attribute(0x0014, TlvDeprecated),
+        // accelerationTimeLift:          Attribute(0x000f, TlvDeprecated),
+        // decelerationTimeLift:          Attribute(0x000f, TlvDeprecated),
+        mode: Attribute(0x0017, TlvBitmap(TlvUInt8, WindowCoveringMode)),
+        // intermediateSetpointsLift:     Attribute(0x0018, TlvDeprecated),
+        // intermediateSetpointsTilt:     Attribute(0x0019, TlvDeprecated),
+        /** O (no conditions) */
+        safetyStatus: OptionalAttribute(
+            0x001a,
+            TlvBitmap(TlvUInt16, WindowCoveringSafetyStatus)
+        ),
+    },
+
+    // ToDo validate response types for commands.  They are required, but the Spec doesn't define a return type
+    /** @see {@link MatterApplicationClusterSpecificationV1_0} § 5.3.6 */
+    commands: {
+        /** Upon receipt of this command, the Window Covering will adjust its position so the physical lift/slide and tilt is at the maximum open/up position. */
+        open: Command(0, TlvNoArguments, 0, TlvNoResponse),
+        /** Upon receipt of this command, the Window Covering will adjust its position so the physical lift/slide and tilt is at the maximum closed/down position. */
+        close: Command(1, TlvNoArguments, 1, TlvNoResponse),
+        /** Upon receipt of this command, the Window Covering will stop any adjusting to the physical tilt and lift/slide that is currently occurring. */
+        stop: Command(2, TlvNoArguments, 2, TlvNoResponse),
+
+        /** [LF & ABS] */
+        gotoLiftValue: ConditionalCommand(
+            0x04,
+            GoToLiftValueParams,
+            4,
+            TlvNoResponse,
+            { optionalIf: [LF_ABS] }
+        ),
+        /** LF & PA_LF, [LF] */
+        gotoLiftPercent: ConditionalCommand(
+            0x05,
+            GotoLiftPercentParams,
+            5,
+            TlvNoResponse,
+            { optionalIf: [LF], mandatoryIf: [LF_PALF] }
+        ),
+        /** [TL & ABS ]*/
+        gotoTiltValue: ConditionalCommand(
+            0x07,
+            GotoTiltValueParams,
+            7,
+            TlvNoResponse,
+            { optionalIf: [LF_ABS] }
+        ),
+        /** [TL & PA_TL], [TL]*/
+        gotoTiltPercent: ConditionalCommand(
+            0x08,
+            GotoTiltPercentParams,
+            8,
+            TlvNoResponse,
+            { optionalIf: [TL], mandatoryIf: [TL_PATL] }
+        ),
+    },
+});

--- a/packages/matter.js/src/device/Device.ts
+++ b/packages/matter.js/src/device/Device.ts
@@ -11,7 +11,7 @@ import { HandlerFunction, NamedHandler } from "../util/NamedHandler.js";
 import { ClusterClientObj, isClusterClient } from "../cluster/client/ClusterClient.js";
 import { ClusterServerObj, isClusterServer } from "../cluster/server/ClusterServer.js";
 import { Attributes, Cluster, Commands, Events } from "../cluster/Cluster.js";
-import { BitSchema, TypeFromBitSchema } from "../schema/BitmapSchema.js";
+import { BitSchema, TypeFromPartialBitSchema } from "../schema/BitmapSchema.js";
 import { BindingCluster } from "../cluster/BindingCluster.js";
 import { ClusterServer } from "../protocol/interaction/InteractionServer.js";
 
@@ -153,17 +153,17 @@ export class Device extends Endpoint {
         return await this.commandHandler.executeHandler(command, ...args);
     }
 
-    protected createOptionalClusterServer<F extends BitSchema, SF extends TypeFromBitSchema<F>, A extends Attributes, C extends Commands, E extends Events>(_cluster: Cluster<F, SF, A, C, E>): ClusterServerObj<A, C, E> {
+    protected createOptionalClusterServer<F extends BitSchema, SF extends TypeFromPartialBitSchema<F>, A extends Attributes, C extends Commands, E extends Events>(_cluster: Cluster<F, SF, A, C, E>): ClusterServerObj<A, C, E> {
         // TODO: Implement this in upper classes to add optional clusters on the fly
         throw new Error("createOptionalClusterServer needs to be implemented by derived classes");
     }
 
-    protected createOptionalClusterClient<F extends BitSchema, SF extends TypeFromBitSchema<F>, A extends Attributes, C extends Commands, E extends Events>(_cluster: Cluster<F, SF, A, C, E>): ClusterClientObj<A, C, E> {
+    protected createOptionalClusterClient<F extends BitSchema, SF extends TypeFromPartialBitSchema<F>, A extends Attributes, C extends Commands, E extends Events>(_cluster: Cluster<F, SF, A, C, E>): ClusterClientObj<A, C, E> {
         // TODO: Implement this in upper classes to add optional clusters on the fly
         throw new Error("createOptionalClusterClient needs to be implemented by derived classes");
     }
 
-    override getClusterServer<F extends BitSchema, SF extends TypeFromBitSchema<F>, A extends Attributes, C extends Commands, E extends Events>(cluster: Cluster<F, SF, A, C, E>): ClusterServerObj<A, C, E> | undefined {
+    override getClusterServer<F extends BitSchema, SF extends TypeFromPartialBitSchema<F>, A extends Attributes, C extends Commands, E extends Events>(cluster: Cluster<F, SF, A, C, E>): ClusterServerObj<A, C, E> | undefined {
         const clusterServer = super.getClusterServer(cluster);
         if (clusterServer !== undefined) {
             return clusterServer;
@@ -177,7 +177,7 @@ export class Device extends Endpoint {
         }
     }
 
-    override getClusterClient<F extends BitSchema, SF extends TypeFromBitSchema<F>, A extends Attributes, C extends Commands, E extends Events>(cluster: Cluster<F, SF, A, C, E>): ClusterClientObj<A, C, E> | undefined {
+    override getClusterClient<F extends BitSchema, SF extends TypeFromPartialBitSchema<F>, A extends Attributes, C extends Commands, E extends Events>(cluster: Cluster<F, SF, A, C, E>): ClusterClientObj<A, C, E> | undefined {
         const clusterClient = super.getClusterClient(cluster);
         if (clusterClient !== undefined) {
             return clusterClient;

--- a/packages/matter.js/src/device/Endpoint.ts
+++ b/packages/matter.js/src/device/Endpoint.ts
@@ -13,7 +13,7 @@ import { AttributeServer, FabricScopedAttributeServer } from "../cluster/server/
 import { CommandServer } from "../cluster/server/CommandServer.js";
 import { DescriptorCluster } from "../cluster/DescriptorCluster.js";
 import { DeviceTypeId } from "../datatype/DeviceTypeId.js";
-import { BitSchema, TypeFromBitSchema } from "../schema/BitmapSchema.js";
+import { BitSchema, TypeFromPartialBitSchema } from "../schema/BitmapSchema.js";
 import { Attributes, Cluster, Commands, Events } from "../cluster/Cluster.js";
 import { ClusterId } from "../datatype/ClusterId.js";
 import { EndpointNumber } from "../datatype/EndpointNumber.js";
@@ -103,7 +103,7 @@ export class Endpoint {
 
     // TODO cleanup with id number vs ClusterId
     // TODO add instance if optional and not existing, maybe get rid of undefined by throwing?
-    getClusterServer<F extends BitSchema, SF extends TypeFromBitSchema<F>, A extends Attributes, C extends Commands, E extends Events>(
+    getClusterServer<F extends BitSchema, SF extends TypeFromPartialBitSchema<F>, A extends Attributes, C extends Commands, E extends Events>(
         cluster: Cluster<F, SF, A, C, E>
     ): ClusterServerObj<A, C, E> | undefined {
         const clusterServer = this.clusterServers.get(cluster.id);
@@ -112,7 +112,7 @@ export class Endpoint {
         }
     }
 
-    getClusterClient<F extends BitSchema, SF extends TypeFromBitSchema<F>, A extends Attributes, C extends Commands, E extends Events>(
+    getClusterClient<F extends BitSchema, SF extends TypeFromPartialBitSchema<F>, A extends Attributes, C extends Commands, E extends Events>(
         cluster: Cluster<F, SF, A, C, E>,
         interactionClient?: InteractionClient
     ): ClusterClientObj<A, C, E> | undefined {
@@ -131,13 +131,13 @@ export class Endpoint {
         return this.clusterClients.get(clusterId);
     }
 
-    hasClusterServer<F extends BitSchema, SF extends TypeFromBitSchema<F>, A extends Attributes, C extends Commands, E extends Events>(
+    hasClusterServer<F extends BitSchema, SF extends TypeFromPartialBitSchema<F>, A extends Attributes, C extends Commands, E extends Events>(
         cluster: Cluster<F, SF, A, C, E>
     ): boolean {
         return this.clusterServers.has(cluster.id);
     }
 
-    hasClusterClient<F extends BitSchema, SF extends TypeFromBitSchema<F>, A extends Attributes, C extends Commands, E extends Events>(
+    hasClusterClient<F extends BitSchema, SF extends TypeFromPartialBitSchema<F>, A extends Attributes, C extends Commands, E extends Events>(
         cluster: Cluster<F, SF, A, C, E>
     ): boolean {
         return this.clusterClients.has(cluster.id);

--- a/packages/matter.js/src/device/OnOffDevices.ts
+++ b/packages/matter.js/src/device/OnOffDevices.ts
@@ -13,7 +13,7 @@ import { AttributeInitialValues, ClusterServerHandlers } from "../cluster/server
 import { IdentifyCluster, } from "../cluster/IdentifyCluster.js";
 import { OnOffCluster } from "../cluster/OnOffCluster.js";
 import { extendPublicHandlerMethods } from "../util/NamedHandler.js";
-import { BitSchema, TypeFromBitSchema } from "../schema/BitmapSchema.js";
+import { BitSchema, TypeFromPartialBitSchema } from "../schema/BitmapSchema.js";
 import { Attributes, Cluster, Commands, Events } from "../cluster/Cluster.js";
 
 type OnOffBaseDeviceCommands = {
@@ -27,7 +27,7 @@ type OnOffBaseDeviceCommands = {
  * @param attributeInitialValues Object with initial attribute values for automatically added clusters
  * @param cluster Cluster to get the initial attribute values for
  */
-function getClusterInitialAttributeValues<F extends BitSchema, SF extends TypeFromBitSchema<F>, A extends Attributes, C extends Commands, E extends Events>(attributeInitialValues: { [key: number]: AttributeInitialValues<any> } | undefined, cluster: Cluster<F, SF, A, C, E>): AttributeInitialValues<A> | undefined {
+function getClusterInitialAttributeValues<F extends BitSchema, SF extends TypeFromPartialBitSchema<F>, A extends Attributes, C extends Commands, E extends Events>(attributeInitialValues: { [key: number]: AttributeInitialValues<any> } | undefined, cluster: Cluster<F, SF, A, C, E>): AttributeInitialValues<A> | undefined {
     if (attributeInitialValues === undefined) return undefined;
     return attributeInitialValues[cluster.id] as AttributeInitialValues<A>;
 }

--- a/packages/matter.js/src/schema/BitmapSchema.ts
+++ b/packages/matter.js/src/schema/BitmapSchema.ts
@@ -30,6 +30,7 @@ export const BitFieldEnum = <E extends number>(offset: number, length: number): 
 
 export type BitSchema = { [key: string]: BitFlag | BitField | BitFieldEnum<any> };
 export type TypeFromBitSchema<T extends BitSchema> = { [K in keyof T]: T[K] extends BitFieldEnum<infer E> ? E : (T[K] extends BitField ? number : boolean) };
+export type TypeFromPartialBitSchema<T extends BitSchema> = { [K in keyof T]?: T[K] extends BitFieldEnum<infer E> ? E : (T[K] extends BitField ? number : boolean) };
 export type TypeFromBitmapSchema<S extends Schema<any, any>> = S extends Schema<infer T, any> ? T : never;
 
 type MaskFromBitSchema<T extends BitSchema> = { [K in keyof T]: number };
@@ -50,6 +51,14 @@ export class BitmapSchemaInternal<T extends BitSchema> extends Schema<TypeFromBi
         }
         this.masks = masks;
         // TODO: validate that bitSchemas is coherent
+    }
+
+    /**
+     * Allow to use a filly defined Bitmap schema as input, but also allow one where only the entries of bits set are
+     * provided, rest is unset.
+     */
+    override encode(value: TypeFromBitSchema<T> | TypeFromPartialBitSchema<T>) {
+        return super.encode(value as TypeFromBitSchema<T>);
     }
 
     override encodeInternal(value: TypeFromBitSchema<T>) {

--- a/packages/matter.js/test/schema/BitmapSchemaTest.ts
+++ b/packages/matter.js/test/schema/BitmapSchemaTest.ts
@@ -38,10 +38,34 @@ describe("BitmapSchema", () => {
 
             expect(result).toBe(0xC4);
         });
+
+        it("encodes a bitmap using the schema with not provided unset bits", () => {
+            const result = TestBitmapSchema.encode({
+                flag1: true,
+                enumTest: EnumTest.VALUE_2,
+                numberTest: 1,
+            });
+
+            expect(result).toBe(0xC4);
+        });
+
+        it("encodes a bitmap using the schema with not provided unset bits #2", () => {
+            const result = TestBitmapSchema.encode({
+                flag1: true,
+            });
+
+            expect(result).toBe(0x4);
+        });
+
+        it("encodes a bitmap using the schema with all unset bits", () => {
+            const result = TestBitmapSchema.encode({});
+
+            expect(result).toBe(0);
+        });
     });
 
     describe("decode", () => {
-        it("decodes a bitmap using the schema", () => {
+        it("decodes a bitmap using the schema with all bit set", () => {
             const result = TestBitmapSchema.decode(0xB4);
 
             expect(result).toEqual({
@@ -49,6 +73,28 @@ describe("BitmapSchema", () => {
                 flag2: true,
                 enumTest: EnumTest.VALUE_1,
                 numberTest: 1,
+            });
+        });
+
+        it("decodes a bitmap using the schema with some set", () => {
+            const result = TestBitmapSchema.decode(0xC4);
+
+            expect(result).toEqual({
+                flag1: true,
+                flag2: false,
+                enumTest: EnumTest.VALUE_2,
+                numberTest: 1,
+            });
+        });
+
+        it("decodes a bitmap using the schema with none set", () => {
+            const result = TestBitmapSchema.decode(0x0);
+
+            expect(result).toEqual({
+                flag1: false,
+                flag2: false,
+                enumTest: 0,
+                numberTest: 0,
             });
         });
     });


### PR DESCRIPTION
This PR is my propsal for the Conditional idea with runtime check and also as basis for typing. The PR includes:

* Enhance BitMap typing and Schemas to allow "Partially" provided Bitmaps by suprerssing the "unset" bits. this should make is easier and less code
* Clusters use this Partial type for Schemas
* Intoduce new types for Attributes, Commands and Events as "Conditional" type to be used in ClusterSchemas (new idea of "the all in one Cluster used as basis for generation and anything). These types allow to specify mandatoryId and optionalIf attributes as array of corresponding cluster types. All this is typed correctly. Conditional* is inherited from Optional, so are all optional by definition
* On ClusterServer instance creation - if Conditional Attrinbutes are used - there is a type checking which logs
* I created (as discussed as idea) new dir cluster/schema with these type of clusters
* I also added then the Window Cluster for the other Extend variants in normal dir (would be replaced by generated one)

Additionally I fixed the command return types because they are TlvNoResponse. And I added some first "scene" flags.  I will do another fixing run later.

Happy to get your feedback