### PR TITLE
Improve line wrapping

### DIFF
--- a/packages/matter.js/src/cluster/definitions/ActionsCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/ActionsCluster.ts
@@ -6,7 +6,15 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import { Cluster as CreateCluster, Attribute, OptionalAttribute, OptionalCommand, TlvNoResponse, Event, EventPriority } from "../../cluster/Cluster.js";
+import {
+    Cluster as CreateCluster,
+    Attribute,
+    OptionalAttribute,
+    OptionalCommand,
+    TlvNoResponse,
+    Event,
+    EventPriority
+} from "../../cluster/Cluster.js";
 import { MatterCoreSpecificationV1_1 } from "../../spec/Specifications.js";
 import { TlvArray } from "../../tlv/TlvArray.js";
 import { TlvObject, TlvField, TlvOptionalField } from "../../tlv/TlvObject.js";
@@ -628,7 +636,12 @@ export namespace Actions {
              *
              * @see {@link MatterCoreSpecificationV1_1} § 9.14.6.2
              */
-            instantActionWithTransition: OptionalCommand(0x1, TlvInstantActionWithTransitionRequest, 0x1, TlvNoResponse),
+            instantActionWithTransition: OptionalCommand(
+                0x1,
+                TlvInstantActionWithTransitionRequest,
+                0x1,
+                TlvNoResponse
+            ),
 
             /**
              * This command triggers the commencement of an action on the involved endpoints. Afterwards, the action’s

--- a/packages/matter.js/src/cluster/definitions/ApplicationBasicCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/ApplicationBasicCluster.ts
@@ -6,7 +6,13 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import { Cluster as CreateCluster, OptionalFixedAttribute, FixedAttribute, Attribute, AccessLevel } from "../../cluster/Cluster.js";
+import {
+    Cluster as CreateCluster,
+    OptionalFixedAttribute,
+    FixedAttribute,
+    Attribute,
+    AccessLevel
+} from "../../cluster/Cluster.js";
 import { MatterApplicationClusterSpecificationV1_1 } from "../../spec/Specifications.js";
 import { TlvString } from "../../tlv/TlvString.js";
 import { TlvVendorId, VendorId } from "../../datatype/VendorId.js";

--- a/packages/matter.js/src/cluster/definitions/BallastConfigurationCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/BallastConfigurationCluster.ts
@@ -6,7 +6,14 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import { Cluster as CreateCluster, Attribute, OptionalAttribute, WritableAttribute, AccessLevel, OptionalWritableAttribute } from "../../cluster/Cluster.js";
+import {
+    Cluster as CreateCluster,
+    Attribute,
+    OptionalAttribute,
+    WritableAttribute,
+    AccessLevel,
+    OptionalWritableAttribute
+} from "../../cluster/Cluster.js";
 import { MatterApplicationClusterSpecificationV1_1 } from "../../spec/Specifications.js";
 import { TlvUInt8, TlvBitmap, TlvUInt24 } from "../../tlv/TlvNumber.js";
 import { BitFlag } from "../../schema/BitmapSchema.js";
@@ -103,7 +110,11 @@ export namespace BallastConfiguration {
              *
              * @see {@link MatterApplicationClusterSpecificationV1_1} § 3.3.7.3
              */
-            intrinsicBallastFactor: OptionalWritableAttribute(0x14, TlvNullable(TlvUInt8), { writeAcl: AccessLevel.Manage }),
+            intrinsicBallastFactor: OptionalWritableAttribute(
+                0x14,
+                TlvNullable(TlvUInt8),
+                { writeAcl: AccessLevel.Manage }
+            ),
 
             /**
              * The BallastFactorAdjustment attribute specifies the multiplication factor, as a percentage, to be

--- a/packages/matter.js/src/cluster/definitions/BarrierControlCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/BarrierControlCluster.ts
@@ -6,7 +6,13 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import { Cluster as CreateCluster, Attribute, OptionalWritableAttribute, Command, TlvNoResponse } from "../../cluster/Cluster.js";
+import {
+    Cluster as CreateCluster,
+    Attribute,
+    OptionalWritableAttribute,
+    Command,
+    TlvNoResponse
+} from "../../cluster/Cluster.js";
 import { TlvUInt8, TlvUInt16 } from "../../tlv/TlvNumber.js";
 import { TlvObject, TlvField } from "../../tlv/TlvObject.js";
 import { TlvNoArguments } from "../../tlv/TlvNoArguments.js";

--- a/packages/matter.js/src/cluster/definitions/BinaryInputBasicCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/BinaryInputBasicCluster.ts
@@ -6,7 +6,13 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import { Cluster as CreateCluster, OptionalWritableAttribute, WritableAttribute, OptionalAttribute, Attribute } from "../../cluster/Cluster.js";
+import {
+    Cluster as CreateCluster,
+    OptionalWritableAttribute,
+    WritableAttribute,
+    OptionalAttribute,
+    Attribute
+} from "../../cluster/Cluster.js";
 import { TlvString } from "../../tlv/TlvString.js";
 import { TlvBoolean } from "../../tlv/TlvBoolean.js";
 import { TlvUInt8, TlvUInt32 } from "../../tlv/TlvNumber.js";

--- a/packages/matter.js/src/cluster/definitions/ChannelCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/ChannelCluster.ts
@@ -17,7 +17,13 @@ import {
     AsConditional
 } from "../../cluster/ClusterFactory.js";
 import { BitFlag, BitFlags, TypeFromPartialBitSchema } from "../../schema/BitmapSchema.js";
-import { OptionalAttribute, Command, TlvNoResponse, Attribute, Cluster as CreateCluster } from "../../cluster/Cluster.js";
+import {
+    OptionalAttribute,
+    Command,
+    TlvNoResponse,
+    Attribute,
+    Cluster as CreateCluster
+} from "../../cluster/Cluster.js";
 import { TlvObject, TlvField, TlvOptionalField } from "../../tlv/TlvObject.js";
 import { TlvUInt16, TlvInt16, TlvEnum } from "../../tlv/TlvNumber.js";
 import { TlvString, TlvByteString } from "../../tlv/TlvString.js";
@@ -383,9 +389,13 @@ export namespace Channel {
             channelList: AsConditional(ChannelListComponent.attributes.channelList, { mandatoryIf: [CL] }),
             lineup: AsConditional(LineupInfoComponent.attributes.lineup, { mandatoryIf: [LI] })
         },
+
         commands: {
             ...Cluster.commands,
-            changeChannel: AsConditional(ChannelListOrLineupInfoComponent.commands.changeChannel, { mandatoryIf: [CL, LI] })
+            changeChannel: AsConditional(
+                ChannelListOrLineupInfoComponent.commands.changeChannel,
+                { mandatoryIf: [CL, LI] }
+            )
         }
     });
 }

--- a/packages/matter.js/src/cluster/definitions/ColorControlCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/ColorControlCluster.ts
@@ -893,7 +893,11 @@ export namespace ColorControl {
              *
              * @see {@link MatterApplicationClusterSpecificationV1_1} § 3.2.7.9
              */
-            colorMode: Attribute(0x8, TlvEnum<ColorMode>(), { persistent: true, default: ColorMode.CurrentXAndCurrentY }),
+            colorMode: Attribute(
+                0x8,
+                TlvEnum<ColorMode>(),
+                { persistent: true, default: ColorMode.CurrentXAndCurrentY }
+            ),
 
             /**
              * The Options attribute is meant to be changed only during commissioning. The Options attribute is a
@@ -1050,7 +1054,11 @@ export namespace ColorControl {
              *
              * @see {@link MatterApplicationClusterSpecificationV1_1} § 3.2.10.1
              */
-            whitePointX: OptionalWritableAttribute(0x30, TlvUInt16.bound({ max: 65279 }), { writeAcl: AccessLevel.Manage }),
+            whitePointX: OptionalWritableAttribute(
+                0x30,
+                TlvUInt16.bound({ max: 65279 }),
+                { writeAcl: AccessLevel.Manage }
+            ),
 
             /**
              * The WhitePointY attribute contains the normalized chromaticity value y, as defined in the CIE xyY Color
@@ -1061,7 +1069,11 @@ export namespace ColorControl {
              *
              * @see {@link MatterApplicationClusterSpecificationV1_1} § 3.2.10.2
              */
-            whitePointY: OptionalWritableAttribute(0x31, TlvUInt16.bound({ max: 65279 }), { writeAcl: AccessLevel.Manage }),
+            whitePointY: OptionalWritableAttribute(
+                0x31,
+                TlvUInt16.bound({ max: 65279 }),
+                { writeAcl: AccessLevel.Manage }
+            ),
 
             /**
              * The ColorPointRX attribute contains the normalized chromaticity value x, as defined in the CIE xyY Color
@@ -1072,7 +1084,11 @@ export namespace ColorControl {
              *
              * @see {@link MatterApplicationClusterSpecificationV1_1} § 3.2.10.3
              */
-            colorPointRx: OptionalWritableAttribute(0x32, TlvUInt16.bound({ max: 65279 }), { writeAcl: AccessLevel.Manage }),
+            colorPointRx: OptionalWritableAttribute(
+                0x32,
+                TlvUInt16.bound({ max: 65279 }),
+                { writeAcl: AccessLevel.Manage }
+            ),
 
             /**
              * The ColorPointRY attribute contains the normalized chromaticity value y, as defined in the CIE xyY Color
@@ -1083,7 +1099,11 @@ export namespace ColorControl {
              *
              * @see {@link MatterApplicationClusterSpecificationV1_1} § 3.2.10.4
              */
-            colorPointRy: OptionalWritableAttribute(0x33, TlvUInt16.bound({ max: 65279 }), { writeAcl: AccessLevel.Manage }),
+            colorPointRy: OptionalWritableAttribute(
+                0x33,
+                TlvUInt16.bound({ max: 65279 }),
+                { writeAcl: AccessLevel.Manage }
+            ),
 
             /**
              * The ColorPointRIntensity attribute contains a representation of the relative intensity of the red color
@@ -1095,37 +1115,65 @@ export namespace ColorControl {
              *
              * @see {@link MatterApplicationClusterSpecificationV1_1} § 3.2.10.5
              */
-            colorPointRIntensity: OptionalWritableAttribute(0x34, TlvNullable(TlvUInt8), { writeAcl: AccessLevel.Manage }),
+            colorPointRIntensity: OptionalWritableAttribute(
+                0x34,
+                TlvNullable(TlvUInt8),
+                { writeAcl: AccessLevel.Manage }
+            ),
 
             /**
              * @see {@link MatterApplicationClusterSpecificationV1_1} § 3.2.10
              */
-            colorPointGx: OptionalWritableAttribute(0x36, TlvUInt16.bound({ max: 65279 }), { writeAcl: AccessLevel.Manage }),
+            colorPointGx: OptionalWritableAttribute(
+                0x36,
+                TlvUInt16.bound({ max: 65279 }),
+                { writeAcl: AccessLevel.Manage }
+            ),
 
             /**
              * @see {@link MatterApplicationClusterSpecificationV1_1} § 3.2.10
              */
-            colorPointGy: OptionalWritableAttribute(0x37, TlvUInt16.bound({ max: 65279 }), { writeAcl: AccessLevel.Manage }),
+            colorPointGy: OptionalWritableAttribute(
+                0x37,
+                TlvUInt16.bound({ max: 65279 }),
+                { writeAcl: AccessLevel.Manage }
+            ),
 
             /**
              * @see {@link MatterApplicationClusterSpecificationV1_1} § 3.2.10
              */
-            colorPointGIntensity: OptionalWritableAttribute(0x38, TlvNullable(TlvUInt8), { writeAcl: AccessLevel.Manage }),
+            colorPointGIntensity: OptionalWritableAttribute(
+                0x38,
+                TlvNullable(TlvUInt8),
+                { writeAcl: AccessLevel.Manage }
+            ),
 
             /**
              * @see {@link MatterApplicationClusterSpecificationV1_1} § 3.2.10
              */
-            colorPointBx: OptionalWritableAttribute(0x3a, TlvUInt16.bound({ max: 65279 }), { writeAcl: AccessLevel.Manage }),
+            colorPointBx: OptionalWritableAttribute(
+                0x3a,
+                TlvUInt16.bound({ max: 65279 }),
+                { writeAcl: AccessLevel.Manage }
+            ),
 
             /**
              * @see {@link MatterApplicationClusterSpecificationV1_1} § 3.2.10
              */
-            colorPointBy: OptionalWritableAttribute(0x3b, TlvUInt16.bound({ max: 65279 }), { writeAcl: AccessLevel.Manage }),
+            colorPointBy: OptionalWritableAttribute(
+                0x3b,
+                TlvUInt16.bound({ max: 65279 }),
+                { writeAcl: AccessLevel.Manage }
+            ),
 
             /**
              * @see {@link MatterApplicationClusterSpecificationV1_1} § 3.2.10
              */
-            colorPointBIntensity: OptionalWritableAttribute(0x3c, TlvNullable(TlvUInt8), { writeAcl: AccessLevel.Manage }),
+            colorPointBIntensity: OptionalWritableAttribute(
+                0x3c,
+                TlvNullable(TlvUInt8),
+                { writeAcl: AccessLevel.Manage }
+            ),
 
             /**
              * The EnhancedColorMode attribute specifies which attributes are currently determining the color of the
@@ -1184,7 +1232,11 @@ export namespace ColorControl {
              *
              * @see {@link MatterApplicationClusterSpecificationV1_1} § 3.2.7.2
              */
-            currentSaturation: Attribute(0x1, TlvUInt8.bound({ max: 254 }), { scene: true, persistent: true, default: 0 })
+            currentSaturation: Attribute(
+                0x1,
+                TlvUInt8.bound({ max: 254 }),
+                { scene: true, persistent: true, default: 0 }
+            )
         },
 
         commands: {
@@ -1239,7 +1291,11 @@ export namespace ColorControl {
              *
              * @see {@link MatterApplicationClusterSpecificationV1_1} § 3.2.7.4
              */
-            currentX: Attribute(0x3, TlvUInt16.bound({ max: 65279 }), { scene: true, persistent: true, default: 24939 }),
+            currentX: Attribute(
+                0x3,
+                TlvUInt16.bound({ max: 65279 }),
+                { scene: true, persistent: true, default: 24939 }
+            ),
 
             /**
              * The CurrentY attribute contains the current value of the normalized chromaticity value y, as defined in
@@ -1250,7 +1306,11 @@ export namespace ColorControl {
              *
              * @see {@link MatterApplicationClusterSpecificationV1_1} § 3.2.7.5
              */
-            currentY: Attribute(0x4, TlvUInt16.bound({ max: 65279 }), { scene: true, persistent: true, default: 24701 })
+            currentY: Attribute(
+                0x4,
+                TlvUInt16.bound({ max: 65279 }),
+                { scene: true, persistent: true, default: 24701 }
+            )
         },
 
         commands: {
@@ -1428,7 +1488,12 @@ export namespace ColorControl {
              *
              * @see {@link MatterApplicationClusterSpecificationV1_1} § 3.2.11.18
              */
-            enhancedMoveToHueAndSaturation: Command(0x43, TlvEnhancedMoveToHueAndSaturationRequest, 0x43, TlvNoResponse)
+            enhancedMoveToHueAndSaturation: Command(
+                0x43,
+                TlvEnhancedMoveToHueAndSaturationRequest,
+                0x43,
+                TlvNoResponse
+            )
         }
     });
 
