### PR TITLE
Use own StorageContext per Node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,9 @@ All Changes without a GitHub Username in brackets are from the core team: @Apoll
   * Feature: Enhance Storage system to allow to create subcontext stores to allow better separation of data
   * Feature: Allow to also remove devices from Aggregators
   * Feature: Optionally allow to define discovery capabilities when generating Pairing codee 
-* * Reference implementation/Examples:
+* Reference implementation/Examples:
+  * Breaking: The storage key structure got changed to allow multi node operations within one process. This requires to change the storage key structure and to migrate or reset the storage.
+    * Migration: prepend any storage key except Device.* and Controller.* with "0." in the filename
   * Deprecation: The CLI Examples LegacyDeviceNode and LegacyControllerNode is removed in this version! Use the new variants please.
   * Example script are moved to package matter-node.js-examples
 * Misc:

--- a/packages/matter-node.js/test/IntegrationTest.ts
+++ b/packages/matter-node.js/test/IntegrationTest.ts
@@ -492,7 +492,7 @@ describe("Integration Test", () => {
 
     describe("storage", () => {
         it("server storage has fabric fields stored correctly stringified", async () => {
-            const storedFabrics = fakeServerStorage.get(["FabricManager"], "fabrics");
+            const storedFabrics = fakeServerStorage.get(["0", "FabricManager"], "fabrics");
             assert.ok(Array.isArray(storedFabrics));
             assert.equal(storedFabrics.length, 1);
             const firstFabric = storedFabrics[0] as FabricJsonObject;
@@ -507,25 +507,25 @@ describe("Integration Test", () => {
             assert.ok(groupsClusterData instanceof Map);
             assert.equal(groupsClusterData.get(1), "Group 1");
 
-            assert.equal(fakeServerStorage.get(["FabricManager"], "nextFabricIndex"), 2);
+            assert.equal(fakeServerStorage.get(["0", "FabricManager"], "nextFabricIndex"), 2);
 
-            const onOffValue = fakeServerStorage.get<{ value: any, version: number }>(["Cluster-1-6"], "onOff");
+            const onOffValue = fakeServerStorage.get<{ value: any, version: number }>(["0", "Cluster-1-6"], "onOff");
             assert.ok(typeof onOffValue === "object");
             assert.equal(onOffValue.version, 2);
             assert.equal(onOffValue.value, false);
 
-            const storedServerResumptionRecords = fakeServerStorage.get(["SessionManager"], "resumptionRecords");
+            const storedServerResumptionRecords = fakeServerStorage.get(["0", "SessionManager"], "resumptionRecords");
             assert.ok(Array.isArray(storedServerResumptionRecords));
             assert.equal(storedServerResumptionRecords.length, 1);
 
-            assert.equal(fakeControllerStorage.get(["RootCertificateManager"], "rootCertId"), BigInt(0));
-            assert.equal(fakeControllerStorage.get(["MatterController"], "fabricCommissioned"), true);
+            assert.equal(fakeControllerStorage.get(["0", "RootCertificateManager"], "rootCertId"), BigInt(0));
+            assert.equal(fakeControllerStorage.get(["0", "MatterController"], "fabricCommissioned"), true);
 
-            const storedControllerResumptionRecords = fakeServerStorage.get(["SessionManager"], "resumptionRecords");
+            const storedControllerResumptionRecords = fakeServerStorage.get(["0", "SessionManager"], "resumptionRecords");
             assert.ok(Array.isArray(storedControllerResumptionRecords));
             assert.equal(storedControllerResumptionRecords.length, 1);
 
-            const storedControllerFabrics = fakeControllerStorage.get(["MatterController"], "fabric");
+            const storedControllerFabrics = fakeControllerStorage.get(["0", "MatterController"], "fabric");
             assert.ok(typeof storedControllerFabrics === "object");
         });
     });

--- a/packages/matter-node.js/test/interaction/InteractionProtocolTest.ts
+++ b/packages/matter-node.js/test/interaction/InteractionProtocolTest.ts
@@ -234,6 +234,7 @@ describe("InteractionProtocol", () => {
         it("replies with attribute values", async () => {
             const storageManager = new StorageManager(new StorageBackendMemory());
             await storageManager.initialize();
+            const storageContext = storageManager.createContext("test");
             const endpoint = new Endpoint([DummyTestDevice], { endpointId: 0 });
             endpoint.addClusterServer(ClusterServer(BasicInformationCluster, {
                 dataModelRevision: 1,
@@ -255,7 +256,7 @@ describe("InteractionProtocol", () => {
             }, {}, {
                 startUp: true
             }));
-            const interactionProtocol = new InteractionServer(storageManager);
+            const interactionProtocol = new InteractionServer(storageContext);
             interactionProtocol.setRootEndpoint(endpoint);
 
             const result = interactionProtocol.handleReadRequest(({ channel: { getName: () => "test" } }) as MessageExchange<any>, READ_REQUEST);
@@ -289,9 +290,10 @@ describe("InteractionProtocol", () => {
 
             const storageManager = new StorageManager(new StorageBackendMemory());
             await storageManager.initialize();
+            const storageContext = storageManager.createContext("test");
             const endpoint = new Endpoint([DummyTestDevice], { endpointId: 0 });
             endpoint.addClusterServer(basicCluster);
-            const interactionProtocol = new InteractionServer(storageManager);
+            const interactionProtocol = new InteractionServer(storageContext);
             interactionProtocol.setRootEndpoint(endpoint);
 
             const result = interactionProtocol.handleWriteRequest(({ channel: { getName: () => "test" } }) as MessageExchange<any>, WRITE_REQUEST);
@@ -314,9 +316,10 @@ describe("InteractionProtocol", () => {
 
             const storageManager = new StorageManager(new StorageBackendMemory());
             await storageManager.initialize();
+            const storageContext = storageManager.createContext("test");
             const endpoint = new Endpoint([DummyTestDevice], { endpointId: 0 });
             endpoint.addClusterServer(accessControlCluster);
-            const interactionProtocol = new InteractionServer(storageManager);
+            const interactionProtocol = new InteractionServer(storageContext);
             interactionProtocol.setRootEndpoint(endpoint);
 
             const testFabric = new Fabric(new FabricIndex(1), new FabricId(BigInt(1)), new NodeId(BigInt(1)), new NodeId(BigInt(2)), ByteArray.fromHex("00"), ByteArray.fromHex("00"), { privateKey: ByteArray.fromHex("00"), publicKey: ByteArray.fromHex("00") }, new VendorId(1), ByteArray.fromHex("00"), ByteArray.fromHex("00"), ByteArray.fromHex("00"), ByteArray.fromHex("00"), ByteArray.fromHex("00"), "");
@@ -358,9 +361,10 @@ describe("InteractionProtocol", () => {
 
             const storageManager = new StorageManager(new StorageBackendMemory());
             await storageManager.initialize();
+            const storageContext = storageManager.createContext("test");
             const endpoint = new Endpoint([DummyTestDevice], { endpointId: 0 });
             endpoint.addClusterServer(basicCluster);
-            const interactionProtocol = new InteractionServer(storageManager);
+            const interactionProtocol = new InteractionServer(storageContext);
             interactionProtocol.setRootEndpoint(endpoint);
 
             const result = interactionProtocol.handleWriteRequest(({ channel: { getName: () => "test" } }) as MessageExchange<any>, MASS_WRITE_REQUEST);
@@ -392,9 +396,10 @@ describe("InteractionProtocol", () => {
 
             const storageManager = new StorageManager(new StorageBackendMemory());
             await storageManager.initialize();
+            const storageContext = storageManager.createContext("test");
             const endpoint = new Endpoint([DummyTestDevice], { endpointId: 0 });
             endpoint.addClusterServer(onOffCluster);
-            const interactionProtocol = new InteractionServer(storageManager);
+            const interactionProtocol = new InteractionServer(storageContext);
             interactionProtocol.setRootEndpoint(endpoint);
 
             const result = await interactionProtocol.handleInvokeRequest(({ channel: { getName: () => "test" } }) as MessageExchange<any>, INVOKE_COMMAND_REQUEST_WITH_EMPTY_ARGS, {} as Message);
@@ -422,9 +427,10 @@ describe("InteractionProtocol", () => {
 
             const storageManager = new StorageManager(new StorageBackendMemory());
             await storageManager.initialize();
+            const storageContext = storageManager.createContext("test");
             const endpoint = new Endpoint([DummyTestDevice], { endpointId: 0 });
             endpoint.addClusterServer(onOffCluster);
-            const interactionProtocol = new InteractionServer(storageManager);
+            const interactionProtocol = new InteractionServer(storageContext);
             interactionProtocol.setRootEndpoint(endpoint);
 
             const result = await interactionProtocol.handleInvokeRequest(({ channel: { getName: () => "test" } }) as MessageExchange<any>, INVOKE_COMMAND_REQUEST_WITH_NO_ARGS, {} as Message);
@@ -451,9 +457,10 @@ describe("InteractionProtocol", () => {
 
             const storageManager = new StorageManager(new StorageBackendMemory());
             await storageManager.initialize();
+            const storageContext = storageManager.createContext("test");
             const endpoint = new Endpoint([DummyTestDevice], { endpointId: 0 });
             endpoint.addClusterServer(onOffCluster);
-            const interactionProtocol = new InteractionServer(storageManager);
+            const interactionProtocol = new InteractionServer(storageContext);
             interactionProtocol.setRootEndpoint(endpoint);
 
             const result = await interactionProtocol.handleInvokeRequest(({ channel: { getName: () => "test" } }) as MessageExchange<any>, INVOKE_COMMAND_REQUEST_INVALID, {} as Message);

--- a/packages/matter.js/src/CommissioningController.ts
+++ b/packages/matter.js/src/CommissioningController.ts
@@ -6,7 +6,7 @@
 import { MatterNode } from "./MatterNode.js";
 import { UdpInterface } from "./net/UdpInterface.js";
 import { MdnsScanner } from "./mdns/MdnsScanner.js";
-import { StorageManager } from "./storage/StorageManager.js";
+import { StorageContext } from "./storage/StorageContext.js";
 import { MatterController } from "./MatterController.js";
 import { InteractionClient, ClusterClient } from "./protocol/interaction/InteractionClient.js";
 import { NodeId } from "./datatype/NodeId.js";
@@ -63,7 +63,7 @@ export class CommissioningController extends MatterNode {
 
     readonly delayedPairing: boolean;
 
-    private storageManager?: StorageManager;
+    private storage?: StorageContext;
     private mdnsScanner?: MdnsScanner;
 
     private controllerInstance?: MatterController;
@@ -98,7 +98,7 @@ export class CommissioningController extends MatterNode {
         if (this.controllerInstance !== undefined) {
             throw new Error("Controller instance already connected!");
         }
-        if (this.mdnsScanner === undefined || this.storageManager === undefined) {
+        if (this.mdnsScanner === undefined || this.storage === undefined) {
             throw new Error("Add the node to the Matter instance before!");
         }
 
@@ -106,7 +106,7 @@ export class CommissioningController extends MatterNode {
             this.mdnsScanner,
             await UdpInterface.create(this.port, "udp4", this.listeningAddressIpv4),
             await UdpInterface.create(this.port, "udp6", this.listeningAddressIpv6),
-            this.storageManager
+            this.storage
         );
 
         if (this.controllerInstance.isCommissioned()) {
@@ -128,11 +128,11 @@ export class CommissioningController extends MatterNode {
     }
 
     /**
-     * Set the StorageManager instance. Should be only used internally
-     * @param storageManager
+     * Set the Storage instance. Should be only used internally
+     * @param storage storage context to use
      */
-    setStorageManager(storageManager: StorageManager) {
-        this.storageManager = storageManager;
+    setStorage(storage: StorageContext) {
+        this.storage = storage;
     }
 
     /**

--- a/packages/matter.js/src/CommissioningController.ts
+++ b/packages/matter.js/src/CommissioningController.ts
@@ -110,7 +110,7 @@ export class CommissioningController extends MatterNode {
             this.mdnsScanner,
             await UdpInterface.create(this.port, "udp4", this.listeningAddressIpv4),
             await UdpInterface.create(this.port, "udp6", this.listeningAddressIpv6),
-            this.storage
+            this.storage,
             this.commissioningOptions
         );
 

--- a/packages/matter.js/src/MatterController.ts
+++ b/packages/matter.js/src/MatterController.ts
@@ -81,6 +81,7 @@ export class MatterController {
         private readonly netInterfaceIpv6: NetInterface,
         private readonly certificateManager: RootCertificateManager,
         private readonly fabric: Fabric,
+        private readonly storage: StorageContext,
         commissioningOptions?: CommissioningData
     ) {
         this.controllerStorage = this.storage.createContext("MatterController");

--- a/packages/matter.js/src/MatterController.ts
+++ b/packages/matter.js/src/MatterController.ts
@@ -33,7 +33,6 @@ import { BasicInformationCluster } from "./cluster/BasicInformationCluster.js";
 import { CommissioningError, CommissioningSuccessFailureResponse, GeneralCommissioningCluster, RegulatoryLocationType } from "./cluster/GeneralCommissioningCluster.js";
 import { CertificateChainType, OperationalCredentialsCluster, TlvCertSigningRequest } from "./cluster/OperationalCredentialsCluster.js";
 import { ByteArray } from "./util/ByteArray.js";
-import { StorageManager } from "./storage/StorageManager.js";
 
 const FABRIC_INDEX = new FabricIndex(1);
 const FABRIC_ID = BigInt(1);
@@ -41,9 +40,9 @@ const ADMIN_VENDOR_ID = new VendorId(752);
 const logger = Logger.get("MatterController");
 
 export class MatterController {
-    public static async create(scanner: Scanner, netInterfaceIpv4: NetInterface, netInterfaceIpv6: NetInterface, storageManager: StorageManager) {
+    public static async create(scanner: Scanner, netInterfaceIpv4: NetInterface, netInterfaceIpv6: NetInterface, storage: StorageContext) {
         const CONTROLLER_NODE_ID = new NodeId(Crypto.getRandomBigUInt64());
-        const certificateManager = new RootCertificateManager(storageManager);
+        const certificateManager = new RootCertificateManager(storage);
 
         const ipkValue = Crypto.getRandomData(16);
         const fabricBuilder = new FabricBuilder(FABRIC_INDEX)
@@ -54,12 +53,12 @@ export class MatterController {
         fabricBuilder.setOperationalCert(certificateManager.generateNoc(fabricBuilder.getPublicKey(), FABRIC_ID, CONTROLLER_NODE_ID));
 
         // Check if we have a fabric stored in the storage, if yes initialize this one, else build a new one
-        const controllerStorage = storageManager.createContext("MatterController");
+        const controllerStorage = storage.createContext("MatterController");
         if (controllerStorage.has("fabric")) {
             const storedFabric = Fabric.createFromStorageObject(controllerStorage.get<FabricJsonObject>("fabric"));
-            return new MatterController(scanner, netInterfaceIpv4, netInterfaceIpv6, certificateManager, storedFabric, storageManager);
+            return new MatterController(scanner, netInterfaceIpv4, netInterfaceIpv6, certificateManager, storedFabric, storage);
         } else {
-            return new MatterController(scanner, netInterfaceIpv4, netInterfaceIpv6, certificateManager, await fabricBuilder.build(), storageManager);
+            return new MatterController(scanner, netInterfaceIpv4, netInterfaceIpv6, certificateManager, await fabricBuilder.build(), storage);
         }
     }
 
@@ -76,11 +75,11 @@ export class MatterController {
         private readonly netInterfaceIpv6: NetInterface,
         private readonly certificateManager: RootCertificateManager,
         private readonly fabric: Fabric,
-        private readonly storageManager: StorageManager
+        private readonly storage: StorageContext,
     ) {
-        this.controllerStorage = this.storageManager.createContext("MatterController");
+        this.controllerStorage = this.storage.createContext("MatterController");
 
-        this.sessionManager = new SessionManager(this, this.storageManager);
+        this.sessionManager = new SessionManager(this, this.storage);
         this.sessionManager.initFromStorage([this.fabric]);
 
         this.exchangeManager = new ExchangeManager<MatterController>(this.sessionManager, this.channelManager);
@@ -109,7 +108,6 @@ export class MatterController {
         let generalCommissioningClusterClient = ClusterClient(GeneralCommissioningCluster, 0, interactionClient);
         this.ensureSuccess(await generalCommissioningClusterClient.armFailSafe({ breadcrumb: BigInt(1), expiryLengthSeconds: 60 }));
         this.ensureSuccess(await generalCommissioningClusterClient.setRegulatoryConfig({ breadcrumb: BigInt(2), newRegulatoryConfig: RegulatoryLocationType.IndoorOutdoor, countryCode: "US" }));
-
 
         const operationalCredentialsClusterClient = ClusterClient(OperationalCredentialsCluster, 0, interactionClient);
         const { certificate: deviceAttestation } = await operationalCredentialsClusterClient.requestCertChain({ type: CertificateChainType.DeviceAttestation });

--- a/packages/matter.js/src/MatterDevice.ts
+++ b/packages/matter.js/src/MatterDevice.ts
@@ -27,7 +27,7 @@ import { NodeId } from "./datatype/NodeId.js";
 import { Logger } from "./log/Logger.js";
 import { Time, Timer } from "./time/Time.js";
 import { ByteArray } from "./util/ByteArray.js";
-import { StorageManager } from "./storage/StorageManager.js";
+import { StorageContext } from "./storage/StorageContext.js";
 
 const logger = Logger.get("MatterDevice");
 
@@ -52,12 +52,12 @@ export class MatterDevice {
         private readonly vendorId: VendorId,
         private readonly productId: number,
         private readonly discriminator: number,
-        private readonly storageManager: StorageManager,
+        private readonly storage: StorageContext,
         private readonly udpPort: number,
     ) {
-        this.fabricManager = new FabricManager(this.storageManager);
+        this.fabricManager = new FabricManager(this.storage);
 
-        this.sessionManager = new SessionManager(this, this.storageManager);
+        this.sessionManager = new SessionManager(this, this.storage);
         this.sessionManager.initFromStorage(this.fabricManager.getFabrics());
 
         this.exchangeManager = new ExchangeManager<MatterDevice>(this.sessionManager, this.channelManager);

--- a/packages/matter.js/src/MatterServer.ts
+++ b/packages/matter.js/src/MatterServer.ts
@@ -13,6 +13,11 @@ import { CommissioningController } from "./CommissioningController.js";
 // TODO Move Mdns instances internally
 // TODO enhance storage manager to support multiple nodes
 
+export type NodeOptions = {
+    /** Unique node id to use for the storage context of this node. If not provided the order of node addition is used. */
+    uniqueNodeId?: string;
+}
+
 /**
  * Main Matter server class that represents the process on the host allowing to commission and pair multiple devices
  * by reusing MDNS scanner and Broadcaster
@@ -35,9 +40,10 @@ export class MatterServer {
     /**
      * Add a CommissioningServer node to the server
      *
-     * @param commisioningServer CommissioningServer node to add
+     * @param commissioningServer CommissioningServer node to add
+     * @param nodeOptions Optional options for the node (e.g. unique node id)
      */
-    addCommissioningServer(commisioningServer: CommissioningServer) {
+    addCommissioningServer(commissioningServer: CommissioningServer, nodeOptions?: NodeOptions) {
         if (this.nodes.length > 0) {
             throw new Error("Only one node is allowed for now");
         }
@@ -52,21 +58,22 @@ export class MatterServer {
                 portCheckMap.set(nodePort, true);
             }
         }
-        commisioningServer.setStorageManager(this.storageManager);
-        this.nodes.push(commisioningServer);
+        commissioningServer.setStorage(this.storageManager.createContext(nodeOptions?.uniqueNodeId ?? this.nodes.length.toString()));
+        this.nodes.push(commissioningServer);
     }
 
     /**
      * Add a Controller node to the server
      *
      * @param commissioningController Controller node to add
+     * @param nodeOptions Optional options for the node (e.g. unique node id)
      */
-    addCommissioningController(commissioningController: CommissioningController) {
+    addCommissioningController(commissioningController: CommissioningController, nodeOptions?: NodeOptions) {
         if (this.nodes.length > 0) {
             throw new Error("Only one node is allowed for now");
         }
 
-        commissioningController.setStorageManager(this.storageManager);
+        commissioningController.setStorage(this.storageManager.createContext(nodeOptions?.uniqueNodeId ?? this.nodes.length.toString()));
         this.nodes.push(commissioningController);
     }
 

--- a/packages/matter.js/src/certificate/RootCertificateManager.ts
+++ b/packages/matter.js/src/certificate/RootCertificateManager.ts
@@ -9,7 +9,7 @@ import { Crypto, KeyPair } from "../crypto/Crypto.js";
 import { ByteArray } from "../util/ByteArray.js";
 import { NodeId } from "../datatype/NodeId.js";
 import { Time } from "../time/Time.js";
-import { StorageManager } from "../storage/StorageManager.js";
+import { StorageContext } from "../storage/StorageContext.js";
 
 export class RootCertificateManager {
     private rootCertId = BigInt(0);
@@ -18,8 +18,8 @@ export class RootCertificateManager {
     private rootCertBytes = this.generateRootCert();
     private nextCertificateId = 1;
 
-    constructor(storageManager: StorageManager) {
-        const storage = storageManager.createContext("RootCertificateManager");
+    constructor(storageContext: StorageContext) {
+        const storage = storageContext.createContext("RootCertificateManager");
 
         // Read from storage if we have them stored, else store the just generated data
         if (storage.has("rootCertId")) {

--- a/packages/matter.js/src/fabric/FabricManager.ts
+++ b/packages/matter.js/src/fabric/FabricManager.ts
@@ -8,7 +8,6 @@ import { Fabric, FabricBuilder, FabricJsonObject } from "./Fabric.js";
 import { MatterError } from "../common/MatterError.js";
 import { FabricIndex } from "../datatype/FabricIndex.js";
 import { StorageContext } from "../storage/StorageContext.js";
-import { StorageManager } from "../storage/StorageManager.js";
 import { ByteArray } from "../util/ByteArray.js";
 
 /** Specific Error for when a fabric is not found. */
@@ -20,8 +19,8 @@ export class FabricManager {
     private fabricBuilder?: FabricBuilder;
     private readonly fabricStorage: StorageContext;
 
-    constructor(storageManager: StorageManager) {
-        this.fabricStorage = storageManager.createContext("FabricManager");
+    constructor(storage: StorageContext) {
+        this.fabricStorage = storage.createContext("FabricManager");
         const fabrics = this.fabricStorage.get<FabricJsonObject[]>("fabrics", []);
         fabrics.forEach(fabric => this.addFabric(Fabric.createFromStorageObject(fabric)));
         this.nextFabricIndex = this.fabricStorage.get("nextFabricIndex", this.nextFabricIndex);

--- a/packages/matter.js/src/protocol/interaction/EventHandler.ts
+++ b/packages/matter.js/src/protocol/interaction/EventHandler.ts
@@ -5,8 +5,7 @@
  */
 
 import { StorageContext } from "../../storage/StorageContext.js";
-import { StorageManager } from "../../storage/StorageManager.js";
-import { EventPriority } from "../../cluster/index.js";
+import { EventPriority } from "../../cluster/Cluster.js";
 
 const MAX_EVENTS = 10_000;
 
@@ -43,8 +42,8 @@ export class EventHandler {
         [EventPriority.Debug]: new Array<EventStorageData<any>>(),
     }
 
-    constructor(storageManager: StorageManager) {
-        this.eventStorage = storageManager.createContext("EventHandler");
+    constructor(storage: StorageContext) {
+        this.eventStorage = storage.createContext("EventHandler");
         this.eventNumber = this.eventStorage.get("lastEventNumber", this.eventNumber);
     }
 

--- a/packages/matter.js/src/protocol/interaction/InteractionServer.ts
+++ b/packages/matter.js/src/protocol/interaction/InteractionServer.ts
@@ -36,7 +36,6 @@ import {
 } from "../../cluster/server/AttributeServer.js";
 import { Logger } from "../../log/Logger.js";
 import { StorageContext } from "../../storage/StorageContext.js";
-import { StorageManager } from "../../storage/StorageManager.js";
 import { capitalize } from "../../util/String.js";
 import { Endpoint } from "../../device/Endpoint.js";
 import { AttributeId } from "../../datatype/AttributeId.js";
@@ -400,10 +399,10 @@ export function eventPathToId({ endpointId, clusterId, eventId }: TypeFromSchema
 export class InteractionServer implements ProtocolHandler<MatterDevice> {
     private endpointStructure = new InteractionEndpointStructure();
     private nextSubscriptionId = Crypto.getRandomUInt32();
-    private eventHandler = new EventHandler(this.storageManager);
+    private eventHandler = new EventHandler(this.storage);
 
     constructor(
-        private readonly storageManager: StorageManager
+        private readonly storage: StorageContext
     ) { }
 
     getId() {
@@ -416,7 +415,7 @@ export class InteractionServer implements ProtocolHandler<MatterDevice> {
 
         for (const endpoint of this.endpointStructure.endpoints.values()) {
             for (const cluster of endpoint.getAllClusterServers()) {
-                cluster._setStorage(this.storageManager.createContext(`Cluster-${endpoint.id}-${cluster.id}`));
+                cluster._setStorage(this.storage.createContext(`Cluster-${endpoint.id}-${cluster.id}`));
                 cluster._registerEventHandler(this.eventHandler);
             }
         }

--- a/packages/matter.js/src/session/SessionManager.ts
+++ b/packages/matter.js/src/session/SessionManager.ts
@@ -9,7 +9,6 @@ import { NodeId } from "../datatype/NodeId.js";
 import { Fabric } from "../fabric/Fabric.js";
 import { ByteArray } from "../util/ByteArray.js";
 import { StorageContext } from "../storage/StorageContext.js";
-import { StorageManager } from "../storage/StorageManager.js";
 import { SecureSession } from "./SecureSession.js";
 import { Session } from "./Session.js";
 import { UnsecureSession } from "./UnsecureSession.js";
@@ -42,9 +41,9 @@ export class SessionManager<ContextT> {
 
     constructor(
         private readonly context: ContextT,
-        storageManager: StorageManager,
+        storage: StorageContext,
     ) {
-        this.sessionStorage = storageManager.createContext("SessionManager")
+        this.sessionStorage = storage.createContext("SessionManager")
         this.unsecureSession = new UnsecureSession(context);
         this.sessions.set(UNICAST_UNSECURE_SESSION_ID, this.unsecureSession);
     }

--- a/packages/matter.js/src/storage/StorageContext.ts
+++ b/packages/matter.js/src/storage/StorageContext.ts
@@ -33,8 +33,6 @@ export class StorageContext {
     createContext(context: string) {
         if (context.length === 0) throw new Error("Context must not be an empty string");
         if (context.includes('.')) throw new Error("Context must not contain dots!");
-        const newContext = this.contexts;
-        newContext.push(context);
-        return new StorageContext(this.storage, newContext);
+        return new StorageContext(this.storage, [...this.contexts, context]);
     }
 }

--- a/packages/matter.js/test/device/MatterNodeStructureTest.ts
+++ b/packages/matter.js/test/device/MatterNodeStructureTest.ts
@@ -323,7 +323,8 @@ describe("Endpoint Structures", () => {
             const testStorage = new StorageBackendMemory();
             const testStorageManager = new StorageManager(testStorage);
             await testStorageManager.initialize();
-            const endpointStorage = testStorageManager.createContext("EndpointStructure");
+            const testStorageContext = testStorageManager.createContext("TestContext");
+            const endpointStorage = testStorageContext.createContext("EndpointStructure");
 
             const node = new CommissioningServer({
                 port: 5540,
@@ -357,7 +358,7 @@ describe("Endpoint Structures", () => {
                     certificationDeclaration: ByteArray.fromHex("00"),
                 }
             });
-            node.setStorageManager(testStorageManager);
+            node.setStorage(testStorageContext);
             addRequiredRootClusters(node);
 
             const onoffLightDevice = new OnOffLightDevice();
@@ -417,7 +418,8 @@ describe("Endpoint Structures", () => {
             const testStorage = new StorageBackendMemory();
             const testStorageManager = new StorageManager(testStorage);
             await testStorageManager.initialize();
-            const endpointStorage = testStorageManager.createContext("EndpointStructure");
+            const testStorageContext = testStorageManager.createContext("TestContext");
+            const endpointStorage = testStorageContext.createContext("EndpointStructure");
 
             const node = new CommissioningServer({
                 port: 5540,
@@ -451,7 +453,7 @@ describe("Endpoint Structures", () => {
                     certificationDeclaration: ByteArray.fromHex("00"),
                 }
             });
-            node.setStorageManager(testStorageManager);
+            node.setStorage(testStorageContext);
             addRequiredRootClusters(node);
 
             const onoffLightDevice = new OnOffLightDevice(undefined, { uniqueStorageKey: "test-unique-id" });
@@ -511,7 +513,8 @@ describe("Endpoint Structures", () => {
             const testStorage = new StorageBackendMemory();
             const testStorageManager = new StorageManager(testStorage);
             await testStorageManager.initialize();
-            const endpointStorage = testStorageManager.createContext("EndpointStructure");
+            const testStorageContext = testStorageManager.createContext("TestContext");
+            const endpointStorage = testStorageContext.createContext("EndpointStructure");
             endpointStorage.set("serial_node-matter-0000-index_0", 10)
 
             const node = new CommissioningServer({
@@ -546,7 +549,7 @@ describe("Endpoint Structures", () => {
                     certificationDeclaration: ByteArray.fromHex("00"),
                 }
             });
-            node.setStorageManager(testStorageManager);
+            node.setStorage(testStorageContext);
             addRequiredRootClusters(node);
 
             const onoffLightDevice = new OnOffLightDevice();
@@ -606,7 +609,8 @@ describe("Endpoint Structures", () => {
             const testStorage = new StorageBackendMemory();
             const testStorageManager = new StorageManager(testStorage);
             await testStorageManager.initialize();
-            const endpointStorage = testStorageManager.createContext("EndpointStructure");
+            const testStorageContext = testStorageManager.createContext("TestContext");
+            const endpointStorage = testStorageContext.createContext("EndpointStructure");
             endpointStorage.set("serial_node-matter-0000-custom_test-unique-id", 10)
 
             const node = new CommissioningServer({
@@ -641,7 +645,7 @@ describe("Endpoint Structures", () => {
                     certificationDeclaration: ByteArray.fromHex("00"),
                 }
             });
-            node.setStorageManager(testStorageManager);
+            node.setStorage(testStorageContext);
             addRequiredRootClusters(node);
 
             const onoffLightDevice = new OnOffLightDevice(undefined, { uniqueStorageKey: "test-unique-id" });
@@ -993,6 +997,7 @@ describe("Endpoint Structures", () => {
             const testStorage = new StorageBackendMemory();
             const testStorageManager = new StorageManager(testStorage);
             await testStorageManager.initialize();
+            const testStorageContext = testStorageManager.createContext("TestContext");
 
             const node = new CommissioningServer({
                 port: 5540,
@@ -1026,7 +1031,7 @@ describe("Endpoint Structures", () => {
                     certificationDeclaration: ByteArray.fromHex("00"),
                 }
             });
-            node.setStorageManager(testStorageManager);
+            node.setStorage(testStorageContext);
             addRequiredRootClusters(node);
 
             const aggregator1 = new Aggregator();
@@ -1158,7 +1163,8 @@ describe("Endpoint Structures", () => {
             const testStorage = new StorageBackendMemory();
             const testStorageManager = new StorageManager(testStorage);
             await testStorageManager.initialize();
-            const endpointStorage = testStorageManager.createContext("EndpointStructure");
+            const testStorageContext = testStorageManager.createContext("TestContext");
+            const endpointStorage = testStorageContext.createContext("EndpointStructure");
 
             const node = new CommissioningServer({
                 port: 5540,
@@ -1192,7 +1198,7 @@ describe("Endpoint Structures", () => {
                     certificationDeclaration: ByteArray.fromHex("00"),
                 }
             });
-            node.setStorageManager(testStorageManager);
+            node.setStorage(testStorageContext);
             addRequiredRootClusters(node);
 
             const aggregator1 = new Aggregator([], { endpointId: 37 });
@@ -1367,7 +1373,8 @@ describe("Endpoint Structures", () => {
             const testStorage = new StorageBackendMemory();
             const testStorageManager = new StorageManager(testStorage);
             await testStorageManager.initialize();
-            const endpointStorage = testStorageManager.createContext("EndpointStructure");
+            const testStorageContext = testStorageManager.createContext("TestContext");
+            const endpointStorage = testStorageContext.createContext("EndpointStructure");
             endpointStorage.set("serial_node-matter-0000-index_0-custom_3333", 3);
 
             const node = new CommissioningServer({
@@ -1402,7 +1409,7 @@ describe("Endpoint Structures", () => {
                     certificationDeclaration: ByteArray.fromHex("00"),
                 }
             });
-            node.setStorageManager(testStorageManager);
+            node.setStorage(testStorageContext);
             addRequiredRootClusters(node);
 
             const aggregator1 = new Aggregator([], { endpointId: 37 });


### PR DESCRIPTION
This PR adjusts the storage structure for MatterServer nodes to prepare for Multi-Node operations in one process.

For this we use StorageContexts (with a unique node id or index of addition to array) in most playes. Only the MatterServer  stays with StorageManager. This means that the outside API do not change, only existing storages become incompatible. This is ok because the upcoming 0.5.0 is breaking anyway and it is added to the CHangelog. Bug ideally afterwards we do not need to change it again :-)