### PR TITLE
Work around TS type inference limitations 

### DIFF
--- a/packages/matter-node.js-examples/src/examples/DeviceNode.ts
+++ b/packages/matter-node.js-examples/src/examples/DeviceNode.ts
@@ -164,9 +164,8 @@ class Device {
             // the device implementor based on the relevant networking stack.
             // The NetworkCommissioningCluster and all logics are described in Matter Core Specifications section 11.8
             const firstNetworkId = new ByteArray(32);
-            const WifiCluster = NetworkCommissioning.Cluster.with(NetworkCommissioning.Feature.WiFiNetworkInterface);
             commissioningServer.addRootClusterServer(ClusterServer(
-                WifiCluster,
+                NetworkCommissioning.Cluster.with(NetworkCommissioning.Feature.WiFiNetworkInterface),
                 {
                     maxNetworks: 1,
                     interfaceEnabled: true,
@@ -317,7 +316,7 @@ class Device {
                             networkIndex: 0
                         };
                     },
-                } as ClusterServerHandlers<typeof WifiCluster>
+                }
             ));
         }
 

--- a/packages/matter-node.js/test/cluster/GroupsServerTest.ts
+++ b/packages/matter-node.js/test/cluster/GroupsServerTest.ts
@@ -46,7 +46,7 @@ describe("Groups Server test", () => {
             },
             {
                 identify: async ({ request: { identifyTime } }) => { console.log(identifyTime); /* */ }
-            } as ClusterServerHandlers<typeof Identify.Cluster>
+            }
         );
 
         testSession = await createTestSessionWithFabric();

--- a/packages/matter.js/src/CommissioningServer.ts
+++ b/packages/matter.js/src/CommissioningServer.ts
@@ -307,7 +307,7 @@ export class CommissioningServer extends MatterNode {
                 },
                 {
                     testEventTrigger: async (args) => await this.commandHandler.executeHandler("testEventTrigger", args)
-                } as ClusterServerHandlers<typeof GeneralDiagnosticsCluster>,
+                },
                 {
                     bootReason: true
                 }

--- a/packages/matter.js/src/cluster/index.ts
+++ b/packages/matter.js/src/cluster/index.ts
@@ -7,7 +7,6 @@
 // Export general Cluster specific types
 export * from "./Cluster.js";
 export * from "./ClusterHelper.js";
-export { NetworkCommissioning } from "./definitions/index.js";
 
 // Export all Cluster definitions
 export * from "./definitions/index.js";

--- a/packages/matter.js/src/protocol/interaction/InteractionServer.ts
+++ b/packages/matter.js/src/protocol/interaction/InteractionServer.ts
@@ -61,10 +61,17 @@ function isConditionMatching<F extends BitSchema, SF extends TypeFromPartialBitS
     return false;
 }
 
