### PR TITLE
Conditional elements in "complete" clusters

### DIFF
--- a/models/.gitattributes
+++ b/models/.gitattributes
@@ -1,0 +1,2 @@
+spec.ts linguist-generated=true
+chip.ts linguist-generated=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -9150,7 +9150,8 @@
                 "matter-bridge": "dist/examples/BridgedDevicesNode.js",
                 "matter-composeddevice": "dist/examples/ComposedDeviceNode.js",
                 "matter-controller": "dist/examples/ControllerNode.js",
-                "matter-device": "dist/examples/DeviceNode.js"
+                "matter-device": "dist/examples/DeviceNode.js",
+                "matter-multidevice": "dist/examples/MultiDeviceNode.js"
             },
             "devDependencies": {
                 "@typescript-eslint/eslint-plugin": "^5.59.6",

--- a/packages/matter-node.js/test/cluster/GeneralCommissioningServerTest.ts
+++ b/packages/matter-node.js/test/cluster/GeneralCommissioningServerTest.ts
@@ -105,7 +105,7 @@ describe("GeneralCommissioning Server test", () => {
             assert.deepEqual(result, { code: 0, response: { debugText: "", errorCode: CommissioningError.Ok }, responseId: 3 });
             assert.deepEqual(generalCommissioningServer!.getRegulatoryConfigAttribute(), RegulatoryLocationType.Indoor);
             assert.deepEqual(generalCommissioningServer!.getBreadcrumbAttribute(), BigInt(4));
-            assert.deepEqual(basicInformationServer!.getLocationAttribute(), "XX");
+            assert.deepEqual(basicInformationServer!.getLocationAttribute(), "CA");
         });
     });
 

--- a/packages/matter.js/.gitattributes
+++ b/packages/matter.js/.gitattributes
@@ -1,4 +1,2 @@
-src/models/spec.ts linguist-generated=true
-src/models/chip.ts linguist-generated=true
 src/model/standard/elements/*.ts linguist-generated=true
 src/cluster/definitions/*.ts linguist-generated=true

--- a/packages/matter.js/src/cluster/ClusterFactory.ts
+++ b/packages/matter.js/src/cluster/ClusterFactory.ts
@@ -8,7 +8,17 @@ import { MatterError } from "../common/MatterError.js";
 import { BitSchema, TypeFromPartialBitSchema } from "../schema/BitmapSchema.js";
 import { serialize } from "../util/String.js";
 import { Merge } from "../util/Type.js";
-import { Attributes, Cluster, Commands, Events, GlobalAttributes } from "./Cluster.js";
+import {
+    Attribute,
+    Attributes,
+    Cluster,
+    Command,
+    Commands,
+    ConditionalFeatureList,
+    Event,
+    Events,
+    GlobalAttributes,
+} from "./Cluster.js";
 
 export class IllegalClusterError extends MatterError { }
 
@@ -242,4 +252,37 @@ export function ExtensionRequiredCluster<
     factory: W
 }): ExtensionRequiredCluster<W> {
     return { with: factory };
+}
+
+export type ClusterElement<F extends BitSchema> =
+    Attribute<any, F>
+    | Command<any, any, F>
+    | Event<any, F>;
+
+export type AsConditional<
+    F extends BitSchema,
+    E extends ClusterElement<F>
+> = Omit<E, "optional"> & { optional: false, isConditional: true };
+
+export type ClusterElementConditions<F extends BitSchema> = {
+    optionalIf: ConditionalFeatureList<F>,
+    mandatoryIf: ConditionalFeatureList<F>
+}
+
+export function AsConditional<
+    F extends BitSchema,
+    E extends ClusterElement<F>
+>(
+    element: E,
+    { optionalIf = [], mandatoryIf = [] }: Partial<ClusterElementConditions<F>>
+) {
+    const result = {
+        ...element,
+        optional: false,
+        isConditional: true,
+        optionalIf: optionalIf,
+        mandatoryIf: mandatoryIf
+    };
+    result.optional = false;
+    return result as AsConditional<F, E>;
 }

--- a/packages/matter.js/src/cluster/definitions/AccessControlCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/AccessControlCluster.ts
@@ -6,7 +6,15 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import { Cluster, WritableFabricScopedAttribute, AccessLevel, OptionalWritableFabricScopedAttribute, FixedAttribute, Event, EventPriority } from "../../cluster/Cluster.js";
+import {
+    Cluster,
+    WritableFabricScopedAttribute,
+    AccessLevel,
+    OptionalWritableFabricScopedAttribute,
+    FixedAttribute,
+    Event,
+    EventPriority
+} from "../../cluster/Cluster.js";
 import { MatterCoreSpecificationV1_1 } from "../../spec/Specifications.js";
 import { TlvArray } from "../../tlv/TlvArray.js";
 import { TlvObject, TlvField } from "../../tlv/TlvObject.js";

--- a/packages/matter.js/src/cluster/definitions/AdministratorCommissioningCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/AdministratorCommissioningCluster.ts
@@ -7,7 +7,14 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { MatterCoreSpecificationV1_1 } from "../../spec/Specifications.js";
-import { BaseClusterComponent, ClusterComponent, ExtensibleCluster, validateFeatureSelection, ClusterForBaseCluster } from "../../cluster/ClusterFactory.js";
+import {
+    BaseClusterComponent,
+    ClusterComponent,
+    ExtensibleCluster,
+    validateFeatureSelection,
+    ClusterForBaseCluster,
+    AsConditional
+} from "../../cluster/ClusterFactory.js";
 import { BitFlag, BitFlags, TypeFromPartialBitSchema } from "../../schema/BitmapSchema.js";
 import { Attribute, Command, TlvNoResponse, Cluster } from "../../cluster/Cluster.js";
 import { TlvEnum, TlvUInt16, TlvUInt32 } from "../../tlv/TlvNumber.js";
@@ -304,6 +311,7 @@ export type AdministratorCommissioningExtension<SF extends TypeFromPartialBitSch
     ClusterForBaseCluster<typeof AdministratorCommissioningBase, SF>
     & { supportedFeatures: SF }
     & (SF extends { basic: true } ? typeof BasicComponent : {});
+const BC = { basic: true };
 
 /**
  * This cluster supports all AdministratorCommissioning features. It may support illegal feature combinations.
@@ -312,6 +320,17 @@ export type AdministratorCommissioningExtension<SF extends TypeFromPartialBitSch
  * legal per the Matter specification.
  */
 export const AdministratorCommissioningComplete = Cluster({
-    ...AdministratorCommissioningCluster,
-    commands: { ...BasicComponent.commands }
+    id: AdministratorCommissioningCluster.id,
+    name: AdministratorCommissioningCluster.name,
+    revision: AdministratorCommissioningCluster.revision,
+    features: AdministratorCommissioningCluster.features,
+    attributes: AdministratorCommissioningCluster.attributes,
+
+    commands: {
+        ...AdministratorCommissioningCluster.commands,
+        openBasicCommissioningWindow: AsConditional(
+            BasicComponent.commands.openBasicCommissioningWindow,
+            { mandatoryIf: [BC] }
+        )
+    }
 });

--- a/packages/matter.js/src/cluster/definitions/ApplicationLauncherCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/ApplicationLauncherCluster.ts
@@ -7,7 +7,14 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { MatterApplicationClusterSpecificationV1_1 } from "../../spec/Specifications.js";
-import { BaseClusterComponent, ClusterComponent, ExtensibleCluster, validateFeatureSelection, ClusterForBaseCluster } from "../../cluster/ClusterFactory.js";
+import {
+    BaseClusterComponent,
+    ClusterComponent,
+    ExtensibleCluster,
+    validateFeatureSelection,
+    ClusterForBaseCluster,
+    AsConditional
+} from "../../cluster/ClusterFactory.js";
 import { BitFlag, BitFlags, TypeFromPartialBitSchema } from "../../schema/BitmapSchema.js";
 import { OptionalAttribute, Command, Attribute, Cluster } from "../../cluster/Cluster.js";
 import { TlvObject, TlvField, TlvOptionalField } from "../../tlv/TlvObject.js";
@@ -306,6 +313,7 @@ export type ApplicationLauncherExtension<SF extends TypeFromPartialBitSchema<typ
     ClusterForBaseCluster<typeof ApplicationLauncherBase, SF>
     & { supportedFeatures: SF }
     & (SF extends { applicationPlatform: true } ? typeof ApplicationPlatformComponent : {});
+const AP = { applicationPlatform: true };
 
 /**
  * This cluster supports all ApplicationLauncher features. It may support illegal feature combinations.
@@ -314,6 +322,13 @@ export type ApplicationLauncherExtension<SF extends TypeFromPartialBitSchema<typ
  * legal per the Matter specification.
  */
 export const ApplicationLauncherComplete = Cluster({
-    ...ApplicationLauncherCluster,
-    attributes: { ...ApplicationPlatformComponent.attributes }
+    id: ApplicationLauncherCluster.id,
+    name: ApplicationLauncherCluster.name,
+    revision: ApplicationLauncherCluster.revision,
+    features: ApplicationLauncherCluster.features,
+    attributes: {
+        ...ApplicationLauncherCluster.attributes,
+        catalogList: AsConditional(ApplicationPlatformComponent.attributes.catalogList, { mandatoryIf: [AP] })
+    },
+    commands: ApplicationLauncherCluster.commands
 });

--- a/packages/matter.js/src/cluster/definitions/AudioOutputCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/AudioOutputCluster.ts
@@ -7,7 +7,14 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { MatterApplicationClusterSpecificationV1_1 } from "../../spec/Specifications.js";
-import { BaseClusterComponent, ClusterComponent, ExtensibleCluster, validateFeatureSelection, ClusterForBaseCluster } from "../../cluster/ClusterFactory.js";
+import {
+    BaseClusterComponent,
+    ClusterComponent,
+    ExtensibleCluster,
+    validateFeatureSelection,
+    ClusterForBaseCluster,
+    AsConditional
+} from "../../cluster/ClusterFactory.js";
 import { BitFlag, BitFlags, TypeFromPartialBitSchema } from "../../schema/BitmapSchema.js";
 import { Attribute, Command, TlvNoResponse, Cluster } from "../../cluster/Cluster.js";
 import { TlvArray } from "../../tlv/TlvArray.js";
@@ -179,6 +186,7 @@ export type AudioOutputExtension<SF extends TypeFromPartialBitSchema<typeof Audi
     ClusterForBaseCluster<typeof AudioOutputBase, SF>
     & { supportedFeatures: SF }
     & (SF extends { nameUpdates: true } ? typeof NameUpdatesComponent : {});
+const NU = { nameUpdates: true };
 
 /**
  * This cluster supports all AudioOutput features. It may support illegal feature combinations.
@@ -186,4 +194,14 @@ export type AudioOutputExtension<SF extends TypeFromPartialBitSchema<typeof Audi
  * If you use this cluster you must manually specify which features are active and ensure the set of active features is
  * legal per the Matter specification.
  */
-export const AudioOutputComplete = Cluster({ ...AudioOutputCluster, commands: { ...NameUpdatesComponent.commands } });
+export const AudioOutputComplete = Cluster({
+    id: AudioOutputCluster.id,
+    name: AudioOutputCluster.name,
+    revision: AudioOutputCluster.revision,
+    features: AudioOutputCluster.features,
+    attributes: AudioOutputCluster.attributes,
+    commands: {
+        ...AudioOutputCluster.commands,
+        renameOutput: AsConditional(NameUpdatesComponent.commands.renameOutput, { mandatoryIf: [NU] })
+    }
+});

--- a/packages/matter.js/src/cluster/definitions/BasicInformationCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/BasicInformationCluster.ts
@@ -6,7 +6,18 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import { Cluster, FixedAttribute, WritableAttribute, AccessLevel, OptionalFixedAttribute, OptionalWritableAttribute, OptionalAttribute, Event, EventPriority, OptionalEvent } from "../../cluster/Cluster.js";
+import {
+    Cluster,
+    FixedAttribute,
+    WritableAttribute,
+    AccessLevel,
+    OptionalFixedAttribute,
+    OptionalWritableAttribute,
+    OptionalAttribute,
+    Event,
+    EventPriority,
+    OptionalEvent
+} from "../../cluster/Cluster.js";
 import { MatterCoreSpecificationV1_1 } from "../../spec/Specifications.js";
 import { TlvUInt16, TlvUInt32, TlvEnum } from "../../tlv/TlvNumber.js";
 import { TlvString } from "../../tlv/TlvString.js";

--- a/packages/matter.js/src/cluster/definitions/BinaryInputBasicCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/BinaryInputBasicCluster.ts
@@ -32,4 +32,4 @@ export const BinaryInputBasicCluster = Cluster({
         statusFlags: Attribute(0x6f, TlvUInt8),
         applicationType: OptionalAttribute(0x100, TlvUInt32)
     }
-});
+})

--- a/packages/matter.js/src/cluster/definitions/BridgedDeviceBasicInformationCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/BridgedDeviceBasicInformationCluster.ts
@@ -6,7 +6,17 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import { Cluster, OptionalFixedAttribute, OptionalWritableAttribute, AccessLevel, Attribute, OptionalAttribute, OptionalEvent, EventPriority, Event } from "../../cluster/Cluster.js";
+import {
+    Cluster,
+    OptionalFixedAttribute,
+    OptionalWritableAttribute,
+    AccessLevel,
+    Attribute,
+    OptionalAttribute,
+    OptionalEvent,
+    EventPriority,
+    Event
+} from "../../cluster/Cluster.js";
 import { MatterCoreSpecificationV1_1 } from "../../spec/Specifications.js";
 import { TlvString } from "../../tlv/TlvString.js";
 import { TlvVendorId } from "../../datatype/VendorId.js";

