### PR TITLE
Return correct status on Write Interactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ All Changes without a GitHub Username in brackets are from the core team: @Apoll
   * Fix: Make sure an error received from sending subscription seed data reports is not bubbling up and activate subscription after successful seeding
   * Fix: Allows Node.js Buffer objects to be persisted to storage as a Uint8Arrays that they subclass
   * Fix: Fix a Subscription timer duplication issue and collect attribute changes within a 50ms window to reduce the number of subscription messages
-  * Fix: Return correct Error-Status for Read-Requests
+  * Fix: Return correct Error-Status for Read-/Write-Requests
   * Refactor: Refactor Endpoint structuring and determination to allow dynamic and updating structures
 * matter.js API:
   * Breaking: 

--- a/TODO.md
+++ b/TODO.md
@@ -15,9 +15,9 @@ The following are things on my (@Apollon77) TODO list for the project right now 
 * Add generic cluster handlers for all clusters that are not yet covered
 
 ## Core topics
-* (!) Return correct error in write/invoke/subscribe when endpoint/cluster is unknown (in comparism to attributes)
+* (!) Return correct error in invoke/subscribe when endpoint/cluster is unknown (in comparison to attributes)
 * (!) Make sure to always return correct responses for requests and not have "dead return" states
-* (!) Refactor throw in command handler to be catched per command and converted correctly to response
+* (!) Refactor throw in command handler to be caught per command and converted correctly to response
 * Monitor subscriptions and remove/resubscribe them when the device did not answered withing maxInterval, how notify device?
 * DataReport chunking when sending too long arrays
 * Add support for group casts and groups in general (after Multicast refactor)

--- a/packages/matter-node.js/test/interaction/InteractionProtocolTest.ts
+++ b/packages/matter-node.js/test/interaction/InteractionProtocolTest.ts
@@ -107,6 +107,16 @@ const WRITE_REQUEST: WriteRequest = {
             dataVersion: 0,
         },
         {
+            path: { endpointId: 0, clusterId: 0x99, attributeId: 4 },
+            data: TlvUInt8.encodeTlv(3),
+            dataVersion: 0,
+        },
+        {
+            path: { endpointId: 1, clusterId: 0x28, attributeId: 4 },
+            data: TlvUInt8.encodeTlv(3),
+            dataVersion: 0,
+        },
+        {
             path: { endpointId: 0, clusterId: 0x28, attributeId: 5 },
             data: TlvString.encodeTlv("test"),
             dataVersion: 0,
@@ -119,7 +129,13 @@ const WRITE_RESPONSE: WriteResponse = {
     interactionModelRevision: 1,
     writeResponses: [
         {
-            path: { attributeId: 100, clusterId: 40, endpointId: 0 }, status: { status: 136 }
+            path: { attributeId: 100, clusterId: 40, endpointId: 0 }, status: { status: 134 }
+        },
+        {
+            path: { attributeId: 4, clusterId: 0x99, endpointId: 0 }, status: { status: 195 }
+        },
+        {
+            path: { attributeId: 4, clusterId: 40, endpointId: 1 }, status: { status: 127 }
         },
         {
             path: { attributeId: 5, clusterId: 40, endpointId: 0 }, status: { status: 0 }
@@ -137,6 +153,16 @@ const MASS_WRITE_REQUEST: WriteRequest = {
             data: TlvString.encodeTlv("test"),
             dataVersion: 0,
         },
+        {
+            path: { endpointId: 0, clusterId: 0x99 },
+            data: TlvString.encodeTlv("test"),
+            dataVersion: 0,
+        },
+        {
+            path: { endpointId: 1, clusterId: 0x28 },
+            data: TlvString.encodeTlv("test"),
+            dataVersion: 0,
+        }
     ],
     moreChunkedMessages: false,
 };

--- a/packages/matter.js/src/protocol/interaction/InteractionEndpointStructure.ts
+++ b/packages/matter.js/src/protocol/interaction/InteractionEndpointStructure.ts
@@ -4,12 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Endpoint } from "../../device/index.js";
 import {
-    AttributeServer, ClusterServerObj, CommandServer, FabricScopedAttributeServer, FixedAttributeServer
-} from "../../cluster/index.js";
+    AttributeServer, FabricScopedAttributeServer, FixedAttributeServer
+} from "../../cluster/server/AttributeServer.js";
+import { ClusterServerObj } from "../../cluster/server/ClusterServer.js";
+import { CommandServer } from "../../cluster/server/CommandServer.js";
 import { EventServer } from "../../cluster/server/EventServer.js";
