### PR TITLE
Enhance ClusterClient logging

### DIFF
--- a/packages/matter.js/src/cluster/ClusterHelper.ts
+++ b/packages/matter.js/src/cluster/ClusterHelper.ts
@@ -31,6 +31,9 @@ import { TemperatureMeasurementCluster } from "./TemperatureMeasurementCluster.j
 import { RelativeHumidityCluster, SoilMoistureMeasurementCluster, LeafWetnessMeasurementCluster } from "./WaterContentMeasurementCluster.js";
 import { GeneralDiagnosticsCluster } from "./GeneralDiagnosticsCluster.js";
 import { GroupKeyManagementCluster } from "./GroupKeyManagementCluster.js";
+import { NodeId } from "../datatype/NodeId.js";
+import { TlvAttributePath, TlvCommandPath, TlvEventPath } from "../protocol/interaction/InteractionProtocol.js";
+import { TypeFromSchema } from "../tlv/TlvSchema.js";
 
 export const AllClustersMap: { [key: Cluster<any, any, any, any, any>["id"]]: Cluster<any, any, any, any, any> } = {
     [AccessControlCluster.id]: AccessControlCluster,
@@ -70,7 +73,17 @@ interface CachedAttributeInfo {
     attribute: Attribute<any, any>;
     name: string;
 }
+interface CachedEventInfo {
+    event: Attribute<any, any>;
+    name: string;
+}
+interface CachedCommandInfo {
+    command: Attribute<any, any>;
+    name: string;
+}
 const clusterAttributeCache = new Map<number, Map<number, CachedAttributeInfo>>();
+const clusterEventCache = new Map<number, Map<number, CachedEventInfo>>();
+const clusterCommandCache = new Map<number, Map<number, CachedCommandInfo>>();
 
 export function getClusterById(clusterId: number): Cluster<any, any, any, any, any> {
     return AllClustersMap[clusterId];
@@ -96,4 +109,106 @@ export function getClusterAttributeById(clusterDef: Cluster<any, any, any, any, 
         return undefined;
     }
     return attributeMap.get(attributeId);
+}
+
+export function getClusterEventById(clusterDef: Cluster<any, any, any, any, any>, eventId: number): CachedEventInfo | undefined {
+    if (!clusterEventCache.has(clusterDef.id)) {
+        const eventMap = new Map<number, CachedEventInfo>();
+
+        const { events } = clusterDef;
+
+        // Add accessors
+        for (const eventName in events) {
+            const event = events[eventName];
+            eventMap.set(event.id, { event, name: eventName });
+        }
+
+        clusterEventCache.set(clusterDef.id, eventMap);
+        return eventMap.get(eventId);
+    }
+    const eventMap = clusterEventCache.get(clusterDef.id);
+    if (eventMap === undefined) {
+        return undefined;
+    }
+    return eventMap.get(eventId);
+}
+
+export function getClusterCommandById(clusterDef: Cluster<any, any, any, any, any>, commandId: number): CachedCommandInfo | undefined {
+    if (!clusterCommandCache.has(clusterDef.id)) {
+        const commandMap = new Map<number, CachedCommandInfo>();
+
+        const { commands } = clusterDef;
+
+        // Add accessors
+        for (const commandName in commands) {
+            const command = commands[commandName];
+            commandMap.set(command.requestId, { command, name: commandName });
+        }
+
+        clusterCommandCache.set(clusterDef.id, commandMap);
+        return commandMap.get(commandId);
+    }
+    const commandMap = clusterCommandCache.get(clusterDef.id);
+    if (commandMap === undefined) {
+        return undefined;
+    }
+    return commandMap.get(commandId);
+}
+
+function toHex(value: number | bigint | undefined) {
+    return value === undefined ? "*" : `0x${value.toString(16)}`;
+}
+
+function resolveEndpointClusterName(nodeId: NodeId | undefined, endpointId: number | undefined, clusterId: number | undefined) {
+    let elementName = nodeId === undefined ? "" : `${toHex(nodeId.id)}/`;
+    if (endpointId === undefined) {
+        elementName += "*";
+    } else {
+        elementName += `${toHex(endpointId)}`;
+    }
+
+    if (clusterId === undefined) {
+        return `${elementName}/*`;
+    }
+    const cluster = getClusterById(clusterId);
+    if (cluster === undefined) {
+        return `${elementName}/unknown(${toHex(clusterId)})`;
+    }
+    return `${elementName}/${cluster.name}(${toHex(clusterId)})`;
+}
+
+export function resolveAttributeName({ nodeId, endpointId, clusterId, attributeId }: TypeFromSchema<typeof TlvAttributePath>) {
+    const endpointClusterName = resolveEndpointClusterName(nodeId, endpointId, clusterId);
+    if (endpointId === undefined || clusterId === undefined || attributeId === undefined) {
+        return `${endpointClusterName}/${toHex(attributeId)}`;
+    }
+    const attribute = getClusterAttributeById(getClusterById(clusterId), attributeId);
+    if (attribute === undefined) {
+        return `${endpointClusterName}/unknown(${toHex(attributeId)})`;
+    }
+    return `${endpointClusterName}/${attribute.name}(${toHex(attributeId)})`;
+}
+
+export function resolveEventName({ nodeId, endpointId, clusterId, eventId }: TypeFromSchema<typeof TlvEventPath>) {
+    const endpointClusterName = resolveEndpointClusterName(nodeId, endpointId, clusterId);
+    if (endpointId === undefined || clusterId === undefined || eventId === undefined) {
+        return `${endpointClusterName}/${toHex(eventId)}`;
+    }
+    const event = getClusterEventById(getClusterById(clusterId), eventId);
+    if (event === undefined) {
+        return `${endpointClusterName}/unknown(${toHex(eventId)})`;
+    }
+    return `${endpointClusterName}/${event.name}(${toHex(eventId)})`;
+}
+
+export function resolveCommandName({ endpointId, clusterId, commandId }: TypeFromSchema<typeof TlvCommandPath>) {
+    const endpointClusterName = resolveEndpointClusterName(undefined, endpointId, clusterId);
+    if (endpointId === undefined || clusterId === undefined || commandId === undefined) {
+        return `${endpointClusterName}/${toHex(commandId)}`;
+    }
+    const command = getClusterCommandById(getClusterById(clusterId), commandId);
+    if (command === undefined) {
+        return `${endpointClusterName}/unknown(${toHex(commandId)})`;
+    }
+    return `${endpointClusterName}/${command.name}(${toHex(commandId)})`;
 }

--- a/packages/matter.js/src/protocol/interaction/InteractionMessenger.ts
+++ b/packages/matter.js/src/protocol/interaction/InteractionMessenger.ts
@@ -95,6 +95,10 @@ class InteractionMessenger<ContextT> {
         const { status } = TlvStatusResponse.decode(payload);
         if (status !== StatusCode.Success) throw new StatusResponseError(`Received error status: ${status}`, status);
     }
+
+    getExchangeChannelName() {
+        return this.exchange.channel.getName();
+    }
 }
 
 export class InteractionServerMessenger extends InteractionMessenger<MatterDevice> {


### PR DESCRIPTION
This PR adds some new resolveName methods and use them in the AllClusters-Context for logging in ClusterClient cases to have more visibility in Controller logics