@@ -1582,14 +1647,20 @@ export namespace ColorControl {
         attributes: {
             ...Cluster.attributes,
             currentHue: AsConditional(HueSaturationComponent.attributes.currentHue, { mandatoryIf: [HS] }),
-            currentSaturation: AsConditional(HueSaturationComponent.attributes.currentSaturation, { mandatoryIf: [HS] }),
+            currentSaturation: AsConditional(
+                HueSaturationComponent.attributes.currentSaturation,
+                { mandatoryIf: [HS] }
+            ),
             currentX: AsConditional(XyComponent.attributes.currentX, { mandatoryIf: [XY] }),
             currentY: AsConditional(XyComponent.attributes.currentY, { mandatoryIf: [XY] }),
             colorTemperatureMireds: AsConditional(
                 ColorTemperatureComponent.attributes.colorTemperatureMireds,
                 { mandatoryIf: [CT] }
             ),
-            enhancedCurrentHue: AsConditional(EnhancedHueComponent.attributes.enhancedCurrentHue, { mandatoryIf: [EHUE] }),
+            enhancedCurrentHue: AsConditional(
+                EnhancedHueComponent.attributes.enhancedCurrentHue,
+                { mandatoryIf: [EHUE] }
+            ),
             colorLoopActive: AsConditional(ColorLoopComponent.attributes.colorLoopActive, { mandatoryIf: [CL] }),
             colorLoopDirection: AsConditional(ColorLoopComponent.attributes.colorLoopDirection, { mandatoryIf: [CL] }),
             colorLoopTime: AsConditional(ColorLoopComponent.attributes.colorLoopTime, { mandatoryIf: [CL] }),

--- a/packages/matter.js/src/cluster/definitions/DoorLockCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/DoorLockCluster.ts
@@ -1424,7 +1424,11 @@ export namespace DoorLock {
              *
              * @see {@link MatterApplicationClusterSpecificationV1_1} § 5.2.3.22
              */
-            language: OptionalWritableAttribute(0x21, TlvString.bound({ maxLength: 3 }), { writeAcl: AccessLevel.Manage }),
+            language: OptionalWritableAttribute(
+                0x21,
+                TlvString.bound({ maxLength: 3 }),
+                { writeAcl: AccessLevel.Manage }
+            ),
 
             /**
              * The settings for the LED support three different modes
@@ -1997,7 +2001,11 @@ export namespace DoorLock {
              *
              * @see {@link MatterApplicationClusterSpecificationV1_1} § 5.2.3.34
              */
-            wrongCodeEntryLimit: WritableAttribute(0x30, TlvUInt8.bound({ min: 1 }), { writeAcl: AccessLevel.Administer }),
+            wrongCodeEntryLimit: WritableAttribute(
+                0x30,
+                TlvUInt8.bound({ min: 1 }),
+                { writeAcl: AccessLevel.Administer }
+            ),
 
             /**
              * The number of seconds that the lock shuts down following wrong code entry. Valid range is 1-255 seconds.
@@ -2307,7 +2315,11 @@ export namespace DoorLock {
             extendCluster(cluster, CredentialOverTheAirAccessComponent, { credentialOverTheAirAccess: true });
             extendCluster(cluster, NotificationAndPinCredentialComponent, { notification: true, pinCredential: true });
             extendCluster(cluster, NotificationComponent, { notification: true });
-            extendCluster(cluster, NotificationAndRfidCredentialComponent, { notification: true, rfidCredential: true });
+            extendCluster(
+                cluster,
+                NotificationAndRfidCredentialComponent,
+                { notification: true, rfidCredential: true }
+            );
             extendCluster(cluster, PinCredentialNotUserComponent, { pinCredential: true, user: false });
             extendCluster(
                 cluster,
@@ -2387,7 +2399,10 @@ export namespace DoorLock {
             ...Cluster.attributes,
             doorState: AsConditional(DoorPositionSensorComponent.attributes.doorState, { mandatoryIf: [DPS] }),
             doorOpenEvents: AsConditional(DoorPositionSensorComponent.attributes.doorOpenEvents, { optionalIf: [DPS] }),
-            doorClosedEvents: AsConditional(DoorPositionSensorComponent.attributes.doorClosedEvents, { optionalIf: [DPS] }),
+            doorClosedEvents: AsConditional(
+                DoorPositionSensorComponent.attributes.doorClosedEvents,
+                { optionalIf: [DPS] }
+            ),
             openPeriod: AsConditional(DoorPositionSensorComponent.attributes.openPeriod, { optionalIf: [DPS] }),
             numberOfLogRecordsSupported: AsConditional(
                 LoggingComponent.attributes.numberOfLogRecordsSupported,
@@ -2419,9 +2434,18 @@ export namespace DoorLock {
             ),
             maxPinCodeLength: AsConditional(PinCredentialComponent.attributes.maxPinCodeLength, { mandatoryIf: [PIN] }),
             minPinCodeLength: AsConditional(PinCredentialComponent.attributes.minPinCodeLength, { mandatoryIf: [PIN] }),
-            maxRfidCodeLength: AsConditional(RfidCredentialComponent.attributes.maxRfidCodeLength, { mandatoryIf: [RID] }),
-            minRfidCodeLength: AsConditional(RfidCredentialComponent.attributes.minRfidCodeLength, { mandatoryIf: [RID] }),
-            credentialRulesSupport: AsConditional(UserComponent.attributes.credentialRulesSupport, { mandatoryIf: [USR] }),
+            maxRfidCodeLength: AsConditional(
+                RfidCredentialComponent.attributes.maxRfidCodeLength,
+                { mandatoryIf: [RID] }
+            ),
+            minRfidCodeLength: AsConditional(
+                RfidCredentialComponent.attributes.minRfidCodeLength,
+                { mandatoryIf: [RID] }
+            ),
+            credentialRulesSupport: AsConditional(
+                UserComponent.attributes.credentialRulesSupport,
+                { mandatoryIf: [USR] }
+            ),
             numberOfCredentialsSupportedPerUser: AsConditional(
                 UserComponent.attributes.numberOfCredentialsSupportedPerUser,
                 { mandatoryIf: [USR] }
@@ -2435,7 +2459,10 @@ export namespace DoorLock {
                 PinCredentialOrRfidCredentialComponent.attributes.userCodeTemporaryDisableTime,
                 { mandatoryIf: [PIN, RID] }
             ),
-            sendPinOverTheAir: AsConditional(PinCredentialComponent.attributes.sendPinOverTheAir, { optionalIf: [PIN] }),
+            sendPinOverTheAir: AsConditional(
+                PinCredentialComponent.attributes.sendPinOverTheAir,
+                { optionalIf: [PIN] }
+            ),
             requirePiNforRemoteOperation: AsConditional(
                 CredentialOverTheAirAccessComponent.attributes.requirePiNforRemoteOperation,
                 { optionalIf: [COTA] }
@@ -2474,9 +2501,18 @@ export namespace DoorLock {
         commands: {
             ...Cluster.commands,
             getLogRecord: AsConditional(LoggingComponent.commands.getLogRecord, { mandatoryIf: [LOG] }),
-            setPinCode: AsConditional(PinCredentialNotUserComponent.commands.setPinCode, { mandatoryIf: [PIN_NOT_USR] }),
-            getPinCode: AsConditional(PinCredentialNotUserComponent.commands.getPinCode, { mandatoryIf: [PIN_NOT_USR] }),
-            clearPinCode: AsConditional(PinCredentialNotUserComponent.commands.clearPinCode, { mandatoryIf: [PIN_NOT_USR] }),
+            setPinCode: AsConditional(
+                PinCredentialNotUserComponent.commands.setPinCode,
+                { mandatoryIf: [PIN_NOT_USR] }
+            ),
+            getPinCode: AsConditional(
+                PinCredentialNotUserComponent.commands.getPinCode,
+                { mandatoryIf: [PIN_NOT_USR] }
+            ),
+            clearPinCode: AsConditional(
+                PinCredentialNotUserComponent.commands.clearPinCode,
+                { mandatoryIf: [PIN_NOT_USR] }
+            ),
             clearAllPinCodes: AsConditional(
                 PinCredentialNotUserComponent.commands.clearAllPinCodes,
                 { mandatoryIf: [PIN_NOT_USR] }
@@ -2533,8 +2569,14 @@ export namespace DoorLock {
                 PinCredentialAndRfidCredentialAndFingerCredentialsNotUserComponent.commands.getUserType,
                 { optionalIf: [PIN_RID_FGP_NOT_USR] }
             ),
-            setRfidCode: AsConditional(RfidCredentialNotUserComponent.commands.setRfidCode, { mandatoryIf: [RID_NOT_USR] }),
-            getRfidCode: AsConditional(RfidCredentialNotUserComponent.commands.getRfidCode, { mandatoryIf: [RID_NOT_USR] }),
+            setRfidCode: AsConditional(
+                RfidCredentialNotUserComponent.commands.setRfidCode,
+                { mandatoryIf: [RID_NOT_USR] }
+            ),
+            getRfidCode: AsConditional(
+                RfidCredentialNotUserComponent.commands.getRfidCode,
+                { mandatoryIf: [RID_NOT_USR] }
+            ),
             clearRfidCode: AsConditional(
                 RfidCredentialNotUserComponent.commands.clearRfidCode,
                 { mandatoryIf: [RID_NOT_USR] }

--- a/packages/matter.js/src/cluster/definitions/ElectricalMeasurementCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/ElectricalMeasurementCluster.ts
@@ -6,7 +6,13 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import { Cluster as CreateCluster, OptionalAttribute, OptionalWritableAttribute, OptionalCommand, TlvNoResponse } from "../../cluster/Cluster.js";
+import {
+    Cluster as CreateCluster,
+    OptionalAttribute,
+    OptionalWritableAttribute,
+    OptionalCommand,
+    TlvNoResponse
+} from "../../cluster/Cluster.js";
 import { TlvUInt32, TlvInt16, TlvUInt16, TlvInt32, TlvInt8, TlvUInt8 } from "../../tlv/TlvNumber.js";
 import { TlvNoArguments } from "../../tlv/TlvNoArguments.js";
 import { TlvObject, TlvField } from "../../tlv/TlvObject.js";
@@ -166,7 +172,13 @@ export namespace ElectricalMeasurement {
 
         commands: {
             getProfileInfoCommand: OptionalCommand(0x0, TlvNoArguments, 0x0, TlvNoResponse),
-            getMeasurementProfileCommand: OptionalCommand(0x1, TlvGetMeasurementProfileCommandRequest, 0x1, TlvNoResponse)
+
+            getMeasurementProfileCommand: OptionalCommand(
+                0x1,
+                TlvGetMeasurementProfileCommandRequest,
+                0x1,
+                TlvNoResponse
+            )
         }
     });
 }

--- a/packages/matter.js/src/cluster/definitions/EthernetNetworkDiagnosticsCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/EthernetNetworkDiagnosticsCluster.ts
@@ -17,7 +17,13 @@ import {
     AsConditional
 } from "../../cluster/ClusterFactory.js";
 import { BitFlag, BitFlags, TypeFromPartialBitSchema } from "../../schema/BitmapSchema.js";
-import { OptionalAttribute, Attribute, Command, TlvNoResponse, Cluster as CreateCluster } from "../../cluster/Cluster.js";
+import {
+    OptionalAttribute,
+    Attribute,
+    Command,
+    TlvNoResponse,
+    Cluster as CreateCluster
+} from "../../cluster/Cluster.js";
 import { TlvEnum, TlvUInt64 } from "../../tlv/TlvNumber.js";
 import { TlvNullable } from "../../tlv/TlvNullable.js";
 import { TlvBoolean } from "../../tlv/TlvBoolean.js";

--- a/packages/matter.js/src/cluster/definitions/GeneralCommissioningCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/GeneralCommissioningCluster.ts
@@ -6,7 +6,14 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import { Cluster as CreateCluster, WritableAttribute, AccessLevel, FixedAttribute, Attribute, Command } from "../../cluster/Cluster.js";
+import {
+    Cluster as CreateCluster,
+    WritableAttribute,
+    AccessLevel,
+    FixedAttribute,
+    Attribute,
+    Command
+} from "../../cluster/Cluster.js";
 import { MatterCoreSpecificationV1_1 } from "../../spec/Specifications.js";
 import { TlvUInt64, TlvUInt16, TlvEnum } from "../../tlv/TlvNumber.js";
 import { TlvObject, TlvField } from "../../tlv/TlvObject.js";

--- a/packages/matter.js/src/cluster/definitions/GeneralDiagnosticsCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/GeneralDiagnosticsCluster.ts
@@ -458,7 +458,11 @@ export namespace GeneralDiagnostics {
              *
              * @see {@link MatterCoreSpecificationV1_1} § 11.11.6.4
              */
-            totalOperationalHours: OptionalAttribute(0x3, TlvUInt32, { persistent: true, omitChanges: true, default: 0 }),
+            totalOperationalHours: OptionalAttribute(
+                0x3,
+                TlvUInt32,
+                { persistent: true, omitChanges: true, default: 0 }
+            ),
 
             /**
              * The BootReason attribute shall indicate the reason for the Node’s most recent boot.
@@ -496,7 +500,11 @@ export namespace GeneralDiagnostics {
              *
              * @see {@link MatterCoreSpecificationV1_1} § 11.11.6.7
              */
-            activeRadioFaults: OptionalAttribute(0x6, TlvArray(TlvEnum<RadioFault>(), { maxLength: 7 }), { default: [] }),
+            activeRadioFaults: OptionalAttribute(
+                0x6,
+                TlvArray(TlvEnum<RadioFault>(), { maxLength: 7 }),
+                { default: [] }
+            ),
 
             /**
              * The ActiveNetworkFaults attribute shall indicate the set of faults currently detected by the Node. When

--- a/packages/matter.js/src/cluster/definitions/GroupKeyManagementCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/GroupKeyManagementCluster.ts
@@ -7,7 +7,12 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { MatterCoreSpecificationV1_1 } from "../../spec/Specifications.js";
-import { BaseClusterComponent, ExtensibleCluster, validateFeatureSelection, ClusterForBaseCluster } from "../../cluster/ClusterFactory.js";
+import {
+    BaseClusterComponent,
+    ExtensibleCluster,
+    validateFeatureSelection,
+    ClusterForBaseCluster
+} from "../../cluster/ClusterFactory.js";
 import { BitFlag, BitFlags, TypeFromPartialBitSchema } from "../../schema/BitmapSchema.js";
 import {
     WritableFabricScopedAttribute,
@@ -298,7 +303,11 @@ export namespace GroupKeyManagement {
              *
              * @see {@link MatterCoreSpecificationV1_1} § 11.2.7.2
              */
-            groupTable: FabricScopedAttribute(0x1, TlvArray(TlvGroupInfoMapStruct, { maxLength: 254 }), { default: [] }),
+            groupTable: FabricScopedAttribute(
+                0x1,
+                TlvArray(TlvGroupInfoMapStruct, { maxLength: 254 }),
+                { default: [] }
+            ),
 
             /**
              * This attribute shall indicate the maximum number of groups that this node supports per fabric. The value

--- a/packages/matter.js/src/cluster/definitions/GroupsCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/GroupsCluster.ts
@@ -7,7 +7,12 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { MatterApplicationClusterSpecificationV1_1 } from "../../spec/Specifications.js";
-import { BaseClusterComponent, ExtensibleCluster, validateFeatureSelection, ClusterForBaseCluster } from "../../cluster/ClusterFactory.js";
+import {
+    BaseClusterComponent,
+    ExtensibleCluster,
+    validateFeatureSelection,
+    ClusterForBaseCluster
+} from "../../cluster/ClusterFactory.js";
 import { BitFlag, BitFlags, TypeFromPartialBitSchema } from "../../schema/BitmapSchema.js";
 import { FixedAttribute, Command, TlvNoResponse, Cluster as CreateCluster } from "../../cluster/Cluster.js";
 import { TlvUInt8, TlvBitmap, TlvEnum } from "../../tlv/TlvNumber.js";

--- a/packages/matter.js/src/cluster/definitions/IdentifyCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/IdentifyCluster.ts
@@ -16,7 +16,14 @@ import {
     AsConditional
 } from "../../cluster/ClusterFactory.js";
 import { BitFlag, BitFlags, TypeFromPartialBitSchema } from "../../schema/BitmapSchema.js";
-import { WritableAttribute, Attribute, Command, TlvNoResponse, OptionalCommand, Cluster as CreateCluster } from "../../cluster/Cluster.js";
+import {
+    WritableAttribute,
+    Attribute,
+    Command,
+    TlvNoResponse,
+    OptionalCommand,
+    Cluster as CreateCluster
+} from "../../cluster/Cluster.js";
 import { TlvUInt16, TlvEnum } from "../../tlv/TlvNumber.js";
 import { TlvObject, TlvField } from "../../tlv/TlvObject.js";
 import { TlvNoArguments } from "../../tlv/TlvNoArguments.js";

--- a/packages/matter.js/src/cluster/definitions/KeypadInputCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/KeypadInputCluster.ts
@@ -7,7 +7,12 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { MatterApplicationClusterSpecificationV1_1 } from "../../spec/Specifications.js";
-import { BaseClusterComponent, ExtensibleCluster, validateFeatureSelection, ClusterForBaseCluster } from "../../cluster/ClusterFactory.js";
+import {
+    BaseClusterComponent,
+    ExtensibleCluster,
+    validateFeatureSelection,
+    ClusterForBaseCluster
+} from "../../cluster/ClusterFactory.js";
 import { BitFlag, BitFlags, TypeFromPartialBitSchema } from "../../schema/BitmapSchema.js";
 import { Command, Cluster as CreateCluster } from "../../cluster/Cluster.js";
 import { TlvObject, TlvField } from "../../tlv/TlvObject.js";

--- a/packages/matter.js/src/cluster/definitions/LevelControlCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/LevelControlCluster.ts
@@ -508,7 +508,10 @@ export namespace LevelControl {
 
         commands: {
             ...Cluster.commands,
-            moveToClosestFrequency: AsConditional(FrequencyComponent.commands.moveToClosestFrequency, { mandatoryIf: [FQ] })
+            moveToClosestFrequency: AsConditional(
+                FrequencyComponent.commands.moveToClosestFrequency,
+                { mandatoryIf: [FQ] }
+            )
         }
     });
 }

--- a/packages/matter.js/src/cluster/definitions/NetworkCommissioningCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/NetworkCommissioningCluster.ts
@@ -18,7 +18,14 @@ import {
     AsConditional
 } from "../../cluster/ClusterFactory.js";
 import { BitFlag, BitFlags, TypeFromPartialBitSchema } from "../../schema/BitmapSchema.js";
-import { FixedAttribute, AccessLevel, Attribute, WritableAttribute, Command, Cluster as CreateCluster } from "../../cluster/Cluster.js";
+import {
+    FixedAttribute,
+    AccessLevel,
+    Attribute,
+    WritableAttribute,
+    Command,
+    Cluster as CreateCluster
+} from "../../cluster/Cluster.js";
 import { TlvUInt8, TlvEnum, TlvInt32, TlvUInt64, TlvBitmap, TlvUInt16, TlvInt8 } from "../../tlv/TlvNumber.js";
 import { TlvArray } from "../../tlv/TlvArray.js";
 import { TlvObject, TlvField, TlvOptionalField } from "../../tlv/TlvObject.js";

--- a/packages/matter.js/src/cluster/definitions/OnOffCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/OnOffCluster.ts
@@ -16,7 +16,14 @@ import {
     AsConditional
 } from "../../cluster/ClusterFactory.js";
 import { BitFlag, BitField, BitFlags, TypeFromPartialBitSchema } from "../../schema/BitmapSchema.js";
-import { Attribute, Command, TlvNoResponse, WritableAttribute, AccessLevel, Cluster as CreateCluster } from "../../cluster/Cluster.js";
+import {
+    Attribute,
+    Command,
+    TlvNoResponse,
+    WritableAttribute,
+    AccessLevel,
+    Cluster as CreateCluster
+} from "../../cluster/Cluster.js";
 import { TlvBoolean } from "../../tlv/TlvBoolean.js";
 import { TlvNoArguments } from "../../tlv/TlvNoArguments.js";
 import { TlvUInt16, TlvEnum, TlvUInt8, TlvBitmap } from "../../tlv/TlvNumber.js";
@@ -331,17 +338,26 @@ export namespace OnOff {
             ),
             onTime: AsConditional(LevelControlForLightingComponent.attributes.onTime, { mandatoryIf: [LT] }),
             offWaitTime: AsConditional(LevelControlForLightingComponent.attributes.offWaitTime, { mandatoryIf: [LT] }),
-            startUpOnOff: AsConditional(LevelControlForLightingComponent.attributes.startUpOnOff, { mandatoryIf: [LT] })
+            startUpOnOff: AsConditional(
+                LevelControlForLightingComponent.attributes.startUpOnOff,
+                { mandatoryIf: [LT] }
+            )
         },
 
         commands: {
             ...Cluster.commands,
-            offWithEffect: AsConditional(LevelControlForLightingComponent.commands.offWithEffect, { mandatoryIf: [LT] }),
+            offWithEffect: AsConditional(
+                LevelControlForLightingComponent.commands.offWithEffect,
+                { mandatoryIf: [LT] }
+            ),
             onWithRecallGlobalScene: AsConditional(
                 LevelControlForLightingComponent.commands.onWithRecallGlobalScene,
                 { mandatoryIf: [LT] }
             ),
-            onWithTimedOff: AsConditional(LevelControlForLightingComponent.commands.onWithTimedOff, { mandatoryIf: [LT] })
+            onWithTimedOff: AsConditional(
+                LevelControlForLightingComponent.commands.onWithTimedOff,
+                { mandatoryIf: [LT] }
+            )
         }
     });
 }

--- a/packages/matter.js/src/cluster/definitions/OperationalCredentialsCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/OperationalCredentialsCluster.ts
@@ -6,7 +6,15 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import { Cluster as CreateCluster, FabricScopedAttribute, AccessLevel, FixedAttribute, Attribute, Command, TlvNoResponse } from "../../cluster/Cluster.js";
+import {
+    Cluster as CreateCluster,
+    FabricScopedAttribute,
+    AccessLevel,
+    FixedAttribute,
+    Attribute,
+    Command,
+    TlvNoResponse
+} from "../../cluster/Cluster.js";
 import { MatterCoreSpecificationV1_1 } from "../../spec/Specifications.js";
 import { TlvArray } from "../../tlv/TlvArray.js";
 import { TlvObject, TlvField, TlvOptionalField } from "../../tlv/TlvObject.js";

--- a/packages/matter.js/src/cluster/definitions/PowerSourceCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/PowerSourceCluster.ts
@@ -1085,7 +1085,11 @@ export namespace PowerSource {
              *
              * @see {@link MatterCoreSpecificationV1_1} § 11.7.6.13
              */
-            batPercentRemaining: OptionalAttribute(0xc, TlvNullable(TlvUInt8.bound({ max: 200 })), { omitChanges: true }),
+            batPercentRemaining: OptionalAttribute(
+                0xc,
+                TlvNullable(TlvUInt8.bound({ max: 200 })),
+                { omitChanges: true }
+            ),
 
             /**
              * This attribute shall indicate the estimated time in seconds before the battery will no longer be able to
@@ -1366,7 +1370,10 @@ export namespace PowerSource {
                 { optionalIf: [WIRED] }
             ),
             wiredCurrentType: AsConditional(WiredComponent.attributes.wiredCurrentType, { mandatoryIf: [WIRED] }),
-            wiredAssessedCurrent: AsConditional(WiredComponent.attributes.wiredAssessedCurrent, { optionalIf: [WIRED] }),
+            wiredAssessedCurrent: AsConditional(
+                WiredComponent.attributes.wiredAssessedCurrent,
+                { optionalIf: [WIRED] }
+            ),
             wiredNominalVoltage: AsConditional(WiredComponent.attributes.wiredNominalVoltage, { optionalIf: [WIRED] }),
             wiredMaximumCurrent: AsConditional(WiredComponent.attributes.wiredMaximumCurrent, { optionalIf: [WIRED] }),
             wiredPresent: AsConditional(WiredComponent.attributes.wiredPresent, { optionalIf: [WIRED] }),
@@ -1375,7 +1382,10 @@ export namespace PowerSource {
             batPercentRemaining: AsConditional(BatteryComponent.attributes.batPercentRemaining, { optionalIf: [BAT] }),
             batTimeRemaining: AsConditional(BatteryComponent.attributes.batTimeRemaining, { optionalIf: [BAT] }),
             batChargeLevel: AsConditional(BatteryComponent.attributes.batChargeLevel, { mandatoryIf: [BAT] }),
-            batReplacementNeeded: AsConditional(BatteryComponent.attributes.batReplacementNeeded, { mandatoryIf: [BAT] }),
+            batReplacementNeeded: AsConditional(
+                BatteryComponent.attributes.batReplacementNeeded,
+                { mandatoryIf: [BAT] }
+            ),
             batReplaceability: AsConditional(BatteryComponent.attributes.batReplaceability, { mandatoryIf: [BAT] }),
             batPresent: AsConditional(BatteryComponent.attributes.batPresent, { optionalIf: [BAT] }),
             activeBatFaults: AsConditional(BatteryComponent.attributes.activeBatFaults, { optionalIf: [BAT] }),
@@ -1387,8 +1397,14 @@ export namespace PowerSource {
                 ReplaceableComponent.attributes.batCommonDesignation,
                 { optionalIf: [REPLC] }
             ),
-            batAnsiDesignation: AsConditional(ReplaceableComponent.attributes.batAnsiDesignation, { optionalIf: [REPLC] }),
-            batIecDesignation: AsConditional(ReplaceableComponent.attributes.batIecDesignation, { optionalIf: [REPLC] }),
+            batAnsiDesignation: AsConditional(
+                ReplaceableComponent.attributes.batAnsiDesignation,
+                { optionalIf: [REPLC] }
+            ),
+            batIecDesignation: AsConditional(
+                ReplaceableComponent.attributes.batIecDesignation,
+                { optionalIf: [REPLC] }
+            ),
             batApprovedChemistry: AsConditional(
                 ReplaceableComponent.attributes.batApprovedChemistry,
                 { optionalIf: [REPLC] }
@@ -1404,7 +1420,10 @@ export namespace PowerSource {
                 RechargeableComponent.attributes.batFunctionalWhileCharging,
                 { mandatoryIf: [RECHG] }
             ),
-            batChargingCurrent: AsConditional(RechargeableComponent.attributes.batChargingCurrent, { optionalIf: [RECHG] }),
+            batChargingCurrent: AsConditional(
+                RechargeableComponent.attributes.batChargingCurrent,
+                { optionalIf: [RECHG] }
+            ),
             activeBatChargeFaults: AsConditional(
                 RechargeableComponent.attributes.activeBatChargeFaults,
                 { optionalIf: [RECHG] }
@@ -1414,7 +1433,10 @@ export namespace PowerSource {
         events: {
             wiredFaultChange: AsConditional(WiredComponent.events.wiredFaultChange, { optionalIf: [WIRED] }),
             batFaultChange: AsConditional(BatteryComponent.events.batFaultChange, { optionalIf: [BAT] }),
-            batChargeFaultChange: AsConditional(RechargeableComponent.events.batChargeFaultChange, { optionalIf: [RECHG] })
+            batChargeFaultChange: AsConditional(
+                RechargeableComponent.events.batChargeFaultChange,
+                { optionalIf: [RECHG] }
+            )
         }
     });
 }

--- a/packages/matter.js/src/cluster/definitions/ProxyConfigurationCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/ProxyConfigurationCluster.ts
@@ -50,7 +50,11 @@ export namespace ProxyConfiguration {
              *
              * @see {@link MatterCoreSpecificationV1_1} § 9.15.14.5.1
              */
-            configurationList: WritableAttribute(0x0, TlvArray(TlvConfigurationStruct), { persistent: true, default: [] })
+            configurationList: WritableAttribute(
+                0x0,
+                TlvArray(TlvConfigurationStruct),
+                { persistent: true, default: [] }
+            )
         }
     });
 }

