### PR TITLE
Implement setRegulatoryConfig as per specs in Device and Controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,10 @@ All Changes without a GitHub Username in brackets are from the core team: @Apoll
     * Added FabricScopedAttributeServer which gets and sets the value based on the provided fabric
     * Updated ClusterServerObj and ClusterClientObj typings to respect these Attribute types
     * Updated all Cluster definitions that use such attribute types
-    * Add Interface for Events which requires to define the supported events when creating a ClusterServer (Event Logic WIP in separate PR)
+  * Breaking: Add Interface for Events which requires to define the supported events when creating a ClusterServer (Event Logic WIP in separate PR)
+  * Breaking: GeneralCommissioningServerHandler is now a function that takes configuration for setRegulatoryConfig handling
+  * Feature: Enhance CommissioningServer options to also specify GeneralCommissioningServer details and settings
+  * Feature: Adjust RegulatoryConfig Handling in Device and Controller to match with specifications
   * Feature: Endpoint Structures use custom-unique-id (from EndpointOptions)/uniqueStorageKey (from BasicInformationCluster)/serialNumber (from BasicInformationCluster)/ Index (in this order) to store and restore the endpoint ID in structures
   * Feature: (@mahimamandhanaa) Add BTP (Bluetooth Transport Protocol) codec class for encoding and decoding of BTP messages
   * Feature: Enhanced BitMap typing and Schemas to allow "Partially" provided Bitmaps by suppressing the "unset" bits

--- a/packages/matter-node.js/test/IntegrationTest.ts
+++ b/packages/matter-node.js/test/IntegrationTest.ts
@@ -14,7 +14,8 @@ Crypto.get = () => new CryptoNode();
 
 import {
     OnOffCluster, BasicInformationCluster, OperationalCertStatus, OperationalCredentialsCluster, DescriptorCluster,
-    IdentifyCluster, GroupsCluster, AccessControlCluster, ScenesCluster
+    IdentifyCluster, GroupsCluster, AccessControlCluster, ScenesCluster, GeneralCommissioningCluster,
+    RegulatoryLocationType
 } from "@project-chip/matter.js/cluster";
 import { VendorId, FabricIndex, GroupId, ClusterId } from "@project-chip/matter.js/datatype";
 
@@ -77,7 +78,11 @@ describe("Integration Test", () => {
             passcode: setupPin,
             listeningAddressIpv4: "1.2.3.4",
             listeningAddressIpv6: CLIENT_IP,
-            delayedPairing: true
+            delayedPairing: true,
+            commissioningOptions: {
+                regulatoryLocation: RegulatoryLocationType.Indoor,
+                regulatoryCountryCode: "DE"
+            }
         });
         matterClient.addCommissioningController(commissioningController);
 
@@ -102,7 +107,8 @@ describe("Integration Test", () => {
                 productName,
                 productId,
                 partNumber: "123456",
-                nodeLabel: ""
+                nodeLabel: "",
+                location: "US",
             },
             delayedAnnouncement: true, // delay because we need to override Mdns classes
         });
@@ -163,6 +169,15 @@ describe("Integration Test", () => {
             defaultInteractionClient = await commissioningController.createInteractionClient();
             assert.ok(defaultInteractionClient);
         });
+
+        it("Verify that commissioning changed the Regulatory Config/Location values", async () => {
+            const generalCommissioningCluster = commissioningController.getRootClusterClient(GeneralCommissioningCluster);
+            assert.equal(await generalCommissioningCluster?.getRegulatoryConfigAttribute(), RegulatoryLocationType.Indoor);
+
+            const basicInfoCluster = commissioningController.getRootClusterClient(BasicInformationCluster);
+            assert.equal(await basicInfoCluster?.getLocationAttribute(), "DE");
+        });
+
     });
 
 