--- a/packages/matter.js/src/cluster/definitions/ChannelCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/ChannelCluster.ts
@@ -13,7 +13,8 @@ import {
     ExtensibleCluster,
     validateFeatureSelection,
     extendCluster,
-    ClusterForBaseCluster
+    ClusterForBaseCluster,
+    AsConditional
 } from "../../cluster/ClusterFactory.js";
 import { BitFlag, BitFlags, TypeFromPartialBitSchema } from "../../schema/BitmapSchema.js";
 import { OptionalAttribute, Command, TlvNoResponse, Attribute, Cluster } from "../../cluster/Cluster.js";
@@ -362,6 +363,9 @@ export type ChannelExtension<SF extends TypeFromPartialBitSchema<typeof ChannelB
     & (SF extends { lineupInfo: true } ? typeof LineupInfoComponent : {})
     & (SF extends { channelList: true } | { lineupInfo: true } ? typeof ChannelListOrLineupInfoComponent : {});
 
+const CL = { channelList: true };
+const LI = { lineupInfo: true };
+
 /**
  * This cluster supports all Channel features. It may support illegal feature combinations.
  *
@@ -369,7 +373,17 @@ export type ChannelExtension<SF extends TypeFromPartialBitSchema<typeof ChannelB
  * legal per the Matter specification.
  */
 export const ChannelComplete = Cluster({
-    ...ChannelCluster,
-    attributes: { ...ChannelListComponent.attributes, ...LineupInfoComponent.attributes },
-    commands: { ...ChannelListOrLineupInfoComponent.commands }
+    id: ChannelCluster.id,
+    name: ChannelCluster.name,
+    revision: ChannelCluster.revision,
+    features: ChannelCluster.features,
+    attributes: {
+        ...ChannelCluster.attributes,
+        channelList: AsConditional(ChannelListComponent.attributes.channelList, { mandatoryIf: [CL] }),
+        lineup: AsConditional(LineupInfoComponent.attributes.lineup, { mandatoryIf: [LI] })
+    },
+    commands: {
+        ...ChannelCluster.commands,
+        changeChannel: AsConditional(ChannelListOrLineupInfoComponent.commands.changeChannel, { mandatoryIf: [CL, LI] })
+    }
 });

--- a/packages/matter.js/src/cluster/definitions/ChannelCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/ChannelCluster.ts
@@ -7,7 +7,14 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { MatterApplicationClusterSpecificationV1_1 } from "../../spec/Specifications.js";
-import { BaseClusterComponent, ClusterComponent, ExtensibleCluster, validateFeatureSelection, extendCluster, ClusterForBaseCluster } from "../../cluster/ClusterFactory.js";
+import {
+    BaseClusterComponent,
+    ClusterComponent,
+    ExtensibleCluster,
+    validateFeatureSelection,
+    extendCluster,
+    ClusterForBaseCluster
+} from "../../cluster/ClusterFactory.js";
 import { BitFlag, BitFlags, TypeFromPartialBitSchema } from "../../schema/BitmapSchema.js";
 import { OptionalAttribute, Command, TlvNoResponse, Attribute, Cluster } from "../../cluster/Cluster.js";
 import { TlvObject, TlvField, TlvOptionalField } from "../../tlv/TlvObject.js";

--- a/packages/matter.js/src/cluster/definitions/ColorControlCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/ColorControlCluster.ts
@@ -7,9 +7,27 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { MatterApplicationClusterSpecificationV1_1 } from "../../spec/Specifications.js";
-import { BaseClusterComponent, ClusterComponent, ExtensibleCluster, validateFeatureSelection, extendCluster, ClusterForBaseCluster } from "../../cluster/ClusterFactory.js";
+import {
+    BaseClusterComponent,
+    ClusterComponent,
+    ExtensibleCluster,
+    validateFeatureSelection,
+    extendCluster,
+    ClusterForBaseCluster
+} from "../../cluster/ClusterFactory.js";
 import { BitFlag, BitField, BitFlags, TypeFromPartialBitSchema } from "../../schema/BitmapSchema.js";
-import { OptionalAttribute, Attribute, WritableAttribute, FixedAttribute, OptionalFixedAttribute, OptionalWritableAttribute, AccessLevel, Command, TlvNoResponse, Cluster } from "../../cluster/Cluster.js";
+import {
+    OptionalAttribute,
+    Attribute,
+    WritableAttribute,
+    FixedAttribute,
+    OptionalFixedAttribute,
+    OptionalWritableAttribute,
+    AccessLevel,
+    Command,
+    TlvNoResponse,
+    Cluster
+} from "../../cluster/Cluster.js";
 import { TlvUInt16, TlvEnum, TlvUInt8, TlvBitmap, TlvUInt32, TlvInt16 } from "../../tlv/TlvNumber.js";
 import { TlvString } from "../../tlv/TlvString.js";
 import { TlvNullable } from "../../tlv/TlvNullable.js";

--- a/packages/matter.js/src/cluster/definitions/ContentLauncherCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/ContentLauncherCluster.ts
@@ -7,7 +7,14 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { MatterApplicationClusterSpecificationV1_1 } from "../../spec/Specifications.js";
-import { BaseClusterComponent, ClusterComponent, ExtensibleCluster, validateFeatureSelection, extendCluster, ClusterForBaseCluster } from "../../cluster/ClusterFactory.js";
+import {
+    BaseClusterComponent,
+    ClusterComponent,
+    ExtensibleCluster,
+    validateFeatureSelection,
+    extendCluster,
+    ClusterForBaseCluster
+} from "../../cluster/ClusterFactory.js";
 import { BitFlag, BitFlags, TypeFromPartialBitSchema } from "../../schema/BitmapSchema.js";
 import { Attribute, Command, Cluster } from "../../cluster/Cluster.js";
 import { TlvArray } from "../../tlv/TlvArray.js";

--- a/packages/matter.js/src/cluster/definitions/DoorLockCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/DoorLockCluster.ts
@@ -7,9 +7,30 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { MatterApplicationClusterSpecificationV1_1 } from "../../spec/Specifications.js";
-import { BaseClusterComponent, ClusterComponent, ExtensibleCluster, validateFeatureSelection, extendCluster, preventCluster, ClusterForBaseCluster } from "../../cluster/ClusterFactory.js";
+import {
+    BaseClusterComponent,
+    ClusterComponent,
+    ExtensibleCluster,
+    validateFeatureSelection,
+    extendCluster,
+    preventCluster,
+    ClusterForBaseCluster
+} from "../../cluster/ClusterFactory.js";
 import { BitFlag, BitsFromPartial, BitFlags, TypeFromPartialBitSchema } from "../../schema/BitmapSchema.js";
-import { Attribute, OptionalWritableAttribute, AccessLevel, WritableAttribute, FixedAttribute, OptionalAttribute, Command, TlvNoResponse, OptionalCommand, Event, EventPriority, Cluster } from "../../cluster/Cluster.js";
+import {
+    Attribute,
+    OptionalWritableAttribute,
+    AccessLevel,
+    WritableAttribute,
+    FixedAttribute,
+    OptionalAttribute,
+    Command,
+    TlvNoResponse,
+    OptionalCommand,
+    Event,
+    EventPriority,
+    Cluster
+} from "../../cluster/Cluster.js";
 import { TlvEnum, TlvUInt8, TlvUInt32, TlvUInt16, TlvBitmap, TlvEpochS } from "../../tlv/TlvNumber.js";
 import { TlvNullable } from "../../tlv/TlvNullable.js";
 import { TlvBoolean } from "../../tlv/TlvBoolean.js";

--- a/packages/matter.js/src/cluster/definitions/EthernetNetworkDiagnosticsCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/EthernetNetworkDiagnosticsCluster.ts
@@ -13,7 +13,8 @@ import {
     ExtensibleCluster,
     validateFeatureSelection,
     extendCluster,
-    ClusterForBaseCluster
+    ClusterForBaseCluster,
+    AsConditional
 } from "../../cluster/ClusterFactory.js";
 import { BitFlag, BitFlags, TypeFromPartialBitSchema } from "../../schema/BitmapSchema.js";
 import { OptionalAttribute, Attribute, Command, TlvNoResponse, Cluster } from "../../cluster/Cluster.js";
@@ -281,6 +282,9 @@ export type EthernetNetworkDiagnosticsExtension<SF extends TypeFromPartialBitSch
     & (SF extends { errorCounts: true } ? typeof ErrorCountsComponent : {})
     & (SF extends { packetCounts: true } | { errorCounts: true } ? typeof PacketCountsOrErrorCountsComponent : {});
 
+const PKTCNT = { packetCounts: true };
+const ERRCNT = { errorCounts: true };
+
 /**
  * This cluster supports all EthernetNetworkDiagnostics features. It may support illegal feature combinations.
  *
@@ -288,7 +292,19 @@ export type EthernetNetworkDiagnosticsExtension<SF extends TypeFromPartialBitSch
  * legal per the Matter specification.
  */
 export const EthernetNetworkDiagnosticsComplete = Cluster({
-    ...EthernetNetworkDiagnosticsCluster,
-    attributes: { ...PacketCountsComponent.attributes, ...ErrorCountsComponent.attributes },
-    commands: { ...PacketCountsOrErrorCountsComponent.commands }
+    id: EthernetNetworkDiagnosticsCluster.id,
+    name: EthernetNetworkDiagnosticsCluster.name,
+    revision: EthernetNetworkDiagnosticsCluster.revision,
+    features: EthernetNetworkDiagnosticsCluster.features,
+
+    attributes: {
+        ...EthernetNetworkDiagnosticsCluster.attributes,
+        packetRxCount: AsConditional(PacketCountsComponent.attributes.packetRxCount, { mandatoryIf: [PKTCNT] }),
+        packetTxCount: AsConditional(PacketCountsComponent.attributes.packetTxCount, { mandatoryIf: [PKTCNT] }),
+        txErrCount: AsConditional(ErrorCountsComponent.attributes.txErrCount, { mandatoryIf: [ERRCNT] }),
+        collisionCount: AsConditional(ErrorCountsComponent.attributes.collisionCount, { mandatoryIf: [ERRCNT] }),
+        overrunCount: AsConditional(ErrorCountsComponent.attributes.overrunCount, { mandatoryIf: [ERRCNT] })
+    },
+
+    commands: { resetCounts: AsConditional(PacketCountsOrErrorCountsComponent.commands.resetCounts, { mandatoryIf: [PKTCNT, ERRCNT] }) }
 });

--- a/packages/matter.js/src/cluster/definitions/EthernetNetworkDiagnosticsCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/EthernetNetworkDiagnosticsCluster.ts
@@ -7,7 +7,14 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { MatterCoreSpecificationV1_1 } from "../../spec/Specifications.js";
-import { BaseClusterComponent, ClusterComponent, ExtensibleCluster, validateFeatureSelection, extendCluster, ClusterForBaseCluster } from "../../cluster/ClusterFactory.js";
+import {
+    BaseClusterComponent,
+    ClusterComponent,
+    ExtensibleCluster,
+    validateFeatureSelection,
+    extendCluster,
+    ClusterForBaseCluster
+} from "../../cluster/ClusterFactory.js";
 import { BitFlag, BitFlags, TypeFromPartialBitSchema } from "../../schema/BitmapSchema.js";
 import { OptionalAttribute, Attribute, Command, TlvNoResponse, Cluster } from "../../cluster/Cluster.js";
 import { TlvEnum, TlvUInt64 } from "../../tlv/TlvNumber.js";

--- a/packages/matter.js/src/cluster/definitions/FanControlCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/FanControlCluster.ts
@@ -13,7 +13,8 @@ import {
     ExtensibleCluster,
     validateFeatureSelection,
     extendCluster,
-    ClusterForBaseCluster
+    ClusterForBaseCluster,
+    AsConditional
 } from "../../cluster/ClusterFactory.js";
 import { BitFlag, BitFlags, TypeFromPartialBitSchema } from "../../schema/BitmapSchema.js";
 import { WritableAttribute, Attribute, FixedAttribute, Cluster } from "../../cluster/Cluster.js";
@@ -381,6 +382,10 @@ export type FanControlExtension<SF extends TypeFromPartialBitSchema<typeof FanCo
     & (SF extends { rocking: true } ? typeof RockingComponent : {})
     & (SF extends { wind: true } ? typeof WindComponent : {});
 
+const SPD = { multiSpeed: true };
+const RCK = { rocking: true };
+const WND = { wind: true };
+
 /**
  * This cluster supports all FanControl features. It may support illegal feature combinations.
  *
@@ -388,6 +393,19 @@ export type FanControlExtension<SF extends TypeFromPartialBitSchema<typeof FanCo
  * legal per the Matter specification.
  */
 export const FanControlComplete = Cluster({
-    ...FanControlCluster,
-    attributes: { ...MultiSpeedComponent.attributes, ...RockingComponent.attributes, ...WindComponent.attributes }
+    id: FanControlCluster.id,
+    name: FanControlCluster.name,
+    revision: FanControlCluster.revision,
+    features: FanControlCluster.features,
+
+    attributes: {
+        ...FanControlCluster.attributes,
+        speedMax: AsConditional(MultiSpeedComponent.attributes.speedMax, { mandatoryIf: [SPD] }),
+        speedSetting: AsConditional(MultiSpeedComponent.attributes.speedSetting, { mandatoryIf: [SPD] }),
+        speedCurrent: AsConditional(MultiSpeedComponent.attributes.speedCurrent, { mandatoryIf: [SPD] }),
+        rockSupport: AsConditional(RockingComponent.attributes.rockSupport, { mandatoryIf: [RCK] }),
+        rockSetting: AsConditional(RockingComponent.attributes.rockSetting, { mandatoryIf: [RCK] }),
+        windSupport: AsConditional(WindComponent.attributes.windSupport, { mandatoryIf: [WND] }),
+        windSetting: AsConditional(WindComponent.attributes.windSetting, { mandatoryIf: [WND] })
+    }
 });