--- a/packages/matter.js/src/cluster/definitions/PulseWidthModulationCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/PulseWidthModulationCluster.ts
@@ -462,7 +462,10 @@ export namespace PulseWidthModulation {
 
         commands: {
             ...Cluster.commands,
-            moveToClosestFrequency: AsConditional(FrequencyComponent.commands.moveToClosestFrequency, { mandatoryIf: [FQ] })
+            moveToClosestFrequency: AsConditional(
+                FrequencyComponent.commands.moveToClosestFrequency,
+                { mandatoryIf: [FQ] }
+            )
         }
     });
 }

--- a/packages/matter.js/src/cluster/definitions/ScenesCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/ScenesCluster.ts
@@ -7,9 +7,21 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { MatterApplicationClusterSpecificationV1_1 } from "../../spec/Specifications.js";
-import { BaseClusterComponent, ExtensibleCluster, validateFeatureSelection, ClusterForBaseCluster } from "../../cluster/ClusterFactory.js";
+import {
+    BaseClusterComponent,
+    ExtensibleCluster,
+    validateFeatureSelection,
+    ClusterForBaseCluster
+} from "../../cluster/ClusterFactory.js";
 import { BitFlag, BitField, BitFlags, TypeFromPartialBitSchema } from "../../schema/BitmapSchema.js";
-import { Attribute, OptionalAttribute, Command, TlvNoResponse, OptionalCommand, Cluster as CreateCluster } from "../../cluster/Cluster.js";
+import {
+    Attribute,
+    OptionalAttribute,
+    Command,
+    TlvNoResponse,
+    OptionalCommand,
+    Cluster as CreateCluster
+} from "../../cluster/Cluster.js";
 import { TlvUInt8, TlvBitmap, TlvUInt16, TlvEnum } from "../../tlv/TlvNumber.js";
 import { TlvGroupId, GroupId } from "../../datatype/GroupId.js";
 import { TlvBoolean } from "../../tlv/TlvBoolean.js";
@@ -119,7 +131,10 @@ export namespace Scenes {
      *
      * @see {@link MatterApplicationClusterSpecificationV1_1} § 1.4.9.4
      */
-    export const TlvRemoveSceneRequest = TlvObject({ groupId: TlvField(0, TlvGroupId), sceneId: TlvField(1, TlvUInt8) });
+    export const TlvRemoveSceneRequest = TlvObject({
+        groupId: TlvField(0, TlvGroupId),
+        sceneId: TlvField(1, TlvUInt8)
+    });
 
     /**
      * @see {@link MatterApplicationClusterSpecificationV1_1} § 1.4.9.14

--- a/packages/matter.js/src/cluster/definitions/SoftwareDiagnosticsCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/SoftwareDiagnosticsCluster.ts
@@ -16,7 +16,15 @@ import {
     AsConditional
 } from "../../cluster/ClusterFactory.js";
 import { BitFlag, BitFlags, TypeFromPartialBitSchema } from "../../schema/BitmapSchema.js";
-import { OptionalAttribute, OptionalEvent, EventPriority, Attribute, Command, TlvNoResponse, Cluster as CreateCluster } from "../../cluster/Cluster.js";
+import {
+    OptionalAttribute,
+    OptionalEvent,
+    EventPriority,
+    Attribute,
+    Command,
+    TlvNoResponse,
+    Cluster as CreateCluster
+} from "../../cluster/Cluster.js";
 import { TlvArray } from "../../tlv/TlvArray.js";
 import { TlvObject, TlvField, TlvOptionalField } from "../../tlv/TlvObject.js";
 import { TlvUInt64, TlvUInt32 } from "../../tlv/TlvNumber.js";

--- a/packages/matter.js/src/cluster/definitions/ThermostatCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/ThermostatCluster.ts
@@ -712,7 +712,11 @@ export namespace Thermostat {
             controlSequenceOfOperation: WritableAttribute(
                 0x1b,
                 TlvEnum<ControlSequenceOfOperation>(),
-                { persistent: true, default: ControlSequenceOfOperation.CoolingAndHeating, writeAcl: AccessLevel.Manage }
+                {
+                    persistent: true,
+                    default: ControlSequenceOfOperation.CoolingAndHeating,
+                    writeAcl: AccessLevel.Manage
+                }
             ),
 
             /**
@@ -1388,7 +1392,11 @@ export namespace Thermostat {
              *
              * @see {@link MatterApplicationClusterSpecificationV1_1} § 4.3.7.38
              */
-            occupiedSetbackMin: FixedAttribute(0x35, TlvNullable(TlvUInt8.bound({ min: 0, max: 254 })), { default: null }),
+            occupiedSetbackMin: FixedAttribute(
+                0x35,
+                TlvNullable(TlvUInt8.bound({ min: 0, max: 254 })),
+                { default: null }
+            ),
 
             /**
              * This attribute specifies the maximum value that the Thermostat server will allow the OccupiedSetback
@@ -1452,7 +1460,11 @@ export namespace Thermostat {
              *
              * @see {@link MatterApplicationClusterSpecificationV1_1} § 4.3.7.42
              */
-            unoccupiedSetbackMax: OptionalFixedAttribute(0x39, TlvNullable(TlvUInt8.bound({ max: 254 })), { default: null })
+            unoccupiedSetbackMax: OptionalFixedAttribute(
+                0x39,
+                TlvNullable(TlvUInt8.bound({ max: 254 })),
+                { default: null }
+            )
         }
     });
 
@@ -1572,12 +1584,30 @@ export namespace Thermostat {
                 HeatingComponent.attributes.unoccupiedHeatingSetpoint,
                 { optionalIf: [HEAT] }
             ),