--- a/packages/matter-node.js/test/cluster/GeneralCommissioningServerTest.ts
+++ b/packages/matter-node.js/test/cluster/GeneralCommissioningServerTest.ts
@@ -1,0 +1,192 @@
+/**
+ * @license
+ * Copyright 2022-2023 Project CHIP Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Crypto } from "@project-chip/matter.js/crypto";
+import { CryptoNode } from "../../src/crypto/CryptoNode";
+
+Crypto.get = () => new CryptoNode();
+
+import { Time, TimeFake } from "@project-chip/matter.js/time";
+
+Time.get = () => new TimeFake(0);
+
+import * as assert from "assert";
+import { ClusterServer } from "@project-chip/matter.js/interaction";
+import { SecureSession } from "@project-chip/matter.js/session";
+import {
+    ClusterServerObjForCluster, BasicInformationCluster, GeneralCommissioningCluster,
+    GeneralCommissioningClusterHandler, RegulatoryLocationType, CommissioningError
+} from "@project-chip/matter.js/cluster";
+import { SessionType, Message } from "@project-chip/matter.js/codec";
+import { callCommandOnClusterServer, createTestSessionWithFabric } from "./ClusterServerTestingUtil";
+import { Endpoint, DeviceTypes } from "@project-chip/matter.js/device";
+import { VendorId } from "@project-chip/matter.js/datatype";
+
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+
+describe("GeneralCommissioning Server test", () => {
+    let generalCommissioningServer: ClusterServerObjForCluster<typeof GeneralCommissioningCluster> | undefined;
+    let basicInformationServer: ClusterServerObjForCluster<typeof BasicInformationCluster> | undefined;
+    let testSession: SecureSession<any> | undefined
+    let endpoint: Endpoint | undefined;
+
+    // TODO make that nicer and maybe  move to a "testing support library"
+    async function initializeTestEnv(location: string, regulatoryConfig: RegulatoryLocationType, locationCapability: RegulatoryLocationType, allowCountryCodeChange: boolean, countryCodeWhitelist?: string[]) {
+        generalCommissioningServer = ClusterServer(
+            GeneralCommissioningCluster,
+            {
+                breadcrumb: BigInt(0),
+                basicCommissioningInfo: {
+                    failSafeExpiryLengthSeconds: 100,
+                    maxCumulativeFailsafeSeconds: 200,
+                },
+                regulatoryConfig,
+                locationCapability,
+                supportsConcurrentConnections: true,
+            }, GeneralCommissioningClusterHandler({ allowCountryCodeChange, countryCodeWhitelist }));
+        basicInformationServer = ClusterServer(BasicInformationCluster, {
+            dataModelRevision: 1,
+            vendorId: new VendorId(1),
+            vendorName: "test",
+            productId: 1,
+            productName: "test",
+            nodeLabel: "",
+            hardwareVersion: 0,
+            hardwareVersionString: "0",
+            location,
+            localConfigDisabled: false,
+            softwareVersion: 1,
+            softwareVersionString: "v1",
+            capabilityMinima: {
+                caseSessionsPerFabric: 3,
+                subscriptionsPerFabric: 3
+            },
+            serialNumber: `0000000000`
+        }, {}, {
+            startUp: true
+        });
+
+        testSession = await createTestSessionWithFabric();
+
+        endpoint = new Endpoint([DeviceTypes.ON_OFF_LIGHT], { endpointId: 1 });
+        endpoint.addClusterServer(basicInformationServer);
+        endpoint.addClusterServer(generalCommissioningServer);
+    }
+
+    describe("setRegulatoryConfig: Allow changing commissionable info and country", () => {
+        beforeAll(async () => {
+            await initializeTestEnv("US", RegulatoryLocationType.IndoorOutdoor, RegulatoryLocationType.IndoorOutdoor, true);
+        });
+
+        it("setRegulatoryConfig success", async () => {
+            const result = await callCommandOnClusterServer(generalCommissioningServer!, "setRegulatoryConfig", { breadcrumb: BigInt(2), newRegulatoryConfig: RegulatoryLocationType.Indoor, countryCode: "DE" }, endpoint!, testSession, { packetHeader: { sessionType: SessionType.Unicast } } as Message);
+
+            assert.deepEqual(result, { code: 0, response: { debugText: "", errorCode: CommissioningError.Ok }, responseId: 3 });
+            assert.deepEqual(generalCommissioningServer!.getRegulatoryConfigAttribute(), RegulatoryLocationType.Indoor);
+            assert.deepEqual(generalCommissioningServer!.getBreadcrumbAttribute(), BigInt(2));
+            assert.deepEqual(basicInformationServer!.getLocationAttribute(), "DE");
+        });
+
+        it("setRegulatoryConfig success #2", async () => {
+            const result = await callCommandOnClusterServer(generalCommissioningServer!, "setRegulatoryConfig", { breadcrumb: BigInt(3), newRegulatoryConfig: RegulatoryLocationType.Outdoor, countryCode: "CA" }, endpoint!, testSession, { packetHeader: { sessionType: SessionType.Unicast } } as Message);
+
+            assert.deepEqual(result, { code: 0, response: { debugText: "", errorCode: CommissioningError.Ok }, responseId: 3 });
+            assert.deepEqual(generalCommissioningServer!.getRegulatoryConfigAttribute(), RegulatoryLocationType.Outdoor);
+            assert.deepEqual(generalCommissioningServer!.getBreadcrumbAttribute(), BigInt(3));
+            assert.deepEqual(basicInformationServer!.getLocationAttribute(), "CA");
+        });
+
+        it("setRegulatoryConfig success #3 without changing country", async () => {
+            const result = await callCommandOnClusterServer(generalCommissioningServer!, "setRegulatoryConfig", { breadcrumb: BigInt(4), newRegulatoryConfig: RegulatoryLocationType.Indoor, countryCode: "XX" }, endpoint!, testSession, { packetHeader: { sessionType: SessionType.Unicast } } as Message);
+
+            assert.deepEqual(result, { code: 0, response: { debugText: "", errorCode: CommissioningError.Ok }, responseId: 3 });
+            assert.deepEqual(generalCommissioningServer!.getRegulatoryConfigAttribute(), RegulatoryLocationType.Indoor);
+            assert.deepEqual(generalCommissioningServer!.getBreadcrumbAttribute(), BigInt(4));
+            assert.deepEqual(basicInformationServer!.getLocationAttribute(), "XX");
+        });
+    });
+
+    describe("setRegulatoryConfig: Allow changing regulatory location info but not country", () => {
+        beforeAll(async () => {
+            await initializeTestEnv("DE", RegulatoryLocationType.IndoorOutdoor, RegulatoryLocationType.IndoorOutdoor, false);
+        });
+
+        it("setRegulatoryConfig country error", async () => {
+            const result = await callCommandOnClusterServer(generalCommissioningServer!, "setRegulatoryConfig", { breadcrumb: BigInt(2), newRegulatoryConfig: RegulatoryLocationType.Indoor, countryCode: "US" }, endpoint!, testSession, { packetHeader: { sessionType: SessionType.Unicast } } as Message);
+
+            assert.deepEqual(result, { code: 0, response: { debugText: "Country code change not allowed: US", errorCode: CommissioningError.ValueOutsideRange }, responseId: 3 });
+            assert.deepEqual(generalCommissioningServer!.getRegulatoryConfigAttribute(), RegulatoryLocationType.IndoorOutdoor);
+            assert.deepEqual(generalCommissioningServer!.getBreadcrumbAttribute(), BigInt(0));
+            assert.deepEqual(basicInformationServer!.getLocationAttribute(), "DE");
+        });
+
+        it("setRegulatoryConfig success without changing country", async () => {
+            const result = await callCommandOnClusterServer(generalCommissioningServer!, "setRegulatoryConfig", { breadcrumb: BigInt(2), newRegulatoryConfig: RegulatoryLocationType.Outdoor, countryCode: "DE" }, endpoint!, testSession, { packetHeader: { sessionType: SessionType.Unicast } } as Message);
+
+            assert.deepEqual(result, { code: 0, response: { debugText: "", errorCode: 0 }, responseId: 3 });
+            assert.deepEqual(generalCommissioningServer!.getRegulatoryConfigAttribute(), RegulatoryLocationType.Outdoor);
+            assert.deepEqual(generalCommissioningServer!.getBreadcrumbAttribute(), BigInt(2));
+            assert.deepEqual(basicInformationServer!.getLocationAttribute(), "DE");
+        });
+    });
+
+    describe("setRegulatoryConfig: Allow changing nothing", () => {
+        beforeAll(async () => {
+            await initializeTestEnv("XX", RegulatoryLocationType.Indoor, RegulatoryLocationType.Indoor, false);
+        });
+
+        it("setRegulatoryConfig country error", async () => {
+            const result = await callCommandOnClusterServer(generalCommissioningServer!, "setRegulatoryConfig", { breadcrumb: BigInt(2), newRegulatoryConfig: RegulatoryLocationType.Outdoor, countryCode: "DE" }, endpoint!, testSession, { packetHeader: { sessionType: SessionType.Unicast } } as Message);
+
+            assert.deepEqual(result, { code: 0, response: { debugText: "Country code change not allowed: DE", errorCode: CommissioningError.ValueOutsideRange }, responseId: 3 });
+            assert.deepEqual(generalCommissioningServer!.getRegulatoryConfigAttribute(), RegulatoryLocationType.Indoor);
+            assert.deepEqual(generalCommissioningServer!.getBreadcrumbAttribute(), BigInt(0));
+            assert.deepEqual(basicInformationServer!.getLocationAttribute(), "XX");
+        });
+
+        it("setRegulatoryConfig regulatory location error", async () => {
+            const result = await callCommandOnClusterServer(generalCommissioningServer!, "setRegulatoryConfig", { breadcrumb: BigInt(2), newRegulatoryConfig: RegulatoryLocationType.Outdoor, countryCode: "XX" }, endpoint!, testSession, { packetHeader: { sessionType: SessionType.Unicast } } as Message);
+
+            assert.deepEqual(result, { code: 0, response: { debugText: "Invalid regulatory location: Outdoor", errorCode: CommissioningError.ValueOutsideRange }, responseId: 3 });
+            assert.deepEqual(generalCommissioningServer!.getRegulatoryConfigAttribute(), RegulatoryLocationType.Indoor);
+            assert.deepEqual(generalCommissioningServer!.getBreadcrumbAttribute(), BigInt(0));
+            assert.deepEqual(basicInformationServer!.getLocationAttribute(), "XX");
+        });
+
+        it("setRegulatoryConfig success without changing anything", async () => {
+            const result = await callCommandOnClusterServer(generalCommissioningServer!, "setRegulatoryConfig", { breadcrumb: BigInt(2), newRegulatoryConfig: RegulatoryLocationType.Indoor, countryCode: "XX" }, endpoint!, testSession, { packetHeader: { sessionType: SessionType.Unicast } } as Message);
+
+            assert.deepEqual(result, { code: 0, response: { debugText: "", errorCode: CommissioningError.Ok }, responseId: 3 });
+            assert.deepEqual(generalCommissioningServer!.getRegulatoryConfigAttribute(), RegulatoryLocationType.Indoor);
+            assert.deepEqual(generalCommissioningServer!.getBreadcrumbAttribute(), BigInt(2));
+            assert.deepEqual(basicInformationServer!.getLocationAttribute(), "XX");
+        });
+    });
+
+    describe("setRegulatoryConfig: Allow changing country on whitelist", () => {
+        beforeAll(async () => {
+            await initializeTestEnv("XX", RegulatoryLocationType.Indoor, RegulatoryLocationType.Indoor, true, ["DE", "CA"]);
+        });
+
+        it("setRegulatoryConfig country error", async () => {
+            const result = await callCommandOnClusterServer(generalCommissioningServer!, "setRegulatoryConfig", { breadcrumb: BigInt(2), newRegulatoryConfig: RegulatoryLocationType.Indoor, countryCode: "US" }, endpoint!, testSession, { packetHeader: { sessionType: SessionType.Unicast } } as Message);
+
+            assert.deepEqual(result, { code: 0, response: { debugText: "Country code change not allowed: US", errorCode: CommissioningError.ValueOutsideRange }, responseId: 3 });
+            assert.deepEqual(generalCommissioningServer!.getRegulatoryConfigAttribute(), RegulatoryLocationType.Indoor);
+            assert.deepEqual(generalCommissioningServer!.getBreadcrumbAttribute(), BigInt(0));
+            assert.deepEqual(basicInformationServer!.getLocationAttribute(), "XX");
+        });
+
+        it("setRegulatoryConfig success", async () => {
+            const result = await callCommandOnClusterServer(generalCommissioningServer!, "setRegulatoryConfig", { breadcrumb: BigInt(2), newRegulatoryConfig: RegulatoryLocationType.Indoor, countryCode: "DE" }, endpoint!, testSession, { packetHeader: { sessionType: SessionType.Unicast } } as Message);
+
+            assert.deepEqual(result, { code: 0, response: { debugText: "", errorCode: CommissioningError.Ok }, responseId: 3 });
+            assert.deepEqual(generalCommissioningServer!.getRegulatoryConfigAttribute(), RegulatoryLocationType.Indoor);
+            assert.deepEqual(generalCommissioningServer!.getBreadcrumbAttribute(), BigInt(2));
+            assert.deepEqual(basicInformationServer!.getLocationAttribute(), "DE");
+        });
+    });
+});

--- a/packages/matter.js/src/CommissioningController.ts
+++ b/packages/matter.js/src/CommissioningController.ts
@@ -7,7 +7,7 @@ import { MatterNode } from "./MatterNode.js";
 import { UdpInterface } from "./net/UdpInterface.js";
 import { MdnsScanner } from "./mdns/MdnsScanner.js";
 import { StorageManager } from "./storage/StorageManager.js";
-import { MatterController } from "./MatterController.js";
+import { CommissioningData, MatterController } from "./MatterController.js";
 import { InteractionClient, ClusterClient } from "./protocol/interaction/InteractionClient.js";
 import { NodeId } from "./datatype/NodeId.js";
 import { structureReadDataToClusterObject } from "./protocol/interaction/AttributeDataDecoder.js";
@@ -47,8 +47,10 @@ export interface CommissioningControllerOptions {
 
     delayedPairing?: boolean;
 
-    passcode: number,
-    discriminator: number,
+    passcode: number, // TODO: Move into commissioningOptions
+    discriminator: number, // TODO: Move into commissioningOptions
+
+    commissioningOptions?: CommissioningData
 }
 
 export class CommissioningController extends MatterNode {
@@ -60,6 +62,7 @@ export class CommissioningController extends MatterNode {
 
     private readonly passcode: number;
     private readonly discriminator: number;
+    private readonly commissioningOptions?: CommissioningData;
 
     readonly delayedPairing: boolean;
 
@@ -88,6 +91,7 @@ export class CommissioningController extends MatterNode {
 
         this.passcode = options.passcode;
         this.discriminator = options.discriminator;
+        this.commissioningOptions = options.commissioningOptions;
     }
 
     /**
@@ -106,7 +110,8 @@ export class CommissioningController extends MatterNode {
             this.mdnsScanner,
             await UdpInterface.create(this.port, "udp4", this.listeningAddressIpv4),
             await UdpInterface.create(this.port, "udp6", this.listeningAddressIpv6),
-            this.storageManager
+            this.storageManager,
+            this.commissioningOptions
         );
 
         if (this.controllerInstance.isCommissioned()) {

--- a/packages/matter.js/src/CommissioningServer.ts
+++ b/packages/matter.js/src/CommissioningServer.ts
@@ -87,7 +87,13 @@ export interface CommissioningServerOptions {
         productName: string;
     }
     | AttributeInitialValues<typeof BasicInformationCluster.attributes>;
+
     certificates?: OperationalCredentialsServerConf;
+
+    generalCommissioning?: Partial<AttributeInitialValues<typeof GeneralCommissioningCluster.attributes>> & {
+        allowCountryCodeChange?: boolean; // Default true if not set
+        countryCodeWhitelist?: string[];
+    };
 }
 
 /**
@@ -164,7 +170,7 @@ export class CommissioningServer extends MatterNode {
                         nodeLabel: "",
                         hardwareVersion: 0,
                         hardwareVersionString: "0",
-                        location: "US",
+                        location: "XX",
                         localConfigDisabled: false,
                         softwareVersion: 1,
                         softwareVersionString: "v1",
@@ -218,16 +224,19 @@ export class CommissioningServer extends MatterNode {
             ClusterServer(
                 GeneralCommissioningCluster,
                 {
-                    breadcrumb: BigInt(0),
-                    basicCommissioningInfo: {
+                    breadcrumb: options.generalCommissioning?.breadcrumb ?? BigInt(0),
+                    basicCommissioningInfo: options.generalCommissioning?.basicCommissioningInfo ?? {
                         failSafeExpiryLengthSeconds: 60 /* 1min */,
                         maxCumulativeFailsafeSeconds: 900 /* Recommended according to Specs */
                     },