--- a/packages/matter.js/src/cluster/definitions/FanControlCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/FanControlCluster.ts
@@ -7,7 +7,14 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { MatterApplicationClusterSpecificationV1_1 } from "../../spec/Specifications.js";
-import { BaseClusterComponent, ClusterComponent, ExtensibleCluster, validateFeatureSelection, extendCluster, ClusterForBaseCluster } from "../../cluster/ClusterFactory.js";
+import {
+    BaseClusterComponent,
+    ClusterComponent,
+    ExtensibleCluster,
+    validateFeatureSelection,
+    extendCluster,
+    ClusterForBaseCluster
+} from "../../cluster/ClusterFactory.js";
 import { BitFlag, BitFlags, TypeFromPartialBitSchema } from "../../schema/BitmapSchema.js";
 import { WritableAttribute, Attribute, FixedAttribute, Cluster } from "../../cluster/Cluster.js";
 import { TlvEnum, TlvUInt8, TlvBitmap } from "../../tlv/TlvNumber.js";

--- a/packages/matter.js/src/cluster/definitions/FixedLabelCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/FixedLabelCluster.ts
@@ -37,4 +37,4 @@ export const FixedLabelCluster = Cluster({
          */
         labelList: Attribute(0x0, TlvArray(TlvLabelStruct), { persistent: true, default: [] })
     }
-});
+})

--- a/packages/matter.js/src/cluster/definitions/FlowMeasurementCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/FlowMeasurementCluster.ts
@@ -62,4 +62,4 @@ export const FlowMeasurementCluster = Cluster({
          */
         tolerance: OptionalAttribute(0x3, TlvUInt16.bound({ max: 2048 }), { default: 0 })
     }
-});
+})

--- a/packages/matter.js/src/cluster/definitions/GroupKeyManagementCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/GroupKeyManagementCluster.ts
@@ -451,11 +451,3 @@ export const GroupKeyManagementCluster = ExtensibleCluster({
 export type GroupKeyManagementExtension<SF extends TypeFromPartialBitSchema<typeof GroupKeyManagementBase.features>> =
     ClusterForBaseCluster<typeof GroupKeyManagementBase, SF>
     & { supportedFeatures: SF };
-
-/**
- * This cluster supports all GroupKeyManagement features. It may support illegal feature combinations.
- *
- * If you use this cluster you must manually specify which features are active and ensure the set of active features is
- * legal per the Matter specification.
- */
-export const GroupKeyManagementComplete = Cluster({ ...GroupKeyManagementCluster });

--- a/packages/matter.js/src/cluster/definitions/GroupKeyManagementCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/GroupKeyManagementCluster.ts
@@ -9,7 +9,15 @@
 import { MatterCoreSpecificationV1_1 } from "../../spec/Specifications.js";
 import { BaseClusterComponent, ExtensibleCluster, validateFeatureSelection, ClusterForBaseCluster } from "../../cluster/ClusterFactory.js";
 import { BitFlag, BitFlags, TypeFromPartialBitSchema } from "../../schema/BitmapSchema.js";
-import { WritableFabricScopedAttribute, AccessLevel, FabricScopedAttribute, FixedAttribute, Command, TlvNoResponse, Cluster } from "../../cluster/Cluster.js";
+import {
+    WritableFabricScopedAttribute,
+    AccessLevel,
+    FabricScopedAttribute,
+    FixedAttribute,
+    Command,
+    TlvNoResponse,
+    Cluster
+} from "../../cluster/Cluster.js";
 import { TlvArray } from "../../tlv/TlvArray.js";
 import { TlvObject, TlvField, TlvOptionalField } from "../../tlv/TlvObject.js";
 import { TlvGroupId } from "../../datatype/GroupId.js";

--- a/packages/matter.js/src/cluster/definitions/GroupsCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/GroupsCluster.ts
@@ -276,11 +276,3 @@ export const GroupsCluster = ExtensibleCluster({
 export type GroupsExtension<SF extends TypeFromPartialBitSchema<typeof GroupsBase.features>> =
     ClusterForBaseCluster<typeof GroupsBase, SF>
     & { supportedFeatures: SF };
-
-/**
- * This cluster supports all Groups features. It may support illegal feature combinations.
- *
- * If you use this cluster you must manually specify which features are active and ensure the set of active features is
- * legal per the Matter specification.
- */
-export const GroupsComplete = Cluster({ ...GroupsCluster });

--- a/packages/matter.js/src/cluster/definitions/IdentifyCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/IdentifyCluster.ts
@@ -7,7 +7,14 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { MatterApplicationClusterSpecificationV1_1 } from "../../spec/Specifications.js";
-import { BaseClusterComponent, ClusterComponent, ExtensibleCluster, validateFeatureSelection, ClusterForBaseCluster } from "../../cluster/ClusterFactory.js";
+import {
+    BaseClusterComponent,
+    ClusterComponent,
+    ExtensibleCluster,
+    validateFeatureSelection,
+    ClusterForBaseCluster,
+    AsConditional
+} from "../../cluster/ClusterFactory.js";
 import { BitFlag, BitFlags, TypeFromPartialBitSchema } from "../../schema/BitmapSchema.js";
 import { WritableAttribute, Attribute, Command, TlvNoResponse, OptionalCommand, Cluster } from "../../cluster/Cluster.js";
 import { TlvUInt16, TlvEnum } from "../../tlv/TlvNumber.js";
@@ -288,6 +295,7 @@ export type IdentifyExtension<SF extends TypeFromPartialBitSchema<typeof Identif
     ClusterForBaseCluster<typeof IdentifyBase, SF>
     & { supportedFeatures: SF }
     & (SF extends { query: true } ? typeof QueryComponent : {});
+const QRY = { query: true };
 
 /**
  * This cluster supports all Identify features. It may support illegal feature combinations.
@@ -295,4 +303,14 @@ export type IdentifyExtension<SF extends TypeFromPartialBitSchema<typeof Identif
  * If you use this cluster you must manually specify which features are active and ensure the set of active features is
  * legal per the Matter specification.
  */
-export const IdentifyComplete = Cluster({ ...IdentifyCluster, commands: { ...QueryComponent.commands } });
+export const IdentifyComplete = Cluster({
+    id: IdentifyCluster.id,
+    name: IdentifyCluster.name,
+    revision: IdentifyCluster.revision,
+    features: IdentifyCluster.features,
+    attributes: IdentifyCluster.attributes,
+    commands: {
+        ...IdentifyCluster.commands,
+        identifyQuery: AsConditional(QueryComponent.commands.identifyQuery, { mandatoryIf: [QRY] })
+    }
+});

--- a/packages/matter.js/src/cluster/definitions/IlluminanceMeasurementCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/IlluminanceMeasurementCluster.ts
@@ -75,4 +75,4 @@ export const IlluminanceMeasurementCluster = Cluster({
          */
         lightSensorType: OptionalAttribute(0x4, TlvNullable(TlvUInt8), { default: null })
     }
-});
+})

--- a/packages/matter.js/src/cluster/definitions/KeypadInputCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/KeypadInputCluster.ts
@@ -254,11 +254,3 @@ export const KeypadInputCluster = ExtensibleCluster({
 export type KeypadInputExtension<SF extends TypeFromPartialBitSchema<typeof KeypadInputBase.features>> =
     ClusterForBaseCluster<typeof KeypadInputBase, SF>
     & { supportedFeatures: SF };
-
-/**
- * This cluster supports all KeypadInput features. It may support illegal feature combinations.
- *
- * If you use this cluster you must manually specify which features are active and ensure the set of active features is
- * legal per the Matter specification.
- */
-export const KeypadInputComplete = Cluster({ ...KeypadInputCluster });

--- a/packages/matter.js/src/cluster/definitions/LeafWetnessMeasurementCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/LeafWetnessMeasurementCluster.ts
@@ -66,4 +66,4 @@ export const LeafWetnessMeasurementCluster = Cluster({
          */
         tolerance: OptionalAttribute(0x3, TlvUInt16.bound({ max: 2048 }))
     }
-});
+})

--- a/packages/matter.js/src/cluster/definitions/LevelControlCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/LevelControlCluster.ts
@@ -13,7 +13,8 @@ import {
     ExtensibleCluster,
     validateFeatureSelection,
     extendCluster,
-    ClusterForBaseCluster
+    ClusterForBaseCluster,
+    AsConditional
 } from "../../cluster/ClusterFactory.js";
 import { BitFlag, BitFlags, TypeFromPartialBitSchema } from "../../schema/BitmapSchema.js";
 import {
@@ -478,6 +479,8 @@ export type LevelControlExtension<SF extends TypeFromPartialBitSchema<typeof Lev
     & { supportedFeatures: SF }
     & (SF extends { lighting: true } ? typeof LightingComponent : {})
     & (SF extends { frequency: true } ? typeof FrequencyComponent : {});
+const LT = { lighting: true };
+const FQ = { frequency: true };
 
 /**
  * This cluster supports all LevelControl features. It may support illegal feature combinations.
@@ -486,7 +489,22 @@ export type LevelControlExtension<SF extends TypeFromPartialBitSchema<typeof Lev
  * legal per the Matter specification.
  */
 export const LevelControlComplete = Cluster({
-    ...LevelControlCluster,
-    attributes: { ...LightingComponent.attributes, ...FrequencyComponent.attributes },
-    commands: { ...FrequencyComponent.commands }
+    id: LevelControlCluster.id,
+    name: LevelControlCluster.name,
+    revision: LevelControlCluster.revision,
+    features: LevelControlCluster.features,
+
+    attributes: {
+        ...LevelControlCluster.attributes,
+        remainingTime: AsConditional(LightingComponent.attributes.remainingTime, { mandatoryIf: [LT] }),
+        currentFrequency: AsConditional(FrequencyComponent.attributes.currentFrequency, { mandatoryIf: [FQ] }),
+        minFrequency: AsConditional(FrequencyComponent.attributes.minFrequency, { mandatoryIf: [FQ] }),
+        maxFrequency: AsConditional(FrequencyComponent.attributes.maxFrequency, { mandatoryIf: [FQ] }),
+        startUpCurrentLevel: AsConditional(LightingComponent.attributes.startUpCurrentLevel, { mandatoryIf: [LT] })
+    },
+
+    commands: {
+        ...LevelControlCluster.commands,
+        moveToClosestFrequency: AsConditional(FrequencyComponent.commands.moveToClosestFrequency, { mandatoryIf: [FQ] })
+    }
 });

--- a/packages/matter.js/src/cluster/definitions/LevelControlCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/LevelControlCluster.ts
@@ -7,9 +7,25 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { MatterApplicationClusterSpecificationV1_1 } from "../../spec/Specifications.js";
-import { BaseClusterComponent, ClusterComponent, ExtensibleCluster, validateFeatureSelection, extendCluster, ClusterForBaseCluster } from "../../cluster/ClusterFactory.js";
+import {
+    BaseClusterComponent,
+    ClusterComponent,
+    ExtensibleCluster,
+    validateFeatureSelection,
+    extendCluster,
+    ClusterForBaseCluster
+} from "../../cluster/ClusterFactory.js";
 import { BitFlag, BitFlags, TypeFromPartialBitSchema } from "../../schema/BitmapSchema.js";
-import { Attribute, OptionalAttribute, WritableAttribute, OptionalWritableAttribute, Command, TlvNoResponse, AccessLevel, Cluster } from "../../cluster/Cluster.js";
+import {
+    Attribute,
+    OptionalAttribute,
+    WritableAttribute,
+    OptionalWritableAttribute,
+    Command,
+    TlvNoResponse,
+    AccessLevel,
+    Cluster
+} from "../../cluster/Cluster.js";
 import { TlvUInt8, TlvBitmap, TlvUInt16, TlvEnum } from "../../tlv/TlvNumber.js";
 import { TlvNullable } from "../../tlv/TlvNullable.js";
 import { TlvObject, TlvField } from "../../tlv/TlvObject.js";

--- a/packages/matter.js/src/cluster/definitions/LocalizationConfigurationCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/LocalizationConfigurationCluster.ts
@@ -55,4 +55,4 @@ export const LocalizationConfigurationCluster = Cluster({
          */
         supportedLocales: FixedAttribute(0x1, TlvArray(TlvString, { maxLength: 32 }), { default: [] })
     }
-});
+})

--- a/packages/matter.js/src/cluster/definitions/LowPowerCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/LowPowerCluster.ts
@@ -30,4 +30,4 @@ export const LowPowerCluster = Cluster({
          */
         sleep: Command(0x0, TlvNoArguments, 0x0, TlvNoResponse)
     }
-});
+})

--- a/packages/matter.js/src/cluster/definitions/MediaInputCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/MediaInputCluster.ts
@@ -7,7 +7,14 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { MatterApplicationClusterSpecificationV1_1 } from "../../spec/Specifications.js";
-import { BaseClusterComponent, ClusterComponent, ExtensibleCluster, validateFeatureSelection, ClusterForBaseCluster } from "../../cluster/ClusterFactory.js";
+import {
+    BaseClusterComponent,
+    ClusterComponent,
+    ExtensibleCluster,
+    validateFeatureSelection,
+    ClusterForBaseCluster,
+    AsConditional
+} from "../../cluster/ClusterFactory.js";
 import { BitFlag, BitFlags, TypeFromPartialBitSchema } from "../../schema/BitmapSchema.js";
 import { Attribute, Command, TlvNoResponse, Cluster } from "../../cluster/Cluster.js";
 import { TlvArray } from "../../tlv/TlvArray.js";