-import { TypeFromSchema } from "../../tlv/index.js";
+import { NodeId } from "../../datatype/NodeId.js";
+import { Endpoint } from "../../device/Endpoint.js";
+import { TypeFromSchema } from "../../tlv/TlvSchema.js";
 import { TlvAttributePath, TlvCommandPath, TlvEventPath } from "./InteractionProtocol.js";
 import {
     AttributePath, attributePathToId, AttributeWithPath, CommandPath, commandPathToId, CommandWithPath, EventPath,
@@ -89,47 +92,48 @@ export class InteractionEndpointStructure {
         this.endpoints.set(endpoint.id, endpoint);
     }
 
-    toHex(value: number | undefined) {
+    toHex(value: number | bigint | undefined) {
         return value === undefined ? "*" : `0x${value.toString(16)}`;
     }
 
-    resolveGenericElementName(endpointId: number | undefined, clusterId: number | undefined, elementId: number | undefined, elementMap: Map<string, any>) {
+    resolveGenericElementName(nodeId: NodeId | undefined, endpointId: number | undefined, clusterId: number | undefined, elementId: number | undefined, elementMap: Map<string, any>) {
+        const nodeIdPrefix = nodeId === undefined ? "" : `${this.toHex(nodeId.id)}/`;
         if (endpointId === undefined) {
-            return `*/${this.toHex(clusterId)}/${this.toHex(elementId)}`;
+            return `${nodeIdPrefix}*/${this.toHex(clusterId)}/${this.toHex(elementId)}`;
         }
         const endpoint = this.endpoints.get(endpointId);
         if (endpoint === undefined) {
-            return `unknown(${this.toHex(endpointId)})/${this.toHex(clusterId)}/${this.toHex(elementId)}`;
+            return `${nodeIdPrefix}unknown(${this.toHex(endpointId)})/${this.toHex(clusterId)}/${this.toHex(elementId)}`;
         }
         const endpointName = `${endpoint.name}(${this.toHex(endpointId)})`;
 
         if (clusterId === undefined) {
-            return `${endpointName}/*/${this.toHex(elementId)}`;
+            return `${nodeIdPrefix}${endpointName}/*/${this.toHex(elementId)}`;
         }
         const cluster = endpoint.getClusterServerById(clusterId);
         if (cluster === undefined) {
-            return `${endpointName}/unknown(${this.toHex(clusterId)})/${this.toHex(elementId)}`;
+            return `${nodeIdPrefix}${endpointName}/unknown(${this.toHex(clusterId)})/${this.toHex(elementId)}`;
         }
         const clusterName = `${cluster.name}(${this.toHex(clusterId)})`;
 
         if (elementId === undefined) {
-            return `${endpointName}/${clusterName}/*`;
+            return `${nodeIdPrefix}${endpointName}/${clusterName}/*`;
         }
         const element = elementMap.get(genericElementPathToId(endpointId, clusterId, elementId));
         const elementName = `${element?.name ?? "unknown"}(${this.toHex(elementId)})`;
-        return `${endpointName}/${clusterName}/${elementName}`;
+        return `${nodeIdPrefix}${endpointName}/${clusterName}/${elementName}`;
     }
 
-    resolveAttributeName({ endpointId, clusterId, attributeId }: TypeFromSchema<typeof TlvAttributePath>) {
-        return this.resolveGenericElementName(endpointId, clusterId, attributeId, this.attributes);
+    resolveAttributeName({ nodeId, endpointId, clusterId, attributeId }: TypeFromSchema<typeof TlvAttributePath>) {
+        return this.resolveGenericElementName(nodeId, endpointId, clusterId, attributeId, this.attributes);
     }
 
-    resolveEventName({ endpointId, clusterId, eventId }: TypeFromSchema<typeof TlvEventPath>) {
-        return this.resolveGenericElementName(endpointId, clusterId, eventId, this.events);
+    resolveEventName({ nodeId, endpointId, clusterId, eventId }: TypeFromSchema<typeof TlvEventPath>) {
+        return this.resolveGenericElementName(nodeId, endpointId, clusterId, eventId, this.events);
     }
 
     resolveCommandName({ endpointId, clusterId, commandId }: TypeFromSchema<typeof TlvCommandPath>) {
-        return this.resolveGenericElementName(endpointId, clusterId, commandId, this.commands);
+        return this.resolveGenericElementName(undefined, endpointId, clusterId, commandId, this.commands);
     }
 
     getEndpoint(endpointId: number): Endpoint | undefined {
@@ -146,6 +150,14 @@ export class InteractionEndpointStructure {
 
     hasClusterServer(endpointId: number, clusterId: number): boolean {
         return !!this.getClusterServer(endpointId, clusterId);
+    }
+
+    getAttribute(endpointId: number, clusterId: number, attributeId: number): AttributeServer<any> | FabricScopedAttributeServer<any> | FixedAttributeServer<any> | undefined {
+        return this.attributes.get(attributePathToId({ endpointId, clusterId, attributeId }));
+    }
+
+    hasAttribute(endpointId: number, clusterId: number, attributeId: number): boolean {
+        return !!this.getAttribute(endpointId, clusterId, attributeId);
     }
 
     getAttributes(filters: TypeFromSchema<typeof TlvAttributePath>[], onlyWritable = false): AttributeWithPath[] {


### PR DESCRIPTION
This PR does the same that #210 did for Read now also for Write interactions.
Additionally it enhances logging to see if the nodeId is provided for interactions