### PR TITLE
Return AttributeStatus correctly for Read Requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ All Changes without a GitHub Username in brackets are from the core team: @Apoll
   * Fix: Make sure an error received from sending subscription seed data reports is not bubbling up and activate subscription after successful seeding
   * Fix: Allows Node.js Buffer objects to be persisted to storage as a Uint8Arrays that they subclass
   * Fix: Fix a Subscription timer duplication issue and collect attribute changes within a 50ms window to reduce the number of subscription messages
+  * Fix: Return correct Error-Status for Read-Requests
   * Refactor: Refactor Endpoint structuring and determination to allow dynamic and updating structures
 * matter.js API:
   * Breaking: 

--- a/TODO.md
+++ b/TODO.md
@@ -25,7 +25,10 @@ The following are things on my (@Apollon77) TODO list for the project right now 
   * Think about logging of "new" relevant matter data (just these)
   * _matterc support - right now mdnsscanner only checks matter
 * Adjust Fabric storage with sub contexts
-* 
+* Rename index.ts to exports.ts to exclude from being used internally
+* All errors MatterError!
+* Update subscribes when structure gets updated (e.g. new endpoint added)
+* Move announcements and durations into Broadcaster class
 
 ## New API
 
@@ -45,6 +48,7 @@ The following are things on my (@Apollon77) TODO list for the project right now 
 * Investigate/Check specs on how to add new devices to a bridge (check Matter Core specs) to enhance bridge "on the fly"
 * Unique IDs vs endpoint id - idea: dev defined endpoint ids themself or we urge him to always set unique unique serialnumbers or other unique ID
 * Check bridge and composed devices with tuya, smartthings and Alexa again; and test composed device with google
+* Allow to fill Action cluster for rooms/zones and such
 
 ### Controller usage
 * The new Controller (pairable node) API is still WIP in some places to optimize again

--- a/TODO.md
+++ b/TODO.md
@@ -15,7 +15,7 @@ The following are things on my (@Apollon77) TODO list for the project right now 
 * Add generic cluster handlers for all clusters that are not yet covered
 
 ## Core topics
-* (!) Return correct error in read/write/invoke when endpoint/cluster is unknown (in comparism to attributes)
+* (!) Return correct error in write/invoke/subscribe when endpoint/cluster is unknown (in comparism to attributes)
 * (!) Make sure to always return correct responses for requests and not have "dead return" states
 * (!) Refactor throw in command handler to be catched per command and converted correctly to response
 * Monitor subscriptions and remove/resubscribe them when the device did not answered withing maxInterval, how notify device?

--- a/packages/matter-node.js/test/interaction/InteractionProtocolTest.ts
+++ b/packages/matter-node.js/test/interaction/InteractionProtocolTest.ts
@@ -42,6 +42,11 @@ const READ_REQUEST: ReadRequest = {
     attributeRequests: [
         { endpointId: 0, clusterId: 0x28, attributeId: 2 },
         { endpointId: 0, clusterId: 0x28, attributeId: 4 },
+        { endpointId: 0, clusterId: 0x28, attributeId: 400 }, // unsupported attribute
+        { endpointId: 0, clusterId: 0x99, attributeId: 4 }, // unsupported cluster
+        { endpointId: 1, clusterId: 0x28, attributeId: 1 }, // unsupported endpoint
+        { endpointId: undefined, clusterId: 0x28, attributeId: 3 },
+        { endpointId: undefined, clusterId: 0x99, attributeId: 3 }, // ignore
     ],
 };
 
@@ -60,6 +65,31 @@ const READ_RESPONSE: DataReport = {
             attributeData: {
                 path: { endpointId: 0, clusterId: 0x28, attributeId: 4 },
                 data: TlvUInt8.encodeTlv(2),
+                dataVersion: 0,
+            }
+        },
+        {
+            attributeStatus: {
+                path: { endpointId: 0, clusterId: 0x28, attributeId: 400 },
+                status: { status: 134 },
+            }
+        },
+        {
+            attributeStatus: {
+                path: { endpointId: 0, clusterId: 0x99, attributeId: 4 },
+                status: { status: 195 },
+            }
+        },
+        {
+            attributeStatus: {
+                path: { endpointId: 1, clusterId: 0x28, attributeId: 1 },
+                status: { status: 127 },
+            }
+        },
+        {
+            attributeData: {
+                path: { endpointId: 0, clusterId: 0x28, attributeId: 3 },
+                data: TlvString.encodeTlv("product"),
                 dataVersion: 0,
             }
         },