@@ -215,6 +222,7 @@ export type MediaInputExtension<SF extends TypeFromPartialBitSchema<typeof Media
     ClusterForBaseCluster<typeof MediaInputBase, SF>
     & { supportedFeatures: SF }
     & (SF extends { nameUpdates: true } ? typeof NameUpdatesComponent : {});
+const NU = { nameUpdates: true };
 
 /**
  * This cluster supports all MediaInput features. It may support illegal feature combinations.
@@ -222,4 +230,14 @@ export type MediaInputExtension<SF extends TypeFromPartialBitSchema<typeof Media
  * If you use this cluster you must manually specify which features are active and ensure the set of active features is
  * legal per the Matter specification.
  */
-export const MediaInputComplete = Cluster({ ...MediaInputCluster, commands: { ...NameUpdatesComponent.commands } });
+export const MediaInputComplete = Cluster({
+    id: MediaInputCluster.id,
+    name: MediaInputCluster.name,
+    revision: MediaInputCluster.revision,
+    features: MediaInputCluster.features,
+    attributes: MediaInputCluster.attributes,
+    commands: {
+        ...MediaInputCluster.commands,
+        renameInput: AsConditional(NameUpdatesComponent.commands.renameInput, { mandatoryIf: [NU] })
+    }
+});

--- a/packages/matter.js/src/cluster/definitions/MediaPlaybackCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/MediaPlaybackCluster.ts
@@ -7,7 +7,14 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { MatterApplicationClusterSpecificationV1_1 } from "../../spec/Specifications.js";
-import { BaseClusterComponent, ClusterComponent, ExtensibleCluster, validateFeatureSelection, extendCluster, ClusterForBaseCluster } from "../../cluster/ClusterFactory.js";
+import {
+    BaseClusterComponent,
+    ClusterComponent,
+    ExtensibleCluster,
+    validateFeatureSelection,
+    extendCluster,
+    ClusterForBaseCluster
+} from "../../cluster/ClusterFactory.js";
 import { BitFlag, BitFlags, TypeFromPartialBitSchema } from "../../schema/BitmapSchema.js";
 import { Attribute, Command, OptionalCommand, Cluster } from "../../cluster/Cluster.js";
 import { TlvEnum, TlvUInt64, TlvEpochUs, TlvFloat } from "../../tlv/TlvNumber.js";

--- a/packages/matter.js/src/cluster/definitions/ModeSelectCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/ModeSelectCluster.ts
@@ -7,7 +7,14 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { MatterApplicationClusterSpecificationV1_1 } from "../../spec/Specifications.js";
-import { BaseClusterComponent, ClusterComponent, ExtensibleCluster, validateFeatureSelection, ClusterForBaseCluster } from "../../cluster/ClusterFactory.js";
+import {
+    BaseClusterComponent,
+    ClusterComponent,
+    ExtensibleCluster,
+    validateFeatureSelection,
+    ClusterForBaseCluster,
+    AsConditional
+} from "../../cluster/ClusterFactory.js";
 import { BitFlag, BitFlags, TypeFromPartialBitSchema } from "../../schema/BitmapSchema.js";
 import { FixedAttribute, Attribute, OptionalWritableAttribute, Command, TlvNoResponse, WritableAttribute, Cluster } from "../../cluster/Cluster.js";
 import { TlvString } from "../../tlv/TlvString.js";
@@ -266,6 +273,7 @@ export type ModeSelectExtension<SF extends TypeFromPartialBitSchema<typeof ModeS
     ClusterForBaseCluster<typeof ModeSelectBase, SF>
     & { supportedFeatures: SF }
     & (SF extends { onOff: true } ? typeof OnOffComponent : {});
+const DEPONOFF = { onOff: true };
 
 /**
  * This cluster supports all ModeSelect features. It may support illegal feature combinations.
@@ -273,4 +281,14 @@ export type ModeSelectExtension<SF extends TypeFromPartialBitSchema<typeof ModeS
  * If you use this cluster you must manually specify which features are active and ensure the set of active features is
  * legal per the Matter specification.
  */
-export const ModeSelectComplete = Cluster({ ...ModeSelectCluster, attributes: { ...OnOffComponent.attributes } });
+export const ModeSelectComplete = Cluster({
+    id: ModeSelectCluster.id,
+    name: ModeSelectCluster.name,
+    revision: ModeSelectCluster.revision,
+    features: ModeSelectCluster.features,
+    attributes: {
+        ...ModeSelectCluster.attributes,
+        onMode: AsConditional(OnOffComponent.attributes.onMode, { mandatoryIf: [DEPONOFF] })
+    },
+    commands: ModeSelectCluster.commands
+});

--- a/packages/matter.js/src/cluster/definitions/NetworkCommissioningCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/NetworkCommissioningCluster.ts
@@ -1064,10 +1064,7 @@ export const NetworkCommissioningCluster = ExtensibleCluster({
             cluster,
             { wiFiNetworkInterface: true, threadNetworkInterface: true },
             { wiFiNetworkInterface: true, ethernetNetworkInterface: true },
-            { threadNetworkInterface: true, wiFiNetworkInterface: true },
             { threadNetworkInterface: true, ethernetNetworkInterface: true },
-            { ethernetNetworkInterface: true, wiFiNetworkInterface: true },
-            { ethernetNetworkInterface: true, threadNetworkInterface: true },
             { wiFiNetworkInterface: false, threadNetworkInterface: false, ethernetNetworkInterface: false }
         );
 
@@ -1083,10 +1080,7 @@ export type NetworkCommissioningExtension<SF extends TypeFromPartialBitSchema<ty
     & (SF extends { threadNetworkInterface: true } ? typeof ThreadNetworkInterfaceComponent : {})
     & (SF extends { wiFiNetworkInterface: true, threadNetworkInterface: true } ? never : {})
     & (SF extends { wiFiNetworkInterface: true, ethernetNetworkInterface: true } ? never : {})
-    & (SF extends { threadNetworkInterface: true, wiFiNetworkInterface: true } ? never : {})
     & (SF extends { threadNetworkInterface: true, ethernetNetworkInterface: true } ? never : {})
-    & (SF extends { ethernetNetworkInterface: true, wiFiNetworkInterface: true } ? never : {})
-    & (SF extends { ethernetNetworkInterface: true, threadNetworkInterface: true } ? never : {})
     & (SF extends { wiFiNetworkInterface: false, threadNetworkInterface: false, ethernetNetworkInterface: false } ? never : {});
 
 /**

--- a/packages/matter.js/src/cluster/definitions/NetworkCommissioningCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/NetworkCommissioningCluster.ts
@@ -7,7 +7,15 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { MatterCoreSpecificationV1_1 } from "../../spec/Specifications.js";
-import { BaseClusterComponent, ClusterComponent, ExtensibleCluster, validateFeatureSelection, extendCluster, preventCluster, ClusterForBaseCluster } from "../../cluster/ClusterFactory.js";
+import {
+    BaseClusterComponent,
+    ClusterComponent,
+    ExtensibleCluster,
+    validateFeatureSelection,
+    extendCluster,
+    preventCluster,
+    ClusterForBaseCluster
+} from "../../cluster/ClusterFactory.js";
 import { BitFlag, BitFlags, TypeFromPartialBitSchema } from "../../schema/BitmapSchema.js";
 import { FixedAttribute, AccessLevel, Attribute, WritableAttribute, Command, Cluster } from "../../cluster/Cluster.js";
 import { TlvUInt8, TlvEnum, TlvInt32, TlvUInt64, TlvBitmap, TlvUInt16, TlvInt8 } from "../../tlv/TlvNumber.js";

--- a/packages/matter.js/src/cluster/definitions/OnOffCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/OnOffCluster.ts
@@ -7,7 +7,14 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { MatterApplicationClusterSpecificationV1_1 } from "../../spec/Specifications.js";
-import { BaseClusterComponent, ClusterComponent, ExtensibleCluster, validateFeatureSelection, ClusterForBaseCluster } from "../../cluster/ClusterFactory.js";
+import {
+    BaseClusterComponent,
+    ClusterComponent,
+    ExtensibleCluster,
+    validateFeatureSelection,
+    ClusterForBaseCluster,
+    AsConditional
+} from "../../cluster/ClusterFactory.js";
 import { BitFlag, BitField, BitFlags, TypeFromPartialBitSchema } from "../../schema/BitmapSchema.js";
 import { Attribute, Command, TlvNoResponse, WritableAttribute, AccessLevel, Cluster } from "../../cluster/Cluster.js";
 import { TlvBoolean } from "../../tlv/TlvBoolean.js";
@@ -300,6 +307,7 @@ export type OnOffExtension<SF extends TypeFromPartialBitSchema<typeof OnOffBase.
     ClusterForBaseCluster<typeof OnOffBase, SF>
     & { supportedFeatures: SF }
     & (SF extends { levelControlForLighting: true } ? typeof LevelControlForLightingComponent : {});
+const LT = { levelControlForLighting: true };
 
 /**
  * This cluster supports all OnOff features. It may support illegal feature combinations.
@@ -308,7 +316,29 @@ export type OnOffExtension<SF extends TypeFromPartialBitSchema<typeof OnOffBase.
  * legal per the Matter specification.
  */
 export const OnOffComplete = Cluster({
-    ...OnOffCluster,
-    attributes: { ...LevelControlForLightingComponent.attributes },
-    commands: { ...LevelControlForLightingComponent.commands }
+    id: OnOffCluster.id,
+    name: OnOffCluster.name,
+    revision: OnOffCluster.revision,
+    features: OnOffCluster.features,
+
+    attributes: {
+        ...OnOffCluster.attributes,
+        globalSceneControl: AsConditional(
+            LevelControlForLightingComponent.attributes.globalSceneControl,
+            { mandatoryIf: [LT] }
+        ),
+        onTime: AsConditional(LevelControlForLightingComponent.attributes.onTime, { mandatoryIf: [LT] }),
+        offWaitTime: AsConditional(LevelControlForLightingComponent.attributes.offWaitTime, { mandatoryIf: [LT] }),
+        startUpOnOff: AsConditional(LevelControlForLightingComponent.attributes.startUpOnOff, { mandatoryIf: [LT] })
+    },
+
+    commands: {
+        ...OnOffCluster.commands,
+        offWithEffect: AsConditional(LevelControlForLightingComponent.commands.offWithEffect, { mandatoryIf: [LT] }),
+        onWithRecallGlobalScene: AsConditional(
+            LevelControlForLightingComponent.commands.onWithRecallGlobalScene,
+            { mandatoryIf: [LT] }
+        ),
+        onWithTimedOff: AsConditional(LevelControlForLightingComponent.commands.onWithTimedOff, { mandatoryIf: [LT] })
+    }
 });

--- a/packages/matter.js/src/cluster/definitions/OtaSoftwareUpdateRequestorCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/OtaSoftwareUpdateRequestorCluster.ts
@@ -6,7 +6,16 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import { Cluster, WritableFabricScopedAttribute, AccessLevel, Attribute, OptionalCommand, TlvNoResponse, Event, EventPriority } from "../../cluster/Cluster.js";
+import {
+    Cluster,
+    WritableFabricScopedAttribute,
+    AccessLevel,
+    Attribute,
+    OptionalCommand,
+    TlvNoResponse,
+    Event,
+    EventPriority
+} from "../../cluster/Cluster.js";
 import { MatterCoreSpecificationV1_1 } from "../../spec/Specifications.js";
 import { TlvArray } from "../../tlv/TlvArray.js";
 import { TlvObject, TlvField, TlvOptionalField } from "../../tlv/TlvObject.js";

--- a/packages/matter.js/src/cluster/definitions/PowerSourceCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/PowerSourceCluster.ts
@@ -7,7 +7,14 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { MatterCoreSpecificationV1_1 } from "../../spec/Specifications.js";
-import { BaseClusterComponent, ClusterComponent, ExtensibleCluster, validateFeatureSelection, extendCluster, ClusterForBaseCluster } from "../../cluster/ClusterFactory.js";
+import {
+    BaseClusterComponent,
+    ClusterComponent,
+    ExtensibleCluster,
+    validateFeatureSelection,
+    extendCluster,
+    ClusterForBaseCluster
+} from "../../cluster/ClusterFactory.js";
 import { BitFlag, BitFlags, TypeFromPartialBitSchema } from "../../schema/BitmapSchema.js";
 import { Attribute, FixedAttribute, OptionalAttribute, OptionalFixedAttribute, OptionalEvent, EventPriority, Cluster } from "../../cluster/Cluster.js";
 import { TlvEnum, TlvUInt8, TlvUInt32, TlvUInt16 } from "../../tlv/TlvNumber.js";

--- a/packages/matter.js/src/cluster/definitions/PowerSourceConfigurationCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/PowerSourceConfigurationCluster.ts
@@ -39,4 +39,4 @@ export const PowerSourceConfigurationCluster = Cluster({
          */
         sources: Attribute(0x0, TlvArray(TlvEndpointNumber, { maxLength: 6 }), { persistent: true, default: [] })
     }
-});
+})