-                    regulatoryConfig: RegulatoryLocationType.Indoor,
-                    locationCapability: RegulatoryLocationType.IndoorOutdoor,
-                    supportsConcurrentConnections: true
+                    regulatoryConfig: options.generalCommissioning?.regulatoryConfig ?? RegulatoryLocationType.Outdoor, // Default is the most restrictive one
+                    locationCapability: options.generalCommissioning?.locationCapability ?? RegulatoryLocationType.IndoorOutdoor,
+                    supportsConcurrentConnections: options.generalCommissioning?.supportsConcurrentConnections ?? true
                 },
-                GeneralCommissioningClusterHandler
+                GeneralCommissioningClusterHandler({
+                    allowCountryCodeChange: options.generalCommissioning?.allowCountryCodeChange ?? true,
+                    countryCodeWhitelist: options.generalCommissioning?.countryCodeWhitelist ?? undefined
+                })
             )
         );
 

--- a/packages/matter.js/src/cluster/GeneralCommissioningCluster.ts
+++ b/packages/matter.js/src/cluster/GeneralCommissioningCluster.ts
@@ -130,7 +130,7 @@ export const GeneralCommissioningCluster = Cluster({
         basicCommissioningInfo: FixedAttribute(1, TlvBasicCommissioningInfo),
 
         /** Indicates the regulatory configuration for the product. */
-        regulatoryConfig: Attribute(2, TlvEnum<RegulatoryLocationType>()), /* default: value of locationCapability */
+        regulatoryConfig: Attribute(2, TlvEnum<RegulatoryLocationType>(), { persistent: true }), /* default: value of locationCapability */
 
         /** Indicates if this Node needs to be told an exact RegulatoryLocation. */
         locationCapability: FixedAttribute(3, TlvEnum<RegulatoryLocationType>(), { default: RegulatoryLocationType.IndoorOutdoor }),

--- a/packages/matter.js/test/device/MatterNodeStructureTest.ts
+++ b/packages/matter.js/test/device/MatterNodeStructureTest.ts
@@ -137,7 +137,7 @@ function addRequiredRootClusters(node: MatterNode, includeAdminCommissioningClus
                 locationCapability: RegulatoryLocationType.IndoorOutdoor,
                 supportsConcurrentConnections: true
             },
-            GeneralCommissioningClusterHandler
+            GeneralCommissioningClusterHandler()
         )
     );
 


### PR DESCRIPTION
This PR does:
* Breaking: GeneralCommissioningServerHandler is now a function that takes configuration for setRegulatoryConfig handling that can be used to specify how a device behaves
* Feature: Enhance CommissioningServer options to also specify GeneralCommissioningServer details and settings when initializing a Device to set these details
* Also enhance Controller to allow to set the details used during commissioning process (I will move more stuff into there in next time, some places only TODOs added for now)
* Feature: Adjust RegulatoryConfig Handling in Device and Controller to match with specifications
* Add Tests in IntegrationTest and also standalone test