-            minHeatSetpointLimit: AsConditional(HeatingComponent.attributes.minHeatSetpointLimit, { optionalIf: [HEAT] }),
-            maxHeatSetpointLimit: AsConditional(HeatingComponent.attributes.maxHeatSetpointLimit, { optionalIf: [HEAT] }),
-            minCoolSetpointLimit: AsConditional(CoolingComponent.attributes.minCoolSetpointLimit, { optionalIf: [COOL] }),
-            maxCoolSetpointLimit: AsConditional(CoolingComponent.attributes.maxCoolSetpointLimit, { optionalIf: [COOL] }),
-            minSetpointDeadBand: AsConditional(AutoModeComponent.attributes.minSetpointDeadBand, { mandatoryIf: [AUTO] }),
-            thermostatRunningMode: AsConditional(AutoModeComponent.attributes.thermostatRunningMode, { optionalIf: [AUTO] }),
+            minHeatSetpointLimit: AsConditional(
+                HeatingComponent.attributes.minHeatSetpointLimit,
+                { optionalIf: [HEAT] }
+            ),
+            maxHeatSetpointLimit: AsConditional(
+                HeatingComponent.attributes.maxHeatSetpointLimit,
+                { optionalIf: [HEAT] }
+            ),
+            minCoolSetpointLimit: AsConditional(
+                CoolingComponent.attributes.minCoolSetpointLimit,
+                { optionalIf: [COOL] }
+            ),
+            maxCoolSetpointLimit: AsConditional(
+                CoolingComponent.attributes.maxCoolSetpointLimit,
+                { optionalIf: [COOL] }
+            ),
+            minSetpointDeadBand: AsConditional(
+                AutoModeComponent.attributes.minSetpointDeadBand,
+                { mandatoryIf: [AUTO] }
+            ),
+            thermostatRunningMode: AsConditional(
+                AutoModeComponent.attributes.thermostatRunningMode,
+                { optionalIf: [AUTO] }
+            ),
             startOfWeek: AsConditional(ScheduleConfigurationComponent.attributes.startOfWeek, { mandatoryIf: [SCH] }),
             numberOfWeeklyTransitions: AsConditional(
                 ScheduleConfigurationComponent.attributes.numberOfWeeklyTransitions,

--- a/packages/matter.js/src/cluster/definitions/ThermostatUserInterfaceConfigurationCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/ThermostatUserInterfaceConfigurationCluster.ts
@@ -6,7 +6,12 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import { Cluster as CreateCluster, WritableAttribute, AccessLevel, OptionalWritableAttribute } from "../../cluster/Cluster.js";
+import {
+    Cluster as CreateCluster,
+    WritableAttribute,
+    AccessLevel,
+    OptionalWritableAttribute
+} from "../../cluster/Cluster.js";
 import { MatterApplicationClusterSpecificationV1_1 } from "../../spec/Specifications.js";
 import { TlvEnum } from "../../tlv/TlvNumber.js";
 

--- a/packages/matter.js/src/cluster/definitions/ThreadNetworkDiagnosticsCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/ThreadNetworkDiagnosticsCluster.ts
@@ -17,7 +17,15 @@ import {
     AsConditional
 } from "../../cluster/ClusterFactory.js";
 import { BitFlag, BitFlags, TypeFromPartialBitSchema } from "../../schema/BitmapSchema.js";
-import { Attribute, OptionalAttribute, OptionalEvent, EventPriority, Command, TlvNoResponse, Cluster as CreateCluster } from "../../cluster/Cluster.js";
+import {
+    Attribute,
+    OptionalAttribute,
+    OptionalEvent,
+    EventPriority,
+    Command,
+    TlvNoResponse,
+    Cluster as CreateCluster
+} from "../../cluster/Cluster.js";
 import { TlvUInt16, TlvEnum, TlvUInt64, TlvUInt32, TlvUInt8, TlvInt8 } from "../../tlv/TlvNumber.js";
 import { TlvNullable } from "../../tlv/TlvNullable.js";
 import { TlvString, TlvByteString } from "../../tlv/TlvString.js";
@@ -1197,7 +1205,10 @@ export namespace ThreadNetworkDiagnostics {
             childRoleCount: AsConditional(MleCountsComponent.attributes.childRoleCount, { optionalIf: [MLECNT] }),
             routerRoleCount: AsConditional(MleCountsComponent.attributes.routerRoleCount, { optionalIf: [MLECNT] }),
             leaderRoleCount: AsConditional(MleCountsComponent.attributes.leaderRoleCount, { optionalIf: [MLECNT] }),
-            attachAttemptCount: AsConditional(MleCountsComponent.attributes.attachAttemptCount, { optionalIf: [MLECNT] }),
+            attachAttemptCount: AsConditional(
+                MleCountsComponent.attributes.attachAttemptCount,
+                { optionalIf: [MLECNT] }
+            ),
             partitionIdChangeCount: AsConditional(
                 MleCountsComponent.attributes.partitionIdChangeCount,
                 { optionalIf: [MLECNT] }
@@ -1210,7 +1221,10 @@ export namespace ThreadNetworkDiagnostics {
             txTotalCount: AsConditional(MacCountsComponent.attributes.txTotalCount, { optionalIf: [MACCNT] }),
             txUnicastCount: AsConditional(MacCountsComponent.attributes.txUnicastCount, { optionalIf: [MACCNT] }),
             txBroadcastCount: AsConditional(MacCountsComponent.attributes.txBroadcastCount, { optionalIf: [MACCNT] }),
-            txAckRequestedCount: AsConditional(MacCountsComponent.attributes.txAckRequestedCount, { optionalIf: [MACCNT] }),
+            txAckRequestedCount: AsConditional(
+                MacCountsComponent.attributes.txAckRequestedCount,
+                { optionalIf: [MACCNT] }
+            ),
             txAckedCount: AsConditional(MacCountsComponent.attributes.txAckedCount, { optionalIf: [MACCNT] }),
             txNoAckRequestedCount: AsConditional(
                 MacCountsComponent.attributes.txNoAckRequestedCount,

--- a/packages/matter.js/src/cluster/definitions/UnitLocalizationCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/UnitLocalizationCluster.ts
@@ -144,8 +144,12 @@ export namespace UnitLocalization {
         name: Cluster.name,
         revision: Cluster.revision,
         features: Cluster.features,
+
         attributes: {
-            temperatureUnit: AsConditional(TemperatureUnitComponent.attributes.temperatureUnit, { mandatoryIf: [TEMP] })
+            temperatureUnit: AsConditional(
+                TemperatureUnitComponent.attributes.temperatureUnit,
+                { mandatoryIf: [TEMP] }
+            )
         }
     });
 }

--- a/packages/matter.js/src/cluster/definitions/ValidProxiesCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/ValidProxiesCluster.ts
@@ -40,7 +40,11 @@ export namespace ValidProxies {
              *
              * @see {@link MatterCoreSpecificationV1_1} § 9.15.15.5.1
              */
-            validProxyList: WritableFixedAttribute(0x0, TlvArray(TlvValidProxyStruct), { persistent: true, default: [] })
+            validProxyList: WritableFixedAttribute(
+                0x0,
+                TlvArray(TlvValidProxyStruct),
+                { persistent: true, default: [] }
+            )
         },
 
         commands: {

--- a/packages/matter.js/src/cluster/definitions/WiFiNetworkDiagnosticsCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/WiFiNetworkDiagnosticsCluster.ts
@@ -17,7 +17,15 @@ import {
     AsConditional
 } from "../../cluster/ClusterFactory.js";
 import { BitFlag, BitFlags, TypeFromPartialBitSchema } from "../../schema/BitmapSchema.js";
-import { Attribute, OptionalAttribute, OptionalEvent, EventPriority, Command, TlvNoResponse, Cluster as CreateCluster } from "../../cluster/Cluster.js";
+import {
+    Attribute,
+    OptionalAttribute,
+    OptionalEvent,
+    EventPriority,
+    Command,
+    TlvNoResponse,
+    Cluster as CreateCluster
+} from "../../cluster/Cluster.js";
 import { TlvByteString } from "../../tlv/TlvString.js";
 import { TlvNullable } from "../../tlv/TlvNullable.js";
 import { TlvEnum, TlvUInt16, TlvInt8, TlvUInt64, TlvUInt32 } from "../../tlv/TlvNumber.js";
@@ -272,7 +280,11 @@ export namespace WiFiNetworkDiagnostics {
              *
              * @see {@link MatterCoreSpecificationV1_1} § 11.14.6.5
              */
-            rssi: Attribute(0x4, TlvNullable(TlvInt8.bound({ min: -120, max: 0 })), { omitChanges: true, default: null }),
+            rssi: Attribute(
+                0x4,
+                TlvNullable(TlvInt8.bound({ min: -120, max: 0 })),
+                { omitChanges: true, default: null }
+            ),
 
             /**
              * The CurrentMaxRate attribute shall indicate the current maximum PHY rate of transfer of data in

--- a/packages/matter.js/src/cluster/definitions/WindowCoveringCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/WindowCoveringCluster.ts
@@ -17,7 +17,13 @@ import {
     ClusterForBaseCluster,
     AsConditional
 } from "../../cluster/ClusterFactory.js";
-import { BitFlag, BitsFromPartial, BitFieldEnum, BitFlags, TypeFromPartialBitSchema } from "../../schema/BitmapSchema.js";
+import {
+    BitFlag,
+    BitsFromPartial,
+    BitFieldEnum,
+    BitFlags,
+    TypeFromPartialBitSchema
+} from "../../schema/BitmapSchema.js";
 import {
     FixedAttribute,
     Attribute,
@@ -427,7 +433,10 @@ export namespace WindowCovering {
             configStatus: Attribute(
                 0x7,
                 TlvBitmap(TlvUInt8, ConfigStatus),
-                { persistent: true, default: BitsFromPartial(ConfigStatus, { operational: true, onlineReserved: true }) }
+                {
+                    persistent: true,
+                    default: BitsFromPartial(ConfigStatus, { operational: true, onlineReserved: true })
+                }
             ),
 
             /**
@@ -458,7 +467,11 @@ export namespace WindowCovering {
              *
              * @see {@link MatterApplicationClusterSpecificationV1_1} § 5.3.5.21
              */
-            mode: WritableAttribute(0x17, TlvBitmap(TlvUInt8, Mode), { persistent: true, writeAcl: AccessLevel.Manage }),
+            mode: WritableAttribute(
+                0x17,
+                TlvBitmap(TlvUInt8, Mode),
+                { persistent: true, writeAcl: AccessLevel.Manage }
+            ),
 
             /**
              * The SafetyStatus attribute reflects the state of the safety sensors and the common issues preventing
@@ -592,7 +605,11 @@ export namespace WindowCovering {
              *
              * @see {@link MatterApplicationClusterSpecificationV1_1} § 5.3.5.18
              */
-            installedClosedLimitLift: Attribute(0x11, TlvUInt16.bound({ max: 65534 }), { persistent: true, default: 65534 })
+            installedClosedLimitLift: Attribute(
+                0x11,
+                TlvUInt16.bound({ max: 65534 }),
+                { persistent: true, default: 65534 }
+            )
         }
     });
 
@@ -636,7 +653,11 @@ export namespace WindowCovering {
              *
              * @see {@link MatterApplicationClusterSpecificationV1_1} § 5.3.5.20
              */
-            installedClosedLimitTilt: Attribute(0x13, TlvUInt16.bound({ max: 65534 }), { persistent: true, default: 65534 })
+            installedClosedLimitTilt: Attribute(
+                0x13,
+                TlvUInt16.bound({ max: 65534 }),
+                { persistent: true, default: 65534 }
+            )
         }
     });
 
@@ -990,8 +1011,14 @@ export namespace WindowCovering {
                 TiltAndPositionAwareTiltAndAbsolutePositionComponent.attributes.currentPositionTilt,
                 { optionalIf: [TL_PA_TL_ABS] }
             ),