--- a/packages/matter.js/src/cluster/definitions/PressureMeasurementCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/PressureMeasurementCluster.ts
@@ -7,7 +7,14 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { MatterApplicationClusterSpecificationV1_1 } from "../../spec/Specifications.js";
-import { BaseClusterComponent, ClusterComponent, ExtensibleCluster, validateFeatureSelection, ClusterForBaseCluster } from "../../cluster/ClusterFactory.js";
+import {
+    BaseClusterComponent,
+    ClusterComponent,
+    ExtensibleCluster,
+    validateFeatureSelection,
+    ClusterForBaseCluster,
+    AsConditional
+} from "../../cluster/ClusterFactory.js";
 import { BitFlag, BitFlags, TypeFromPartialBitSchema } from "../../schema/BitmapSchema.js";
 import { Attribute, OptionalAttribute, Cluster } from "../../cluster/Cluster.js";
 import { TlvInt16, TlvUInt16, TlvInt8 } from "../../tlv/TlvNumber.js";
@@ -177,6 +184,8 @@ export type PressureMeasurementExtension<SF extends TypeFromPartialBitSchema<typ
     & { supportedFeatures: SF }
     & (SF extends { extended: true } ? typeof ExtendedComponent : {});
 
+const EXT = { extended: true };
+
 /**
  * This cluster supports all PressureMeasurement features. It may support illegal feature combinations.
  *
@@ -184,6 +193,17 @@ export type PressureMeasurementExtension<SF extends TypeFromPartialBitSchema<typ
  * legal per the Matter specification.
  */
 export const PressureMeasurementComplete = Cluster({
-    ...PressureMeasurementCluster,
-    attributes: { ...ExtendedComponent.attributes }
+    id: PressureMeasurementCluster.id,
+    name: PressureMeasurementCluster.name,
+    revision: PressureMeasurementCluster.revision,
+    features: PressureMeasurementCluster.features,
+
+    attributes: {
+        ...PressureMeasurementCluster.attributes,
+        scaledValue: AsConditional(ExtendedComponent.attributes.scaledValue, { mandatoryIf: [EXT] }),
+        minScaledValue: AsConditional(ExtendedComponent.attributes.minScaledValue, { mandatoryIf: [EXT] }),
+        maxScaledValue: AsConditional(ExtendedComponent.attributes.maxScaledValue, { mandatoryIf: [EXT] }),
+        scaledTolerance: AsConditional(ExtendedComponent.attributes.scaledTolerance, { optionalIf: [EXT] }),
+        scale: AsConditional(ExtendedComponent.attributes.scale, { mandatoryIf: [EXT] })
+    }
 });

--- a/packages/matter.js/src/cluster/definitions/ProxyDiscoveryCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/ProxyDiscoveryCluster.ts
@@ -30,4 +30,4 @@ export const ProxyDiscoveryCluster = Cluster({
          */
         proxyDiscoverRequest: Command(0x0, TlvNoArguments, 0x0, TlvNoResponse)
     }
-});
+})

--- a/packages/matter.js/src/cluster/definitions/PulseWidthModulationCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/PulseWidthModulationCluster.ts
@@ -7,9 +7,25 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { MatterApplicationClusterSpecificationV1_1 } from "../../spec/Specifications.js";
-import { BaseClusterComponent, ClusterComponent, ExtensibleCluster, validateFeatureSelection, extendCluster, ClusterForBaseCluster } from "../../cluster/ClusterFactory.js";
+import {
+    BaseClusterComponent,
+    ClusterComponent,
+    ExtensibleCluster,
+    validateFeatureSelection,
+    extendCluster,
+    ClusterForBaseCluster
+} from "../../cluster/ClusterFactory.js";
 import { BitFlag, BitFlags, TypeFromPartialBitSchema } from "../../schema/BitmapSchema.js";
-import { Attribute, OptionalAttribute, WritableAttribute, OptionalWritableAttribute, Command, TlvNoResponse, AccessLevel, Cluster } from "../../cluster/Cluster.js";
+import {
+    Attribute,
+    OptionalAttribute,
+    WritableAttribute,
+    OptionalWritableAttribute,
+    Command,
+    TlvNoResponse,
+    AccessLevel,
+    Cluster
+} from "../../cluster/Cluster.js";
 import { TlvUInt8, TlvBitmap, TlvUInt16, TlvEnum } from "../../tlv/TlvNumber.js";
 import { TlvNullable } from "../../tlv/TlvNullable.js";
 import { TlvObject, TlvField } from "../../tlv/TlvObject.js";

--- a/packages/matter.js/src/cluster/definitions/PumpConfigurationAndControlCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/PumpConfigurationAndControlCluster.ts
@@ -14,7 +14,8 @@ import {
     validateFeatureSelection,
     extendCluster,
     preventCluster,
-    ClusterForBaseCluster
+    ClusterForBaseCluster,
+    AsConditional
 } from "../../cluster/ClusterFactory.js";
 import { BitFlag, BitFlags, TypeFromPartialBitSchema } from "../../schema/BitmapSchema.js";
 import {
@@ -957,6 +958,13 @@ export type PumpConfigurationAndControlExtension<SF extends TypeFromPartialBitSc
     & (SF extends { constantTemperature: true } ? typeof ConstantTemperatureComponent : {})
     & (SF extends { constantPressure: false, compensatedPressure: false, constantFlow: false, constantSpeed: false, constantTemperature: false } ? never : {});
 
+const PRSCONST = { constantPressure: true };
+const AUTO = { automatic: true };
+const PRSCOMP = { compensatedPressure: true };
+const SPD = { constantSpeed: true };
+const FLW = { constantFlow: true };
+const TEMP = { constantTemperature: true };
+
 /**
  * This cluster supports all PumpConfigurationAndControl features. It may support illegal feature combinations.
  *
@@ -964,14 +972,42 @@ export type PumpConfigurationAndControlExtension<SF extends TypeFromPartialBitSc
  * legal per the Matter specification.
  */
 export const PumpConfigurationAndControlComplete = Cluster({
-    ...PumpConfigurationAndControlCluster,
+    id: PumpConfigurationAndControlCluster.id,
+    name: PumpConfigurationAndControlCluster.name,
+    revision: PumpConfigurationAndControlCluster.revision,
+    features: PumpConfigurationAndControlCluster.features,
 
     attributes: {
-        ...ConstantPressureComponent.attributes,
-        ...AutomaticComponent.attributes,
-        ...CompensatedPressureComponent.attributes,
-        ...ConstantSpeedComponent.attributes,
-        ...ConstantFlowComponent.attributes,
-        ...ConstantTemperatureComponent.attributes
-    }
+        ...PumpConfigurationAndControlCluster.attributes,
+        minConstPressure: AsConditional(
+            ConstantPressureComponent.attributes.minConstPressure,
+            { mandatoryIf: [PRSCONST], optionalIf: [AUTO] }
+        ),
+        maxConstPressure: AsConditional(
+            ConstantPressureComponent.attributes.maxConstPressure,
+            { mandatoryIf: [PRSCONST], optionalIf: [AUTO] }
+        ),
+        minCompPressure: AsConditional(
+            AutomaticComponent.attributes.minCompPressure,
+            { optionalIf: [AUTO], mandatoryIf: [PRSCOMP] }
+        ),
+        maxCompPressure: AsConditional(
+            AutomaticComponent.attributes.maxCompPressure,
+            { optionalIf: [AUTO], mandatoryIf: [PRSCOMP] }
+        ),
+        minConstSpeed: AsConditional(
+            AutomaticComponent.attributes.minConstSpeed,
+            { optionalIf: [AUTO], mandatoryIf: [SPD] }
+        ),
+        maxConstSpeed: AsConditional(
+            AutomaticComponent.attributes.maxConstSpeed,
+            { optionalIf: [AUTO], mandatoryIf: [SPD] }
+        ),
+        minConstFlow: AsConditional(AutomaticComponent.attributes.minConstFlow, { optionalIf: [AUTO], mandatoryIf: [FLW] }),
+        maxConstFlow: AsConditional(AutomaticComponent.attributes.maxConstFlow, { optionalIf: [AUTO], mandatoryIf: [FLW] }),
+        minConstTemp: AsConditional(AutomaticComponent.attributes.minConstTemp, { optionalIf: [AUTO], mandatoryIf: [TEMP] }),
+        maxConstTemp: AsConditional(AutomaticComponent.attributes.maxConstTemp, { optionalIf: [AUTO], mandatoryIf: [TEMP] })
+    },
+
+    events: PumpConfigurationAndControlCluster.events
 });

--- a/packages/matter.js/src/cluster/definitions/PumpConfigurationAndControlCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/PumpConfigurationAndControlCluster.ts
@@ -7,9 +7,28 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { MatterApplicationClusterSpecificationV1_1 } from "../../spec/Specifications.js";
-import { BaseClusterComponent, ClusterComponent, ExtensibleCluster, validateFeatureSelection, extendCluster, preventCluster, ClusterForBaseCluster } from "../../cluster/ClusterFactory.js";
+import {
+    BaseClusterComponent,
+    ClusterComponent,
+    ExtensibleCluster,
+    validateFeatureSelection,
+    extendCluster,
+    preventCluster,
+    ClusterForBaseCluster
+} from "../../cluster/ClusterFactory.js";
 import { BitFlag, BitFlags, TypeFromPartialBitSchema } from "../../schema/BitmapSchema.js";
-import { FixedAttribute, OptionalAttribute, Attribute, OptionalWritableAttribute, AccessLevel, WritableAttribute, OptionalEvent, EventPriority, OptionalFixedAttribute, Cluster } from "../../cluster/Cluster.js";
+import {
+    FixedAttribute,
+    OptionalAttribute,
+    Attribute,
+    OptionalWritableAttribute,
+    AccessLevel,
+    WritableAttribute,
+    OptionalEvent,
+    EventPriority,
+    OptionalFixedAttribute,
+    Cluster
+} from "../../cluster/Cluster.js";
 import { TlvInt16, TlvUInt16, TlvBitmap, TlvEnum, TlvUInt24, TlvUInt32 } from "../../tlv/TlvNumber.js";
 import { TlvNullable } from "../../tlv/TlvNullable.js";
 import { TlvNoArguments } from "../../tlv/TlvNoArguments.js";

--- a/packages/matter.js/src/cluster/definitions/RelativeHumidityMeasurementCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/RelativeHumidityMeasurementCluster.ts
@@ -68,4 +68,4 @@ export const RelativeHumidityMeasurementCluster = Cluster({
          */
         tolerance: OptionalAttribute(0x3, TlvUInt16.bound({ max: 2048 }))
     }
-});
+})

--- a/packages/matter.js/src/cluster/definitions/ScenesCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/ScenesCluster.ts
@@ -508,11 +508,3 @@ export const ScenesCluster = ExtensibleCluster({
 export type ScenesExtension<SF extends TypeFromPartialBitSchema<typeof ScenesBase.features>> =
     ClusterForBaseCluster<typeof ScenesBase, SF>
     & { supportedFeatures: SF };
-
-/**
- * This cluster supports all Scenes features. It may support illegal feature combinations.
- *
- * If you use this cluster you must manually specify which features are active and ensure the set of active features is
- * legal per the Matter specification.
- */
-export const ScenesComplete = Cluster({ ...ScenesCluster });

--- a/packages/matter.js/src/cluster/definitions/SoftwareDiagnosticsCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/SoftwareDiagnosticsCluster.ts
@@ -7,7 +7,14 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { MatterCoreSpecificationV1_1 } from "../../spec/Specifications.js";
-import { BaseClusterComponent, ClusterComponent, ExtensibleCluster, validateFeatureSelection, ClusterForBaseCluster } from "../../cluster/ClusterFactory.js";
+import {
+    BaseClusterComponent,
+    ClusterComponent,
+    ExtensibleCluster,
+    validateFeatureSelection,
+    ClusterForBaseCluster,
+    AsConditional
+} from "../../cluster/ClusterFactory.js";
 import { BitFlag, BitFlags, TypeFromPartialBitSchema } from "../../schema/BitmapSchema.js";
 import { OptionalAttribute, OptionalEvent, EventPriority, Attribute, Command, TlvNoResponse, Cluster } from "../../cluster/Cluster.js";
 import { TlvArray } from "../../tlv/TlvArray.js";
@@ -229,6 +236,7 @@ export type SoftwareDiagnosticsExtension<SF extends TypeFromPartialBitSchema<typ
     ClusterForBaseCluster<typeof SoftwareDiagnosticsBase, SF>
     & { supportedFeatures: SF }
     & (SF extends { watermarks: true } ? typeof WatermarksComponent : {});
+const WTRMRK = { watermarks: true };
 
 /**
  * This cluster supports all SoftwareDiagnostics features. It may support illegal feature combinations.
@@ -237,7 +245,19 @@ export type SoftwareDiagnosticsExtension<SF extends TypeFromPartialBitSchema<typ
  * legal per the Matter specification.
  */
 export const SoftwareDiagnosticsComplete = Cluster({
-    ...SoftwareDiagnosticsCluster,
-    attributes: { ...WatermarksComponent.attributes },
-    commands: { ...WatermarksComponent.commands }
+    id: SoftwareDiagnosticsCluster.id,
+    name: SoftwareDiagnosticsCluster.name,
+    revision: SoftwareDiagnosticsCluster.revision,
+    features: SoftwareDiagnosticsCluster.features,
+
+    attributes: {
+        ...SoftwareDiagnosticsCluster.attributes,
+        currentHeapHighWatermark: AsConditional(
+            WatermarksComponent.attributes.currentHeapHighWatermark,
+            { mandatoryIf: [WTRMRK] }
+        )
+    },
+
+    commands: { resetWatermarks: AsConditional(WatermarksComponent.commands.resetWatermarks, { mandatoryIf: [WTRMRK] }) },
+    events: SoftwareDiagnosticsCluster.events
 });

--- a/packages/matter.js/src/cluster/definitions/SoilMoistureMeasurementCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/SoilMoistureMeasurementCluster.ts
@@ -66,4 +66,4 @@ export const SoilMoistureMeasurementCluster = Cluster({
          */
         tolerance: OptionalAttribute(0x3, TlvUInt16.bound({ max: 2048 }))
     }
-});
+})