-export function ClusterServer<F extends BitSchema, SF extends TypeFromPartialBitSchema<F>, A extends Attributes, C extends Commands, E extends Events>(
+export function ClusterServer<
+    F extends BitSchema,
+    SF extends TypeFromPartialBitSchema<F>,
+    A extends Attributes,
+    C extends Commands,
+    E extends Events,
+    H extends ClusterServerHandlers<Cluster<F, SF, A, C, E>>
+>(
     clusterDef: Cluster<F, SF, A, C, E>,
     attributesInitialValues: AttributeInitialValues<A>,
-    handlers: ClusterServerHandlers<Cluster<F, SF, A, C, E>>,
+    handlers: H,
     supportedEvents: SupportedEventsList<E> = <SupportedEventsList<E>>{}
 ): ClusterServerObj<A, C, E> {
     const {

--- a/packages/matter.js/test/cluster/ClusterFactoryTest.ts
+++ b/packages/matter.js/test/cluster/ClusterFactoryTest.ts
@@ -8,7 +8,10 @@ import { BaseClusterComponent, ClusterComponent, ClusterForBaseCluster, Extensib
 import { Attribute, Cluster, Command, Event, EventPriority, TlvNoResponse } from "../../src/cluster/Cluster.js";
 import { TlvUInt8 } from "../../src/tlv/TlvNumber.js";
 import { TlvNoArguments } from "../../src/tlv/TlvNoArguments.js";
-import { BitFlag, BitFlags, TypeFromPartialBitSchema } from "../../src/schema/BitmapSchema.js";
+import { BitFlag, BitFlags, BitSchema, TypeFromPartialBitSchema } from "../../src/schema/BitmapSchema.js";
+import { TlvField, TlvObject, FieldType } from "../../src/tlv/TlvObject.js";
+import { ClusterServer } from "../../src/protocol/interaction/InteractionServer.js";
+import { ClusterServerHandlers, ClusterServerObj } from "../../src/cluster/server/ClusterServer.js";
 
 enum Feature {
     Extended = "Extended",
@@ -31,7 +34,7 @@ const METADATA = {
     features: FEATURES
 }
 
-const ELEMENTS = {
+const ELEMENTS = ClusterComponent({
     attributes: {
         attr1: Attribute(1, TlvUInt8)
     },
@@ -41,19 +44,22 @@ const ELEMENTS = {
     events: {
         ev1: Event(3, EventPriority.Debug, TlvNoArguments)
     }
-}
+})
 
-const ELEMENTS2 = {
+const ELEMENTS2 = ClusterComponent({
     attributes: {
         attr2: Attribute(4, TlvUInt8)
     },
     commands: {
-        cmd2: Command(5, TlvNoArguments, 5, TlvNoResponse)
+        cmd2: Command(
+            5, TlvObject({ cmd2RequestField: TlvField(1, TlvUInt8) }),
+            5, TlvObject({ cmd2ResponseField: TlvField(1, TlvUInt8) })
+        )
     },
     events: {
         ev2: Event(6, EventPriority.Debug, TlvNoArguments)
     }
-}
+})
 
 function expectMetadata(component: BaseClusterComponent<any, any, any, any>) {
     expect(component.id).toBe(METADATA.id);
@@ -249,5 +255,139 @@ describe("ClusterFactory", () => {
                 TestExtensibleCluster.with("Extended", "AbsolutelyFabulous", "BitterDisappointment");
             }).toThrowError(IllegalClusterError);
         })
+    })
+
+    /**
+     * Not a runtime test.  If this compiles the test "passes".
+     * 
+     * Ensures that ClusterServer instantiates correctly from extended
+     * clusters.
+     */
+    it("ClusterServer type is correct for automatic cluster", () => {
+        const MyCluster = TestExtensibleCluster.with("Extended");
+
+        // Create handlers directly
+        const handlers: ClusterServerHandlers<typeof MyCluster> = {
+            cmd1: ({ attributes: { attr1, attr2 }, session, endpoint}) => {
+                attr1; attr2; session; endpoint;
+            },
+            cmd2: ({ request: { cmd2RequestField },  attributes: { attr1, attr2 }, session, endpoint}) => {
+                cmd2RequestField; attr1; attr2; session; endpoint;
+                return { cmd2ResponseField: 5 };
+            },
+            getAttr1: ({ attributes: { attr1, attr2 }, session, endpoint}) => {
+                if (attr1 == undefined || attr2 == undefined || session === undefined || endpoint === undefined) throw new Error("Missing attribute");
+                return 5;
+            }
+        };
+        handlers;
+
+        // Create cluster server
+        ClusterServer(
+            MyCluster,
+            {
+                attr1: 1,
+                attr2: 2,
+            },
+            {
+                cmd1: ({ attributes: { attr1, attr2 }, session, endpoint}) => {
+                    attr1; attr2; session; endpoint;
+                },
+                cmd2: ({ request: { cmd2RequestField },  attributes: { attr1, attr2 }, session, endpoint}) => {
+                    cmd2RequestField; attr1; attr2; session; endpoint;
+                    return { cmd2ResponseField: 5 };
+                },
+                getAttr1: ({ attributes: { attr1, attr2 }, session, endpoint}) => {
+                    if (attr1 == undefined || attr2 == undefined || session === undefined || endpoint === undefined) throw new Error("Missing attribute");
+                    return 5;
+                }
+            } as ClusterServerHandlers<typeof MyCluster>, // TODO - cast should not be necessary, TS should infer
+            {
+                ev1: true,
+                ev2: true,
+            }
+        );
+    })
+
+    /**
+     * Not a runtime test.  If this compiles the test "passes".
+     * 
+     * Equivalent of above but removes ClusterFactory from the equation.
+     */
+    it("ClusterServer type is correct for manually defined equivalent", () => {
+        const MyCluster = Cluster({
+            id: 0x901,
+            name: "MyCluster",
+            revision: 2,
+            features: {
+                extended: BitFlag(0),
+                fancy: BitFlag(1),
+                absolutelyFabulous: BitFlag(2),
+                bitterDisappointment: BitFlag(3)
+            },
+            supportedFeatures: {
+                extended: true,
+                fancy: false,
+                absolutelyFabulous: false,
+                bitterDisappointment: false
+            },
+            attributes: {
+                attr1: Attribute(1, TlvUInt8),
+                attr2: Attribute(4, TlvUInt8)
+            },
+            commands: {
+                cmd1: Command(2, TlvNoArguments, 2, TlvNoResponse),
+                cmd2: Command(
+                    5, TlvObject({ cmd2RequestField: TlvField(1, TlvUInt8) }),
+                    5, TlvObject({ cmd2ResponseField: TlvField(1, TlvUInt8) })
+                )
+            },
+            events: {
+                ev1: Event(3, EventPriority.Debug, TlvNoArguments),
+                ev2: Event(6, EventPriority.Debug, TlvNoArguments)
+            }
+        })
+
+        // Create handlers directly
+        const handlers: ClusterServerHandlers<typeof MyCluster> = {
+            cmd1: ({ attributes: { attr1, attr2 }, session, endpoint}) => {
+                attr1; attr2; session; endpoint;
+            },
+            cmd2: ({ request: { cmd2RequestField },  attributes: { attr1, attr2 }, session, endpoint}) => {
+                cmd2RequestField; attr1; attr2; session; endpoint;
+                return { cmd2ResponseField: 5 };
+            },
+            getAttr1: ({ attributes: { attr1, attr2 }, session, endpoint}) => {
+                if (attr1 == undefined || attr2 == undefined || session === undefined || endpoint === undefined) throw new Error("Missing attribute");
+                return 5;
+            }
+        };
+        handlers;
+
+        // Create the cluster server
+        ClusterServer(
+            MyCluster,
+            {
+                attr1: 1,
+                attr2: 2,
+            },
+            {
+                cmd1: ({ attributes: { attr1, attr2 }, session, endpoint}) => {
+                    attr1; attr2; session; endpoint;
+                },
+                cmd2: ({ request: { cmd2RequestField },  attributes: { attr1, attr2 }, session, endpoint}) => {
+                    cmd2RequestField; attr1; attr2; session; endpoint;
+                    return { cmd2ResponseField: 5 };
+                },
+                getAttr1: ({ attributes: { attr1, attr2 }, session, endpoint}) => {
+                    if (attr1 == undefined || attr2 == undefined || session === undefined || endpoint === undefined) throw new Error("Missing attribute");
+                    return 5;
+                }
+            } as ClusterServerHandlers<typeof MyCluster>, // TODO - cast should not be necessary, TS should infer
+            {
+                ev1: true,
+                ev2: true,
+            }
+        );
     })
 })

--- a/packages/matter.js/test/cluster/ClusterFactoryTest.ts
+++ b/packages/matter.js/test/cluster/ClusterFactoryTest.ts
@@ -8,10 +8,10 @@ import { BaseClusterComponent, ClusterComponent, ClusterForBaseCluster, Extensib
 import { Attribute, Cluster, Command, Event, EventPriority, TlvNoResponse } from "../../src/cluster/Cluster.js";
 import { TlvUInt8 } from "../../src/tlv/TlvNumber.js";
 import { TlvNoArguments } from "../../src/tlv/TlvNoArguments.js";
-import { BitFlag, BitFlags, BitSchema, TypeFromPartialBitSchema } from "../../src/schema/BitmapSchema.js";
-import { TlvField, TlvObject, FieldType } from "../../src/tlv/TlvObject.js";
+import { BitFlag, BitFlags, TypeFromPartialBitSchema } from "../../src/schema/BitmapSchema.js";
+import { TlvField, TlvObject } from "../../src/tlv/TlvObject.js";
 import { ClusterServer } from "../../src/protocol/interaction/InteractionServer.js";
-import { ClusterServerHandlers, ClusterServerObj } from "../../src/cluster/server/ClusterServer.js";
+import { ClusterServerHandlers } from "../../src/cluster/server/ClusterServer.js";
 
 enum Feature {
     Extended = "Extended",
@@ -268,14 +268,14 @@ describe("ClusterFactory", () => {
 
         // Create handlers directly
         const handlers: ClusterServerHandlers<typeof MyCluster> = {
-            cmd1: ({ attributes: { attr1, attr2 }, session, endpoint}) => {
+            cmd1: ({ attributes: { attr1, attr2 }, session, endpoint }) => {
                 attr1; attr2; session; endpoint;
             },
-            cmd2: ({ request: { cmd2RequestField },  attributes: { attr1, attr2 }, session, endpoint}) => {
+            cmd2: ({ request: { cmd2RequestField }, attributes: { attr1, attr2 }, session, endpoint }) => {
                 cmd2RequestField; attr1; attr2; session; endpoint;
                 return { cmd2ResponseField: 5 };
             },
-            getAttr1: ({ attributes: { attr1, attr2 }, session, endpoint}) => {
+            getAttr1: ({ attributes: { attr1, attr2 }, session, endpoint }) => {
                 if (attr1 == undefined || attr2 == undefined || session === undefined || endpoint === undefined) throw new Error("Missing attribute");
                 return 5;
             }
@@ -288,24 +288,22 @@ describe("ClusterFactory", () => {
             {
                 attr1: 1,
                 attr2: 2,
+            }, {
+            cmd1: ({ attributes: { attr1, attr2 }, session, endpoint }) => {
+                attr1; attr2; session; endpoint;
             },
-            {
-                cmd1: ({ attributes: { attr1, attr2 }, session, endpoint}) => {
-                    attr1; attr2; session; endpoint;
-                },
-                cmd2: ({ request: { cmd2RequestField },  attributes: { attr1, attr2 }, session, endpoint}) => {
-                    cmd2RequestField; attr1; attr2; session; endpoint;
-                    return { cmd2ResponseField: 5 };
-                },
-                getAttr1: ({ attributes: { attr1, attr2 }, session, endpoint}) => {
-                    if (attr1 == undefined || attr2 == undefined || session === undefined || endpoint === undefined) throw new Error("Missing attribute");
-                    return 5;
-                }
-            } as ClusterServerHandlers<typeof MyCluster>, // TODO - cast should not be necessary, TS should infer
-            {
-                ev1: true,
-                ev2: true,
+            cmd2: ({ request: { cmd2RequestField }, attributes: { attr1, attr2 }, session, endpoint }) => {
+                cmd2RequestField; attr1; attr2; session; endpoint;
+                return { cmd2ResponseField: 5 };
+            },
+            getAttr1: ({ attributes: { attr1, attr2 }, session, endpoint }) => {
+                if (attr1 == undefined || attr2 == undefined || session === undefined || endpoint === undefined) throw new Error("Missing attribute");
+                return 5;
             }
+        }, {
+            ev1: true,
+            ev2: true,
+        }
         );
     })
 
@@ -350,14 +348,14 @@ describe("ClusterFactory", () => {
 
         // Create handlers directly
         const handlers: ClusterServerHandlers<typeof MyCluster> = {
-            cmd1: ({ attributes: { attr1, attr2 }, session, endpoint}) => {
+            cmd1: ({ attributes: { attr1, attr2 }, session, endpoint }) => {
                 attr1; attr2; session; endpoint;
             },
-            cmd2: ({ request: { cmd2RequestField },  attributes: { attr1, attr2 }, session, endpoint}) => {
+            cmd2: ({ request: { cmd2RequestField }, attributes: { attr1, attr2 }, session, endpoint }) => {
                 cmd2RequestField; attr1; attr2; session; endpoint;
                 return { cmd2ResponseField: 5 };
             },
-            getAttr1: ({ attributes: { attr1, attr2 }, session, endpoint}) => {
+            getAttr1: ({ attributes: { attr1, attr2 }, session, endpoint }) => {
                 if (attr1 == undefined || attr2 == undefined || session === undefined || endpoint === undefined) throw new Error("Missing attribute");
                 return 5;
             }
@@ -370,24 +368,22 @@ describe("ClusterFactory", () => {
             {
                 attr1: 1,
                 attr2: 2,
+            }, {
+            cmd1: ({ attributes: { attr1, attr2 }, session, endpoint }) => {
+                attr1; attr2; session; endpoint;
             },
-            {
-                cmd1: ({ attributes: { attr1, attr2 }, session, endpoint}) => {
-                    attr1; attr2; session; endpoint;
-                },
-                cmd2: ({ request: { cmd2RequestField },  attributes: { attr1, attr2 }, session, endpoint}) => {
-                    cmd2RequestField; attr1; attr2; session; endpoint;
-                    return { cmd2ResponseField: 5 };
-                },
-                getAttr1: ({ attributes: { attr1, attr2 }, session, endpoint}) => {
-                    if (attr1 == undefined || attr2 == undefined || session === undefined || endpoint === undefined) throw new Error("Missing attribute");
-                    return 5;
-                }
-            } as ClusterServerHandlers<typeof MyCluster>, // TODO - cast should not be necessary, TS should infer
-            {
-                ev1: true,
-                ev2: true,
+            cmd2: ({ request: { cmd2RequestField }, attributes: { attr1, attr2 }, session, endpoint }) => {
+                cmd2RequestField; attr1; attr2; session; endpoint;
+                return { cmd2ResponseField: 5 };
+            },
+            getAttr1: ({ attributes: { attr1, attr2 }, session, endpoint }) => {
+                if (attr1 == undefined || attr2 == undefined || session === undefined || endpoint === undefined) throw new Error("Missing attribute");
+                return 5;
             }
+        }, {
+            ev1: true,
+            ev2: true,
+        }
         );
     })
 })


### PR DESCRIPTION
Slightly redefine ClusterServer so that handler argument inference is less fragile.  Previously we sometimes needed to cast handlers using "as ClusterServerHandlers<typeof MyCluster>" because tsc was bailing prematurely resulting in "any" argument types.

Added compile-time test cases in ClusterFactoryTest.ts to cover.
