### PR TITLE
Fix UTF8 string TLV encoding

### DIFF
--- a/packages/matter-node.js-examples/src/examples/BridgedDevicesNode.ts
+++ b/packages/matter-node.js-examples/src/examples/BridgedDevicesNode.ts
@@ -130,6 +130,17 @@ class BridgedDevice {
         for (let i = 1; i <= numDevices; i++) {
             const onOffDevice = getParameter(`type${i}`) === "socket" ? new OnOffPluginUnitDevice() : new OnOffLightDevice();
             onOffDevice.addOnOffListener(on => commandExecutor(on ? `on${i}` : `off${i}`)?.());
+
+            onOffDevice.addCommandHandler(
+                "identify",
+                async ({ request: { identifyTime } }) =>{
+                    console.log(
+                        `Identify called for OnOffDevice  ${onOffDevice.name} with id: ${i} and identifyTime: ${identifyTime}`
+                    );
+                }
+            )
+
+
             aggregator.addBridgedDevice(onOffDevice, {
                 nodeLabel: `OnOff ${onOffDevice instanceof OnOffPluginUnitDevice ? 'Socket' : 'Light'} ${i}`,
                 serialNumber: `node-matter-${uniqueId}-${i}`,

--- a/packages/matter-node.js-examples/src/examples/BridgedDevicesNode.ts
+++ b/packages/matter-node.js-examples/src/examples/BridgedDevicesNode.ts
@@ -130,17 +130,6 @@ class BridgedDevice {
         for (let i = 1; i <= numDevices; i++) {
             const onOffDevice = getParameter(`type${i}`) === "socket" ? new OnOffPluginUnitDevice() : new OnOffLightDevice();
             onOffDevice.addOnOffListener(on => commandExecutor(on ? `on${i}` : `off${i}`)?.());
-
-            onOffDevice.addCommandHandler(
-                "identify",
-                async ({ request: { identifyTime } }) =>{
-                    console.log(
-                        `Identify called for OnOffDevice  ${onOffDevice.name} with id: ${i} and identifyTime: ${identifyTime}`
-                    );
-                }
-            )
-
-
             aggregator.addBridgedDevice(onOffDevice, {
                 nodeLabel: `OnOff ${onOffDevice instanceof OnOffPluginUnitDevice ? 'Socket' : 'Light'} ${i}`,
                 serialNumber: `node-matter-${uniqueId}-${i}`,

--- a/packages/matter.js/src/codec/DnsCodec.ts
+++ b/packages/matter.js/src/codec/DnsCodec.ts
@@ -272,8 +272,9 @@ export class DnsCodec {
     private static encodeTxtRecord(entries: string[]) {
         const writer = new DataWriter(Endian.Big);
         entries.forEach(entry => {
-            writer.writeUInt8(entry.length);
-            writer.writeUtf8String(entry);
+            const entryData = ByteArray.fromString(entry);
+            writer.writeUInt8(entryData.length);
+            writer.writeByteArray(entryData);
         });
         return writer.toByteArray();
     }
@@ -290,8 +291,9 @@ export class DnsCodec {
     private static encodeQName(qname: string) {
         const writer = new DataWriter(Endian.Big);
         qname.split(".").forEach(label => {
-            writer.writeUInt8(label.length);
-            writer.writeUtf8String(label);
+            const labelData = ByteArray.fromString(label);
+            writer.writeUInt8(labelData.length);
+            writer.writeByteArray(labelData);
         });
         writer.writeUInt8(0);
         return writer.toByteArray();

--- a/packages/matter.js/src/tlv/TlvCodec.ts
+++ b/packages/matter.js/src/tlv/TlvCodec.ts
@@ -352,8 +352,9 @@ export class TlvCodec {
             }
             case TlvType.Utf8String: {
                 const string = value as TlvToPrimitive[typeof typeLength.type];
-                this.writeUInt(writer, typeLength.length, string.length);
-                return writer.writeUtf8String(string);
+                const stringData = ByteArray.fromString(string);
+                this.writeUInt(writer, typeLength.length, stringData.length);
+                return writer.writeByteArray(stringData);
             }
             case TlvType.ByteString: {
                 const byteArray = value as TlvToPrimitive[typeof typeLength.type];

--- a/packages/matter.js/src/util/DataWriter.ts
+++ b/packages/matter.js/src/util/DataWriter.ts
@@ -88,12 +88,6 @@ export class DataWriter<E extends Endian> {
         this.length += 8;
     }
 
-    writeUtf8String(value: string) {
-        const bytes = ByteArray.fromString(value);
-        this.chunks.push(bytes);
-        this.length += bytes.byteLength;
-    }
-
     writeByteArray(value: ByteArray) {
         this.chunks.push(value);
         this.length += value.byteLength;

--- a/packages/matter.js/test/tlv/TlvStringTest.ts
+++ b/packages/matter.js/test/tlv/TlvStringTest.ts
@@ -29,6 +29,12 @@ describe("TlvString", () => {
 
             expect(result.toHex()).toBe("0c0474657374");
         });
+
+        it("encodes a string that gets utf8 encoded", () => {
+            const result = TlvString.encode("testè");
+
+            expect(result.toHex()).toBe("0c0674657374c3a8");
+        });
     });
 
     describe("decode", () => {
@@ -36,6 +42,12 @@ describe("TlvString", () => {
             const result = TlvString.decode(ByteArray.fromHex("0c0474657374"));
 
             expect(result).toBe("test");
+        });
+
+        it("decodes a string that was utf8", () => {
+            const result = TlvString.decode(ByteArray.fromHex("0c0674657374c3a8"));
+
+            expect(result).toBe("testè");
         });
     });
 


### PR DESCRIPTION
I removed the DataWriter.writeUtf8String method for now because all usages in our code need to write the length of the data before the string. The problem with the method was that it encoded the string into UTF8 if needed - so the length of the written bytes changed without anyone noticing.