### PR TITLE
Make Broadcasting port dynamic and add UDC Announce

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ All Changes without a GitHub Username in brackets are from the core team: @Apoll
   * Feature: (@mahimamandhanaa) Add BTP (Bluetooth Transport Protocol) codec class for encoding and decoding of BTP messages
   * Feature: Enhanced BitMap typing and Schemas to allow "Partially" provided Bitmaps by suppressing the "unset" bits
   * Feature: Allow to define discoveryCapabilities structure when getting pairing code in CommissioningServer
+  * Enhance: Device port in MDNSBroadcaster is now dynamically set and add UDC (User directed Commissioning) Announcements
+  * Enhance: Enhanced MessageCodec and check some more fields
   * Enhance: Added possibility to define conditional cluster attribute/Command/event definitions and introduce runtime checking for these. Part of Cluster Structure rework still WIP
   * Enhance: (@vves) Add Window Covering Cluster definition  
   * Enhance: Split up and corrected PowerSource and PressureMeasurement Cluster based on Matter 1.1 Specs

--- a/packages/matter-node.js-examples/package.json
+++ b/packages/matter-node.js-examples/package.json
@@ -30,7 +30,8 @@
         "matter-device": "ts-node --project tsconfig.dist.json src/examples/DeviceNode.ts",
         "matter-bridge": "ts-node --project tsconfig.dist.json src/examples/BridgedDevicesNode.ts",
         "matter-composeddevice": "ts-node --project tsconfig.dist.json src/examples/ComposedDeviceNode.ts",