--- a/packages/matter.js/src/cluster/definitions/SwitchCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/SwitchCluster.ts
@@ -358,7 +358,6 @@ export const SwitchCluster = ExtensibleCluster({
             { momentarySwitchMultiPress: true, momentarySwitch: false },
             { momentarySwitchMultiPress: true, momentarySwitchRelease: false },
             { latchingSwitch: true, momentarySwitch: true },
-            { momentarySwitch: true, latchingSwitch: true },
             { latchingSwitch: false, momentarySwitch: false }
         );
 
@@ -380,7 +379,6 @@ export type SwitchExtension<SF extends TypeFromPartialBitSchema<typeof SwitchBas
     & (SF extends { momentarySwitchMultiPress: true, momentarySwitch: false } ? never : {})
     & (SF extends { momentarySwitchMultiPress: true, momentarySwitchRelease: false } ? never : {})
     & (SF extends { latchingSwitch: true, momentarySwitch: true } ? never : {})
-    & (SF extends { momentarySwitch: true, latchingSwitch: true } ? never : {})
     & (SF extends { latchingSwitch: false, momentarySwitch: false } ? never : {});
 
 /**

--- a/packages/matter.js/src/cluster/definitions/SwitchCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/SwitchCluster.ts
@@ -7,7 +7,15 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { MatterApplicationClusterSpecificationV1_1 } from "../../spec/Specifications.js";
-import { BaseClusterComponent, ClusterComponent, ExtensibleCluster, validateFeatureSelection, extendCluster, preventCluster, ClusterForBaseCluster } from "../../cluster/ClusterFactory.js";
+import {
+    BaseClusterComponent,
+    ClusterComponent,
+    ExtensibleCluster,
+    validateFeatureSelection,
+    extendCluster,
+    preventCluster,
+    ClusterForBaseCluster
+} from "../../cluster/ClusterFactory.js";
 import { BitFlag, BitFlags, TypeFromPartialBitSchema } from "../../schema/BitmapSchema.js";
 import { FixedAttribute, Attribute, Event, EventPriority, Cluster } from "../../cluster/Cluster.js";
 import { TlvUInt8 } from "../../tlv/TlvNumber.js";

--- a/packages/matter.js/src/cluster/definitions/TemperatureMeasurementCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/TemperatureMeasurementCluster.ts
@@ -64,4 +64,4 @@ export const TemperatureMeasurementCluster = Cluster({
          */
         tolerance: OptionalAttribute(0x3, TlvUInt16.bound({ max: 2048 }), { default: 0 })
     }
-});
+})

--- a/packages/matter.js/src/cluster/definitions/ThermostatCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/ThermostatCluster.ts
@@ -7,9 +7,29 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { MatterApplicationClusterSpecificationV1_1 } from "../../spec/Specifications.js";
-import { BaseClusterComponent, ClusterComponent, ExtensibleCluster, validateFeatureSelection, extendCluster, preventCluster, ClusterForBaseCluster } from "../../cluster/ClusterFactory.js";
+import {
+    BaseClusterComponent,
+    ClusterComponent,
+    ExtensibleCluster,
+    validateFeatureSelection,
+    extendCluster,
+    preventCluster,
+    ClusterForBaseCluster
+} from "../../cluster/ClusterFactory.js";
 import { BitFlag, BitsFromPartial, BitFlags, TypeFromPartialBitSchema } from "../../schema/BitmapSchema.js";
-import { Attribute, OptionalAttribute, OptionalWritableAttribute, AccessLevel, WritableAttribute, Command, TlvNoResponse, OptionalCommand, OptionalFixedAttribute, FixedAttribute, Cluster } from "../../cluster/Cluster.js";
+import {
+    Attribute,
+    OptionalAttribute,
+    OptionalWritableAttribute,
+    AccessLevel,
+    WritableAttribute,
+    Command,
+    TlvNoResponse,
+    OptionalCommand,
+    OptionalFixedAttribute,
+    FixedAttribute,
+    Cluster
+} from "../../cluster/Cluster.js";
 import { TlvInt16, TlvUInt8, TlvBitmap, TlvEnum, TlvUInt16, TlvUInt32, TlvInt8 } from "../../tlv/TlvNumber.js";
 import { TlvNullable } from "../../tlv/TlvNullable.js";
 import { TlvObject, TlvField } from "../../tlv/TlvObject.js";

--- a/packages/matter.js/src/cluster/definitions/ThreadNetworkDiagnosticsCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/ThreadNetworkDiagnosticsCluster.ts
@@ -13,7 +13,8 @@ import {
     ExtensibleCluster,
     validateFeatureSelection,
     extendCluster,
-    ClusterForBaseCluster
+    ClusterForBaseCluster,
+    AsConditional
 } from "../../cluster/ClusterFactory.js";
 import { BitFlag, BitFlags, TypeFromPartialBitSchema } from "../../schema/BitmapSchema.js";
 import { Attribute, OptionalAttribute, OptionalEvent, EventPriority, Command, TlvNoResponse, Cluster } from "../../cluster/Cluster.js";
@@ -1163,6 +1164,10 @@ export type ThreadNetworkDiagnosticsExtension<SF extends TypeFromPartialBitSchem
     & (SF extends { mleCounts: true } ? typeof MleCountsComponent : {})
     & (SF extends { macCounts: true } ? typeof MacCountsComponent : {});
 
+const ERRCNT = { errorCounts: true };
+const MLECNT = { mleCounts: true };
+const MACCNT = { macCounts: true };
+
 /**
  * This cluster supports all ThreadNetworkDiagnostics features. It may support illegal feature combinations.
  *
@@ -1170,7 +1175,82 @@ export type ThreadNetworkDiagnosticsExtension<SF extends TypeFromPartialBitSchem
  * legal per the Matter specification.
  */
 export const ThreadNetworkDiagnosticsComplete = Cluster({
-    ...ThreadNetworkDiagnosticsCluster,
-    attributes: { ...ErrorCountsComponent.attributes, ...MleCountsComponent.attributes, ...MacCountsComponent.attributes },
-    commands: { ...ErrorCountsComponent.commands }
+    id: ThreadNetworkDiagnosticsCluster.id,
+    name: ThreadNetworkDiagnosticsCluster.name,
+    revision: ThreadNetworkDiagnosticsCluster.revision,
+    features: ThreadNetworkDiagnosticsCluster.features,
+
+    attributes: {
+        ...ThreadNetworkDiagnosticsCluster.attributes,
+        overrunCount: AsConditional(ErrorCountsComponent.attributes.overrunCount, { mandatoryIf: [ERRCNT] }),
+        detachedRoleCount: AsConditional(MleCountsComponent.attributes.detachedRoleCount, { optionalIf: [MLECNT] }),
+        childRoleCount: AsConditional(MleCountsComponent.attributes.childRoleCount, { optionalIf: [MLECNT] }),
+        routerRoleCount: AsConditional(MleCountsComponent.attributes.routerRoleCount, { optionalIf: [MLECNT] }),
+        leaderRoleCount: AsConditional(MleCountsComponent.attributes.leaderRoleCount, { optionalIf: [MLECNT] }),
+        attachAttemptCount: AsConditional(MleCountsComponent.attributes.attachAttemptCount, { optionalIf: [MLECNT] }),
+        partitionIdChangeCount: AsConditional(
+            MleCountsComponent.attributes.partitionIdChangeCount,
+            { optionalIf: [MLECNT] }
+        ),
+        betterPartitionAttachAttemptCount: AsConditional(
+            MleCountsComponent.attributes.betterPartitionAttachAttemptCount,
+            { optionalIf: [MLECNT] }
+        ),
+        parentChangeCount: AsConditional(MleCountsComponent.attributes.parentChangeCount, { optionalIf: [MLECNT] }),
+        txTotalCount: AsConditional(MacCountsComponent.attributes.txTotalCount, { optionalIf: [MACCNT] }),
+        txUnicastCount: AsConditional(MacCountsComponent.attributes.txUnicastCount, { optionalIf: [MACCNT] }),
+        txBroadcastCount: AsConditional(MacCountsComponent.attributes.txBroadcastCount, { optionalIf: [MACCNT] }),
+        txAckRequestedCount: AsConditional(MacCountsComponent.attributes.txAckRequestedCount, { optionalIf: [MACCNT] }),
+        txAckedCount: AsConditional(MacCountsComponent.attributes.txAckedCount, { optionalIf: [MACCNT] }),
+        txNoAckRequestedCount: AsConditional(MacCountsComponent.attributes.txNoAckRequestedCount, { optionalIf: [MACCNT] }),
+        txDataCount: AsConditional(MacCountsComponent.attributes.txDataCount, { optionalIf: [MACCNT] }),
+        txDataPollCount: AsConditional(MacCountsComponent.attributes.txDataPollCount, { optionalIf: [MACCNT] }),
+        txBeaconCount: AsConditional(MacCountsComponent.attributes.txBeaconCount, { optionalIf: [MACCNT] }),
+        txBeaconRequestCount: AsConditional(MacCountsComponent.attributes.txBeaconRequestCount, { optionalIf: [MACCNT] }),
+        txOtherCount: AsConditional(MacCountsComponent.attributes.txOtherCount, { optionalIf: [MACCNT] }),
+        txRetryCount: AsConditional(MacCountsComponent.attributes.txRetryCount, { optionalIf: [MACCNT] }),
+        txDirectMaxRetryExpiryCount: AsConditional(
+            MacCountsComponent.attributes.txDirectMaxRetryExpiryCount,
+            { optionalIf: [MACCNT] }
+        ),
+        txIndirectMaxRetryExpiryCount: AsConditional(
+            MacCountsComponent.attributes.txIndirectMaxRetryExpiryCount,
+            { optionalIf: [MACCNT] }
+        ),
+        txErrCcaCount: AsConditional(MacCountsComponent.attributes.txErrCcaCount, { optionalIf: [MACCNT] }),
+        txErrAbortCount: AsConditional(MacCountsComponent.attributes.txErrAbortCount, { optionalIf: [MACCNT] }),
+        txErrBusyChannelCount: AsConditional(MacCountsComponent.attributes.txErrBusyChannelCount, { optionalIf: [MACCNT] }),
+        rxTotalCount: AsConditional(MacCountsComponent.attributes.rxTotalCount, { optionalIf: [MACCNT] }),
+        rxUnicastCount: AsConditional(MacCountsComponent.attributes.rxUnicastCount, { optionalIf: [MACCNT] }),
+        rxBroadcastCount: AsConditional(MacCountsComponent.attributes.rxBroadcastCount, { optionalIf: [MACCNT] }),
+        rxDataCount: AsConditional(MacCountsComponent.attributes.rxDataCount, { optionalIf: [MACCNT] }),
+        rxDataPollCount: AsConditional(MacCountsComponent.attributes.rxDataPollCount, { optionalIf: [MACCNT] }),
+        rxBeaconCount: AsConditional(MacCountsComponent.attributes.rxBeaconCount, { optionalIf: [MACCNT] }),
+        rxBeaconRequestCount: AsConditional(MacCountsComponent.attributes.rxBeaconRequestCount, { optionalIf: [MACCNT] }),
+        rxOtherCount: AsConditional(MacCountsComponent.attributes.rxOtherCount, { optionalIf: [MACCNT] }),
+        rxAddressFilteredCount: AsConditional(
+            MacCountsComponent.attributes.rxAddressFilteredCount,
+            { optionalIf: [MACCNT] }
+        ),
+        rxDestAddrFilteredCount: AsConditional(
+            MacCountsComponent.attributes.rxDestAddrFilteredCount,
+            { optionalIf: [MACCNT] }
+        ),
+        rxDuplicatedCount: AsConditional(MacCountsComponent.attributes.rxDuplicatedCount, { optionalIf: [MACCNT] }),
+        rxErrNoFrameCount: AsConditional(MacCountsComponent.attributes.rxErrNoFrameCount, { optionalIf: [MACCNT] }),
+        rxErrUnknownNeighborCount: AsConditional(
+            MacCountsComponent.attributes.rxErrUnknownNeighborCount,
+            { optionalIf: [MACCNT] }
+        ),
+        rxErrInvalidScrAddrCount: AsConditional(
+            MacCountsComponent.attributes.rxErrInvalidScrAddrCount,
+            { optionalIf: [MACCNT] }
+        ),
+        rxErrSecCount: AsConditional(MacCountsComponent.attributes.rxErrSecCount, { optionalIf: [MACCNT] }),
+        rxErrFcsCount: AsConditional(MacCountsComponent.attributes.rxErrFcsCount, { optionalIf: [MACCNT] }),
+        rxErrOtherCount: AsConditional(MacCountsComponent.attributes.rxErrOtherCount, { optionalIf: [MACCNT] })
+    },
+
+    commands: { resetCounts: AsConditional(ErrorCountsComponent.commands.resetCounts, { mandatoryIf: [ERRCNT] }) },
+    events: ThreadNetworkDiagnosticsCluster.events
 });