-            numberOfActuationsLift: AsConditional(LiftComponent.attributes.numberOfActuationsLift, { optionalIf: [LF] }),
-            numberOfActuationsTilt: AsConditional(TiltComponent.attributes.numberOfActuationsTilt, { optionalIf: [TL] }),
+            numberOfActuationsLift: AsConditional(
+                LiftComponent.attributes.numberOfActuationsLift,
+                { optionalIf: [LF] }
+            ),
+            numberOfActuationsTilt: AsConditional(
+                TiltComponent.attributes.numberOfActuationsTilt,
+                { optionalIf: [TL] }
+            ),
             currentPositionLiftPercentage: AsConditional(
                 LiftAndPositionAwareLiftComponent.attributes.currentPositionLiftPercentage,
                 { optionalIf: [LF_PA_LF] }
@@ -1036,12 +1063,18 @@ export namespace WindowCovering {
 
         commands: {
             ...Cluster.commands,
-            goToLiftValue: AsConditional(LiftAndAbsolutePositionComponent.commands.goToLiftValue, { optionalIf: [LF_ABS] }),
+            goToLiftValue: AsConditional(
+                LiftAndAbsolutePositionComponent.commands.goToLiftValue,
+                { optionalIf: [LF_ABS] }
+            ),
             goToLiftPercentage: AsConditional(
                 LiftComponent.commands.goToLiftPercentage,
                 { optionalIf: [LF], mandatoryIf: [LF_PA_LF] }
             ),
-            goToTiltValue: AsConditional(TiltAndAbsolutePositionComponent.commands.goToTiltValue, { optionalIf: [TL_ABS] }),
+            goToTiltValue: AsConditional(
+                TiltAndAbsolutePositionComponent.commands.goToTiltValue,
+                { optionalIf: [TL_ABS] }
+            ),
             goToTiltPercentage: AsConditional(
                 TiltComponent.commands.goToTiltPercentage,
                 { optionalIf: [TL], mandatoryIf: [TL_PA_TL] }

--- a/packages/matter.js/src/cluster/definitions/index.ts
+++ b/packages/matter.js/src/cluster/definitions/index.ts
@@ -21,16 +21,25 @@ export { IlluminanceMeasurementCluster, IlluminanceMeasurement } from "./Illumin
 export { TemperatureMeasurementCluster, TemperatureMeasurement } from "./TemperatureMeasurementCluster.js";
 export { PressureMeasurementCluster, PressureMeasurement } from "./PressureMeasurementCluster.js";
 export { FlowMeasurementCluster, FlowMeasurement } from "./FlowMeasurementCluster.js";
-export { RelativeHumidityMeasurementCluster, RelativeHumidityMeasurement } from "./RelativeHumidityMeasurementCluster.js";
+export {
+    RelativeHumidityMeasurementCluster,
+    RelativeHumidityMeasurement
+} from "./RelativeHumidityMeasurementCluster.js";
 export { LeafWetnessMeasurementCluster, LeafWetnessMeasurement } from "./LeafWetnessMeasurementCluster.js";
 export { SoilMoistureMeasurementCluster, SoilMoistureMeasurement } from "./SoilMoistureMeasurementCluster.js";
 export { OccupancySensingCluster, OccupancySensing } from "./OccupancySensingCluster.js";
 export { ColorControlCluster, ColorControl } from "./ColorControlCluster.js";
 export { BallastConfigurationCluster, BallastConfiguration } from "./BallastConfigurationCluster.js";
-export { PumpConfigurationAndControlCluster, PumpConfigurationAndControl } from "./PumpConfigurationAndControlCluster.js";
+export {
+    PumpConfigurationAndControlCluster,
+    PumpConfigurationAndControl
+} from "./PumpConfigurationAndControlCluster.js";
 export { ThermostatCluster, Thermostat } from "./ThermostatCluster.js";
 export { FanControlCluster, FanControl } from "./FanControlCluster.js";
-export { ThermostatUserInterfaceConfigurationCluster, ThermostatUserInterfaceConfiguration } from "./ThermostatUserInterfaceConfigurationCluster.js";
+export {
+    ThermostatUserInterfaceConfigurationCluster,
+    ThermostatUserInterfaceConfiguration
+} from "./ThermostatUserInterfaceConfigurationCluster.js";
 export { DoorLockCluster, DoorLock } from "./DoorLockCluster.js";
 export { WindowCoveringCluster, WindowCovering } from "./WindowCoveringCluster.js";
 export { AccountLoginCluster, AccountLogin } from "./AccountLoginCluster.js";
@@ -48,7 +57,10 @@ export { BindingCluster, Binding } from "./BindingCluster.js";
 export { FixedLabelCluster, FixedLabel } from "./FixedLabelCluster.js";
 export { UserLabelCluster, UserLabel } from "./UserLabelCluster.js";
 export { AccessControlCluster, AccessControl } from "./AccessControlCluster.js";
-export { BridgedDeviceBasicInformationCluster, BridgedDeviceBasicInformation } from "./BridgedDeviceBasicInformationCluster.js";
+export {
+    BridgedDeviceBasicInformationCluster,
+    BridgedDeviceBasicInformation
+} from "./BridgedDeviceBasicInformationCluster.js";
 export { ActionsCluster, Actions } from "./ActionsCluster.js";
 export { ProxyDiscoveryCluster, ProxyDiscovery } from "./ProxyDiscoveryCluster.js";
 export { ProxyConfigurationCluster, ProxyConfiguration } from "./ProxyConfigurationCluster.js";

--- a/packages/matter.js/src/model/standard/elements/AccessControl.ts
+++ b/packages/matter.js/src/model/standard/elements/AccessControl.ts
@@ -220,7 +220,10 @@ Matter.children.push({
                     tag: "datatype", name: "Changed", id: 0x0, conformance: "M",
                     description: "Entry or extension was changed"
                 },
-                { tag: "datatype", name: "Added", id: 0x1, conformance: "M", description: "Entry or extension was added" },
+                {
+                    tag: "datatype", name: "Added", id: 0x1, conformance: "M",
+                    description: "Entry or extension was added"
+                },
                 {
                     tag: "datatype", name: "Removed", id: 0x2, conformance: "M",
                     description: "Entry or extension was removed"
@@ -273,12 +276,18 @@ Matter.children.push({
             xref: { document: "core", section: "9.10.4.3" },
 
             children: [
-                { tag: "datatype", name: "Pase", id: 0x1, conformance: "M", description: "Passcode authenticated session" },
+                {
+                    tag: "datatype", name: "Pase", id: 0x1, conformance: "M",
+                    description: "Passcode authenticated session"
+                },
                 {
                     tag: "datatype", name: "Case", id: 0x2, conformance: "M",
                     description: "Certificate authenticated session"
                 },
-                { tag: "datatype", name: "Group", id: 0x3, conformance: "M", description: "Group authenticated session" }
+                {
+                    tag: "datatype", name: "Group", id: 0x3, conformance: "M",
+                    description: "Group authenticated session"
+                }
             ]
         },
 

--- a/packages/matter.js/src/model/standard/elements/Actions.ts
+++ b/packages/matter.js/src/model/standard/elements/Actions.ts
@@ -559,9 +559,15 @@ Matter.children.push({
             xref: { document: "core", section: "9.14.4.3" },
 
             children: [
-                { tag: "datatype", name: "Inactive", id: 0x0, conformance: "M", description: "The action is not active" },
+                {
+                    tag: "datatype", name: "Inactive", id: 0x0, conformance: "M",
+                    description: "The action is not active"
+                },
                 { tag: "datatype", name: "Active", id: 0x1, conformance: "M", description: "The action is active" },
-                { tag: "datatype", name: "Paused", id: 0x2, conformance: "M", description: "The action has been paused" },
+                {
+                    tag: "datatype", name: "Paused", id: 0x2, conformance: "M",
+                    description: "The action has been paused"
+                },
                 {
                     tag: "datatype", name: "Disabled", id: 0x3, conformance: "M",
                     description: "The action has been disabled"

--- a/packages/matter.js/src/model/standard/elements/AdministratorCommissioning.ts
+++ b/packages/matter.js/src/model/standard/elements/AdministratorCommissioning.ts
@@ -220,7 +220,10 @@ Matter.children.push({
                 "TIVE_INTERVAL for at least the entire duration of the CommissioningTimeout.",
 
             xref: { document: "core", section: "11.18.8.2" },
-            children: [{ tag: "datatype", name: "CommissioningTimeout", id: 0x0, type: "uint16", conformance: "M", constraint: "desc" }]
+            children: [{
+                tag: "datatype", name: "CommissioningTimeout", id: 0x0, type: "uint16", conformance: "M",
+                constraint: "desc"
+            }]
         },
 
         {

--- a/packages/matter.js/src/model/standard/elements/ApplicationBasic.ts
+++ b/packages/matter.js/src/model/standard/elements/ApplicationBasic.ts
@@ -117,7 +117,10 @@ Matter.children.push({
             xref: { document: "cluster", section: "6.3.4.2" },
 
             children: [
-                { tag: "datatype", name: "Stopped", id: 0x0, conformance: "M", description: "Application is not running." },
+                {
+                    tag: "datatype", name: "Stopped", id: 0x0, conformance: "M",
+                    description: "Application is not running."
+                },
                 {
                     tag: "datatype", name: "ActiveVisibleFocus", id: 0x1, conformance: "M",
                     description: "Application is running, is visible to the user, and is the active target for input."

--- a/packages/matter.js/src/model/standard/elements/BinaryInputBasic.ts
+++ b/packages/matter.js/src/model/standard/elements/BinaryInputBasic.ts
@@ -26,9 +26,15 @@ Matter.children.push({
             tag: "attribute", name: "InactiveText", id: 0x2e, type: "string", access: "RW", conformance: "O",
             constraint: "max 16", default: ""
         },
-        { tag: "attribute", name: "OutOfService", id: 0x51, type: "bool", access: "RW", conformance: "M", default: true },
+        {
+            tag: "attribute", name: "OutOfService", id: 0x51, type: "bool", access: "RW", conformance: "M",
+            default: true
+        },
         { tag: "attribute", name: "Polarity", id: 0x54, type: "enum8", conformance: "O", default: 0 },
-        { tag: "attribute", name: "PresentValue", id: 0x55, type: "bool", access: "RW", conformance: "M", quality: "P" },
+        {
+            tag: "attribute", name: "PresentValue", id: 0x55, type: "bool", access: "RW", conformance: "M",
+            quality: "P"
+        },
         { tag: "attribute", name: "Reliability", id: 0x67, type: "enum8", access: "RW", conformance: "O", default: 0 },
         { tag: "attribute", name: "StatusFlags", id: 0x6f, type: "map8", conformance: "M", default: 0, quality: "P" },
         { tag: "attribute", name: "ApplicationType", id: 0x100, type: "uint32", conformance: "O" }

--- a/packages/matter.js/src/model/standard/elements/BridgedDeviceBasicInformation.ts
+++ b/packages/matter.js/src/model/standard/elements/BridgedDeviceBasicInformation.ts
@@ -60,13 +60,19 @@ Matter.children.push({
             constraint: "max 32",
             xref: { document: "core", section: "9.13.4" }
         },
-        { tag: "attribute", name: "ProductId", id: 0x4, conformance: "X", xref: { document: "core", section: "9.13.4" } },
+        {
+            tag: "attribute", name: "ProductId", id: 0x4, conformance: "X",
+            xref: { document: "core", section: "9.13.4" }
+        },
         {
             tag: "attribute", name: "NodeLabel", id: 0x5, type: "string", access: "RW", conformance: "O",
             constraint: "max 32", default: "",
             xref: { document: "core", section: "9.13.4" }
         },
-        { tag: "attribute", name: "Location", id: 0x6, conformance: "X", xref: { document: "core", section: "9.13.4" } },
+        {
+            tag: "attribute", name: "Location", id: 0x6, conformance: "X",
+            xref: { document: "core", section: "9.13.4" }
+        },
         {
             tag: "attribute", name: "HardwareVersion", id: 0x7, type: "uint16", conformance: "O", default: 0,
             xref: { document: "core", section: "9.13.4" }

--- a/packages/matter.js/src/model/standard/elements/ColorControl.ts
+++ b/packages/matter.js/src/model/standard/elements/ColorControl.ts
@@ -690,7 +690,10 @@ Matter.children.push({
             xref: { document: "cluster", section: "3.2.11.7" },
 
             children: [
-                { tag: "datatype", name: "Saturation", id: 0x0, type: "uint8", conformance: "M", constraint: "0 to 254" },
+                {
+                    tag: "datatype", name: "Saturation", id: 0x0, type: "uint8", conformance: "M",
+                    constraint: "0 to 254"
+                },
                 {
                     tag: "datatype", name: "TransitionTime", id: 0x1, type: "uint16", conformance: "M",
                     constraint: "0 to 65534"
@@ -789,7 +792,10 @@ Matter.children.push({
 
             children: [
                 { tag: "datatype", name: "Hue", id: 0x0, type: "uint8", conformance: "M", constraint: "0 to 254" },
-                { tag: "datatype", name: "Saturation", id: 0x1, type: "uint8", conformance: "M", constraint: "0 to 254" },
+                {
+                    tag: "datatype", name: "Saturation", id: 0x1, type: "uint8", conformance: "M",
+                    constraint: "0 to 254"
+                },
                 {
                     tag: "datatype", name: "TransitionTime", id: 0x2, type: "uint16", conformance: "M",
                     constraint: "0 to 65534"
@@ -811,8 +817,14 @@ Matter.children.push({
             xref: { document: "cluster", section: "3.2.11.11" },
 
             children: [
-                { tag: "datatype", name: "ColorX", id: 0x0, type: "uint16", conformance: "M", constraint: "0 to 65279" },
-                { tag: "datatype", name: "ColorY", id: 0x1, type: "uint16", conformance: "M", constraint: "0 to 65279" },
+                {
+                    tag: "datatype", name: "ColorX", id: 0x0, type: "uint16", conformance: "M",
+                    constraint: "0 to 65279"
+                },
+                {
+                    tag: "datatype", name: "ColorY", id: 0x1, type: "uint16", conformance: "M",
+                    constraint: "0 to 65279"
+                },
                 {
                     tag: "datatype", name: "TransitionTime", id: 0x2, type: "uint16", conformance: "M",
                     constraint: "0 to 65534"

--- a/packages/matter.js/src/model/standard/elements/ContentLauncher.ts
+++ b/packages/matter.js/src/model/standard/elements/ContentLauncher.ts
@@ -53,7 +53,10 @@ Matter.children.push({
                     tag: "datatype", name: "Dash", constraint: "0",
                     description: "Device supports Dynamic Adaptive Streaming over HTTP (DASH)"
                 },
-                { tag: "datatype", name: "Hls", constraint: "1", description: "Device supports HTTP Live Streaming (HLS)" }
+                {
+                    tag: "datatype", name: "Hls", constraint: "1",
+                    description: "Device supports HTTP Live Streaming (HLS)"
+                }
             ]
         },
 

--- a/packages/matter.js/src/model/standard/elements/DoorLock.ts
+++ b/packages/matter.js/src/model/standard/elements/DoorLock.ts
@@ -111,7 +111,10 @@ Matter.children.push({
                     tag: "datatype", name: "NotFullyLocked", id: 0x0, conformance: "M",
                     description: "Lock state is not fully locked"
                 },
-                { tag: "datatype", name: "Locked", id: 0x1, conformance: "M", description: "Lock state is fully locked" },
+                {
+                    tag: "datatype", name: "Locked", id: 0x1, conformance: "M",
+                    description: "Lock state is fully locked"
+                },
                 {
                     tag: "datatype", name: "Unlocked", id: 0x2, conformance: "M",
                     description: "Lock state is fully unlocked"
@@ -133,7 +136,10 @@ Matter.children.push({
                     tag: "datatype", name: "Magnetic", id: 0x1, conformance: "M",
                     description: "Physical lock type is magnetic"
                 },
-                { tag: "datatype", name: "Other", id: 0x2, conformance: "M", description: "Physical lock type is other" },
+                {
+                    tag: "datatype", name: "Other", id: 0x2, conformance: "M",
+                    description: "Physical lock type is other"
+                },
                 {
                     tag: "datatype", name: "Mortise", id: 0x3, conformance: "M",
                     description: "Physical lock type is mortise"
@@ -1210,7 +1216,10 @@ Matter.children.push({
                     children: [{ tag: "datatype", name: "entry", type: "CredentialStruct" }]
                 },
                 { tag: "datatype", name: "CreatorFabricIndex", type: "fabric-idx", conformance: "M", quality: "X" },
-                { tag: "datatype", name: "LastModifiedFabricIndex", type: "fabric-idx", conformance: "M", quality: "X" },
+                {
+                    tag: "datatype", name: "LastModifiedFabricIndex", type: "fabric-idx", conformance: "M",
+                    quality: "X"
+                },
                 { tag: "datatype", name: "NextUserIndex", type: "uint16", conformance: "M", quality: "X" }
             ]
         },
@@ -1274,7 +1283,10 @@ Matter.children.push({
                 { tag: "datatype", name: "CredentialExists", type: "bool", conformance: "M" },
                 { tag: "datatype", name: "UserIndex", type: "uint16", conformance: "M", quality: "X" },
                 { tag: "datatype", name: "CreatorFabricIndex", type: "fabric-idx", conformance: "M", quality: "X" },
-                { tag: "datatype", name: "LastModifiedFabricIndex", type: "fabric-idx", conformance: "M", quality: "X" },
+                {
+                    tag: "datatype", name: "LastModifiedFabricIndex", type: "fabric-idx", conformance: "M",
+                    quality: "X"
+                },
                 { tag: "datatype", name: "NextCredentialIndex", type: "uint16", conformance: "M", quality: "X" }
             ]
         },
@@ -1292,7 +1304,10 @@ Matter.children.push({
             xref: { document: "cluster", section: "5.2.6.1" },
 
             children: [
-                { tag: "datatype", name: "LockJammed", id: 0x0, conformance: "M", description: "Locking Mechanism Jammed" },
+                {
+                    tag: "datatype", name: "LockJammed", id: 0x0, conformance: "M",
+                    description: "Locking Mechanism Jammed"
+                },
                 {
                     tag: "datatype", name: "LockFactoryReset", id: 0x1, conformance: "O",
                     description: "Lock Reset to Factory Defaults"
@@ -1314,7 +1329,10 @@ Matter.children.push({
                     description: "Forced Door Open under Door Locked Condition"
                 },
                 { tag: "datatype", name: "DoorAjar", id: 0x7, conformance: "[DPS]", description: "Door ajar" },
-                { tag: "datatype", name: "ForcedUser", id: 0x8, conformance: "[USR]", description: "Force User SOS alarm" }
+                {
+                    tag: "datatype", name: "ForcedUser", id: 0x8, conformance: "[USR]",
+                    description: "Force User SOS alarm"
+                }
             ]
         },
 
@@ -1374,7 +1392,10 @@ Matter.children.push({
             xref: { document: "cluster", section: "5.2.6.5" },
 
             children: [
-                { tag: "datatype", name: "Add", id: 0x0, conformance: "M", description: "Data is being added or was added" },
+                {
+                    tag: "datatype", name: "Add", id: 0x0, conformance: "M",
+                    description: "Data is being added or was added"
+                },
                 {
                     tag: "datatype", name: "Clear", id: 0x1, conformance: "M",
                     description: "Data is being cleared or was cleared"
@@ -1412,8 +1433,14 @@ Matter.children.push({
 
             children: [
                 { tag: "datatype", name: "DoorOpen", id: 0x0, conformance: "DPS", description: "Door state is open" },
-                { tag: "datatype", name: "DoorClosed", id: 0x1, conformance: "DPS", description: "Door state is closed" },
-                { tag: "datatype", name: "DoorJammed", id: 0x2, conformance: "[DPS]", description: "Door state is jammed" },
+                {
+                    tag: "datatype", name: "DoorClosed", id: 0x1, conformance: "DPS",
+                    description: "Door state is closed"
+                },
+                {
+                    tag: "datatype", name: "DoorJammed", id: 0x2, conformance: "[DPS]",
+                    description: "Door state is jammed"
+                },
                 {
                     tag: "datatype", name: "DoorForcedOpen", id: 0x3, conformance: "[DPS]",
                     description: "Door state is currently forced open"

--- a/packages/matter.js/src/model/standard/elements/ElectricalMeasurement.ts
+++ b/packages/matter.js/src/model/standard/elements/ElectricalMeasurement.ts
@@ -59,11 +59,26 @@ Matter.children.push({
             tag: "attribute", name: "TotalApparentPower", id: 0x306, type: "uint32", conformance: "O",
             constraint: "max 16777215", default: 1
         },
-        { tag: "attribute", name: "Measured1StHarmonicCurrent", id: 0x307, type: "int16", conformance: "O", default: 32768 },
-        { tag: "attribute", name: "Measured3RdHarmonicCurrent", id: 0x308, type: "int16", conformance: "O", default: 32768 },
-        { tag: "attribute", name: "Measured5ThHarmonicCurrent", id: 0x309, type: "int16", conformance: "O", default: 32768 },
-        { tag: "attribute", name: "Measured7ThHarmonicCurrent", id: 0x30a, type: "int16", conformance: "O", default: 32768 },
-        { tag: "attribute", name: "Measured9ThHarmonicCurrent", id: 0x30b, type: "int16", conformance: "O", default: 32768 },
+        {
+            tag: "attribute", name: "Measured1StHarmonicCurrent", id: 0x307, type: "int16", conformance: "O",
+            default: 32768
+        },
+        {
+            tag: "attribute", name: "Measured3RdHarmonicCurrent", id: 0x308, type: "int16", conformance: "O",
+            default: 32768
+        },
+        {
+            tag: "attribute", name: "Measured5ThHarmonicCurrent", id: 0x309, type: "int16", conformance: "O",
+            default: 32768
+        },
+        {
+            tag: "attribute", name: "Measured7ThHarmonicCurrent", id: 0x30a, type: "int16", conformance: "O",
+            default: 32768
+        },
+        {
+            tag: "attribute", name: "Measured9ThHarmonicCurrent", id: 0x30b, type: "int16", conformance: "O",
+            default: 32768
+        },
         {
             tag: "attribute", name: "Measured11ThHarmonicCurrent", id: 0x30c, type: "int16", conformance: "O",
             default: 32768
@@ -117,8 +132,14 @@ Matter.children.push({
             constraint: "min -127", default: 0
         },
         { tag: "attribute", name: "InstantaneousVoltage", id: 0x500, type: "int16", conformance: "O", default: 65535 },
-        { tag: "attribute", name: "InstantaneousLineCurrent", id: 0x501, type: "uint16", conformance: "O", default: 65535 },
-        { tag: "attribute", name: "InstantaneousActiveCurrent", id: 0x502, type: "int16", conformance: "O", default: 65535 },
+        {
+            tag: "attribute", name: "InstantaneousLineCurrent", id: 0x501, type: "uint16", conformance: "O",
+            default: 65535
+        },
+        {
+            tag: "attribute", name: "InstantaneousActiveCurrent", id: 0x502, type: "int16", conformance: "O",
+            default: 65535
+        },
         {
             tag: "attribute", name: "InstantaneousReactiveCurrent", id: 0x503, type: "int16", conformance: "O",
             default: 65535
@@ -200,11 +221,20 @@ Matter.children.push({
         { tag: "attribute", name: "AcVoltageOverload", id: 0x801, type: "int16", conformance: "O", default: 65535 },
         { tag: "attribute", name: "AcCurrentOverload", id: 0x802, type: "int16", conformance: "O", default: 65535 },
         { tag: "attribute", name: "AcPowerOverload", id: 0x803, type: "int16", conformance: "O", default: 65535 },
-        { tag: "attribute", name: "AcReactivePowerOverload", id: 0x804, type: "int16", conformance: "O", default: 65535 },
+        {
+            tag: "attribute", name: "AcReactivePowerOverload", id: 0x804, type: "int16", conformance: "O",
+            default: 65535
+        },
         { tag: "attribute", name: "AverageRmsOverVoltage", id: 0x805, type: "int16", conformance: "O", default: 65535 },
-        { tag: "attribute", name: "AverageRmsUnderVoltage", id: 0x806, type: "int16", conformance: "O", default: 65535 },
+        {
+            tag: "attribute", name: "AverageRmsUnderVoltage", id: 0x806, type: "int16", conformance: "O",
+            default: 65535
+        },
         { tag: "attribute", name: "RmsExtremeOverVoltage", id: 0x807, type: "int16", conformance: "O", default: 65535 },
-        { tag: "attribute", name: "RmsExtremeUnderVoltage", id: 0x808, type: "int16", conformance: "O", default: 65535 },
+        {
+            tag: "attribute", name: "RmsExtremeUnderVoltage", id: 0x808, type: "int16", conformance: "O",
+            default: 65535
+        },
         { tag: "attribute", name: "RmsVoltageSag", id: 0x809, type: "int16", conformance: "O", default: 65535 },
         { tag: "attribute", name: "RmsVoltageSwell", id: 0x80a, type: "int16", conformance: "O", default: 65535 },
         { tag: "attribute", name: "LineCurrentPhaseB", id: 0x901, type: "uint16", conformance: "O", default: 65535 },
@@ -245,8 +275,14 @@ Matter.children.push({
             tag: "attribute", name: "RmsExtremeUnderVoltagePeriodPhaseB", id: 0x915, type: "uint16",
             conformance: "O", default: 0
         },
-        { tag: "attribute", name: "RmsVoltageSagPeriodPhaseB", id: 0x916, type: "uint16", conformance: "O", default: 0 },
-        { tag: "attribute", name: "RmsVoltageSwellPeriodPhaseB", id: 0x917, type: "uint16", conformance: "O", default: 0 },
+        {
+            tag: "attribute", name: "RmsVoltageSagPeriodPhaseB", id: 0x916, type: "uint16", conformance: "O",
+            default: 0
+        },
+        {
+            tag: "attribute", name: "RmsVoltageSwellPeriodPhaseB", id: 0x917, type: "uint16", conformance: "O",
+            default: 0
+        },
         { tag: "attribute", name: "LineCurrentPhaseC", id: 0xa01, type: "uint16", conformance: "O", default: 65535 },
         { tag: "attribute", name: "ActiveCurrentPhaseC", id: 0xa02, type: "int16", conformance: "O", default: 65535 },
         { tag: "attribute", name: "ReactiveCurrentPhaseC", id: 0xa03, type: "int16", conformance: "O", default: 65535 },
@@ -285,8 +321,14 @@ Matter.children.push({
             tag: "attribute", name: "RmsExtremeUnderVoltagePeriodPhaseC", id: 0xa15, type: "uint16",
             conformance: "O", default: 0
         },
-        { tag: "attribute", name: "RmsVoltageSagPeriodPhaseC", id: 0xa16, type: "uint16", conformance: "O", default: 0 },
-        { tag: "attribute", name: "RmsVoltageSwellPeriodPhaseC", id: 0xa17, type: "uint16", conformance: "O", default: 0 },
+        {
+            tag: "attribute", name: "RmsVoltageSagPeriodPhaseC", id: 0xa16, type: "uint16", conformance: "O",
+            default: 0
+        },
+        {
+            tag: "attribute", name: "RmsVoltageSwellPeriodPhaseC", id: 0xa17, type: "uint16", conformance: "O",
+            default: 0
+        },
 
         {
             tag: "command", name: "GetProfileInfoResponseCommand", id: 0x0, conformance: "O",

--- a/packages/matter.js/src/model/standard/elements/FanControl.ts
+++ b/packages/matter.js/src/model/standard/elements/FanControl.ts
@@ -31,7 +31,10 @@ Matter.children.push({
                     tag: "datatype", name: "RCK", constraint: "2", description: "Rocking",
                     details: "Rocking movement supported"
                 },
-                { tag: "datatype", name: "WND", constraint: "3", description: "Wind", details: "Wind emulation supported" }
+                {
+                    tag: "datatype", name: "WND", constraint: "3", description: "Wind",
+                    details: "Wind emulation supported"
+                }
             ]
         },
 

--- a/packages/matter.js/src/model/standard/elements/GeneralCommissioning.ts
+++ b/packages/matter.js/src/model/standard/elements/GeneralCommissioning.ts
@@ -223,8 +223,12 @@ Matter.children.push({
                 "     Node rollback the state of all non fabric-scoped data present in the Fail-Safe context.",
 
             xref: { document: "core", section: "11.9.6.2" },
+
             children: [
-                { tag: "datatype", name: "ExpiryLengthSeconds", id: 0x0, type: "uint16", conformance: "M", default: 900 },
+                {
+                    tag: "datatype", name: "ExpiryLengthSeconds", id: 0x0, type: "uint16", conformance: "M",
+                    default: 900
+                },
                 { tag: "datatype", name: "Breadcrumb", id: 0x1, type: "uint64", conformance: "M" }
             ]
         },

--- a/packages/matter.js/src/model/standard/elements/GeneralDiagnostics.ts
+++ b/packages/matter.js/src/model/standard/elements/GeneralDiagnostics.ts
@@ -420,7 +420,10 @@ Matter.children.push({
                     tag: "datatype", name: "Unspecified", id: 0x0, conformance: "M",
                     description: "Indicates an interface of an unspecified type."
                 },
-                { tag: "datatype", name: "WiFi", id: 0x1, conformance: "O", description: "Indicates a Wi-Fi interface." },
+                {
+                    tag: "datatype", name: "WiFi", id: 0x1, conformance: "O",
+                    description: "Indicates a Wi-Fi interface."
+                },
                 {
                     tag: "datatype", name: "Ethernet", id: 0x2, conformance: "O",
                     description: "Indicates a Ethernet interface."
@@ -429,7 +432,10 @@ Matter.children.push({
                     tag: "datatype", name: "Cellular", id: 0x3, conformance: "O",
                     description: "Indicates a Cellular interface."
                 },
-                { tag: "datatype", name: "Thread", id: 0x4, conformance: "O", description: "Indicates a Thread interface." }
+                {
+                    tag: "datatype", name: "Thread", id: 0x4, conformance: "O",
+                    description: "Indicates a Thread interface."
+                }
             ]
         },
 

--- a/packages/matter.js/src/model/standard/elements/MediaPlayback.ts
+++ b/packages/matter.js/src/model/standard/elements/MediaPlayback.ts
@@ -323,7 +323,10 @@ Matter.children.push({
                     tag: "datatype", name: "Playing", id: 0x0, conformance: "M",
                     description: "Media is currently playing (includes FF and REW)"
                 },
-                { tag: "datatype", name: "Paused", id: 0x1, conformance: "M", description: "Media is currently paused" },
+                {
+                    tag: "datatype", name: "Paused", id: 0x1, conformance: "M",
+                    description: "Media is currently paused"
+                },
                 {
                     tag: "datatype", name: "NotPlaying", id: 0x2, conformance: "M",
                     description: "Media is not currently playing"

--- a/packages/matter.js/src/model/standard/elements/ModeSelect.ts
+++ b/packages/matter.js/src/model/standard/elements/ModeSelect.ts
@@ -138,7 +138,9 @@ Matter.children.push({
                 "\n" +
                 "server shall respond with an INVALID_COMMAND status response.",
             xref: { document: "cluster", section: "1.8.6.1" },
-            children: [{ tag: "datatype", name: "NewMode", id: 0x0, type: "uint8", conformance: "M", constraint: "desc" }]
+            children: [
+                { tag: "datatype", name: "NewMode", id: 0x0, type: "uint8", conformance: "M", constraint: "desc" }
+            ]
         },
 
         {

--- a/packages/matter.js/src/model/standard/elements/NetworkCommissioning.ts
+++ b/packages/matter.js/src/model/standard/elements/NetworkCommissioning.ts
@@ -473,8 +473,12 @@ Matter.children.push({
                 "See Section 11.8.7.1.2, “Breadcrumb Field” for usage.",
 
             xref: { document: "core", section: "11.8.7.7" },
+
             children: [
-                { tag: "datatype", name: "NetworkId", id: 0x0, type: "octstr", conformance: "M", constraint: "1 to 32" },
+                {
+                    tag: "datatype", name: "NetworkId", id: 0x0, type: "octstr", conformance: "M",
+                    constraint: "1 to 32"
+                },
                 { tag: "datatype", name: "Breadcrumb", id: 0x1, type: "uint64", conformance: "O" }
             ]
         },
@@ -518,7 +522,10 @@ Matter.children.push({
                     tag: "datatype", name: "NetworkingStatus", id: 0x0, type: "NetworkCommissioningStatusEnum",
                     conformance: "M", constraint: "desc"
                 },
-                { tag: "datatype", name: "DebugText", id: 0x1, type: "string", conformance: "O", constraint: "max 512" },
+                {
+                    tag: "datatype", name: "DebugText", id: 0x1, type: "string", conformance: "O",
+                    constraint: "max 512"
+                },
 
                 {
                     tag: "datatype", name: "NetworkIndex", id: 0x2, type: "uint8", conformance: "O",
@@ -606,8 +613,12 @@ Matter.children.push({
                 "See Section 11.8.7.1.2, “Breadcrumb Field” for usage.",
 
             xref: { document: "core", section: "11.8.7.9" },
+
             children: [
-                { tag: "datatype", name: "NetworkId", id: 0x0, type: "octstr", conformance: "M", constraint: "1 to 32" },
+                {
+                    tag: "datatype", name: "NetworkId", id: 0x0, type: "octstr", conformance: "M",
+                    constraint: "1 to 32"
+                },
                 { tag: "datatype", name: "Breadcrumb", id: 0x1, type: "uint64", conformance: "O" }
             ]
         },
@@ -750,8 +761,12 @@ Matter.children.push({
                 "lowest priority network in the list.",
 
             xref: { document: "core", section: "11.8.7.11" },
+
             children: [
-                { tag: "datatype", name: "NetworkId", id: 0x0, type: "octstr", conformance: "M", constraint: "1 to 32" },
+                {
+                    tag: "datatype", name: "NetworkId", id: 0x0, type: "octstr", conformance: "M",
+                    constraint: "1 to 32"
+                },
                 { tag: "datatype", name: "NetworkIndex", id: 0x1, type: "uint8", conformance: "M", constraint: "desc" },
                 { tag: "datatype", name: "Breadcrumb", id: 0x2, type: "uint64", conformance: "O" }
             ]
@@ -943,9 +958,15 @@ Matter.children.push({
             xref: { document: "core", section: "11.8.5.6" },
 
             children: [
-                { tag: "datatype", name: "PanId", id: 0x0, type: "uint16", conformance: "TH", constraint: "0 to 65534" },
+                {
+                    tag: "datatype", name: "PanId", id: 0x0, type: "uint16", conformance: "TH",
+                    constraint: "0 to 65534"
+                },
                 { tag: "datatype", name: "ExtendedPanId", id: 0x1, type: "uint64", conformance: "TH" },
-                { tag: "datatype", name: "NetworkName", id: 0x2, type: "string", conformance: "TH", constraint: "1 to 16" },
+                {
+                    tag: "datatype", name: "NetworkName", id: 0x2, type: "string", conformance: "TH",
+                    constraint: "1 to 16"
+                },
                 { tag: "datatype", name: "Channel", id: 0x3, type: "uint16", conformance: "TH" },
                 { tag: "datatype", name: "Version", id: 0x4, type: "uint8", conformance: "TH" },
                 {

--- a/packages/matter.js/src/model/standard/elements/OnOff.ts
+++ b/packages/matter.js/src/model/standard/elements/OnOff.ts
@@ -206,8 +206,14 @@ Matter.children.push({
             xref: { document: "cluster", section: "1.5.5.1" },
 
             children: [
-                { tag: "datatype", name: "Off", id: 0x0, conformance: "M", description: "Set the OnOff attribute to FALSE" },
-                { tag: "datatype", name: "On", id: 0x1, conformance: "M", description: "Set the OnOff attribute to TRUE" },
+                {
+                    tag: "datatype", name: "Off", id: 0x0, conformance: "M",
+                    description: "Set the OnOff attribute to FALSE"
+                },
+                {
+                    tag: "datatype", name: "On", id: 0x1, conformance: "M",
+                    description: "Set the OnOff attribute to TRUE"
+                },
                 {
                     tag: "datatype", name: "Toggle", id: 0x2, conformance: "M",
                     description: "If the previous value of the OnOff attribute is equal to FALSE, set the OnOff attribute to TRUE. If the previous value of the OnOff attribute is equal to TRUE, set the OnOff attribute to FALSE (toggle)."

--- a/packages/matter.js/src/model/standard/elements/OperationalCredentials.ts
+++ b/packages/matter.js/src/model/standard/elements/OperationalCredentials.ts
@@ -118,9 +118,7 @@ Matter.children.push({
                 "recipient shall fail the command with a Status Code of INVALID_COMMAND. The AttestationNonce field " +
                 "shall be used in the computation of the Attestation Information.",
             xref: { document: "core", section: "11.17.6.1" },
-            children: [
-                { tag: "datatype", name: "AttestationNonce", id: 0x0, type: "octstr", conformance: "M", constraint: "32" }
-            ]
+            children: [{ tag: "datatype", name: "AttestationNonce", id: 0x0, type: "octstr", conformance: "M", constraint: "32" }]
         },
 
         {
@@ -269,7 +267,10 @@ Matter.children.push({
 
             children: [
                 { tag: "datatype", name: "NocValue", id: 0x0, type: "octstr", conformance: "M", constraint: "max 400" },
-                { tag: "datatype", name: "IcacValue", id: 0x1, type: "octstr", conformance: "O", constraint: "max 400" },
+                {
+                    tag: "datatype", name: "IcacValue", id: 0x1, type: "octstr", conformance: "O",
+                    constraint: "max 400"
+                },
 
                 {
                     tag: "datatype", name: "IpkValue", id: 0x2, type: "octstr", conformance: "M", constraint: "16",
@@ -565,7 +566,10 @@ Matter.children.push({
                 "updated.",
 
             xref: { document: "core", section: "11.17.6.11" },
-            children: [{ tag: "datatype", name: "Label", id: 0x0, type: "string", access: "F", conformance: "M", constraint: "max 32" }]
+            children: [{
+                tag: "datatype", name: "Label", id: 0x0, type: "string", access: "F", conformance: "M",
+                constraint: "max 32"
+            }]
         },
 
         {
@@ -628,7 +632,10 @@ Matter.children.push({
                 "session with the target.",
 
             xref: { document: "core", section: "11.17.6.12" },
-            children: [{ tag: "datatype", name: "FabricIndex", id: 0x0, type: "fabric-idx", conformance: "M", constraint: "1 to 254" }]
+            children: [{
+                tag: "datatype", name: "FabricIndex", id: 0x0, type: "fabric-idx", conformance: "M",
+                constraint: "1 to 254"
+            }]
         },
 
         {
@@ -663,7 +670,10 @@ Matter.children.push({
                 "root of trust using the RemoveFabric command.",
 
             xref: { document: "core", section: "11.17.6.13" },
-            children: [{ tag: "datatype", name: "RootCaCertificate", id: 0x0, type: "octstr", conformance: "M", constraint: "max 400" }]
+            children: [{
+                tag: "datatype", name: "RootCaCertificate", id: 0x0, type: "octstr", conformance: "M",
+                constraint: "max 400"
+            }]
         },
 
         {

--- a/packages/matter.js/src/model/standard/elements/OtaSoftwareUpdateProvider.ts
+++ b/packages/matter.js/src/model/standard/elements/OtaSoftwareUpdateProvider.ts
@@ -35,7 +35,10 @@ Matter.children.push({
                 },
                 { tag: "datatype", name: "HardwareVersion", id: 0x4, type: "uint16", conformance: "O" },
                 { tag: "datatype", name: "Location", id: 0x5, type: "string", conformance: "O", constraint: "2" },
-                { tag: "datatype", name: "RequestorCanConsent", id: 0x6, type: "bool", conformance: "O", default: true },
+                {
+                    tag: "datatype", name: "RequestorCanConsent", id: 0x6, type: "bool", conformance: "O",
+                    default: true
+                },
                 {
                     tag: "datatype", name: "MetadataForProvider", id: 0x7, type: "octstr", conformance: "O",
                     constraint: "max 512"
@@ -56,7 +59,10 @@ Matter.children.push({
                     tag: "datatype", name: "SoftwareVersionString", id: 0x4, type: "string", conformance: "O",
                     constraint: "1 to 64"
                 },
-                { tag: "datatype", name: "UpdateToken", id: 0x5, type: "octstr", conformance: "O", constraint: "8 to 32" },
+                {
+                    tag: "datatype", name: "UpdateToken", id: 0x5, type: "octstr", conformance: "O",
+                    constraint: "8 to 32"
+                },
                 { tag: "datatype", name: "UserConsentNeeded", id: 0x6, type: "bool", conformance: "O", default: true },
                 {
                     tag: "datatype", name: "MetadataForRequestor", id: 0x7, type: "octstr", conformance: "O",
@@ -72,8 +78,12 @@ Matter.children.push({
                 "This field may be used by the OTA Provider to track minimal lifecycle state to allow finer-grained " +
                 "scheduling of the application of Software Images by OTA Requestors.",
             xref: { document: "core", section: "11.19.6.5.18" },
+
             children: [
-                { tag: "datatype", name: "UpdateToken", id: 0x0, type: "octstr", conformance: "M", constraint: "8 to 32" },
+                {
+                    tag: "datatype", name: "UpdateToken", id: 0x0, type: "octstr", conformance: "M",
+                    constraint: "8 to 32"
+                },
                 { tag: "datatype", name: "NewVersion", id: 0x1, type: "uint32", conformance: "M" }
             ]
         },
@@ -124,8 +134,12 @@ Matter.children.push({
                 "cached Software Images, or use it for other similar administrative purposes.",
 
             xref: { document: "core", section: "11.19.6.5.22" },
+
             children: [
-                { tag: "datatype", name: "UpdateToken", id: 0x0, type: "octstr", conformance: "M", constraint: "8 to 32" },
+                {
+                    tag: "datatype", name: "UpdateToken", id: 0x0, type: "octstr", conformance: "M",
+                    constraint: "8 to 32"
+                },
                 { tag: "datatype", name: "SoftwareVersion", id: 0x1, type: "uint32", conformance: "M" }
             ]
         },
@@ -191,7 +205,10 @@ Matter.children.push({
                     tag: "datatype", name: "BdxAsynchronous", id: 0x1, conformance: "O",
                     description: "Indicates support for asynchronous BDX."
                 },
-                { tag: "datatype", name: "Https", id: 0x2, conformance: "O", description: "Indicates support for HTTPS." },
+                {
+                    tag: "datatype", name: "Https", id: 0x2, conformance: "O",
+                    description: "Indicates support for HTTPS."
+                },
                 {
                     tag: "datatype", name: "VendorSpecific", id: 0x3, conformance: "O",
                     description: "Indicates support for vendor specific protocol."

--- a/packages/matter.js/src/model/standard/elements/OtaSoftwareUpdateRequestor.ts
+++ b/packages/matter.js/src/model/standard/elements/OtaSoftwareUpdateRequestor.ts
@@ -80,7 +80,10 @@ Matter.children.push({
             xref: { document: "core", section: "11.19.7.7.1" },
 
             children: [
-                { tag: "datatype", name: "PreviousState", id: 0x0, type: "UpdateStateEnum", conformance: "M", default: 0 },
+                {
+                    tag: "datatype", name: "PreviousState", id: 0x0, type: "UpdateStateEnum", conformance: "M",
+                    default: 0
+                },
                 { tag: "datatype", name: "NewState", id: 0x1, type: "UpdateStateEnum", conformance: "M" },
                 { tag: "datatype", name: "Reason", id: 0x2, type: "ChangeReasonEnum", conformance: "M" },
                 {

--- a/packages/matter.js/src/model/standard/elements/PowerSource.ts
+++ b/packages/matter.js/src/model/standard/elements/PowerSource.ts
@@ -24,8 +24,14 @@ Matter.children.push({
             xref: { document: "core", section: "11.7.4" },
 
             children: [
-                { tag: "datatype", name: "WIRED", constraint: "0", description: "Wired", details: "A wired power source" },
-                { tag: "datatype", name: "BAT", constraint: "1", description: "Battery", details: "A battery power source" },
+                {
+                    tag: "datatype", name: "WIRED", constraint: "0", description: "Wired",
+                    details: "A wired power source"
+                },
+                {
+                    tag: "datatype", name: "BAT", constraint: "1", description: "Battery",
+                    details: "A battery power source"
+                },
                 {
                     tag: "datatype", name: "RECHG", constraint: "2", description: "Rechargeable",
                     details: "A rechargeable battery power source (requires Battery feature)"
@@ -602,79 +608,277 @@ Matter.children.push({
                 { tag: "datatype", name: "4V5", id: 0x5, conformance: "M", description: "Common type is as specified" },
                 { tag: "datatype", name: "6V0", id: 0x6, conformance: "M", description: "Common type is as specified" },
                 { tag: "datatype", name: "9V0", id: 0x7, conformance: "M", description: "Common type is as specified" },
-                { tag: "datatype", name: "12Aa", id: 0x8, conformance: "M", description: "Common type is as specified" },
-                { tag: "datatype", name: "Aaaa", id: 0x9, conformance: "M", description: "Common type is as specified" },
+                {
+                    tag: "datatype", name: "12Aa", id: 0x8, conformance: "M",
+                    description: "Common type is as specified"
+                },
+                {
+                    tag: "datatype", name: "Aaaa", id: 0x9, conformance: "M",
+                    description: "Common type is as specified"
+                },
                 { tag: "datatype", name: "A", id: 0xa, conformance: "M", description: "Common type is as specified" },
                 { tag: "datatype", name: "B", id: 0xb, conformance: "M", description: "Common type is as specified" },
                 { tag: "datatype", name: "F", id: 0xc, conformance: "M", description: "Common type is as specified" },
                 { tag: "datatype", name: "N", id: 0xd, conformance: "M", description: "Common type is as specified" },
                 { tag: "datatype", name: "No6", id: 0xe, conformance: "M", description: "Common type is as specified" },
-                { tag: "datatype", name: "SubC", id: 0xf, conformance: "M", description: "Common type is as specified" },
-                { tag: "datatype", name: "A23", id: 0x10, conformance: "M", description: "Common type is as specified" },
-                { tag: "datatype", name: "A27", id: 0x11, conformance: "M", description: "Common type is as specified" },
-                { tag: "datatype", name: "Ba5800", id: 0x12, conformance: "M", description: "Common type is as specified" },
-                { tag: "datatype", name: "Duplex", id: 0x13, conformance: "M", description: "Common type is as specified" },
-                { tag: "datatype", name: "4Sr44", id: 0x14, conformance: "M", description: "Common type is as specified" },
-                { tag: "datatype", name: "523", id: 0x15, conformance: "M", description: "Common type is as specified" },
-                { tag: "datatype", name: "531", id: 0x16, conformance: "M", description: "Common type is as specified" },
-                { tag: "datatype", name: "15V0", id: 0x17, conformance: "M", description: "Common type is as specified" },
-                { tag: "datatype", name: "22V5", id: 0x18, conformance: "M", description: "Common type is as specified" },
-                { tag: "datatype", name: "30V0", id: 0x19, conformance: "M", description: "Common type is as specified" },
-                { tag: "datatype", name: "45V0", id: 0x1a, conformance: "M", description: "Common type is as specified" },
-                { tag: "datatype", name: "67V5", id: 0x1b, conformance: "M", description: "Common type is as specified" },
+                {
+                    tag: "datatype", name: "SubC", id: 0xf, conformance: "M",
+                    description: "Common type is as specified"
+                },
+                {
+                    tag: "datatype", name: "A23", id: 0x10, conformance: "M",
+                    description: "Common type is as specified"
+                },
+                {
+                    tag: "datatype", name: "A27", id: 0x11, conformance: "M",
+                    description: "Common type is as specified"
+                },
+                {
+                    tag: "datatype", name: "Ba5800", id: 0x12, conformance: "M",
+                    description: "Common type is as specified"
+                },
+                {
+                    tag: "datatype", name: "Duplex", id: 0x13, conformance: "M",
+                    description: "Common type is as specified"
+                },
+                {
+                    tag: "datatype", name: "4Sr44", id: 0x14, conformance: "M",
+                    description: "Common type is as specified"
+                },
+                {
+                    tag: "datatype", name: "523", id: 0x15, conformance: "M",
+                    description: "Common type is as specified"
+                },
+                {
+                    tag: "datatype", name: "531", id: 0x16, conformance: "M",
+                    description: "Common type is as specified"
+                },
+                {
+                    tag: "datatype", name: "15V0", id: 0x17, conformance: "M",
+                    description: "Common type is as specified"
+                },
+                {
+                    tag: "datatype", name: "22V5", id: 0x18, conformance: "M",
+                    description: "Common type is as specified"
+                },
+                {
+                    tag: "datatype", name: "30V0", id: 0x19, conformance: "M",
+                    description: "Common type is as specified"
+                },
+                {
+                    tag: "datatype", name: "45V0", id: 0x1a, conformance: "M",
+                    description: "Common type is as specified"
+                },
+                {
+                    tag: "datatype", name: "67V5", id: 0x1b, conformance: "M",
+                    description: "Common type is as specified"
+                },
                 { tag: "datatype", name: "J", id: 0x1c, conformance: "M", description: "Common type is as specified" },
-                { tag: "datatype", name: "Cr123A", id: 0x1d, conformance: "M", description: "Common type is as specified" },
-                { tag: "datatype", name: "Cr2", id: 0x1e, conformance: "M", description: "Common type is as specified" },
-                { tag: "datatype", name: "2Cr5", id: 0x1f, conformance: "M", description: "Common type is as specified" },
-                { tag: "datatype", name: "CrP2", id: 0x20, conformance: "M", description: "Common type is as specified" },
-                { tag: "datatype", name: "CrV3", id: 0x21, conformance: "M", description: "Common type is as specified" },
-                { tag: "datatype", name: "Sr41", id: 0x22, conformance: "M", description: "Common type is as specified" },
-                { tag: "datatype", name: "Sr43", id: 0x23, conformance: "M", description: "Common type is as specified" },
-                { tag: "datatype", name: "Sr44", id: 0x24, conformance: "M", description: "Common type is as specified" },
-                { tag: "datatype", name: "Sr45", id: 0x25, conformance: "M", description: "Common type is as specified" },
-                { tag: "datatype", name: "Sr48", id: 0x26, conformance: "M", description: "Common type is as specified" },
-                { tag: "datatype", name: "Sr54", id: 0x27, conformance: "M", description: "Common type is as specified" },
-                { tag: "datatype", name: "Sr55", id: 0x28, conformance: "M", description: "Common type is as specified" },
-                { tag: "datatype", name: "Sr57", id: 0x29, conformance: "M", description: "Common type is as specified" },
-                { tag: "datatype", name: "Sr58", id: 0x2a, conformance: "M", description: "Common type is as specified" },
-                { tag: "datatype", name: "Sr59", id: 0x2b, conformance: "M", description: "Common type is as specified" },
-                { tag: "datatype", name: "Sr60", id: 0x2c, conformance: "M", description: "Common type is as specified" },
-                { tag: "datatype", name: "Sr63", id: 0x2d, conformance: "M", description: "Common type is as specified" },
-                { tag: "datatype", name: "Sr64", id: 0x2e, conformance: "M", description: "Common type is as specified" },
-                { tag: "datatype", name: "Sr65", id: 0x2f, conformance: "M", description: "Common type is as specified" },
-                { tag: "datatype", name: "Sr66", id: 0x30, conformance: "M", description: "Common type is as specified" },
-                { tag: "datatype", name: "Sr67", id: 0x31, conformance: "M", description: "Common type is as specified" },
-                { tag: "datatype", name: "Sr68", id: 0x32, conformance: "M", description: "Common type is as specified" },
-                { tag: "datatype", name: "Sr69", id: 0x33, conformance: "M", description: "Common type is as specified" },
-                { tag: "datatype", name: "Sr516", id: 0x34, conformance: "M", description: "Common type is as specified" },
-                { tag: "datatype", name: "Sr731", id: 0x35, conformance: "M", description: "Common type is as specified" },
-                { tag: "datatype", name: "Sr712", id: 0x36, conformance: "M", description: "Common type is as specified" },
-                { tag: "datatype", name: "Lr932", id: 0x37, conformance: "M", description: "Common type is as specified" },
+                {
+                    tag: "datatype", name: "Cr123A", id: 0x1d, conformance: "M",
+                    description: "Common type is as specified"
+                },
+                {
+                    tag: "datatype", name: "Cr2", id: 0x1e, conformance: "M",
+                    description: "Common type is as specified"
+                },
+                {
+                    tag: "datatype", name: "2Cr5", id: 0x1f, conformance: "M",
+                    description: "Common type is as specified"
+                },
+                {
+                    tag: "datatype", name: "CrP2", id: 0x20, conformance: "M",
+                    description: "Common type is as specified"
+                },
+                {
+                    tag: "datatype", name: "CrV3", id: 0x21, conformance: "M",
+                    description: "Common type is as specified"
+                },
+                {
+                    tag: "datatype", name: "Sr41", id: 0x22, conformance: "M",
+                    description: "Common type is as specified"
+                },
+                {
+                    tag: "datatype", name: "Sr43", id: 0x23, conformance: "M",
+                    description: "Common type is as specified"
+                },
+                {
+                    tag: "datatype", name: "Sr44", id: 0x24, conformance: "M",
+                    description: "Common type is as specified"
+                },
+                {
+                    tag: "datatype", name: "Sr45", id: 0x25, conformance: "M",
+                    description: "Common type is as specified"
+                },
+                {
+                    tag: "datatype", name: "Sr48", id: 0x26, conformance: "M",
+                    description: "Common type is as specified"
+                },
+                {
+                    tag: "datatype", name: "Sr54", id: 0x27, conformance: "M",
+                    description: "Common type is as specified"
+                },
+                {
+                    tag: "datatype", name: "Sr55", id: 0x28, conformance: "M",
+                    description: "Common type is as specified"
+                },
+                {
+                    tag: "datatype", name: "Sr57", id: 0x29, conformance: "M",
+                    description: "Common type is as specified"
+                },
+                {
+                    tag: "datatype", name: "Sr58", id: 0x2a, conformance: "M",
+                    description: "Common type is as specified"
+                },
+                {
+                    tag: "datatype", name: "Sr59", id: 0x2b, conformance: "M",
+                    description: "Common type is as specified"
+                },
+                {
+                    tag: "datatype", name: "Sr60", id: 0x2c, conformance: "M",
+                    description: "Common type is as specified"
+                },
+                {
+                    tag: "datatype", name: "Sr63", id: 0x2d, conformance: "M",
+                    description: "Common type is as specified"
+                },
+                {
+                    tag: "datatype", name: "Sr64", id: 0x2e, conformance: "M",
+                    description: "Common type is as specified"
+                },
+                {
+                    tag: "datatype", name: "Sr65", id: 0x2f, conformance: "M",
+                    description: "Common type is as specified"
+                },
+                {
+                    tag: "datatype", name: "Sr66", id: 0x30, conformance: "M",
+                    description: "Common type is as specified"
+                },
+                {
+                    tag: "datatype", name: "Sr67", id: 0x31, conformance: "M",
+                    description: "Common type is as specified"
+                },
+                {
+                    tag: "datatype", name: "Sr68", id: 0x32, conformance: "M",
+                    description: "Common type is as specified"
+                },
+                {
+                    tag: "datatype", name: "Sr69", id: 0x33, conformance: "M",
+                    description: "Common type is as specified"
+                },
+                {
+                    tag: "datatype", name: "Sr516", id: 0x34, conformance: "M",
+                    description: "Common type is as specified"
+                },
+                {
+                    tag: "datatype", name: "Sr731", id: 0x35, conformance: "M",
+                    description: "Common type is as specified"
+                },
+                {
+                    tag: "datatype", name: "Sr712", id: 0x36, conformance: "M",
+                    description: "Common type is as specified"
+                },
+                {
+                    tag: "datatype", name: "Lr932", id: 0x37, conformance: "M",
+                    description: "Common type is as specified"
+                },
                 { tag: "datatype", name: "A5", id: 0x38, conformance: "M", description: "Common type is as specified" },
-                { tag: "datatype", name: "A10", id: 0x39, conformance: "M", description: "Common type is as specified" },
-                { tag: "datatype", name: "A13", id: 0x3a, conformance: "M", description: "Common type is as specified" },
-                { tag: "datatype", name: "A312", id: 0x3b, conformance: "M", description: "Common type is as specified" },
-                { tag: "datatype", name: "A675", id: 0x3c, conformance: "M", description: "Common type is as specified" },
-                { tag: "datatype", name: "Ac41E", id: 0x3d, conformance: "M", description: "Common type is as specified" },
-                { tag: "datatype", name: "10180", id: 0x3e, conformance: "M", description: "Common type is as specified" },
-                { tag: "datatype", name: "10280", id: 0x3f, conformance: "M", description: "Common type is as specified" },
-                { tag: "datatype", name: "10440", id: 0x40, conformance: "M", description: "Common type is as specified" },
-                { tag: "datatype", name: "14250", id: 0x41, conformance: "M", description: "Common type is as specified" },
-                { tag: "datatype", name: "14430", id: 0x42, conformance: "M", description: "Common type is as specified" },
-                { tag: "datatype", name: "14500", id: 0x43, conformance: "M", description: "Common type is as specified" },
-                { tag: "datatype", name: "14650", id: 0x44, conformance: "M", description: "Common type is as specified" },
-                { tag: "datatype", name: "15270", id: 0x45, conformance: "M", description: "Common type is as specified" },
-                { tag: "datatype", name: "16340", id: 0x46, conformance: "M", description: "Common type is as specified" },
-                { tag: "datatype", name: "Rcr123A", id: 0x47, conformance: "M", description: "Common type is as specified" },
-                { tag: "datatype", name: "17500", id: 0x48, conformance: "M", description: "Common type is as specified" },
-                { tag: "datatype", name: "17670", id: 0x49, conformance: "M", description: "Common type is as specified" },
-                { tag: "datatype", name: "18350", id: 0x4a, conformance: "M", description: "Common type is as specified" },
-                { tag: "datatype", name: "18500", id: 0x4b, conformance: "M", description: "Common type is as specified" },
-                { tag: "datatype", name: "18650", id: 0x4c, conformance: "M", description: "Common type is as specified" },
-                { tag: "datatype", name: "19670", id: 0x4d, conformance: "M", description: "Common type is as specified" },
-                { tag: "datatype", name: "25500", id: 0x4e, conformance: "M", description: "Common type is as specified" },
-                { tag: "datatype", name: "26650", id: 0x4f, conformance: "M", description: "Common type is as specified" },
-                { tag: "datatype", name: "32600", id: 0x50, conformance: "M", description: "Common type is as specified" }
+                {
+                    tag: "datatype", name: "A10", id: 0x39, conformance: "M",
+                    description: "Common type is as specified"
+                },
+                {
+                    tag: "datatype", name: "A13", id: 0x3a, conformance: "M",
+                    description: "Common type is as specified"
+                },
+                {
+                    tag: "datatype", name: "A312", id: 0x3b, conformance: "M",
+                    description: "Common type is as specified"
+                },
+                {
+                    tag: "datatype", name: "A675", id: 0x3c, conformance: "M",
+                    description: "Common type is as specified"
+                },
+                {
+                    tag: "datatype", name: "Ac41E", id: 0x3d, conformance: "M",
+                    description: "Common type is as specified"
+                },
+                {
+                    tag: "datatype", name: "10180", id: 0x3e, conformance: "M",
+                    description: "Common type is as specified"
+                },
+                {
+                    tag: "datatype", name: "10280", id: 0x3f, conformance: "M",
+                    description: "Common type is as specified"
+                },
+                {
+                    tag: "datatype", name: "10440", id: 0x40, conformance: "M",
+                    description: "Common type is as specified"
+                },
+                {
+                    tag: "datatype", name: "14250", id: 0x41, conformance: "M",
+                    description: "Common type is as specified"
+                },
+                {
+                    tag: "datatype", name: "14430", id: 0x42, conformance: "M",
+                    description: "Common type is as specified"
+                },
+                {
+                    tag: "datatype", name: "14500", id: 0x43, conformance: "M",
+                    description: "Common type is as specified"
+                },
+                {
+                    tag: "datatype", name: "14650", id: 0x44, conformance: "M",
+                    description: "Common type is as specified"
+                },
+                {
+                    tag: "datatype", name: "15270", id: 0x45, conformance: "M",
+                    description: "Common type is as specified"
+                },
+                {
+                    tag: "datatype", name: "16340", id: 0x46, conformance: "M",
+                    description: "Common type is as specified"
+                },
+                {
+                    tag: "datatype", name: "Rcr123A", id: 0x47, conformance: "M",
+                    description: "Common type is as specified"
+                },
+                {
+                    tag: "datatype", name: "17500", id: 0x48, conformance: "M",
+                    description: "Common type is as specified"
+                },
+                {
+                    tag: "datatype", name: "17670", id: 0x49, conformance: "M",
+                    description: "Common type is as specified"
+                },
+                {
+                    tag: "datatype", name: "18350", id: 0x4a, conformance: "M",
+                    description: "Common type is as specified"
+                },
+                {
+                    tag: "datatype", name: "18500", id: 0x4b, conformance: "M",
+                    description: "Common type is as specified"
+                },
+                {
+                    tag: "datatype", name: "18650", id: 0x4c, conformance: "M",
+                    description: "Common type is as specified"
+                },
+                {
+                    tag: "datatype", name: "19670", id: 0x4d, conformance: "M",
+                    description: "Common type is as specified"
+                },
+                {
+                    tag: "datatype", name: "25500", id: 0x4e, conformance: "M",
+                    description: "Common type is as specified"
+                },
+                {
+                    tag: "datatype", name: "26650", id: 0x4f, conformance: "M",
+                    description: "Common type is as specified"
+                },
+                {
+                    tag: "datatype", name: "32600", id: 0x50, conformance: "M",
+                    description: "Common type is as specified"
+                }
             ]
         },
 
@@ -687,7 +891,10 @@ Matter.children.push({
                     tag: "datatype", name: "Unspecified", id: 0x0, conformance: "M",
                     description: "Cell chemistry is unspecified or unknown"
                 },
-                { tag: "datatype", name: "Alkaline", id: 0x1, conformance: "M", description: "Cell chemistry is alkaline" },
+                {
+                    tag: "datatype", name: "Alkaline", id: 0x1, conformance: "M",
+                    description: "Cell chemistry is alkaline"
+                },
                 {
                     tag: "datatype", name: "LithiumCarbonFluoride", id: 0x2, conformance: "M",
                     description: "Cell chemistry is lithium carbon fluoride"
@@ -728,7 +935,10 @@ Matter.children.push({
                     tag: "datatype", name: "SilverOxide", id: 0xb, conformance: "M",
                     description: "Cell chemistry is silver oxide"
                 },
-                { tag: "datatype", name: "ZincAir", id: 0xc, conformance: "M", description: "Cell chemistry is zinc air" },
+                {
+                    tag: "datatype", name: "ZincAir", id: 0xc, conformance: "M",
+                    description: "Cell chemistry is zinc air"
+                },
                 {
                     tag: "datatype", name: "ZincCarbon", id: 0xd, conformance: "M",
                     description: "Cell chemistry is zinc carbon"
@@ -821,7 +1031,10 @@ Matter.children.push({
                     tag: "datatype", name: "Unknown", id: 0x0, conformance: "M",
                     description: "Unable to determine the charging state"
                 },
-                { tag: "datatype", name: "IsCharging", id: 0x1, conformance: "M", description: "The battery is charging" },
+                {
+                    tag: "datatype", name: "IsCharging", id: 0x1, conformance: "M",
+                    description: "The battery is charging"
+                },
                 {
                     tag: "datatype", name: "IsAtFullCharge", id: 0x2, conformance: "M",
                     description: "The battery is at full charge"

--- a/packages/matter.js/src/model/standard/elements/PumpConfigurationAndControl.ts
+++ b/packages/matter.js/src/model/standard/elements/PumpConfigurationAndControl.ts
@@ -514,7 +514,10 @@ Matter.children.push({
                 },
 
                 { tag: "datatype", name: "SpeedLow", constraint: "2", description: "Setpoint is too low to achieve." },
-                { tag: "datatype", name: "SpeedHigh", constraint: "3", description: "Setpoint is too high to achieve." },
+                {
+                    tag: "datatype", name: "SpeedHigh", constraint: "3",
+                    description: "Setpoint is too high to achieve."
+                },
 
                 {
                     tag: "datatype", name: "LocalOverride", constraint: "4",

--- a/packages/matter.js/src/model/standard/elements/Scenes.ts
+++ b/packages/matter.js/src/model/standard/elements/Scenes.ts
@@ -280,7 +280,10 @@ Matter.children.push({
                 { tag: "datatype", name: "GroupId", id: 0x1, type: "group-id", conformance: "M" },
                 { tag: "datatype", name: "SceneId", id: 0x2, type: "uint8", conformance: "M" },
                 { tag: "datatype", name: "TransitionTime", id: 0x3, type: "uint16", conformance: "desc" },
-                { tag: "datatype", name: "SceneName", id: 0x4, type: "string", conformance: "desc", constraint: "max 16" },
+                {
+                    tag: "datatype", name: "SceneName", id: 0x4, type: "string", conformance: "desc",
+                    constraint: "max 16"
+                },
                 {
                     tag: "datatype", name: "ExtensionFieldSets", id: 0x5, type: "list", conformance: "desc",
                     children: [{ tag: "datatype", name: "entry", type: "ExtensionFieldSet" }]

--- a/packages/matter.js/src/model/standard/elements/Thermostat.ts
+++ b/packages/matter.js/src/model/standard/elements/Thermostat.ts
@@ -840,12 +840,18 @@ Matter.children.push({
 
             children: [
                 { tag: "datatype", name: "Unknown", id: 0x0, conformance: "O", description: "Unknown AC Type" },
-                { tag: "datatype", name: "CoolingFixed", id: 0x1, conformance: "O", description: "Cooling and Fixed Speed" },
+                {
+                    tag: "datatype", name: "CoolingFixed", id: 0x1, conformance: "O",
+                    description: "Cooling and Fixed Speed"
+                },
                 {
                     tag: "datatype", name: "HeatPumpFixed", id: 0x2, conformance: "O",
                     description: "Heat Pump and Fixed Speed"
                 },
-                { tag: "datatype", name: "CoolingInverter", id: 0x3, conformance: "O", description: "Cooling and Inverter" },
+                {
+                    tag: "datatype", name: "CoolingInverter", id: 0x3, conformance: "O",
+                    description: "Cooling and Inverter"
+                },
                 {
                     tag: "datatype", name: "HeatPumpInverter", id: 0x4, conformance: "O",
                     description: "Heat Pump and Inverter"
@@ -870,7 +876,10 @@ Matter.children.push({
             xref: { document: "cluster", section: "4.3.7.46" },
 
             children: [
-                { tag: "datatype", name: "Unknown", id: 0x0, conformance: "O", description: "Unknown Refrigerant Type" },
+                {
+                    tag: "datatype", name: "Unknown", id: 0x0, conformance: "O",
+                    description: "Unknown Refrigerant Type"
+                },
                 { tag: "datatype", name: "R22", id: 0x1, conformance: "O", description: "R22 Refrigerant" },
                 { tag: "datatype", name: "R410A", id: 0x2, conformance: "O", description: "R410a Refrigerant" },
                 { tag: "datatype", name: "R407C", id: 0x3, conformance: "O", description: "R407c Refrigerant" }
@@ -907,7 +916,10 @@ Matter.children.push({
                     tag: "datatype", name: "CompressorFail", constraint: "0",
                     description: "Compressor Failure or Refrigerant Leakage"
                 },
-                { tag: "datatype", name: "RoomSensorFail", constraint: "1", description: "Room Temperature Sensor Failure" },
+                {
+                    tag: "datatype", name: "RoomSensorFail", constraint: "1",
+                    description: "Room Temperature Sensor Failure"
+                },
                 {
                     tag: "datatype", name: "OutdoorSensorFail", constraint: "2",
                     description: "Outdoor Temperature Sensor Failure"
@@ -933,7 +945,10 @@ Matter.children.push({
                 { tag: "datatype", name: "Open", id: 0x2, conformance: "O", description: "Fully Open" },
                 { tag: "datatype", name: "Quarter", id: 0x3, conformance: "O", description: "Quarter Open" },
                 { tag: "datatype", name: "Half", id: 0x4, conformance: "O", description: "Half Open" },
-                { tag: "datatype", name: "ThreeQuarters", id: 0x5, conformance: "O", description: "Three Quarters Open" }
+                {
+                    tag: "datatype", name: "ThreeQuarters", id: 0x5, conformance: "O",
+                    description: "Three Quarters Open"
+                }
             ]
         },
 
@@ -952,9 +967,7 @@ Matter.children.push({
                 "\n" +
                 "Table 87. ACCapacity Values",
             xref: { document: "cluster", section: "4.3.7.51" },
-            children: [
-                { tag: "datatype", name: "BtUh", id: 0x0, conformance: "O", description: "British Thermal Unit per Hour" }
-            ]
+            children: [{ tag: "datatype", name: "BtUh", id: 0x0, conformance: "O", description: "British Thermal Unit per Hour" }]
         },
 
         {

--- a/packages/matter.js/src/model/standard/elements/ThermostatUserInterfaceConfiguration.ts
+++ b/packages/matter.js/src/model/standard/elements/ThermostatUserInterfaceConfiguration.ts
@@ -28,7 +28,10 @@ Matter.children.push({
             xref: { document: "cluster", section: "4.5.5.1" },
 
             children: [
-                { tag: "datatype", name: "Celsius", id: 0x0, conformance: "M", description: "Temperature displayed in °C" },
+                {
+                    tag: "datatype", name: "Celsius", id: 0x0, conformance: "M",
+                    description: "Temperature displayed in °C"
+                },
                 {
                     tag: "datatype", name: "Fahrenheit", id: 0x1, conformance: "M",
                     description: "Temperature displayed in °F"

--- a/packages/matter.js/src/model/standard/elements/ThreadNetworkDiagnostics.ts
+++ b/packages/matter.js/src/model/standard/elements/ThreadNetworkDiagnostics.ts
@@ -697,9 +697,13 @@ Matter.children.push({
         {
             tag: "datatype", name: "ConnectionStatusEnum", type: "enum8", conformance: "M",
             xref: { document: "core", section: "11.13.5.2" },
+
             children: [
                 { tag: "datatype", name: "Connected", id: 0x0, conformance: "M", description: "Node is connected" },
-                { tag: "datatype", name: "NotConnected", id: 0x1, conformance: "M", description: "Node is not connected" }
+                {
+                    tag: "datatype", name: "NotConnected", id: 0x1, conformance: "M",
+                    description: "Node is not connected"
+                }
             ]
         },
 

--- a/packages/matter.js/src/model/standard/elements/TimeSync.ts
+++ b/packages/matter.js/src/model/standard/elements/TimeSync.ts
@@ -229,8 +229,12 @@ Matter.children.push({
                 "zone database [https://www.iana.org/time-zones].",
 
             xref: { document: "core", section: "11.16.10.3" },
+
             children: [
-                { tag: "datatype", name: "Offset", id: 0x0, type: "int32", conformance: "M", constraint: "-43200 to 50400" },
+                {
+                    tag: "datatype", name: "Offset", id: 0x0, type: "int32", conformance: "M",
+                    constraint: "-43200 to 50400"
+                },
                 { tag: "datatype", name: "Name", id: 0x1, type: "string", conformance: "O", constraint: "0 to 64" }
             ]
         },

--- a/tools/generate-clusters.ts
+++ b/tools/generate-clusters.ts
@@ -21,7 +21,9 @@ for (const cluster of mom.clusters) {
     file.save();
 
     if (cluster.id !== undefined) {
-        index.atom(`export { ${file.clusterName}, ${file.typesName} } from "./${file.clusterName}.js"`);
+        const exports = index.expressions(`export {`, `} from "./${file.clusterName}.js"`);
+        exports.atom(file.clusterName);
+        exports.atom(file.typesName);
     }
 }
 


### PR DESCRIPTION
Note -- only two files changed by hand.  Only whitespace changes in generated files.

Two small changes that affect a number of files:

First, do not place object entries on a single line if any entry has multiple lines in it.  The formatter does not approve of this.  Now format will not rewrite any generated files

Second, more accurately assess line length when wrapping.  This includes measuring line suffix and removing spurious padding we previously added for wrapping.  Prevents past behavior of lines expanding just beyond 120 character-limit.