### PR TITLE
Fix Subscription Timer duplication and Optimizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All Changes without a GitHub Username in brackets are from the core team: @Apoll
   * Fix: Fix equality checks in Attribute servers to check deeper than just === (and introduce new util method isDeepEqual)
   * Fix: Make sure an error received from sending subscription seed data reports is not bubbling up and activate subscription after successful seeding
   * Fix: Allows Node.js Buffer objects to be persisted to storage as a Uint8Arrays that they subclass
+  * Fix: Fix a Subscription timer duplication issue and collect attribute changes within a 50ms window to reduce the number of subscription messages
 * matter.js API:
   * Breaking: Adjusted some constructors of the new API and remove the option to pass an array of clusters to be added initially because this was no longer compatible to the strong typing in some places. Use addClusterServer and addClusterClient methods
   * Deprecation: The classes MatterDevice and MatterController are deprecated to be used externally to the library and will be removed in later versions.

--- a/packages/matter-node.js/src/time/TimeNode.ts
+++ b/packages/matter-node.js/src/time/TimeNode.ts
@@ -8,6 +8,7 @@ import { Time, Timer, TimerCallback } from "@project-chip/matter.js/time";
 
 class TimerNode implements Timer {
     private timerId: NodeJS.Timer | undefined;
+    isRunning = false;
 
     constructor(
         private readonly intervalMs: number,
@@ -16,12 +17,18 @@ class TimerNode implements Timer {
     ) { }
 
     start() {
-        this.timerId = (this.periodic ? setInterval : setTimeout)(this.callback, this.intervalMs);
+        this.timerId = (this.periodic ? setInterval : setTimeout)(() => {
+            if (!this.periodic) {
+                this.isRunning = false;
+            }
+            this.callback();
+        }, this.intervalMs);
         return this;
     }
 
     stop() {
         (this.periodic ? clearInterval : clearTimeout)(this.timerId);
+        this.isRunning = false;
         return this;
     }
 }

--- a/packages/matter-node.js/test/IntegrationTest.ts
+++ b/packages/matter-node.js/test/IntegrationTest.ts
@@ -398,9 +398,10 @@ describe("Integration Test", () => {
 
             await fakeTime.advanceTime(2 * 1000);
             await onOffLightDeviceServer.onOff(true);
+            await fakeTime.advanceTime(100);
             const updateReport = await updatePromise;
 
-            assert.deepEqual(updateReport, { value: true, time: startTime + 2 * 1000 });
+            assert.deepEqual(updateReport, { value: true, time: startTime + 2 * 1000 + 100 });
 
             // Await update Report on value change without in between update
             const { promise: lastPromise, resolver: lastResolver } = await getPromiseResolver<{ value: boolean, time: number }>();
@@ -409,12 +410,13 @@ describe("Integration Test", () => {
             // Verify that no update comes in after max cycle time 1h
             await fakeTime.advanceTime(60 * 60 * 1000);
 
-            // ... but on next change immediately then
+            // ... but on next change immediately (means immediately + 50ms, so wait 100ms) then
             await fakeTime.advanceTime(2 * 1000);
             await onOffLightDeviceServer.onOff(false);
+            await fakeTime.advanceTime(100);
             const lastReport = await lastPromise;
 
-            assert.deepEqual(lastReport, { value: false, time: startTime + (60 * 60 + 4) * 1000 });
+            assert.deepEqual(lastReport, { value: false, time: startTime + (60 * 60 + 4) * 1000 + 200 });
         });
 
         it("subscribe an attribute with getter that needs endpoint", async () => {

--- a/packages/matter.js/src/time/Time.ts
+++ b/packages/matter.js/src/time/Time.ts
@@ -26,6 +26,9 @@ export abstract class Time {
 
 export interface Timer {
 
+    /** Is true if this timer is running. */
+    isRunning: boolean;
+
     /** Starts this timer, chainable. */
     start(): Timer;
 

--- a/packages/matter.js/src/time/TimeFake.ts
+++ b/packages/matter.js/src/time/TimeFake.ts
@@ -8,19 +8,33 @@ import { getPromiseResolver } from "../util/Promises.js";
 import { Time, Timer, TimerCallback } from "./Time.js";
 
 class TimerFake implements Timer {
+    isRunning = false;
+    private readonly callback: TimerCallback
+
     constructor(
         private readonly timeFake: TimeFake,
         private readonly durationMs: number,
-        private readonly callback: TimerCallback,
-    ) { }
+        callback: TimerCallback,
+    ) {
+        if (this instanceof IntervalFake) {
+            this.callback = callback;
+        } else {
+            this.callback = () => {
+                this.isRunning = false;
+                callback();
+            }
+        }
+    }
 
     start() {
         this.timeFake.callbackAtTime(this.timeFake.nowMs() + this.durationMs, this.callback);
+        this.isRunning = true;
         return this;
     }
 
     stop() {
         this.timeFake.removeCallback(this.callback);
+        this.isRunning = false;
         return this;
     }
 }

--- a/packages/matter.js/test/util/time/TimeFakeTest.ts
+++ b/packages/matter.js/test/util/time/TimeFakeTest.ts
@@ -45,8 +45,11 @@ describe("TimeFake", () => {
             let firedTime;
 
             const result = timeFake.getPeriodicTimer(30, () => firedTime = timeFake.nowMs());
+            assert.equal(result.isRunning, false);
+
             result.start();
 
+            assert.equal(result.isRunning, true);
             assert.equal(firedTime, undefined);
 
             await timeFake.advanceTime(45);
@@ -56,6 +59,11 @@ describe("TimeFake", () => {
             await timeFake.advanceTime(20);
 
             assert.equal(firedTime, FAKE_TIME + 60);
+
+            assert.equal(result.isRunning, true);
+
+            result.stop();
+            assert.equal(result.isRunning, false);
         });
 
         it("returns a periodic timer that can be stopped", async () => {
@@ -70,6 +78,7 @@ describe("TimeFake", () => {
             await timeFake.advanceTime(45);
 
             assert.equal(firedTime, undefined);
+            assert.equal(result.isRunning, false);
         });
     });
 
@@ -78,27 +87,34 @@ describe("TimeFake", () => {
             let firedTime;
 
             const result = timeFake.getTimer(30, () => firedTime = timeFake.nowMs());
+            assert.equal(result.isRunning, false);
             result.start();
+            assert.equal(result.isRunning, true);
 
             assert.equal(firedTime, undefined);
 
             await timeFake.advanceTime(45);
 
             assert.equal(firedTime, FAKE_TIME + 30);
+            assert.equal(result.isRunning, false);
         });
 
         it("returns a timer that can be stopped", async () => {
             let firedTime;
 
             const result = timeFake.getTimer(30, () => firedTime = timeFake.nowMs());
+            assert.equal(result.isRunning, false);
             result.start();
+            assert.equal(result.isRunning, true);
             result.stop();
+            assert.equal(result.isRunning, false);
 
             assert.equal(firedTime, undefined);
 
             await timeFake.advanceTime(45);
 
             assert.equal(firedTime, undefined);
+            assert.equal(result.isRunning, false);
         });
     });
 });


### PR DESCRIPTION
This PR should fix the current issue with Subscription timer duplication that could happen if multiple data updates came at "the same timepoint".
The main fix would have been to move one line but I decided to also add some optimizations. I now added a 50ms delay on sending data updates to allow more data changes to be collected and submitted together - else only the first change would have been sent out, but the others (assuming when we have changes then multiple attributes can change "at once") would have been queued for next run - or in case of "0" still beeng ttiggered in parallel increasing comnmunication load to the controller.

I think this 50ms delay, even not specified in specs is a reasonable addition.

Additionally the Timer interface and implementations got enhanced by adding a "isRunning" propoerty to find out if a Timer is currently running/active or not.

fixes #185 