### PR TITLE
Fix offset overflow on DataReader

### DIFF
--- a/packages/matter.js/src/util/DataReader.ts
+++ b/packages/matter.js/src/util/DataReader.ts
@@ -67,8 +67,7 @@ export class DataReader<E extends Endian> {
 
     readByteArray(length: number) {
         const offset = this.getOffsetAndAdvance(length);
-        const result = this.buffer.subarray(offset, offset + length);
-        return result;
+        return this.buffer.subarray(offset, offset + length);
     }
 
     getRemainingBytesCount() {
@@ -82,6 +81,9 @@ export class DataReader<E extends Endian> {
     private getOffsetAndAdvance(size: number) {
         const result = this.offset;
         this.offset += size;
+        if (this.offset > this.dataView.byteLength) {
+            this.offset = this.dataView.byteLength;
+        }
         return result;
     }
 }

--- a/packages/matter.js/src/util/DataWriter.ts
+++ b/packages/matter.js/src/util/DataWriter.ts
@@ -105,9 +105,9 @@ export class DataWriter<E extends Endian> {
 
         const result = new ByteArray(this.length);
         let offset = 0;
-        this.chunks.forEach(chunck => {
-            result.set(chunck, offset);
-            offset += chunck.byteLength;
+        this.chunks.forEach(chunk => {
+            result.set(chunk, offset);
+            offset += chunk.byteLength;
         });
         this.chunks.length = 0;
         this.chunks.push(result);


### PR DESCRIPTION
The offset could be increased higher then the  length, resulting in negative "remaining bytes" value