--- a/packages/matter.js/src/cluster/definitions/ThreadNetworkDiagnosticsCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/ThreadNetworkDiagnosticsCluster.ts
@@ -7,7 +7,14 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { MatterCoreSpecificationV1_1 } from "../../spec/Specifications.js";
-import { BaseClusterComponent, ClusterComponent, ExtensibleCluster, validateFeatureSelection, extendCluster, ClusterForBaseCluster } from "../../cluster/ClusterFactory.js";
+import {
+    BaseClusterComponent,
+    ClusterComponent,
+    ExtensibleCluster,
+    validateFeatureSelection,
+    extendCluster,
+    ClusterForBaseCluster
+} from "../../cluster/ClusterFactory.js";
 import { BitFlag, BitFlags, TypeFromPartialBitSchema } from "../../schema/BitmapSchema.js";
 import { Attribute, OptionalAttribute, OptionalEvent, EventPriority, Command, TlvNoResponse, Cluster } from "../../cluster/Cluster.js";
 import { TlvUInt16, TlvEnum, TlvUInt64, TlvUInt32, TlvUInt8, TlvInt8 } from "../../tlv/TlvNumber.js";

--- a/packages/matter.js/src/cluster/definitions/TimeFormatLocalizationCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/TimeFormatLocalizationCluster.ts
@@ -7,7 +7,14 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { MatterCoreSpecificationV1_1 } from "../../spec/Specifications.js";
-import { BaseClusterComponent, ClusterComponent, ExtensibleCluster, validateFeatureSelection, ClusterForBaseCluster } from "../../cluster/ClusterFactory.js";
+import {
+    BaseClusterComponent,
+    ClusterComponent,
+    ExtensibleCluster,
+    validateFeatureSelection,
+    ClusterForBaseCluster,
+    AsConditional
+} from "../../cluster/ClusterFactory.js";
 import { BitFlag, BitFlags, TypeFromPartialBitSchema } from "../../schema/BitmapSchema.js";
 import { WritableAttribute, AccessLevel, FixedAttribute, Cluster } from "../../cluster/Cluster.js";
 import { TlvEnum } from "../../tlv/TlvNumber.js";
@@ -212,6 +219,7 @@ export type TimeFormatLocalizationExtension<SF extends TypeFromPartialBitSchema<
     ClusterForBaseCluster<typeof TimeFormatLocalizationBase, SF>
     & { supportedFeatures: SF }
     & (SF extends { calendarFormat: true } ? typeof CalendarFormatComponent : {});
+const CALFMT = { calendarFormat: true };
 
 /**
  * This cluster supports all TimeFormatLocalization features. It may support illegal feature combinations.
@@ -220,6 +228,17 @@ export type TimeFormatLocalizationExtension<SF extends TypeFromPartialBitSchema<
  * legal per the Matter specification.
  */
 export const TimeFormatLocalizationComplete = Cluster({
-    ...TimeFormatLocalizationCluster,
-    attributes: { ...CalendarFormatComponent.attributes }
+    id: TimeFormatLocalizationCluster.id,
+    name: TimeFormatLocalizationCluster.name,
+    revision: TimeFormatLocalizationCluster.revision,
+    features: TimeFormatLocalizationCluster.features,
+
+    attributes: {
+        ...TimeFormatLocalizationCluster.attributes,
+        activeCalendarType: AsConditional(CalendarFormatComponent.attributes.activeCalendarType, { mandatoryIf: [CALFMT] }),
+        supportedCalendarTypes: AsConditional(
+            CalendarFormatComponent.attributes.supportedCalendarTypes,
+            { mandatoryIf: [CALFMT] }
+        )
+    }
 });

--- a/packages/matter.js/src/cluster/definitions/TimeSyncCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/TimeSyncCluster.ts
@@ -7,9 +7,27 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { MatterCoreSpecificationV1_1 } from "../../spec/Specifications.js";
-import { BaseClusterComponent, ClusterComponent, ExtensibleCluster, validateFeatureSelection, extendCluster, ClusterForBaseCluster } from "../../cluster/ClusterFactory.js";
+import {
+    BaseClusterComponent,
+    ClusterComponent,
+    ExtensibleCluster,
+    validateFeatureSelection,
+    extendCluster,
+    ClusterForBaseCluster
+} from "../../cluster/ClusterFactory.js";
 import { BitFlag, BitFlags, TypeFromPartialBitSchema } from "../../schema/BitmapSchema.js";
-import { Attribute, OptionalAttribute, WritableAttribute, AccessLevel, Command, TlvNoResponse, FixedAttribute, Event, EventPriority, Cluster } from "../../cluster/Cluster.js";
+import {
+    Attribute,
+    OptionalAttribute,
+    WritableAttribute,
+    AccessLevel,
+    Command,
+    TlvNoResponse,
+    FixedAttribute,
+    Event,
+    EventPriority,
+    Cluster
+} from "../../cluster/Cluster.js";
 import { TlvEpochUs, TlvEnum, TlvInt32, TlvUInt16 } from "../../tlv/TlvNumber.js";
 import { TlvNullable } from "../../tlv/TlvNullable.js";
 import { TlvNodeId } from "../../datatype/NodeId.js";

--- a/packages/matter.js/src/cluster/definitions/UnitLocalizationCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/UnitLocalizationCluster.ts
@@ -7,7 +7,14 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { MatterCoreSpecificationV1_1 } from "../../spec/Specifications.js";
-import { BaseClusterComponent, ClusterComponent, ExtensibleCluster, validateFeatureSelection, ClusterForBaseCluster } from "../../cluster/ClusterFactory.js";
+import {
+    BaseClusterComponent,
+    ClusterComponent,
+    ExtensibleCluster,
+    validateFeatureSelection,
+    ClusterForBaseCluster,
+    AsConditional
+} from "../../cluster/ClusterFactory.js";
 import { BitFlag, BitFlags, TypeFromPartialBitSchema } from "../../schema/BitmapSchema.js";
 import { WritableAttribute, AccessLevel, Cluster } from "../../cluster/Cluster.js";
 import { TlvEnum } from "../../tlv/TlvNumber.js";
@@ -126,6 +133,7 @@ export type UnitLocalizationExtension<SF extends TypeFromPartialBitSchema<typeof
     ClusterForBaseCluster<typeof UnitLocalizationBase, SF>
     & { supportedFeatures: SF }
     & (SF extends { temperatureUnit: true } ? typeof TemperatureUnitComponent : {});
+const TEMP = { temperatureUnit: true };
 
 /**
  * This cluster supports all UnitLocalization features. It may support illegal feature combinations.
@@ -134,6 +142,11 @@ export type UnitLocalizationExtension<SF extends TypeFromPartialBitSchema<typeof
  * legal per the Matter specification.
  */
 export const UnitLocalizationComplete = Cluster({
-    ...UnitLocalizationCluster,
-    attributes: { ...TemperatureUnitComponent.attributes }
+    id: UnitLocalizationCluster.id,
+    name: UnitLocalizationCluster.name,
+    revision: UnitLocalizationCluster.revision,
+    features: UnitLocalizationCluster.features,
+    attributes: {
+        temperatureUnit: AsConditional(TemperatureUnitComponent.attributes.temperatureUnit, { mandatoryIf: [TEMP] })
+    }
 });

--- a/packages/matter.js/src/cluster/definitions/UserLabelCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/UserLabelCluster.ts
@@ -36,4 +36,4 @@ export const UserLabelCluster = Cluster({
             { persistent: true, default: [], writeAcl: AccessLevel.Manage }
         )
     }
-});
+})

--- a/packages/matter.js/src/cluster/definitions/WakeOnLanCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/WakeOnLanCluster.ts
@@ -46,4 +46,4 @@ export const WakeOnLanCluster = Cluster({
          */
         linkLocalAddress: OptionalFixedAttribute(0x1, TlvByteString.bound({ length: 16 }))
     }
-});
+})

--- a/packages/matter.js/src/cluster/definitions/WiFiNetworkDiagnosticsCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/WiFiNetworkDiagnosticsCluster.ts
@@ -13,7 +13,8 @@ import {
     ExtensibleCluster,
     validateFeatureSelection,
     extendCluster,
-    ClusterForBaseCluster
+    ClusterForBaseCluster,
+    AsConditional
 } from "../../cluster/ClusterFactory.js";
 import { BitFlag, BitFlags, TypeFromPartialBitSchema } from "../../schema/BitmapSchema.js";
 import { Attribute, OptionalAttribute, OptionalEvent, EventPriority, Command, TlvNoResponse, Cluster } from "../../cluster/Cluster.js";
@@ -442,6 +443,8 @@ export type WiFiNetworkDiagnosticsExtension<SF extends TypeFromPartialBitSchema<
     & { supportedFeatures: SF }
     & (SF extends { errorCounts: true } ? typeof ErrorCountsComponent : {})
     & (SF extends { packetCounts: true } ? typeof PacketCountsComponent : {});
+const ERRCNT = { errorCounts: true };
+const PKTCNT = { packetCounts: true };
 
 /**
  * This cluster supports all WiFiNetworkDiagnostics features. It may support illegal feature combinations.
@@ -450,7 +453,34 @@ export type WiFiNetworkDiagnosticsExtension<SF extends TypeFromPartialBitSchema<
  * legal per the Matter specification.
  */
 export const WiFiNetworkDiagnosticsComplete = Cluster({
-    ...WiFiNetworkDiagnosticsCluster,
-    attributes: { ...ErrorCountsComponent.attributes, ...PacketCountsComponent.attributes },
-    commands: { ...ErrorCountsComponent.commands }
+    id: WiFiNetworkDiagnosticsCluster.id,
+    name: WiFiNetworkDiagnosticsCluster.name,
+    revision: WiFiNetworkDiagnosticsCluster.revision,
+    features: WiFiNetworkDiagnosticsCluster.features,
+
+    attributes: {
+        ...WiFiNetworkDiagnosticsCluster.attributes,
+        beaconLostCount: AsConditional(ErrorCountsComponent.attributes.beaconLostCount, { mandatoryIf: [ERRCNT] }),
+        beaconRxCount: AsConditional(PacketCountsComponent.attributes.beaconRxCount, { mandatoryIf: [PKTCNT] }),
+        packetMulticastRxCount: AsConditional(
+            PacketCountsComponent.attributes.packetMulticastRxCount,
+            { mandatoryIf: [PKTCNT] }
+        ),
+        packetMulticastTxCount: AsConditional(
+            PacketCountsComponent.attributes.packetMulticastTxCount,
+            { mandatoryIf: [PKTCNT] }
+        ),
+        packetUnicastRxCount: AsConditional(
+            PacketCountsComponent.attributes.packetUnicastRxCount,
+            { mandatoryIf: [PKTCNT] }
+        ),
+        packetUnicastTxCount: AsConditional(
+            PacketCountsComponent.attributes.packetUnicastTxCount,
+            { mandatoryIf: [PKTCNT] }
+        ),
+        overrunCount: AsConditional(ErrorCountsComponent.attributes.overrunCount, { mandatoryIf: [ERRCNT] })
+    },
+
+    commands: { resetCounts: AsConditional(ErrorCountsComponent.commands.resetCounts, { mandatoryIf: [ERRCNT] }) },
+    events: WiFiNetworkDiagnosticsCluster.events
 });

--- a/packages/matter.js/src/cluster/definitions/WiFiNetworkDiagnosticsCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/WiFiNetworkDiagnosticsCluster.ts
@@ -7,7 +7,14 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { MatterCoreSpecificationV1_1 } from "../../spec/Specifications.js";
-import { BaseClusterComponent, ClusterComponent, ExtensibleCluster, validateFeatureSelection, extendCluster, ClusterForBaseCluster } from "../../cluster/ClusterFactory.js";
+import {
+    BaseClusterComponent,
+    ClusterComponent,
+    ExtensibleCluster,
+    validateFeatureSelection,
+    extendCluster,
+    ClusterForBaseCluster
+} from "../../cluster/ClusterFactory.js";
 import { BitFlag, BitFlags, TypeFromPartialBitSchema } from "../../schema/BitmapSchema.js";
 import { Attribute, OptionalAttribute, OptionalEvent, EventPriority, Command, TlvNoResponse, Cluster } from "../../cluster/Cluster.js";
 import { TlvByteString } from "../../tlv/TlvString.js";

--- a/packages/matter.js/src/cluster/definitions/WindowCoveringCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/WindowCoveringCluster.ts
@@ -7,9 +7,28 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { MatterApplicationClusterSpecificationV1_1 } from "../../spec/Specifications.js";
-import { BaseClusterComponent, ClusterComponent, ExtensibleCluster, validateFeatureSelection, extendCluster, preventCluster, ClusterForBaseCluster } from "../../cluster/ClusterFactory.js";
+import {
+    BaseClusterComponent,
+    ClusterComponent,
+    ExtensibleCluster,
+    validateFeatureSelection,
+    extendCluster,
+    preventCluster,
+    ClusterForBaseCluster
+} from "../../cluster/ClusterFactory.js";
 import { BitFlag, BitsFromPartial, BitFieldEnum, BitFlags, TypeFromPartialBitSchema } from "../../schema/BitmapSchema.js";
-import { FixedAttribute, Attribute, WritableAttribute, AccessLevel, OptionalAttribute, Command, TlvNoResponse, OptionalFixedAttribute, OptionalCommand, Cluster } from "../../cluster/Cluster.js";
+import {
+    FixedAttribute,
+    Attribute,
+    WritableAttribute,
+    AccessLevel,
+    OptionalAttribute,
+    Command,
+    TlvNoResponse,
+    OptionalFixedAttribute,
+    OptionalCommand,
+    Cluster
+} from "../../cluster/Cluster.js";
 import { TlvEnum, TlvUInt8, TlvBitmap, TlvUInt16, TlvPercent100ths, TlvPercent } from "../../tlv/TlvNumber.js";
 import { TlvNoArguments } from "../../tlv/TlvNoArguments.js";
 import { TlvNullable } from "../../tlv/TlvNullable.js";

