### PR TITLE
Add Global Attributes to ClusterClients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All Changes without a GitHub Username in brackets are from the core team: @Apoll
   * Feature: (@mahimamandhanaa) Add BTP (Bluetooth Transport Protocol) codec class for encoding and decoding of BTP messages
   * Feature: Enhanced BitMap typing and Schemas to allow "Partially" provided Bitmaps by suppressing the "unset" bits
   * Feature: Allow to define discoveryCapabilities structure when getting pairing code in CommissioningServer
+  * Feature: Global Attributes are also accessible in ClusterClient instances (e.g. to get the list of features of the cluster)
   * Enhance: Device port in MDNSBroadcaster is now dynamically set and add UDC (User directed Commissioning) Announcements
   * Enhance: Enhanced MessageCodec and check some more fields
   * Enhance: Added possibility to define conditional cluster attribute/Command/event definitions and introduce runtime checking for these. Part of Cluster Structure rework still WIP

--- a/packages/matter.js/src/CommissioningController.ts
+++ b/packages/matter.js/src/CommissioningController.ts
@@ -173,7 +173,7 @@ export class CommissioningController extends MatterNode {
      */
     async getRootClusterClientWithNewInteractionClient<F extends BitSchema, SF extends TypeFromPartialBitSchema<F>, A extends Attributes, C extends Commands, E extends Events>(
         cluster: Cluster<F, SF, A, C, E>
-    ): Promise<ClusterClientObj<A, C, E> | undefined> {
+    ): Promise<ClusterClientObj<F, A, C, E> | undefined> {
         return super.getRootClusterClient(cluster, await this.createInteractionClient());
     }
 
@@ -284,7 +284,7 @@ export class CommissioningController extends MatterNode {
             throw new Error("No device type found for endpoint");
         }
 
-        const endpointClusters = Array<ClusterServerObj<Attributes, Commands, Events> | ClusterClientObj<Attributes, Commands, Events>>();
+        const endpointClusters = Array<ClusterServerObj<Attributes, Commands, Events> | ClusterClientObj<any, Attributes, Commands, Events>>();
 
         // Add ClusterClients for all server clusters of the device
         for (const clusterId of descriptorData.serverList) {

--- a/packages/matter.js/src/MatterNode.ts
+++ b/packages/matter.js/src/MatterNode.ts
@@ -43,7 +43,7 @@ export abstract class MatterNode {
      *
      * @param cluster ClusterClient object to add
      */
-    addRootClusterClient<A extends Attributes, C extends Commands, E extends Events>(cluster: ClusterClientObj<A, C, E>) {
+    addRootClusterClient<F extends BitSchema, A extends Attributes, C extends Commands, E extends Events>(cluster: ClusterClientObj<F, A, C, E>) {
         this.rootEndpoint.addClusterClient(cluster);
     }
 
@@ -57,7 +57,7 @@ export abstract class MatterNode {
     getRootClusterClient<F extends BitSchema, SF extends TypeFromPartialBitSchema<F>, A extends Attributes, C extends Commands, E extends Events>(
         cluster: Cluster<F, SF, A, C, E>,
         interactionClient?: InteractionClient
-    ): ClusterClientObj<A, C, E> | undefined {
+    ): ClusterClientObj<F, A, C, E> | undefined {
         return this.rootEndpoint.getClusterClient(cluster, interactionClient);
     }
 

--- a/packages/matter.js/src/cluster/Cluster.ts
+++ b/packages/matter.js/src/cluster/Cluster.ts
@@ -389,6 +389,7 @@ export const ConditionalFixedAttribute = <T, V extends T, F extends BitSchema>(i
 
 export type MandatoryAttributeNames<A extends Attributes> = { [K in keyof A]: A[K] extends OptionalAttribute<any, any> ? never : K }[keyof A];
 export type OptionalAttributeNames<A extends Attributes> = { [K in keyof A]: A[K] extends OptionalAttribute<any, any> ? K : never }[keyof A];
+export type GlobalAttributeNames<F extends BitSchema> = keyof GlobalAttributes<F>;
 
 /* Interfaces and helper methods to define a cluster command */
 export const TlvNoResponse = TlvVoid;

--- a/packages/matter.js/src/cluster/client/ClusterClient.ts
+++ b/packages/matter.js/src/cluster/client/ClusterClient.ts
@@ -6,21 +6,23 @@
 import {
     Attribute, AttributeJsType, Attributes, Command, Commands, OptionalAttribute, OptionalWritableAttribute,
     RequestType, ResponseType, WritableAttribute, MandatoryAttributeNames, OptionalAttributeNames,
-    EventType, Events, MandatoryEventNames, OptionalEventNames, Cluster
+    EventType, Events, MandatoryEventNames, OptionalEventNames, Cluster, GlobalAttributes, GlobalAttributeNames
 } from "../Cluster.js";
 import { AttributeClient } from "./AttributeClient.js";
 import { Merge } from "../../util/Type.js";
 import { InteractionClient } from "../../protocol/interaction/InteractionClient.js";
 import { ClusterServerObj } from "../server/ClusterServer.js";
 import { EventClient } from "./EventClient.js";
+import { BitSchema } from "../../schema/BitmapSchema.js";
 
-export type AttributeClients<A extends Attributes> = Merge<{ [P in MandatoryAttributeNames<A>]: AttributeClient<AttributeJsType<A[P]>> }, { [P in OptionalAttributeNames<A>]: AttributeClient<AttributeJsType<A[P]> | undefined> }>;
+export type AttributeClients<F extends BitSchema, A extends Attributes> = Merge<Merge<{ [P in MandatoryAttributeNames<A>]: AttributeClient<AttributeJsType<A[P]>> }, { [P in OptionalAttributeNames<A>]: AttributeClient<AttributeJsType<A[P]> | undefined> }>, { [P in GlobalAttributeNames<F>]: AttributeClient<AttributeJsType<GlobalAttributes<F>[P]>> }>;
 
 export type EventClients<E extends Events> = Merge<{ [P in MandatoryEventNames<E>]: EventClient<EventType<E[P]>> }, { [P in OptionalEventNames<E>]: EventClient<EventType<E[P]> | undefined> }>;
 
 export type SignatureFromCommandSpec<C extends Command<any, any, any>> = (request: RequestType<C>) => Promise<ResponseType<C>>;
 type GetterTypeFromSpec<A extends Attribute<any, any>> = A extends OptionalAttribute<infer T, any> ? (T | undefined) : AttributeJsType<A>;
 type ClientAttributeGetters<A extends Attributes> = { [P in keyof A as `get${Capitalize<string & P>}Attribute`]: () => Promise<GetterTypeFromSpec<A[P]>> };
+type ClientGlobalAttributeGetters<F extends BitSchema> = { [P in GlobalAttributeNames<F> as `get${Capitalize<string & P>}Attribute`]: () => Promise<GetterTypeFromSpec<GlobalAttributes<F>[P]>> };
 type WritableAttributeNames<A extends Attributes> = { [K in keyof A]: A[K] extends WritableAttribute<any, any> ? K : never }[keyof A] | { [K in keyof A]: A[K] extends OptionalWritableAttribute<any, any> ? K : never }[keyof A];
 type ClientAttributeSetters<A extends Attributes> = { [P in WritableAttributeNames<A> as `set${Capitalize<string & P>}Attribute`]: (value: AttributeJsType<A[P]>) => Promise<void> };
 type ClientAttributeSubscribers<A extends Attributes> = { [P in keyof A as `subscribe${Capitalize<string & P>}Attribute`]: (listener: (value: AttributeJsType<A[P]>) => void, minIntervalS: number, maxIntervalS: number) => Promise<void> };
@@ -30,28 +32,29 @@ type CommandServers<C extends Commands> = { [P in keyof C]: SignatureFromCommand
 type ClientEventGetters<E extends Events> = { [P in keyof E as `get${Capitalize<string & P>}Event`]: () => Promise<EventType<E[P]>> };
 type ClientEventSubscribers<E extends Events> = { [P in keyof E as `subscribe${Capitalize<string & P>}Event`]: (listener: (value: EventType<E[P]>) => void, minIntervalS: number, maxIntervalS: number) => Promise<void> };
 
-export type ClusterClientObjForCluster<C extends Cluster<any, any, any, any, any>> = ClusterClientObj<C["attributes"], C["commands"], C["events"]>;
+export type ClusterClientObjForCluster<C extends Cluster<any, any, any, any, any>> = ClusterClientObj<C["features"], C["attributes"], C["commands"], C["events"]>;
 
 /** Strongly typed interface of a cluster client */
-export type ClusterClientObj<A extends Attributes, C extends Commands, E extends Events> =
+export type ClusterClientObj<F extends BitSchema, A extends Attributes, C extends Commands, E extends Events> =
     {
         id: number;
         _type: "ClusterClient";
         name: string;
         endpointId: number;
-        attributes: AttributeClients<A>;
+        attributes: AttributeClients<F, A>;
         events: EventClients<E>;
         commands: CommandServers<C>;
         subscriptAllAttributes: (minIntervalFloorSeconds: number, maxIntervalCeilingSeconds: number) => Promise<void>;
-        _clone: (newInteractionClient?: InteractionClient) => ClusterClientObj<A, C, E>;
+        _clone: (newInteractionClient?: InteractionClient) => ClusterClientObj<F, A, C, E>;
     }
     & ClientAttributeGetters<A>
+    & ClientGlobalAttributeGetters<F>
     & ClientAttributeSetters<A>
     & ClientAttributeSubscribers<A>
     & CommandServers<C>
     & ClientEventGetters<E>
     & ClientEventSubscribers<E>;
 
-export function isClusterClient<A extends Attributes, C extends Commands, E extends Events>(obj: ClusterClientObj<A, C, E> | ClusterServerObj<A, C, E>): obj is ClusterClientObj<A, C, E> {
+export function isClusterClient<F extends BitSchema, A extends Attributes, C extends Commands, E extends Events>(obj: ClusterClientObj<F, A, C, E> | ClusterServerObj<A, C, E>): obj is ClusterClientObj<F, A, C, E> {
     return obj._type === "ClusterClient";
 }

--- a/packages/matter.js/src/cluster/schema/GeneralDiagnostics.ts
+++ b/packages/matter.js/src/cluster/schema/GeneralDiagnostics.ts
@@ -82,7 +82,7 @@ const TlvNetworkInterface = TlvObject({
     /** Indicates whether the Node is currently able to reach off-premise services it uses by utilizing IPv4. */
     offPremiseServicesReachableIPv4: TlvField(2, TlvNullable(TlvBoolean)), /* default null */
 
-    /** Indicates whether the Node is currently able to reach off-premise services it uses by utilizing IPv4. */
+    /** Indicates whether the Node is currently able to reach off-premise services it uses by utilizing IPv6. */
     offPremiseServicesReachableIPv6: TlvField(3, TlvNullable(TlvBoolean)),  /* default null */
 
     /**
@@ -95,7 +95,7 @@ const TlvNetworkInterface = TlvObject({
     iPv4Addresses: TlvField(5, TlvArray(TlvString.bound({ maxLength: 4 }))),
 
     /** List of the unicast IPv6 addresses that are currently assigned to the network interface. */
-    iPv6Addresse: TlvField(6, TlvArray(TlvString.bound({ maxLength: 8 }))),
+    iPv6Addresses: TlvField(6, TlvArray(TlvString.bound({ maxLength: 8 }))),
 
     /** Indicates the type of the interface. */
     type: TlvField(7, TlvEnum<InterfaceType>()),

--- a/packages/matter.js/src/cluster/schema/GroupKeyManagement.ts
+++ b/packages/matter.js/src/cluster/schema/GroupKeyManagement.ts
@@ -133,6 +133,6 @@ export const GroupKeyManagementClusterSchema = Cluster({
         keySetRemove: Command(3, TlvKeySetRemoveRequest, 3, TlvNoResponse), /* isFabricScoped: true */
 
         /** Query a list of all Group Key Sets associated with the accessing fabric. */
-        keySetReadAllIndices: Command(5, TlvNoArguments, 4, TlvKeySetReadAllIndicesResponse), /* isFabricScoped: true */
+        keySetReadAllIndices: Command(4, TlvNoArguments, 5, TlvKeySetReadAllIndicesResponse), /* isFabricScoped: true */
     }
 });

--- a/packages/matter.js/src/cluster/server/ClusterServer.ts
+++ b/packages/matter.js/src/cluster/server/ClusterServer.ts
@@ -24,6 +24,7 @@ import { Endpoint } from "../../device/Endpoint.js";
 import { Fabric } from "../../fabric/Fabric.js";
 import { EventServer } from "./EventServer.js";
 import { EventHandler } from "../../protocol/interaction/EventHandler.js";
+import { BitSchema } from "../../schema/BitmapSchema.js";
 
 /** Cluster attributes accessible on the cluster server */
 type MandatoryAttributeServers<A extends Attributes> = Omit<{ [P in MandatoryAttributeNames<A>]: A[P] extends WritableFabricScopedAttribute<any, any> ? FabricScopedAttributeServer<AttributeJsType<A[P]>> : (A[P] extends FixedAttribute<any, any> ? FixedAttributeServer<AttributeJsType<A[P]>> : AttributeServer<AttributeJsType<A[P]>>) }, keyof GlobalAttributes<any>>;
@@ -159,6 +160,6 @@ export type ClusterServerObj<A extends Attributes, C extends Commands, E extends
     & ServerAttributeSubscribers<A>
     & ServerEventTriggers<E>;
 
-export function isClusterServer<A extends Attributes, C extends Commands, E extends Events>(obj: ClusterClientObj<A, C, E> | ClusterServerObj<A, C, E>): obj is ClusterServerObj<A, C, E> {
+export function isClusterServer<F extends BitSchema, A extends Attributes, C extends Commands, E extends Events>(obj: ClusterClientObj<F, A, C, E> | ClusterServerObj<A, C, E>): obj is ClusterServerObj<A, C, E> {
     return obj._type === "ClusterServer";
 }

--- a/packages/matter.js/src/device/Device.ts
+++ b/packages/matter.js/src/device/Device.ts
@@ -30,7 +30,7 @@ export class PairedDevice extends Endpoint {
      */
     constructor(
         definition: AtLeastOne<DeviceTypeDefinition>,
-        clusters: (ClusterServerObj<Attributes, Commands, Events> | ClusterClientObj<Attributes, Commands, Events>)[] = [],
+        clusters: (ClusterServerObj<Attributes, Commands, Events> | ClusterClientObj<any, Attributes, Commands, Events>)[] = [],
         endpointId: number
     ) {
         super(definition, { endpointId });
@@ -58,7 +58,7 @@ export class PairedDevice extends Endpoint {
     /**
      * @deprecated PairedDevice does not support adding additional clusters
      */
-    override addClusterClient<A extends Attributes, C extends Commands, E extends Events>(cluster: ClusterClientObj<A, C, E>) {
+    override addClusterClient<F extends BitSchema, A extends Attributes, C extends Commands, E extends Events>(cluster: ClusterClientObj<F, A, C, E>) {
         if (this.declineAddingMoreClusters) {
             throw new Error("PairedDevice does not support adding additional clusters");
         }
@@ -158,7 +158,7 @@ export class Device extends Endpoint {
         throw new Error("createOptionalClusterServer needs to be implemented by derived classes");
     }
 
-    protected createOptionalClusterClient<F extends BitSchema, SF extends TypeFromPartialBitSchema<F>, A extends Attributes, C extends Commands, E extends Events>(_cluster: Cluster<F, SF, A, C, E>): ClusterClientObj<A, C, E> {
+    protected createOptionalClusterClient<F extends BitSchema, SF extends TypeFromPartialBitSchema<F>, A extends Attributes, C extends Commands, E extends Events>(_cluster: Cluster<F, SF, A, C, E>): ClusterClientObj<F, A, C, E> {
         // TODO: Implement this in upper classes to add optional clusters on the fly
         throw new Error("createOptionalClusterClient needs to be implemented by derived classes");
     }
@@ -177,7 +177,7 @@ export class Device extends Endpoint {
         }
     }
 
-    override getClusterClient<F extends BitSchema, SF extends TypeFromPartialBitSchema<F>, A extends Attributes, C extends Commands, E extends Events>(cluster: Cluster<F, SF, A, C, E>): ClusterClientObj<A, C, E> | undefined {
+    override getClusterClient<F extends BitSchema, SF extends TypeFromPartialBitSchema<F>, A extends Attributes, C extends Commands, E extends Events>(cluster: Cluster<F, SF, A, C, E>): ClusterClientObj<F, A, C, E> | undefined {
         const clusterClient = super.getClusterClient(cluster);
         if (clusterClient !== undefined) {
             return clusterClient;

--- a/packages/matter.js/src/device/Endpoint.ts
+++ b/packages/matter.js/src/device/Endpoint.ts
@@ -27,7 +27,7 @@ export interface EndpointOptions {
 
 export class Endpoint {
     private readonly clusterServers = new Map<number, ClusterServerObj<Attributes, Commands, Events>>();
-    private readonly clusterClients = new Map<number, ClusterClientObj<Attributes, Commands, Events>>();
+    private readonly clusterClients = new Map<number, ClusterClientObj<any, Attributes, Commands, Events>>();
     private readonly childEndpoints: Endpoint[] = [];
     id: number | undefined;
     uniqueStorageKey: string | undefined;
@@ -121,7 +121,7 @@ export class Endpoint {
         this.structureChangedCallback(); // Inform parent about structure change
     }
 
-    addClusterClient<A extends Attributes, C extends Commands, E extends Events>(cluster: ClusterClientObj<A, C, E>) {
+    addClusterClient<F extends BitSchema, A extends Attributes, C extends Commands, E extends Events>(cluster: ClusterClientObj<F, A, C, E>) {
         this.clusterClients.set(cluster.id, cluster);
         this.descriptorCluster.attributes.clientList.setLocal(Array.from(this.clusterClients.keys()).map((id) => new ClusterId(id)));
         this.structureChangedCallback(); // Inform parent about structure change
@@ -141,10 +141,10 @@ export class Endpoint {
     getClusterClient<F extends BitSchema, SF extends TypeFromPartialBitSchema<F>, A extends Attributes, C extends Commands, E extends Events>(
         cluster: Cluster<F, SF, A, C, E>,
         interactionClient?: InteractionClient
-    ): ClusterClientObj<A, C, E> | undefined {
+    ): ClusterClientObj<F, A, C, E> | undefined {
         const clusterClient = this.clusterClients.get(cluster.id);
         if (clusterClient !== undefined) {
-            return clusterClient._clone(interactionClient) as ClusterClientObj<A, C, E>;
+            return clusterClient._clone(interactionClient) as ClusterClientObj<F, A, C, E>;
         }
         return undefined;
     }
@@ -153,7 +153,7 @@ export class Endpoint {
         return this.clusterServers.get(clusterId);
     }
 
-    getClusterClientById(clusterId: number): ClusterClientObj<Attributes, Commands, Events> | undefined {
+    getClusterClientById(clusterId: number): ClusterClientObj<any, Attributes, Commands, Events> | undefined {
         return this.clusterClients.get(clusterId);
     }
 
@@ -258,7 +258,7 @@ export class Endpoint {
         return Array.from(this.clusterServers.values());
     }
 
-    getAllClusterClients(): ClusterClientObj<Attributes, Commands, Events>[] {
+    getAllClusterClients(): ClusterClientObj<any, Attributes, Commands, Events>[] {
         return Array.from(this.clusterClients.values());
     }
 


### PR DESCRIPTION
This PR adds also acces for the global attributes to cluster clients. They are mainly needed to get info on cluster features