-        "matter-controller": "ts-node --project tsconfig.dist.json src/examples/ControllerNode.ts"
+        "matter-controller": "ts-node --project tsconfig.dist.json src/examples/ControllerNode.ts",
+        "test": "true"
     },
     "bin": {
         "matter-device": "./dist/examples/DeviceNode.js",

--- a/packages/matter-node.js/test/IntegrationTest.ts
+++ b/packages/matter-node.js/test/IntegrationTest.ts
@@ -114,7 +114,7 @@ describe("Integration Test", () => {
 
         // override the mdns scanner to avoid the client to try to resolve the server's address
         commissioningServer.setMdnsScanner(await MdnsScanner.create(SERVER_IP));
-        commissioningServer.setMdnsBroadcaster(await MdnsBroadcaster.create(matterPort, SERVER_IP));
+        commissioningServer.setMdnsBroadcaster(await MdnsBroadcaster.create(SERVER_IP));
         await commissioningServer.advertise();
 
         assert.ok(onOffLightDeviceServer.getClusterServer(OnOffCluster));

--- a/packages/matter.js/src/CommissioningServer.ts
+++ b/packages/matter.js/src/CommissioningServer.ts
@@ -372,7 +372,7 @@ export class CommissioningServer extends MatterNode {
         this.interactionServer.setRootEndpoint(this.rootEndpoint); // Initialize the interaction server with the root endpoint
 
         // TODO adjust later and refactor MatterDevice
-        this.deviceInstance = new MatterDevice(this.deviceName, this.deviceType, vendorId, productId, this.discriminator, this.storageManager)
+        this.deviceInstance = new MatterDevice(this.deviceName, this.deviceType, vendorId, productId, this.discriminator, this.storageManager, this.port)
             .addNetInterface(await UdpInterface.create(this.port, "udp6", this.listeningAddressIpv6))
             .addScanner(this.mdnsScanner)
             .addBroadcaster(this.mdnsBroadcaster)

--- a/packages/matter.js/src/MatterDevice.ts
+++ b/packages/matter.js/src/MatterDevice.ts
@@ -53,6 +53,7 @@ export class MatterDevice {
         private readonly productId: number,
         private readonly discriminator: number,
         private readonly storageManager: StorageManager,
+        private readonly udpPort: number,
     ) {
         this.fabricManager = new FabricManager(this.storageManager);
 
@@ -128,13 +129,13 @@ export class MatterDevice {
                 fabricsToAnnounce.push(fabric);
             }
             for (const broadcaster of this.broadcasters) {
-                broadcaster.setFabrics(fabricsToAnnounce);
+                broadcaster.setFabrics(fabricsToAnnounce, this.udpPort);
                 broadcaster.announce();
             }
         } else {
             // No fabric paired yeet, so announce as "ready for commissioning"
             for (const broadcaster of this.broadcasters) {
-                broadcaster.setCommissionMode(1, this.deviceName, this.deviceType, this.vendorId, this.productId, this.discriminator);
+                broadcaster.setCommissionMode(1, this.deviceName, this.deviceType, this.vendorId, this.productId, this.discriminator, this.udpPort);
                 broadcaster.announce();
             }
         }
@@ -155,7 +156,7 @@ export class MatterDevice {
     addFabric(fabric: Fabric) {
         this.fabricManager.addFabric(fabric);
         this.broadcasters.forEach(broadcaster => {
-            broadcaster.setFabrics([fabric]);
+            broadcaster.setFabrics([fabric], this.udpPort);
             broadcaster.announce();
         });
         return fabric.fabricIndex;
@@ -201,7 +202,7 @@ export class MatterDevice {
     openCommissioningModeWindow(mode: number, discriminator: number, timeout: number) {
         this.commissioningWindowOpened = true;
         this.broadcasters.forEach(broadcaster => {
-            broadcaster.setCommissionMode(mode, this.deviceName, this.deviceType, this.vendorId, this.productId, discriminator);
+            broadcaster.setCommissionMode(mode, this.deviceName, this.deviceType, this.vendorId, this.productId, discriminator, this.udpPort);
         });
         this.startAnnouncement();
 

--- a/packages/matter.js/src/MatterServer.ts
+++ b/packages/matter.js/src/MatterServer.ts
@@ -78,7 +78,7 @@ export class MatterServer {
         // TODO the mdns classes will later be in this class and assigned differently!!
         for (const node of this.nodes) {
             if (node instanceof CommissioningServer) {
-                node.setMdnsBroadcaster(await MdnsBroadcaster.create(node.getPort(), this.mdnsAnnounceInterface));
+                node.setMdnsBroadcaster(await MdnsBroadcaster.create(this.mdnsAnnounceInterface));
                 node.setMdnsScanner(await MdnsScanner.create());
                 if (!node.delayedAnnouncement) {
                     await node.advertise();

--- a/packages/matter.js/src/common/Broadcaster.ts
+++ b/packages/matter.js/src/common/Broadcaster.ts
@@ -8,8 +8,9 @@ import { Fabric } from "../fabric/Fabric.js";
 import { VendorId } from "../datatype/VendorId.js";
 
 export interface Broadcaster {
-    setCommissionMode(mode: number, deviceName: string, deviceType: number, vendorId: VendorId, productId: number, discriminator: number): void;
-    setFabrics(fabrics: Fabric[]): void;
+    setCommissionMode(mode: number, deviceName: string, deviceType: number, vendorId: VendorId, productId: number, discriminator: number, announcedNetPort: number): void;
+    setFabrics(fabrics: Fabric[], announcedNetPort: number): void;
+    setCommissionerInfo(deviceName: string, vendorId: VendorId, productId: number, announcedNetPort: number, deviceType?: number): void;
     announce(): void;
     close(): void;
 }

--- a/packages/matter.js/src/mdns/MdnsBroadcaster.ts
+++ b/packages/matter.js/src/mdns/MdnsBroadcaster.ts
@@ -31,17 +31,7 @@ export class MdnsBroadcaster implements Broadcaster {
         private readonly mdnsServer: MdnsServer,
     ) { }
 
-    /**
-     * Set the Broadcaster data to announce a device ready for commissioning in a special mode
-     *
-     * @param mode
-     * @param deviceName
-     * @param deviceType
-     * @param vendorId
-     * @param productId
-     * @param discriminator
-     * @param announcedNetPort
-     */
+    /** Set the Broadcaster data to announce a device ready for commissioning in a special mode */
     setCommissionMode(mode: number, deviceName: string, deviceType: number, vendorId: VendorId, productId: number, discriminator: number, announcedNetPort: number) {
         logger.debug(`announce commissioning mode ${mode} ${deviceName} ${deviceType} ${vendorId.id} ${productId} ${discriminator}`);
 
@@ -97,12 +87,7 @@ export class MdnsBroadcaster implements Broadcaster {
         });
     }
 
-    /**
-     * Set the Broadcaster Data to announce an device for operative discovery (aka "already paired")
-     *
-     * @param fabrics
-     * @param announcedNetPort
-     */
+    /** Set the Broadcaster Data to announce an device for operative discovery (aka "already paired") */
     setFabrics(fabrics: Fabric[], announcedNetPort: number) {
         this.mdnsServer.setRecordsGenerator(netInterface => {
             const records: Record<any>[] = [
@@ -144,15 +129,7 @@ export class MdnsBroadcaster implements Broadcaster {
         });
     }
 
-    /**
-     * Set the Broadcaster data to announce a Commissioner (aka Commissioner discovery)
-     *
-     * @param deviceName
-     * @param vendorId
-     * @param productId
-     * @param announcedNetPort
-     * @param deviceType
-     */
+    /** Set the Broadcaster data to announce a Commissioner (aka Commissioner discovery) */
     setCommissionerInfo(deviceName: string, vendorId: VendorId, productId: number, announcedNetPort: number, deviceType?: number) {
         logger.debug(`announce commissioner ${announcedNetPort} ${deviceType}`);
 

--- a/packages/matter.js/src/mdns/MdnsBroadcaster.ts
+++ b/packages/matter.js/src/mdns/MdnsBroadcaster.ts
@@ -7,7 +7,10 @@
 import { AAAARecord, ARecord, PtrRecord, SrvRecord, TxtRecord, Record } from "../codec/DnsCodec.js";
 import { Crypto } from "../crypto/Crypto.js";
 import { Broadcaster } from "../common/Broadcaster.js";
-import { getDeviceMatterQname, getFabricQname, MATTER_COMMISSION_SERVICE_QNAME, MATTER_SERVICE_QNAME, SERVICE_DISCOVERY_QNAME } from "./MdnsConsts.js";
+import {
+    getDeviceMatterQname, getFabricQname, MATTER_COMMISSION_SERVICE_QNAME, MATTER_COMMISSIONER_SERVICE_QNAME,
+    MATTER_SERVICE_QNAME, SERVICE_DISCOVERY_QNAME
+} from "./MdnsConsts.js";
 import { MdnsServer } from "./MdnsServer.js";
 import { VendorId } from "../datatype/VendorId.js";
 import { Network } from "../net/Network.js";
@@ -18,18 +21,28 @@ import { Fabric } from "../fabric/Fabric.js";
 const logger = Logger.get("MdnsBroadcaster");
 
 export class MdnsBroadcaster implements Broadcaster {
-    static async create(port: number, multicastInterface?: string) {
-        return new MdnsBroadcaster(await MdnsServer.create(multicastInterface), port);
+    static async create(multicastInterface?: string) {
+        return new MdnsBroadcaster(await MdnsServer.create(multicastInterface));
     }
 
     private readonly network = Network.get();
 
     constructor(
         private readonly mdnsServer: MdnsServer,
-        private readonly port: number,
     ) { }
 
-    setCommissionMode(mode: number, deviceName: string, deviceType: number, vendorId: VendorId, productId: number, discriminator: number) {
+    /**
+     * Set the Broadcaster data to announce a device ready for commissioning in a special mode
+     *
+     * @param mode
+     * @param deviceName
+     * @param deviceType
+     * @param vendorId
+     * @param productId
+     * @param discriminator
+     * @param announcedNetPort
+     */
+    setCommissionMode(mode: number, deviceName: string, deviceType: number, vendorId: VendorId, productId: number, discriminator: number, announcedNetPort: number) {
         logger.debug(`announce commissioning mode ${mode} ${deviceName} ${deviceType} ${vendorId.id} ${productId} ${discriminator}`);
 
         const shortDiscriminator = (discriminator >> 8) & 0x0F;
@@ -59,8 +72,7 @@ export class MdnsBroadcaster implements Broadcaster {
                 PtrRecord(shortDiscriminatorQname, deviceQname),
                 PtrRecord(longDiscriminatorQname, deviceQname),
                 PtrRecord(commissionModeQname, deviceQname),
-                // TODO: the Matter port should not be hardcoded here
-                SrvRecord(deviceQname, { priority: 0, weight: 0, port: this.port, target: hostname }),
+                SrvRecord(deviceQname, { priority: 0, weight: 0, port: announcedNetPort, target: hostname }),
                 TxtRecord(deviceQname, [
                     `VP=${vendorId.id}+${productId}`,  /* Vendor / Product */
                     `DT=${deviceType}`,             /* Device Type */
@@ -85,7 +97,13 @@ export class MdnsBroadcaster implements Broadcaster {
         });
     }
 
-    setFabrics(fabrics: Fabric[]) {
+    /**
+     * Set the Broadcaster Data to announce an device for operative discovery (aka "already paired")
+     *
+     * @param fabrics
+     * @param announcedNetPort
+     */
+    setFabrics(fabrics: Fabric[], announcedNetPort: number) {
         this.mdnsServer.setRecordsGenerator(netInterface => {
             const records: Record<any>[] = [
                 PtrRecord(SERVICE_DISCOVERY_QNAME, MATTER_SERVICE_QNAME),
@@ -110,7 +128,7 @@ export class MdnsBroadcaster implements Broadcaster {
                     PtrRecord(MATTER_SERVICE_QNAME, deviceMatterQname),
                     PtrRecord(fabricQname, deviceMatterQname),
                     // TODO: the Matter port should not be hardcoded here
-                    SrvRecord(deviceMatterQname, { priority: 0, weight: 0, port: this.port, target: hostname }),
+                    SrvRecord(deviceMatterQname, { priority: 0, weight: 0, port: announcedNetPort, target: hostname }),
                     TxtRecord(deviceMatterQname, ["SII=5000", "SAI=300", "T=1"]),
                 ];
                 ips.forEach(ip => {
@@ -121,6 +139,58 @@ export class MdnsBroadcaster implements Broadcaster {
                     }
                 });
                 records.push(...fabricRecords);
+            });
+            return records;
+        });
+    }
+
+    /**
+     * Set the Broadcaster data to announce a Commissioner (aka Commissioner discovery)
+     *
+     * @param deviceName
+     * @param vendorId
+     * @param productId
+     * @param announcedNetPort
+     * @param deviceType
+     */
+    setCommissionerInfo(deviceName: string, vendorId: VendorId, productId: number, announcedNetPort: number, deviceType?: number) {
+        logger.debug(`announce commissioner ${announcedNetPort} ${deviceType}`);
+
+        const instanceId = Crypto.getRandomData(8).toHex().toUpperCase();
+        const deviceTypeQname = `_T${deviceType}._sub.${MATTER_COMMISSIONER_SERVICE_QNAME}`;
+        const vendorQname = `_V${vendorId.id}._sub.${MATTER_COMMISSION_SERVICE_QNAME}`;
+        const deviceQname = `${instanceId}.${MATTER_COMMISSION_SERVICE_QNAME}`;
+
+        this.mdnsServer.setRecordsGenerator(netInterface => {
+            const ipMac = this.network.getIpMac(netInterface);
+            if (ipMac === undefined) return [];
+            const { mac, ips } = ipMac;
+            const hostname = mac.replace(/:/g, "").toUpperCase() + "0000.local";
+            const records = [
+                PtrRecord(SERVICE_DISCOVERY_QNAME, MATTER_COMMISSIONER_SERVICE_QNAME),
+                PtrRecord(MATTER_COMMISSIONER_SERVICE_QNAME, vendorQname),
+                PtrRecord(vendorQname, deviceQname),
+                SrvRecord(deviceQname, { priority: 0, weight: 0, port: announcedNetPort, target: hostname }),
+                TxtRecord(deviceQname, [
+                    `VP=${vendorId.id}+${productId}`,  /* Vendor / Product */
+                    `DT=${deviceType}`,             /* Device Type */
+                    `DN=${deviceName}`,             /* Device Name */
+                    "SII=5000",                     /* Sleepy Idle Interval */
+                    "SAI=300",                      /* Sleepy Active Interval */
+                    "T=0",                          /* TCP not supported */
+                ]),
+            ];
+            if (deviceType !== undefined) {
+                records.push(PtrRecord(SERVICE_DISCOVERY_QNAME, deviceTypeQname));
+                records.push(PtrRecord(deviceTypeQname, deviceQname));
+            }
+
+            ips.forEach(ip => {
+                if (isIPv4(ip)) {
+                    records.push(ARecord(hostname, ip));
+                } else {
+                    records.push(AAAARecord(hostname, ip));
+                }
             });
             return records;
         });

--- a/packages/matter.js/src/mdns/MdnsConsts.ts
+++ b/packages/matter.js/src/mdns/MdnsConsts.ts
@@ -6,6 +6,7 @@
 
 export const SERVICE_DISCOVERY_QNAME = "_services._dns-sd._udp.local";
 export const MATTER_COMMISSION_SERVICE_QNAME = "_matterc._udp.local";
+export const MATTER_COMMISSIONER_SERVICE_QNAME = "_matterd._udp.local";
 export const MATTER_SERVICE_QNAME = "_matter._tcp.local";
 
 export const getFabricQname = (operationalIdString: string) => `_I${operationalIdString}._sub.${MATTER_SERVICE_QNAME}`;

--- a/packages/matter.js/test/mdns/MdnsTest.ts
+++ b/packages/matter.js/test/mdns/MdnsTest.ts
@@ -27,6 +27,7 @@ const SERVER_IPv6 = "fe80::e777:4f5e:c61e:7314";
 const SERVER_MAC = "00:B0:D0:63:C2:26";
 const CLIENT_IP = "192.168.200.2";
 const CLIENT_MAC = "CA:FE:00:00:BE:EF";
+const PORT = 5540;
 
 const serverNetwork = new NetworkFake(SERVER_MAC, [SERVER_IPv4, SERVER_IPv6]);
 const clientNetwork = new NetworkFake(CLIENT_MAC, [CLIENT_IP]);
@@ -45,7 +46,7 @@ describe("MDNS", () => {
         channel = await UdpChannelFake.create(serverNetwork, { listeningPort: 5353, listeningAddress: "224.0.0.251", type: "udp4" });
 
         Network.get = () => serverNetwork;
-        broadcaster = await MdnsBroadcaster.create(5540, FAKE_INTERFACE_NAME);
+        broadcaster = await MdnsBroadcaster.create(FAKE_INTERFACE_NAME);
 
         Network.get = () => { throw new Error("Network should not be requested post creation") };
     });
@@ -61,7 +62,7 @@ describe("MDNS", () => {
             const { promise, resolver } = await getPromiseResolver<ByteArray>();
             channel.onData((_netInterface, _peerAddress, _peerPort, data) => resolver(data));
 
-            broadcaster.setFabrics([{ operationalId: OPERATIONAL_ID, nodeId: NODE_ID } as Fabric]);
+            broadcaster.setFabrics([{ operationalId: OPERATIONAL_ID, nodeId: NODE_ID } as Fabric], PORT);
             broadcaster.announce();
 
             const result = DnsCodec.decode(await promise);
@@ -89,7 +90,7 @@ describe("MDNS", () => {
 
     describe("integration", () => {
         it("the client returns server record if it has been announced", async () => {
-            broadcaster.setFabrics([{ operationalId: OPERATIONAL_ID, nodeId: NODE_ID } as Fabric]);
+            broadcaster.setFabrics([{ operationalId: OPERATIONAL_ID, nodeId: NODE_ID } as Fabric], PORT);
             broadcaster.announce();
 
             const result = await scanner.findDevice({ operationalId: OPERATIONAL_ID } as Fabric, NODE_ID);
@@ -98,7 +99,7 @@ describe("MDNS", () => {
         });
 
         it("the client asks for the server record if it has not been announced", async () => {
-            broadcaster.setFabrics([{ operationalId: OPERATIONAL_ID, nodeId: NODE_ID } as Fabric]);
+            broadcaster.setFabrics([{ operationalId: OPERATIONAL_ID, nodeId: NODE_ID } as Fabric], PORT);
 
             const result = await scanner.findDevice({ operationalId: OPERATIONAL_ID } as Fabric, NODE_ID);
 


### PR DESCRIPTION
This PR is preparing future adjustments and:
* make the ports announced by Broadcaster configurable
* adds a missing announcement type for a "commissioner" to Broadcaster (not yet used, will also come, but that one will be on a different port)