--- a/packages/matter.js/src/cluster/server/GeneralCommissioningServer.ts
+++ b/packages/matter.js/src/cluster/server/GeneralCommissioningServer.ts
@@ -54,7 +54,9 @@ export const GeneralCommissioningClusterHandler: (options?: {
                     debugText: `Country code change not allowed: ${countryCode}`
                 };
             }
-            basicInformationCluster.setLocationAttribute(countryCode);
+            if (countryCode !== "XX") {
+                basicInformationCluster.setLocationAttribute(countryCode);
+            }
         }
 
         // Check and handle regulatory config for LocationCapability
@@ -67,7 +69,7 @@ export const GeneralCommissioningClusterHandler: (options?: {
                 validValues = [RegulatoryLocationType.Indoor];
                 break;
             case (RegulatoryLocationType.IndoorOutdoor):
-                validValues = [RegulatoryLocationType.Indoor, RegulatoryLocationType.Outdoor];
+                validValues = [RegulatoryLocationType.Indoor, RegulatoryLocationType.Outdoor, RegulatoryLocationType.IndoorOutdoor];
                 break;
             default:
                 return { errorCode: CommissioningError.ValueOutsideRange, debugText: `Invalid regulatory location: ${newRegulatoryConfig === RegulatoryLocationType.Indoor ? "Indoor" : "Outdoor"}` };

--- a/packages/matter.js/src/model/logic/cluster-variance/FeatureBitmap.ts
+++ b/packages/matter.js/src/model/logic/cluster-variance/FeatureBitmap.ts
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { camelize } from "../../../util/index.js";
+import { ClusterModel, DatatypeModel } from "../../models/index.js";
+
 export type FeatureFlags = string[];
 export type FeatureBitmap = { [name: string]: boolean };
 export type FeatureNames = { [key: string]: string };
@@ -23,6 +26,9 @@ export function FeatureBitmap(bitmap: FeatureBitmap | FeatureFlags = {}): Featur
  * 
  * If a name isn't present leaves the feature code intact.
  */
-export function translateBitmap(bitmap: FeatureBitmap, mapping: FeatureNames) {
-    return Object.fromEntries(Object.entries(bitmap).map(([k, v]) => [mapping[k] ?? k, v]));
+export function translateBitmap(bitmap: FeatureBitmap, cluster: ClusterModel) {
+    return Object.fromEntries(Object.entries(bitmap).map(([k, v]) => {
+        const feature = cluster.featureMap.get(DatatypeModel, k);
+        return [camelize(feature?.description ?? k, false), v];
+    }));
 }

--- a/packages/matter.js/src/model/logic/cluster-variance/VarianceCondition.ts
+++ b/packages/matter.js/src/model/logic/cluster-variance/VarianceCondition.ts
@@ -4,7 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { FeatureBitmap, FeatureNames, translateBitmap } from "./FeatureBitmap.js";
+import { ClusterModel } from "../../models/index.js";
+import { FeatureBitmap, translateBitmap } from "./FeatureBitmap.js";
 
 /**
  * The condition for supported patterns of complex variance on Cluster
@@ -19,7 +20,7 @@ export type VarianceCondition = {
 /**
  * Convert a VarianceCondition to an array of FeatureBitmaps.
  */
-export function conditionToBitmaps(condition: VarianceCondition, featureNames: FeatureNames = {}): FeatureBitmap[] {
+export function conditionToBitmaps(condition: VarianceCondition, cluster: ClusterModel): FeatureBitmap[] {
     const bitmap = {} as FeatureBitmap;
     if (condition.allOf) {
         for (const name of condition.allOf) {
@@ -31,12 +32,12 @@ export function conditionToBitmaps(condition: VarianceCondition, featureNames: F
     }
 
     if (!condition.anyOf) {
-        return [translateBitmap(bitmap, featureNames)];
+        return [translateBitmap(bitmap, cluster)];
     }
 
     const bitmaps = Array<typeof bitmap>();
     for (const name of condition.anyOf) {
-        bitmaps.push(translateBitmap({ ...bitmap, [name]: true }, featureNames));
+        bitmaps.push(translateBitmap({ ...bitmap, [name]: true }, cluster));
     }
 
     return bitmaps;

--- a/packages/matter.js/src/model/logic/index.ts
+++ b/packages/matter.js/src/model/logic/index.ts
@@ -11,3 +11,5 @@ import "./definition-validation/index.js";
 export * from "./ClusterVariance.js";
 export * from "./RecordValidator.js";
 export * from "./DefaultValue.js";
+export * from "./cluster-variance/FeatureBitmap.js";
+export * from "./cluster-variance/VarianceCondition.js";

--- a/tools/clusters/ConditionalElements.ts
+++ b/tools/clusters/ConditionalElements.ts
@@ -1,0 +1,78 @@
+/**
+ * @license
+ * Copyright 2022-2023 Project CHIP Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ClusterModel, ClusterVariance, Model, FeatureBitmap, VarianceCondition, translateBitmap } from "#matter.js/model/index.js";
+import { serialize } from "#util/string.js";
+
+export type ConditionBitmap = {
+    name: string,
+    bitmap: FeatureBitmap
+}
+
+export type ElementConditions = {
+    optionalIf?: string[],
+    mandatoryIf?: string[]
+};
+
+/**
+ * This class tracks conditions for conditional elements in the exhaustive
+ * cluster.
+ */
+export class ConditionalElements {
+    public definitions = {} as { [name: string]: FeatureBitmap };
+    private conditions = new Map<Model, ElementConditions>();
+
+    constructor(private cluster: ClusterModel, variance: ClusterVariance) {
+        for (const component of variance.components) {
+            if (!component.condition) {
+                continue;
+            }
+            const conditions = this.translateConditions(component.condition);
+            this.addElements(component.optional, "optionalIf", conditions);
+            this.addElements(component.mandatory, "mandatoryIf", conditions);
+        }
+    }
+
+    forModel(model: Model) {
+        return this.conditions.get(model) || {};
+    }
+
+    private translateConditions(condition: VarianceCondition) {
+        const bitmaps = Array<string>();
+        const not = condition.not ? { [condition.not]: false } : {};
+        if (condition.allOf) {
+            bitmaps.push(this.define({ ...FeatureBitmap(condition.allOf), ...not }));
+        }
+        if (condition.anyOf) {
+            for (const feature of condition.anyOf) {
+                bitmaps.push(this.define({ [feature]: true, ...not }));
+            }
+        }
+        return bitmaps;
+    }
+
+    private addElements(models: Model[], type: "optionalIf" | "mandatoryIf", bitmaps: string[]) {
+        models.forEach(model => {
+            let conditions = this.conditions.get(model);
+            if (conditions === undefined) {
+                this.conditions.set(model, { [type]: bitmaps });
+            } else {
+                const currentBitmaps = conditions[type];
+                if (currentBitmaps) {
+                    conditions[type] = [...currentBitmaps, ...bitmaps];
+                } else {
+                    conditions[type] = bitmaps;
+                }
+            }
+        });
+    }
+
+    private define(bitmap: FeatureBitmap) {
+        const name = serialize.asIs(Object.entries(bitmap).map(([k, v]) => v ? k : `NOT_${k}`).join("_"));
+        this.definitions[name] = translateBitmap(bitmap, this.cluster);
+        return name;
+    }
+}

--- a/tools/util/TsFile.ts
+++ b/tools/util/TsFile.ts
@@ -480,7 +480,7 @@ class ExpressionBlock extends NestedBlock {
             case ExpressionLayout.SingleLine:
                 {
                     let line = serializedEntries.map(e => e.trim()).join(", ");
-                    if (isArrayOrObject && !line.startsWith("[") && !line.startsWith("{")) {
+                    if (isArrayOrObject && !this.prefix.endsWith("[") && !line.startsWith("{")) {
                         line = ` ${line} `;
                     }
                     return `${linePrefix}${this.prefix}${line}${this.suffix}`;

--- a/tools/util/TsFile.ts
+++ b/tools/util/TsFile.ts
@@ -43,6 +43,7 @@ function mapSpec(xref?: Specification.CrossReference) {
 export abstract class Entry {
     private documentation?: Documentation;
     private docText?: string;
+    public shouldGroup: boolean = false;
 
     constructor(protected parentBlock: Block | undefined) { }
 
@@ -145,6 +146,10 @@ export class Block extends Entry {
     private addBefore?: Entry;
     private definedNames = new Set<string>();
 
+    protected indent: string = "";
+    protected prefix: string = "";
+    protected suffix: string = "";
+
     constructor(parentBlock: Block | undefined) {
         super(parentBlock);
     }
@@ -165,29 +170,52 @@ export class Block extends Entry {
         return this.entries[index];
     }
 
-    serialize(linePrefix: string) {
-        const pieces = new Array<string>();
-        for (let i = 0; i < this.length; i++) {
-            const entry = this.get(i);
-            const text = entry.toString(linePrefix);
-
-            if (entry instanceof Block && text === "") {
-                continue;
-            }
-
-            pieces.push(`${text}${this.delimiterAfter(i, text)}`);
-
-            if (i < this.length - 1) {
-                if (entry instanceof Block) {
-                    // Always have blank line after blocks with following content
-                    pieces.push("");
-                } else if (entry instanceof Atom && (this.get(i + 1).isDocumented)) {
-                    // Always have blank line after atoms followed by a comment
-                    pieces.push("");
-                }
+    override serialize(linePrefix = "") {
+        const childLinePrefix = `${linePrefix}${this.indent}`;
+        const serializedEntries = Array<string>();
+        for (const entry of this.entries) {
+            const text = entry.toString(childLinePrefix);
+            if (!(entry instanceof Block) || text !== "") {
+                serializedEntries.push(text);
             }
         }
-        return pieces.join("\n");
+        return this.layOutEntries(linePrefix, serializedEntries);
+    }
+
+    layOutEntries(linePrefix: string, serializedEntries: string[]) {
+        const parts = Array<string>();
+        if (this.prefix) {
+            parts.push(`${linePrefix}${this.prefix}`);
+        }
+
+        let needSpace = false;
+        for (let i = 0; i < serializedEntries.length; i++) {
+            // Add delimiter to entry if necessary
+            const entry = `${serializedEntries[i]}${this.delimiterAfter(i, serializedEntries[i])}`;
+
+            // Separate documented and large elements from their siblings
+            if (this.entries[i].isDocumented || (entry.split("\n").length > 5 && !this.entries[i].shouldGroup)) {
+                if (i) {
+                    parts.push("");
+                }
+                needSpace = true;
+            } else if (needSpace) {
+                parts.push("");
+                needSpace = false;
+            }
+
+            if (this.entries[i].isDocumented) {
+                needSpace = true;
+            }
+
+            // Add the entry
+            parts.push(entry);
+        }
+
+        if (this.suffix) {
+            parts.push(`${linePrefix}${this.suffix}`);
+        }
+        return parts.join("\n");
     }
 
     /** Access the (required) parent */
@@ -348,56 +376,11 @@ abstract class NestedBlock extends Block {
     /** Add a TsDoc style comment */
     doc?: string | Documentation;
 
-    constructor(parent: Block | undefined, protected prefix: string, protected suffix: string) {
+    constructor(parent: Block | undefined, prefix: string, suffix: string) {
         super(parent);
-    }
-
-    override serialize(linePrefix = "") {
-        const childLinePrefix = `${linePrefix}${INDENT}`;
-        const serializedEntries = Array<string>();
-        for (const entry of this.entries) {
-            const text = entry.toString(childLinePrefix);
-            if (!(entry instanceof Block) || text !== "") {
-                serializedEntries.push(text);
-            }
-        }
-        return this.layOutEntries(linePrefix, serializedEntries);
-    }
-
-    layOutEntries(linePrefix: string, serializedEntries: string[]) {
-        const parts = Array<string>();
-        if (this.prefix) {
-            parts.push(`${linePrefix}${this.prefix}`);
-        }
-
-        let needSpace = false;
-        for (let i = 0; i < serializedEntries.length; i++) {
-            // Add delimiter to entry if necessary
-            const entry = `${serializedEntries[i]}${this.delimiterAfter(i, serializedEntries[i])}`;
-
-            // Separate documented and large elements from their siblings
-            if (this.entries[i].isDocumented || entry.split("\n").length > 5) {
-                if (i) {
-                    parts.push("");
-                }
-                needSpace = true;
-            } else if (needSpace) {
-                parts.push("");
-                needSpace = false;
-            }
-
-            if (this.entries[i].isDocumented) {
-                needSpace = true;
-            }
-
-            // Add the entry
-            parts.push(entry);
-        }
-
-        if (this.suffix) {
-            parts.push(`${linePrefix}${this.suffix}`);
-        }
-        return parts.join("\n");
+        this.indent = INDENT;
+        this.prefix = prefix;
+        this.suffix = suffix;
     }
 }
 
@@ -553,10 +536,11 @@ export class TsFile extends Block {
     save() {
         if (this.imports.size) {
             const importBlock = this.header.section();
-            importBlock.blank();
             this.imports.forEach((symbols, name) => {
                 if (symbols.length) {
-                    importBlock.atom(`import { ${symbols.join(", ")} } from "${name}.js"`);
+                    const imp = importBlock.expressions("import {", `} from "${name}.js"`);
+                    imp.shouldGroup = true;
+                    symbols.forEach(s => imp.atom(s));
                 } else {
                     importBlock.atom(`import "${name}.js"`);
                 }


### PR DESCRIPTION
This modifies the "complete" clusters (clusters that have all elements regardless of feature selection) to use the "optionalIf" and "mandatoryIf" constructs for runtime validation.

Also includes a few other modest changes.  See individual commits.