--- a/packages/matter.js/src/protocol/interaction/InteractionEndpointStructure.ts
+++ b/packages/matter.js/src/protocol/interaction/InteractionEndpointStructure.ts
@@ -6,7 +6,7 @@
 
 import { Endpoint } from "../../device/index.js";
 import {
-    AttributeServer, CommandServer, FabricScopedAttributeServer, FixedAttributeServer
+    AttributeServer, ClusterServerObj, CommandServer, FabricScopedAttributeServer, FixedAttributeServer
 } from "../../cluster/index.js";
 import { EventServer } from "../../cluster/server/EventServer.js";
 import { TypeFromSchema } from "../../tlv/index.js";
@@ -130,6 +130,30 @@ export class InteractionEndpointStructure {
 
     resolveCommandName({ endpointId, clusterId, commandId }: TypeFromSchema<typeof TlvCommandPath>) {
         return this.resolveGenericElementName(endpointId, clusterId, commandId, this.commands);
+    }
+
+    getEndpoint(endpointId: number): Endpoint | undefined {
+        return this.endpoints.get(endpointId);
+    }
+
+    hasEndpoint(endpointId: number): boolean {
+        return this.endpoints.has(endpointId);
+    }
+
+    getClusterServer(endpointId: number, clusterId: number): ClusterServerObj<any, any, any> | undefined {
+        const endpoint = this.endpoints.get(endpointId);
+        if (endpoint === undefined) {
+            return undefined;
+        }
+        return endpoint.getClusterServerById(clusterId);
+    }
+
+    hasClusterServer(endpointId: number, clusterId: number): boolean {
+        const endpoint = this.endpoints.get(endpointId);
+        if (endpoint === undefined) {
+            return false;
+        }
+        return !!endpoint.getClusterServerById(clusterId);
     }
 
     getAttributes(filters: TypeFromSchema<typeof TlvAttributePath>[], onlyWritable = false): AttributeWithPath[] {

--- a/packages/matter.js/src/protocol/interaction/InteractionEndpointStructure.ts
+++ b/packages/matter.js/src/protocol/interaction/InteractionEndpointStructure.ts
@@ -141,19 +141,11 @@ export class InteractionEndpointStructure {
     }
 
     getClusterServer(endpointId: number, clusterId: number): ClusterServerObj<any, any, any> | undefined {
-        const endpoint = this.endpoints.get(endpointId);
-        if (endpoint === undefined) {
-            return undefined;
-        }
-        return endpoint.getClusterServerById(clusterId);
+        return this.endpoints.get(endpointId)?.getClusterServerById(clusterId);
     }
 
     hasClusterServer(endpointId: number, clusterId: number): boolean {
-        const endpoint = this.endpoints.get(endpointId);
-        if (endpoint === undefined) {
-            return false;
-        }
-        return !!endpoint.getClusterServerById(clusterId);
+        return !!this.getClusterServer(endpointId, clusterId);
     }
 
     getAttributes(filters: TypeFromSchema<typeof TlvAttributePath>[], onlyWritable = false): AttributeWithPath[] {


### PR DESCRIPTION
The current logic was not correctly responsing to unsupported path's on read requests. This PR fixes this.

Fixes #128 

* for non-Wildcard path's (aka concrete paths) the correct error-status needs to be returned (depending on unsupported endpoint, cluster or attribute)
* for Wildcard path's such erors are simply ignored and just data not added

I verified it and a pairing with Apple - see #128 - is not including error 128 anymore.

Comparable PRs will also come for write/subscribe/invoke soon (or might be added here based on timing)