### PR TITLE
FabricIndex support

### DIFF
--- a/models/spec.ts
+++ b/models/spec.ts
@@ -10743,6 +10743,11 @@ export const SpecMatter: MatterElement = {
                                 "is present, the client cluster shall also exist on this endpoint (with this Binding cluster). If " +
                                 "this field is present, the target shall be this cluster on the target endpoint(s).",
                             xref: { document: "core", section: "9.6.5.1.4" }
+                        },
+
+                        {
+                            tag: "datatype", name: "FabricIndex", id: 0xfe, type: "fabric-idx", access: "R F V",
+                            conformance: "M", constraint: "1 to 254"
                         }
                     ]
                 }
@@ -10988,6 +10993,11 @@ export const SpecMatter: MatterElement = {
                                 "This field SHOULD be set if resources are adequate for it; otherwise it shall be set to NULL if " +
                                 "resources are scarce.",
                             xref: { document: "core", section: "9.10.7.1.4" }
+                        },
+
+                        {
+                            tag: "datatype", name: "FabricIndex", id: 0xfe, type: "fabric-idx", access: "R F V",
+                            conformance: "M", constraint: "1 to 254"
                         }
                     ]
                 },
@@ -11041,6 +11051,10 @@ export const SpecMatter: MatterElement = {
                         {
                             tag: "datatype", name: "LatestValue", id: 0x4, type: "AccessControlExtensionStruct", access: "S",
                             conformance: "M", quality: "X"
+                        },
+                        {
+                            tag: "datatype", name: "FabricIndex", id: 0xfe, type: "fabric-idx", access: "R F V",
+                            conformance: "M", constraint: "1 to 254"
                         }
                     ]
                 },
@@ -11247,6 +11261,11 @@ export const SpecMatter: MatterElement = {
 
                             xref: { document: "core", section: "9.10.4.5.4" },
                             children: [{ tag: "datatype", name: "entry", type: "AccessControlTargetStruct" }]
+                        },
+
+                        {
+                            tag: "datatype", name: "FabricIndex", id: 0xfe, type: "fabric-idx", access: "R F V",
+                            conformance: "M", constraint: "1 to 254"
                         }
                     ]
                 },
@@ -11255,23 +11274,30 @@ export const SpecMatter: MatterElement = {
                     tag: "datatype", name: "AccessControlExtensionStruct", type: "struct",
                     xref: { document: "core", section: "9.10.4.6" },
 
-                    children: [{
-                        tag: "datatype", name: "Data", id: 0x1, type: "octstr", access: "S", conformance: "M",
-                        constraint: "max 128",
+                    children: [
+                        {
+                            tag: "datatype", name: "Data", id: 0x1, type: "octstr", access: "S", conformance: "M",
+                            constraint: "max 128",
 
-                        details: "This field may be used by manufacturers to store arbitrary TLV-encoded data related to a fabric’s" +
-                            "\n" +
-                            "Access Control Entries." +
-                            "\n" +
-                            "The contents shall consist of a top-level anonymous list; each list element shall include a " +
-                            "profile-specific tag encoded in fully-qualified form." +
-                            "\n" +
-                            "Administrators may iterate over this list of elements, and interpret selected elements at their " +
-                            "discretion. The content of each element is not specified, but may be coordinated among " +
-                            "manufacturers at their discretion.",
+                            details: "This field may be used by manufacturers to store arbitrary TLV-encoded data related to a fabric’s" +
+                                "\n" +
+                                "Access Control Entries." +
+                                "\n" +
+                                "The contents shall consist of a top-level anonymous list; each list element shall include a " +
+                                "profile-specific tag encoded in fully-qualified form." +
+                                "\n" +
+                                "Administrators may iterate over this list of elements, and interpret selected elements at their " +
+                                "discretion. The content of each element is not specified, but may be coordinated among " +
+                                "manufacturers at their discretion.",
 
-                        xref: { document: "core", section: "9.10.4.6.1" }
-                    }]
+                            xref: { document: "core", section: "9.10.4.6.1" }
+                        },
+
+                        {
+                            tag: "datatype", name: "FabricIndex", id: 0xfe, type: "fabric-idx", access: "R F V",
+                            conformance: "M", constraint: "1 to 254"
+                        }
+                    ]
                 }
             ]
         },
@@ -12827,6 +12853,11 @@ export const SpecMatter: MatterElement = {
                                 "\n" +
                                 "A GroupKeyMapStruct shall NOT accept GroupKeySetID of 0, which is reserved for the IPK.",
                             xref: { document: "core", section: "11.2.6.3.2" }
+                        },
+
+                        {
+                            tag: "datatype", name: "FabricIndex", id: 0xfe, type: "fabric-idx", access: "R F V",
+                            conformance: "M", constraint: "1 to 254"
                         }
                     ]
                 },
@@ -12945,6 +12976,11 @@ export const SpecMatter: MatterElement = {
                             details: "This field provides a name for the group. This field shall contain the last GroupName written for a " +
                                 "given GroupId on any Endpoint via the Groups cluster.",
                             xref: { document: "core", section: "11.2.6.5.2" }
+                        },
+
+                        {
+                            tag: "datatype", name: "FabricIndex", id: 0xfe, type: "fabric-idx", access: "R F V",
+                            conformance: "M", constraint: "1 to 254"
                         }
                     ]
                 }
@@ -19057,6 +19093,10 @@ export const SpecMatter: MatterElement = {
                         {
                             tag: "datatype", name: "IcacValue", id: 0x1, type: "octstr", access: "F", conformance: "O",
                             constraint: "max 400"
+                        },
+                        {
+                            tag: "datatype", name: "FabricIndex", id: 0xfe, type: "fabric-idx", access: "R F V",
+                            conformance: "M", constraint: "1 to 254"
                         }
                     ]
                 },
@@ -19135,10 +19175,17 @@ export const SpecMatter: MatterElement = {
                         "updated.",
 
                     xref: { document: "core", section: "11.17.6.11" },
-                    children: [{
-                        tag: "datatype", name: "Label", id: 0x0, type: "string", access: "F", conformance: "M",
-                        constraint: "max 32"
-                    }]
+
+                    children: [
+                        {
+                            tag: "datatype", name: "Label", id: 0x0, type: "string", access: "F", conformance: "M",
+                            constraint: "max 32"
+                        },
+                        {
+                            tag: "datatype", name: "FabricIndex", id: 0xfe, type: "fabric-idx", access: "R F V",
+                            conformance: "M", constraint: "1 to 254"
+                        }
+                    ]
                 },
 
                 {
@@ -19335,6 +19382,11 @@ export const SpecMatter: MatterElement = {
                             details: "This field shall contain the ICAC or the struct’s associated fabric, encoded using Matter " +
                                 "Certificate Encoding. If no ICAC is present in the chain, this field shall be set to null.",
                             xref: { document: "core", section: "11.17.4.4.2" }
+                        },
+
+                        {
+                            tag: "datatype", name: "FabricIndex", id: 0xfe, type: "fabric-idx", access: "R F V",
+                            conformance: "M", constraint: "1 to 254"
                         }
                     ]
                 },
@@ -19392,6 +19444,11 @@ export const SpecMatter: MatterElement = {
                             details: "This field shall contain a commissioner-set label for the fabric referenced by FabricIndex. This " +
                                 "label is set by the UpdateFabricLabel command.",
                             xref: { document: "core", section: "11.17.4.5.5" }
+                        },
+
+                        {
+                            tag: "datatype", name: "FabricIndex", id: 0xfe, type: "fabric-idx", access: "R F V",
+                            conformance: "M", constraint: "1 to 254"
                         }
                     ]
                 }
@@ -20031,7 +20088,11 @@ export const SpecMatter: MatterElement = {
                             tag: "datatype", name: "MetadataForNode", id: 0x3, type: "octstr", access: "F", conformance: "O",
                             constraint: "max 512"
                         },
-                        { tag: "datatype", name: "Endpoint", id: 0x4, type: "endpoint-no", access: "F", conformance: "M" }
+                        { tag: "datatype", name: "Endpoint", id: 0x4, type: "endpoint-no", access: "F", conformance: "M" },
+                        {
+                            tag: "datatype", name: "FabricIndex", id: 0xfe, type: "fabric-idx", access: "R F V",
+                            conformance: "M", constraint: "1 to 254"
+                        }
                     ]
                 },
 
@@ -20137,7 +20198,11 @@ export const SpecMatter: MatterElement = {
                         {
                             tag: "datatype", name: "ProviderNodeId", id: 0x1, type: "node-id", access: "F", conformance: "M"
                         },
-                        { tag: "datatype", name: "Endpoint", id: 0x2, type: "endpoint-no", access: "F", conformance: "M" }
+                        { tag: "datatype", name: "Endpoint", id: 0x2, type: "endpoint-no", access: "F", conformance: "M" },
+                        {
+                            tag: "datatype", name: "FabricIndex", id: 0xfe, type: "fabric-idx", access: "R F V",
+                            conformance: "M", constraint: "1 to 254"
+                        }
                     ]
                 }
             ]

--- a/models/spec.ts
+++ b/models/spec.ts
@@ -562,10 +562,13 @@ export const SpecMatter: MatterElement = {
                     tag: "command", name: "RecallScene", id: 0x5, access: "O", conformance: "M", direction: "request",
                     response: "status",
                     xref: { document: "cluster", section: "1.4.9.7" },
+
                     children: [
                         { tag: "datatype", name: "GroupId", id: 0x0, type: "group-id", conformance: "M" },
                         { tag: "datatype", name: "SceneId", id: 0x1, type: "uint8", conformance: "M" },
-                        { tag: "datatype", name: "TransitionTime", id: 0x2, type: "uint16", conformance: "O", quality: "X" }
+                        {
+                            tag: "datatype", name: "TransitionTime", id: 0x2, type: "uint16", conformance: "O", quality: "X"
+                        }
                     ]
                 },
 
@@ -1261,8 +1264,12 @@ export const SpecMatter: MatterElement = {
                     xref: { document: "cluster", section: "1.6.6.1" },
 
                     children: [
-                        { tag: "datatype", name: "Level", id: 0x0, type: "uint8", conformance: "M", constraint: "0 to 254" },
-                        { tag: "datatype", name: "TransitionTime", id: 0x1, type: "uint16", conformance: "M", quality: "X" },
+                        {
+                            tag: "datatype", name: "Level", id: 0x0, type: "uint8", conformance: "M", constraint: "0 to 254"
+                        },
+                        {
+                            tag: "datatype", name: "TransitionTime", id: 0x1, type: "uint16", conformance: "M", quality: "X"
+                        },
                         {
                             tag: "datatype", name: "OptionsMask", id: 0x2, type: "Options", conformance: "M",
                             constraint: "desc", default: 0
@@ -1332,7 +1339,9 @@ export const SpecMatter: MatterElement = {
                     children: [
                         { tag: "datatype", name: "StepMode", id: 0x0, type: "enum8", conformance: "M", constraint: "desc" },
                         { tag: "datatype", name: "StepSize", id: 0x1, type: "uint8", conformance: "M" },
-                        { tag: "datatype", name: "TransitionTime", id: 0x2, type: "uint16", conformance: "M", quality: "X" },
+                        {
+                            tag: "datatype", name: "TransitionTime", id: 0x2, type: "uint16", conformance: "M", quality: "X"
+                        },
                         {
                             tag: "datatype", name: "OptionsMask", id: 0x3, type: "Options", conformance: "M",
                             constraint: "desc", default: 0
@@ -1578,8 +1587,12 @@ export const SpecMatter: MatterElement = {
                     xref: { document: "cluster", section: "1.6.6.1" },
 
                     children: [
-                        { tag: "datatype", name: "Level", id: 0x0, type: "uint8", conformance: "M", constraint: "0 to 254" },
-                        { tag: "datatype", name: "TransitionTime", id: 0x1, type: "uint16", conformance: "M", quality: "X" },
+                        {
+                            tag: "datatype", name: "Level", id: 0x0, type: "uint8", conformance: "M", constraint: "0 to 254"
+                        },
+                        {
+                            tag: "datatype", name: "TransitionTime", id: 0x1, type: "uint16", conformance: "M", quality: "X"
+                        },
                         {
                             tag: "datatype", name: "OptionsMask", id: 0x2, type: "Options", conformance: "M",
                             constraint: "desc", default: 0
@@ -1649,7 +1662,9 @@ export const SpecMatter: MatterElement = {
                     children: [
                         { tag: "datatype", name: "StepMode", id: 0x0, type: "enum8", conformance: "M", constraint: "desc" },
                         { tag: "datatype", name: "StepSize", id: 0x1, type: "uint8", conformance: "M" },
-                        { tag: "datatype", name: "TransitionTime", id: 0x2, type: "uint16", conformance: "M", quality: "X" },
+                        {
+                            tag: "datatype", name: "TransitionTime", id: 0x2, type: "uint16", conformance: "M", quality: "X"
+                        },
                         {
                             tag: "datatype", name: "OptionsMask", id: 0x3, type: "Options", conformance: "M",
                             constraint: "desc", default: 0
@@ -2028,7 +2043,9 @@ export const SpecMatter: MatterElement = {
 
                     children: [
                         { tag: "datatype", name: "LS", conformance: "O.a", constraint: "0", description: "LatchingSwitch" },
-                        { tag: "datatype", name: "MS", conformance: "O.a", constraint: "1", description: "MomentarySwitch" },
+                        {
+                            tag: "datatype", name: "MS", conformance: "O.a", constraint: "1", description: "MomentarySwitch"
+                        },
                         {
                             tag: "datatype", name: "MSR", conformance: "[MS]", constraint: "2",
                             description: "MomentarySwitchRelease"
@@ -5930,9 +5947,15 @@ export const SpecMatter: MatterElement = {
                         {
                             tag: "datatype", name: "Unknown", id: 0x0, conformance: "O", description: "Unknown compressor type"
                         },
-                        { tag: "datatype", name: "T1", id: 0x1, conformance: "O", description: "Max working ambient 43 °C" },
-                        { tag: "datatype", name: "T2", id: 0x2, conformance: "O", description: "Max working ambient 35 °C" },
-                        { tag: "datatype", name: "T3", id: 0x3, conformance: "O", description: "Max working ambient 52 °C" }
+                        {
+                            tag: "datatype", name: "T1", id: 0x1, conformance: "O", description: "Max working ambient 43 °C"
+                        },
+                        {
+                            tag: "datatype", name: "T2", id: 0x2, conformance: "O", description: "Max working ambient 35 °C"
+                        },
+                        {
+                            tag: "datatype", name: "T3", id: 0x3, conformance: "O", description: "Max working ambient 52 °C"
+                        }
                     ]
                 },
 
@@ -6612,7 +6635,9 @@ export const SpecMatter: MatterElement = {
                             tag: "datatype", name: "CylindricalLock", id: 0x6,
                             description: "Physical lock type is cylindrical lock"
                         },
-                        { tag: "datatype", name: "TubularLock", id: 0x7, description: "Physical lock type is tubular lock" },
+                        {
+                            tag: "datatype", name: "TubularLock", id: 0x7, description: "Physical lock type is tubular lock"
+                        },
                         {
                             tag: "datatype", name: "InterconnectedLock", id: 0x8,
                             description: "Physical lock type is interconnected lock"
@@ -11103,10 +11128,13 @@ export const SpecMatter: MatterElement = {
                 {
                     tag: "datatype", name: "AccessControlTargetStruct", type: "struct",
                     xref: { document: "core", section: "9.10.4.4" },
+
                     children: [
                         { tag: "datatype", name: "Cluster", id: 0x0, type: "cluster-id", conformance: "M", quality: "X" },
                         { tag: "datatype", name: "Endpoint", id: 0x1, type: "endpoint-no", conformance: "M", quality: "X" },
-                        { tag: "datatype", name: "DeviceType", id: 0x2, type: "devtype-id", conformance: "M", quality: "X" }
+                        {
+                            tag: "datatype", name: "DeviceType", id: 0x2, type: "devtype-id", conformance: "M", quality: "X"
+                        }
                     ]
                 },
 
@@ -15022,7 +15050,9 @@ export const SpecMatter: MatterElement = {
                     xref: { document: "core", section: "11.8.5.1" },
 
                     children: [
-                        { tag: "datatype", name: "Unencrypted", constraint: "0", description: "Supports unencrypted Wi-Fi" },
+                        {
+                            tag: "datatype", name: "Unencrypted", constraint: "0", description: "Supports unencrypted Wi-Fi"
+                        },
                         { tag: "datatype", name: "Wep", constraint: "1", description: "Supports Wi-Fi using WEP security" },
                         {
                             tag: "datatype", name: "WpaPersonal", constraint: "2",
@@ -15088,7 +15118,9 @@ export const SpecMatter: MatterElement = {
                             tag: "datatype", name: "DuplicateNetworkId", id: 0x4,
                             description: "The NetworkID is already among the collection of added networks"
                         },
-                        { tag: "datatype", name: "NetworkNotFound", id: 0x5, description: "Cannot find AP: SSID Not found" },
+                        {
+                            tag: "datatype", name: "NetworkNotFound", id: 0x5, description: "Cannot find AP: SSID Not found"
+                        },
                         {
                             tag: "datatype", name: "RegulatoryError", id: 0x6,
                             description: "Cannot find AP: Mismatch on band/channels/regulatory domain / 2.4GHz vs 5GHz"
@@ -15104,7 +15136,9 @@ export const SpecMatter: MatterElement = {
                         {
                             tag: "datatype", name: "OtherConnectionFailure", id: 0x9, description: "Other association failure"
                         },
-                        { tag: "datatype", name: "Ipv6Failed", id: 0xa, description: "Failure to generate an IPv6 address" },
+                        {
+                            tag: "datatype", name: "Ipv6Failed", id: 0xa, description: "Failure to generate an IPv6 address"
+                        },
                         {
                             tag: "datatype", name: "IpBindFailed", id: 0xb,
                             description: "Failure to bind Wi-Fi <-> IP interfaces"
@@ -15506,7 +15540,9 @@ export const SpecMatter: MatterElement = {
                             tag: "datatype", name: "NewRegulatoryConfig", id: 0x0, type: "RegulatoryLocationTypeEnum",
                             conformance: "M"
                         },
-                        { tag: "datatype", name: "CountryCode", id: 0x1, type: "string", conformance: "M", constraint: "2" },
+                        {
+                            tag: "datatype", name: "CountryCode", id: 0x1, type: "string", conformance: "M", constraint: "2"
+                        },
                         { tag: "datatype", name: "Breadcrumb", id: 0x2, type: "uint64", conformance: "M" }
                     ]
                 },
@@ -15641,10 +15677,13 @@ export const SpecMatter: MatterElement = {
                     details: "This enumeration is used by the RegulatoryConfig and LocationCapability attributes to indicate " +
                         "possible radio usage.",
                     xref: { document: "core", section: "11.9.4.2" },
+
                     children: [
                         { tag: "datatype", name: "Indoor", id: 0x0, conformance: "M", description: "Indoor only" },
                         { tag: "datatype", name: "Outdoor", id: 0x1, conformance: "M", description: "Outdoor only" },
-                        { tag: "datatype", name: "IndoorOutdoor", id: 0x2, conformance: "M", description: "Indoor/Outdoor" }
+                        {
+                            tag: "datatype", name: "IndoorOutdoor", id: 0x2, conformance: "M", description: "Indoor/Outdoor"
+                        }
                     ]
                 },
 
@@ -18071,15 +18110,23 @@ export const SpecMatter: MatterElement = {
 
                     children: [
                         { tag: "datatype", name: "Rate10M", id: 0x0, conformance: "M", description: "PHY rate is 10Mbps" },
-                        { tag: "datatype", name: "Rate100M", id: 0x1, conformance: "M", description: "PHY rate is 100Mbps" },
+                        {
+                            tag: "datatype", name: "Rate100M", id: 0x1, conformance: "M", description: "PHY rate is 100Mbps"
+                        },
                         { tag: "datatype", name: "Rate1G", id: 0x2, conformance: "M", description: "PHY rate is 1Gbps" },
                         { tag: "datatype", name: "Rate25G", id: 0x3, conformance: "M", description: "PHY rate is 2.5Gbps" },
                         { tag: "datatype", name: "Rate5G", id: 0x4, conformance: "M", description: "PHY rate is 5Gbps" },
                         { tag: "datatype", name: "Rate10G", id: 0x5, conformance: "M", description: "PHY rate is 10Gbps" },
                         { tag: "datatype", name: "Rate40G", id: 0x6, conformance: "M", description: "PHY rate is 40Gbps" },
-                        { tag: "datatype", name: "Rate100G", id: 0x7, conformance: "M", description: "PHY rate is 100Gbps" },
-                        { tag: "datatype", name: "Rate200G", id: 0x8, conformance: "M", description: "PHY rate is 200Gbps" },
-                        { tag: "datatype", name: "Rate400G", id: 0x9, conformance: "M", description: "PHY rate is 400Gbps" }
+                        {
+                            tag: "datatype", name: "Rate100G", id: 0x7, conformance: "M", description: "PHY rate is 100Gbps"
+                        },
+                        {
+                            tag: "datatype", name: "Rate200G", id: 0x8, conformance: "M", description: "PHY rate is 200Gbps"
+                        },
+                        {
+                            tag: "datatype", name: "Rate400G", id: 0x9, conformance: "M", description: "PHY rate is 400Gbps"
+                        }
                     ]
                 }
             ]
@@ -19972,7 +20019,9 @@ export const SpecMatter: MatterElement = {
                     xref: { document: "core", section: "11.19.7.6.1" },
 
                     children: [
-                        { tag: "datatype", name: "ProviderNodeId", id: 0x0, type: "node-id", access: "F", conformance: "M" },
+                        {
+                            tag: "datatype", name: "ProviderNodeId", id: 0x0, type: "node-id", access: "F", conformance: "M"
+                        },
                         { tag: "datatype", name: "VendorId", id: 0x1, type: "vendor-id", access: "F", conformance: "M" },
                         {
                             tag: "datatype", name: "AnnouncementReason", id: 0x2, type: "AnnouncementReasonEnum", access: "F",
@@ -20083,8 +20132,11 @@ export const SpecMatter: MatterElement = {
                     tag: "datatype", name: "ProviderLocationStruct", type: "struct",
                     details: "This structure encodes a fabric-scoped location of an OTA provider on a given fabric.",
                     xref: { document: "core", section: "11.19.7.4.20" },
+
                     children: [
-                        { tag: "datatype", name: "ProviderNodeId", id: 0x1, type: "node-id", access: "F", conformance: "M" },
+                        {
+                            tag: "datatype", name: "ProviderNodeId", id: 0x1, type: "node-id", access: "F", conformance: "M"
+                        },
                         { tag: "datatype", name: "Endpoint", id: 0x2, type: "endpoint-no", access: "F", conformance: "M" }
                     ]
                 }

--- a/packages/matter-node.js/test/interaction/InteractionProtocolTest.ts
+++ b/packages/matter-node.js/test/interaction/InteractionProtocolTest.ts
@@ -447,6 +447,7 @@ describe("InteractionProtocol", () => {
                     authMode: 2,
                     subjects: null,
                     targets: null,
+                    fabricIndex: { index: 1 }
                 }
             ]);
         });

--- a/packages/matter.js/src/cluster/definitions/AccessControlCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/AccessControlCluster.ts
@@ -24,6 +24,7 @@ import { TlvNullable } from "../../tlv/TlvNullable.js";
 import { TlvClusterId } from "../../datatype/ClusterId.js";
 import { TlvEndpointNumber } from "../../datatype/EndpointNumber.js";
 import { TlvDeviceTypeId } from "../../datatype/DeviceTypeId.js";
+import { TlvFabricIndex } from "../../datatype/FabricIndex.js";
 import { TlvByteString } from "../../tlv/TlvString.js";
 import { TlvNodeId } from "../../datatype/NodeId.js";
 
@@ -200,7 +201,9 @@ export namespace AccessControl {
          *
          * @see {@link MatterCoreSpecificationV1_1} § 9.10.4.5.4
          */
-        targets: TlvField(4, TlvNullable(TlvArray(TlvAccessControlTargetStruct)))
+        targets: TlvField(4, TlvNullable(TlvArray(TlvAccessControlTargetStruct))),
+
+        fabricIndex: TlvField(254, TlvFabricIndex)
     });
 
     /**
@@ -220,7 +223,9 @@ export namespace AccessControl {
          *
          * @see {@link MatterCoreSpecificationV1_1} § 9.10.4.6.1
          */
-        data: TlvField(1, TlvByteString.bound({ maxLength: 128 }))
+        data: TlvField(1, TlvByteString.bound({ maxLength: 128 })),
+
+        fabricIndex: TlvField(254, TlvFabricIndex)
     });
 
     /**
@@ -285,7 +290,9 @@ export namespace AccessControl {
          *
          * @see {@link MatterCoreSpecificationV1_1} § 9.10.7.1.4
          */
-        latestValue: TlvField(4, TlvNullable(TlvAccessControlEntryStruct))
+        latestValue: TlvField(4, TlvNullable(TlvAccessControlEntryStruct)),
+
+        fabricIndex: TlvField(254, TlvFabricIndex)
     });
 
     /**
@@ -297,7 +304,8 @@ export namespace AccessControl {
         adminNodeId: TlvField(1, TlvNullable(TlvNodeId)),
         adminPasscodeId: TlvField(2, TlvNullable(TlvUInt16)),
         changeType: TlvField(3, TlvEnum<ChangeType>()),
-        latestValue: TlvField(4, TlvNullable(TlvAccessControlExtensionStruct))
+        latestValue: TlvField(4, TlvNullable(TlvAccessControlExtensionStruct)),
+        fabricIndex: TlvField(254, TlvFabricIndex)
     });
 
     /**

--- a/packages/matter.js/src/cluster/definitions/BindingCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/BindingCluster.ts
@@ -9,11 +9,12 @@
 import { Cluster as CreateCluster, WritableFabricScopedAttribute, AccessLevel } from "../../cluster/Cluster.js";
 import { MatterCoreSpecificationV1_1 } from "../../spec/Specifications.js";
 import { TlvArray } from "../../tlv/TlvArray.js";
-import { TlvObject, TlvOptionalField } from "../../tlv/TlvObject.js";
+import { TlvObject, TlvOptionalField, TlvField } from "../../tlv/TlvObject.js";
 import { TlvNodeId } from "../../datatype/NodeId.js";
 import { TlvGroupId } from "../../datatype/GroupId.js";
 import { TlvEndpointNumber } from "../../datatype/EndpointNumber.js";
 import { TlvClusterId } from "../../datatype/ClusterId.js";
+import { TlvFabricIndex } from "../../datatype/FabricIndex.js";
 
 export namespace Binding {
     /**
@@ -50,7 +51,9 @@ export namespace Binding {
          *
          * @see {@link MatterCoreSpecificationV1_1} § 9.6.5.1.4
          */
-        cluster: TlvOptionalField(4, TlvClusterId)
+        cluster: TlvOptionalField(4, TlvClusterId),
+
+        fabricIndex: TlvField(254, TlvFabricIndex)
     });
 
     /**

--- a/packages/matter.js/src/cluster/definitions/GroupKeyManagementCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/GroupKeyManagementCluster.ts
@@ -27,6 +27,7 @@ import { TlvArray } from "../../tlv/TlvArray.js";
 import { TlvObject, TlvField, TlvOptionalField } from "../../tlv/TlvObject.js";
 import { TlvGroupId } from "../../datatype/GroupId.js";
 import { TlvUInt16, TlvEnum, TlvEpochUs } from "../../tlv/TlvNumber.js";
+import { TlvFabricIndex } from "../../datatype/FabricIndex.js";
 import { TlvEndpointNumber } from "../../datatype/EndpointNumber.js";
 import { TlvString, TlvByteString } from "../../tlv/TlvString.js";
 import { TlvNullable } from "../../tlv/TlvNullable.js";
@@ -53,7 +54,9 @@ export namespace GroupKeyManagement {
          *
          * @see {@link MatterCoreSpecificationV1_1} § 11.2.6.3.2
          */
-        groupKeySetId: TlvField(2, TlvUInt16.bound({ min: 1 }))
+        groupKeySetId: TlvField(2, TlvUInt16.bound({ min: 1 })),
+
+        fabricIndex: TlvField(254, TlvFabricIndex)
     });
 
     /**
@@ -77,7 +80,9 @@ export namespace GroupKeyManagement {
          *
          * @see {@link MatterCoreSpecificationV1_1} § 11.2.6.5.2
          */
-        groupName: TlvOptionalField(3, TlvString.bound({ maxLength: 16 }))
+        groupName: TlvOptionalField(3, TlvString.bound({ maxLength: 16 })),
+
+        fabricIndex: TlvField(254, TlvFabricIndex)
     });
 
     /**

--- a/packages/matter.js/src/cluster/definitions/OperationalCredentialsCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/OperationalCredentialsCluster.ts
@@ -20,11 +20,11 @@ import { TlvArray } from "../../tlv/TlvArray.js";
 import { TlvObject, TlvField, TlvOptionalField } from "../../tlv/TlvObject.js";
 import { TlvByteString, TlvString } from "../../tlv/TlvString.js";
 import { TlvNullable } from "../../tlv/TlvNullable.js";
+import { TlvFabricIndex, FabricIndex } from "../../datatype/FabricIndex.js";
 import { TlvVendorId } from "../../datatype/VendorId.js";
 import { TlvFabricId } from "../../datatype/FabricId.js";
 import { TlvNodeId } from "../../datatype/NodeId.js";
 import { TlvUInt8, TlvEnum } from "../../tlv/TlvNumber.js";
-import { TlvFabricIndex, FabricIndex } from "../../datatype/FabricIndex.js";
 import { TlvBoolean } from "../../tlv/TlvBoolean.js";
 import { TlvSubjectId } from "../../datatype/SubjectId.js";
 
@@ -52,7 +52,9 @@ export namespace OperationalCredentials {
          *
          * @see {@link MatterCoreSpecificationV1_1} § 11.17.4.4.2
          */
-        icac: TlvField(2, TlvNullable(TlvByteString.bound({ maxLength: 400 })))
+        icac: TlvField(2, TlvNullable(TlvByteString.bound({ maxLength: 400 }))),
+
+        fabricIndex: TlvField(254, TlvFabricIndex)
     });
 
     /**
@@ -107,7 +109,9 @@ export namespace OperationalCredentials {
          *
          * @see {@link MatterCoreSpecificationV1_1} § 11.17.4.5.5
          */
-        label: TlvField(5, TlvString.bound({ maxLength: 32 }))
+        label: TlvField(5, TlvString.bound({ maxLength: 32 })),
+
+        fabricIndex: TlvField(254, TlvFabricIndex)
     });
 
     /**
@@ -470,7 +474,8 @@ export namespace OperationalCredentials {
      */
     export const TlvUpdateNocRequest = TlvObject({
         nocValue: TlvField(0, TlvByteString.bound({ maxLength: 400 })),
-        icacValue: TlvOptionalField(1, TlvByteString.bound({ maxLength: 400 }))
+        icacValue: TlvOptionalField(1, TlvByteString.bound({ maxLength: 400 })),
+        fabricIndex: TlvField(254, TlvFabricIndex)
     });
 
     /**
@@ -478,7 +483,10 @@ export namespace OperationalCredentials {
      *
      * @see {@link MatterCoreSpecificationV1_1} § 11.17.6.11
      */
-    export const TlvUpdateFabricLabelRequest = TlvObject({ label: TlvField(0, TlvString.bound({ maxLength: 32 })) });
+    export const TlvUpdateFabricLabelRequest = TlvObject({
+        label: TlvField(0, TlvString.bound({ maxLength: 32 })),
+        fabricIndex: TlvField(254, TlvFabricIndex)
+    });
 
     /**
      * Input to the OperationalCredentials removeFabric command

--- a/packages/matter.js/src/cluster/definitions/OtaSoftwareUpdateRequestorCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/OtaSoftwareUpdateRequestorCluster.ts
@@ -21,6 +21,7 @@ import { TlvArray } from "../../tlv/TlvArray.js";
 import { TlvObject, TlvField, TlvOptionalField } from "../../tlv/TlvObject.js";
 import { TlvNodeId } from "../../datatype/NodeId.js";
 import { TlvEndpointNumber } from "../../datatype/EndpointNumber.js";
+import { TlvFabricIndex } from "../../datatype/FabricIndex.js";
 import { TlvBoolean } from "../../tlv/TlvBoolean.js";
 import { TlvEnum, TlvUInt8, TlvUInt32, TlvUInt16, TlvUInt64, TlvInt64 } from "../../tlv/TlvNumber.js";
 import { TlvNullable } from "../../tlv/TlvNullable.js";
@@ -35,7 +36,8 @@ export namespace OtaSoftwareUpdateRequestor {
      */
     export const TlvProviderLocationStruct = TlvObject({
         providerNodeId: TlvField(1, TlvNodeId),
-        endpoint: TlvField(2, TlvEndpointNumber)
+        endpoint: TlvField(2, TlvEndpointNumber),
+        fabricIndex: TlvField(254, TlvFabricIndex)
     });
 
     /**
@@ -120,7 +122,8 @@ export namespace OtaSoftwareUpdateRequestor {
         vendorId: TlvField(1, TlvVendorId),
         announcementReason: TlvField(2, TlvEnum<AnnouncementReason>()),
         metadataForNode: TlvOptionalField(3, TlvByteString.bound({ maxLength: 512 })),
-        endpoint: TlvField(4, TlvEndpointNumber)
+        endpoint: TlvField(4, TlvEndpointNumber),
+        fabricIndex: TlvField(254, TlvFabricIndex)
     });
 
     /**

--- a/packages/matter.js/src/model/elements/Globals.ts
+++ b/packages/matter.js/src/model/elements/Globals.ts
@@ -195,7 +195,7 @@ export const Globals = {
     }),
     FabricIndex: DatatypeElement({
         id: 0xfe, name: "FabricIndex", type: "fabric-idx",
-        constraint: "1 to 254", access: "R V F"
+        constraint: "1 to 254", access: "R V F", conformance: "M"
     }),
 
     // Not defined as global in the specification but used across multiple

--- a/packages/matter.js/src/model/standard/elements/AccessControl.ts
+++ b/packages/matter.js/src/model/standard/elements/AccessControl.ts
@@ -156,6 +156,11 @@ Matter.children.push({
                         "This field SHOULD be set if resources are adequate for it; otherwise it shall be set to NULL if " +
                         "resources are scarce.",
                     xref: { document: "core", section: "9.10.7.1.4" }
+                },
+
+                {
+                    tag: "datatype", name: "FabricIndex", id: 0xfe, type: "fabric-idx", access: "R F V",
+                    conformance: "M", constraint: "1 to 254"
                 }
             ]
         },
@@ -207,6 +212,10 @@ Matter.children.push({
                 {
                     tag: "datatype", name: "LatestValue", id: 0x4, type: "AccessControlExtensionStruct", access: "S",
                     conformance: "M", quality: "X"
+                },
+                {
+                    tag: "datatype", name: "FabricIndex", id: 0xfe, type: "fabric-idx", access: "R F V",
+                    conformance: "M", constraint: "1 to 254"
                 }
             ]
         },
@@ -410,6 +419,11 @@ Matter.children.push({
 
                     xref: { document: "core", section: "9.10.4.5.4" },
                     children: [{ tag: "datatype", name: "entry", type: "AccessControlTargetStruct" }]
+                },
+
+                {
+                    tag: "datatype", name: "FabricIndex", id: 0xfe, type: "fabric-idx", access: "R F V",
+                    conformance: "M", constraint: "1 to 254"
                 }
             ]
         },
@@ -419,23 +433,30 @@ Matter.children.push({
             conformance: "M",
             xref: { document: "core", section: "9.10.4.6" },
 
-            children: [{
-                tag: "datatype", name: "Data", id: 0x1, type: "octstr", access: "S", conformance: "M",
-                constraint: "max 128",
+            children: [
+                {
+                    tag: "datatype", name: "Data", id: 0x1, type: "octstr", access: "S", conformance: "M",
+                    constraint: "max 128",
 
-                details: "This field may be used by manufacturers to store arbitrary TLV-encoded data related to a fabric’s" +
-                    "\n" +
-                    "Access Control Entries." +
-                    "\n" +
-                    "The contents shall consist of a top-level anonymous list; each list element shall include a " +
-                    "profile-specific tag encoded in fully-qualified form." +
-                    "\n" +
-                    "Administrators may iterate over this list of elements, and interpret selected elements at their " +
-                    "discretion. The content of each element is not specified, but may be coordinated among " +
-                    "manufacturers at their discretion.",
+                    details: "This field may be used by manufacturers to store arbitrary TLV-encoded data related to a fabric’s" +
+                        "\n" +
+                        "Access Control Entries." +
+                        "\n" +
+                        "The contents shall consist of a top-level anonymous list; each list element shall include a " +
+                        "profile-specific tag encoded in fully-qualified form." +
+                        "\n" +
+                        "Administrators may iterate over this list of elements, and interpret selected elements at their " +
+                        "discretion. The content of each element is not specified, but may be coordinated among " +
+                        "manufacturers at their discretion.",
 
-                xref: { document: "core", section: "9.10.4.6.1" }
-            }]
+                    xref: { document: "core", section: "9.10.4.6.1" }
+                },
+
+                {
+                    tag: "datatype", name: "FabricIndex", id: 0xfe, type: "fabric-idx", access: "R F V",
+                    conformance: "M", constraint: "1 to 254"
+                }
+            ]
         }
     ]
 });

--- a/packages/matter.js/src/model/standard/elements/Binding.ts
+++ b/packages/matter.js/src/model/standard/elements/Binding.ts
@@ -88,6 +88,11 @@ Matter.children.push({
                         "is present, the client cluster shall also exist on this endpoint (with this Binding cluster). If " +
                         "this field is present, the target shall be this cluster on the target endpoint(s).",
                     xref: { document: "core", section: "9.6.5.1.4" }
+                },
+
+                {
+                    tag: "datatype", name: "FabricIndex", id: 0xfe, type: "fabric-idx", access: "R F V",
+                    conformance: "M", constraint: "1 to 254"
                 }
             ]
         }

--- a/packages/matter.js/src/model/standard/elements/GroupKeyManagement.ts
+++ b/packages/matter.js/src/model/standard/elements/GroupKeyManagement.ts
@@ -270,6 +270,11 @@ Matter.children.push({
                         "\n" +
                         "A GroupKeyMapStruct shall NOT accept GroupKeySetID of 0, which is reserved for the IPK.",
                     xref: { document: "core", section: "11.2.6.3.2" }
+                },
+
+                {
+                    tag: "datatype", name: "FabricIndex", id: 0xfe, type: "fabric-idx", access: "R F V",
+                    conformance: "M", constraint: "1 to 254"
                 }
             ]
         },
@@ -388,6 +393,11 @@ Matter.children.push({
                     details: "This field provides a name for the group. This field shall contain the last GroupName written for a " +
                         "given GroupId on any Endpoint via the Groups cluster.",
                     xref: { document: "core", section: "11.2.6.5.2" }
+                },
+
+                {
+                    tag: "datatype", name: "FabricIndex", id: 0xfe, type: "fabric-idx", access: "R F V",
+                    conformance: "M", constraint: "1 to 254"
                 }
             ]
         }

--- a/packages/matter.js/src/model/standard/elements/OperationalCredentials.ts
+++ b/packages/matter.js/src/model/standard/elements/OperationalCredentials.ts
@@ -488,6 +488,10 @@ Matter.children.push({
                 {
                     tag: "datatype", name: "IcacValue", id: 0x1, type: "octstr", access: "F", conformance: "O",
                     constraint: "max 400"
+                },
+                {
+                    tag: "datatype", name: "FabricIndex", id: 0xfe, type: "fabric-idx", access: "R F V",
+                    conformance: "M", constraint: "1 to 254"
                 }
             ]
         },
@@ -566,10 +570,17 @@ Matter.children.push({
                 "updated.",
 
             xref: { document: "core", section: "11.17.6.11" },
-            children: [{
-                tag: "datatype", name: "Label", id: 0x0, type: "string", access: "F", conformance: "M",
-                constraint: "max 32"
-            }]
+
+            children: [
+                {
+                    tag: "datatype", name: "Label", id: 0x0, type: "string", access: "F", conformance: "M",
+                    constraint: "max 32"
+                },
+                {
+                    tag: "datatype", name: "FabricIndex", id: 0xfe, type: "fabric-idx", access: "R F V",
+                    conformance: "M", constraint: "1 to 254"
+                }
+            ]
         },
 
         {
@@ -766,6 +777,11 @@ Matter.children.push({
                     details: "This field shall contain the ICAC or the struct’s associated fabric, encoded using Matter " +
                         "Certificate Encoding. If no ICAC is present in the chain, this field shall be set to null.",
                     xref: { document: "core", section: "11.17.4.4.2" }
+                },
+
+                {
+                    tag: "datatype", name: "FabricIndex", id: 0xfe, type: "fabric-idx", access: "R F V",
+                    conformance: "M", constraint: "1 to 254"
                 }
             ]
         },
@@ -823,6 +839,11 @@ Matter.children.push({
                     details: "This field shall contain a commissioner-set label for the fabric referenced by FabricIndex. This " +
                         "label is set by the UpdateFabricLabel command.",
                     xref: { document: "core", section: "11.17.4.5.5" }
+                },
+
+                {
+                    tag: "datatype", name: "FabricIndex", id: 0xfe, type: "fabric-idx", access: "R F V",
+                    conformance: "M", constraint: "1 to 254"
                 }
             ]
         }

--- a/packages/matter.js/src/model/standard/elements/OtaSoftwareUpdateRequestor.ts
+++ b/packages/matter.js/src/model/standard/elements/OtaSoftwareUpdateRequestor.ts
@@ -153,7 +153,11 @@ Matter.children.push({
                     tag: "datatype", name: "MetadataForNode", id: 0x3, type: "octstr", access: "F", conformance: "O",
                     constraint: "max 512"
                 },
-                { tag: "datatype", name: "Endpoint", id: 0x4, type: "endpoint-no", access: "F", conformance: "M" }
+                { tag: "datatype", name: "Endpoint", id: 0x4, type: "endpoint-no", access: "F", conformance: "M" },
+                {
+                    tag: "datatype", name: "FabricIndex", id: 0xfe, type: "fabric-idx", access: "R F V",
+                    conformance: "M", constraint: "1 to 254"
+                }
             ]
         },
 
@@ -254,9 +258,14 @@ Matter.children.push({
             tag: "datatype", name: "ProviderLocationStruct", type: "struct", access: "R F", conformance: "M",
             details: "This structure encodes a fabric-scoped location of an OTA provider on a given fabric.",
             xref: { document: "core", section: "11.19.7.4.20" },
+
             children: [
                 { tag: "datatype", name: "ProviderNodeId", id: 0x1, type: "node-id", access: "F", conformance: "M" },
-                { tag: "datatype", name: "Endpoint", id: 0x2, type: "endpoint-no", access: "F", conformance: "M" }
+                { tag: "datatype", name: "Endpoint", id: 0x2, type: "endpoint-no", access: "F", conformance: "M" },
+                {
+                    tag: "datatype", name: "FabricIndex", id: 0xfe, type: "fabric-idx", access: "R F V",
+                    conformance: "M", constraint: "1 to 254"
+                }
             ]
         }
     ]

--- a/packages/matter.js/src/protocol/interaction/AttributeDataDecoder.ts
+++ b/packages/matter.js/src/protocol/interaction/AttributeDataDecoder.ts
@@ -13,7 +13,7 @@ import { TlvSchema, TypeFromSchema } from "../../tlv/TlvSchema.js";
 import { Logger } from "../../log/Logger.js";
 import { TlvAttributeData, TlvAttributeReport } from "./InteractionProtocol.js";
 
-const logger = Logger.get("DataReportDecoder");
+const logger = Logger.get("AttributeDataDecoder");
 
 export interface DecodedAttributeReportValue {
     path: {
@@ -159,7 +159,6 @@ export function decodeChunkedArray<T>(schema: ArraySchema<T>, values: TypeFromSc
             result[listIndex] = schema.elementSchema.decodeTlv(data);
         }
     });
-    schema.validate(result);
     return result;
 }
 

--- a/packages/matter.js/src/protocol/interaction/InteractionServer.ts
+++ b/packages/matter.js/src/protocol/interaction/InteractionServer.ts
@@ -221,30 +221,51 @@ export function ClusterServer<
 
         const { id, schema, writable, persistent, fabricScoped, scene, fixed } = attributeDef[attributeName];
         if ((attributesInitialValues as any)[attributeName] !== undefined) {
-            const validator = typeof schema.validate === 'function' ? schema.validate.bind(schema) : undefined;
             if (fixed) {
-                (attributes as any)[attributeName] = new FixedAttributeServer(id, attributeName, schema, validator ?? (() => { /* no validation */
-                }), writable, (attributesInitialValues as any)[attributeName]);
+                (attributes as any)[attributeName] = new FixedAttributeServer(
+                    id,
+                    attributeName,
+                    schema,
+                    writable,
+                    (attributesInitialValues as any)[attributeName]
+                );
                 result[`get${capitalizedAttributeName}Attribute`] = () => (attributes as any)[attributeName].getLocal();
             }
             else if (fabricScoped) {
-                (attributes as any)[attributeName] = new FabricScopedAttributeServer(id, attributeName, schema, validator ?? (() => { /* no validation */
-                }), writable, (attributesInitialValues as any)[attributeName], clusterDef);
+                (attributes as any)[attributeName] = new FabricScopedAttributeServer(
+                    id,
+                    attributeName,
+                    schema,
+                    writable,
+                    (attributesInitialValues as any)[attributeName],
+                    clusterDef
+                );
                 result[`get${capitalizedAttributeName}Attribute`] = (fabric: Fabric) => (attributes as any)[attributeName].getLocal(fabric);
                 result[`set${capitalizedAttributeName}Attribute`] = <T,>(value: T, fabric: Fabric) => (attributes as any)[attributeName].setLocal(value, fabric);
                 result[`subscribe${capitalizedAttributeName}Attribute`] = <T,>(listener: (newValue: T, oldValue: T) => void) => (attributes as any)[attributeName].addListener(listener);
             } else {
                 const getter = (handlers as any)[`get${capitalize(attributeName)}`];
                 if (getter === undefined) {
-                    (attributes as any)[attributeName] = new AttributeServer(id, attributeName, schema, validator ?? (() => { /* no validation */
-                    }), writable, (attributesInitialValues as any)[attributeName]);
+                    (attributes as any)[attributeName] = new AttributeServer(
+                        id,
+                        attributeName,
+                        schema,
+                        writable,
+                        (attributesInitialValues as any)[attributeName]
+                    );
                 } else {
-                    (attributes as any)[attributeName] = new AttributeGetterServer(id, attributeName, schema, validator ?? (() => { /* no validation */
-                    }), writable, (attributesInitialValues as any)[attributeName], (session, endpoint) => getter({
-                        attributes,
-                        endpoint,
-                        session
-                    }));
+                    (attributes as any)[attributeName] = new AttributeGetterServer(
+                        id,
+                        attributeName,
+                        schema,
+                        writable,
+                        (attributesInitialValues as any)[attributeName],
+                        (session, endpoint) => getter({
+                            attributes,
+                            endpoint,
+                            session
+                        })
+                    );
                 }
                 if (persistent) {
                     const listener = (value: any, version: number) => attributeStorageListener(attributeName, version, value);

--- a/packages/matter.js/src/tlv/TlvNullable.ts
+++ b/packages/matter.js/src/tlv/TlvNullable.ts
@@ -16,7 +16,7 @@ import { MatterCoreSpecificationV1_0 } from "../spec/Specifications.js";
 export class NullableSchema<T> extends TlvSchema<T | null> {
 
     constructor(
-        private readonly schema: TlvSchema<T>,
+        readonly schema: TlvSchema<T>,
     ) {
         super();
     }

--- a/packages/matter.js/src/tlv/TlvObject.ts
+++ b/packages/matter.js/src/tlv/TlvObject.ts
@@ -56,7 +56,9 @@ export class ObjectSchema<F extends TlvFields> extends TlvSchema<TypeFromFields<
             const { id, schema, optional: isOptional } = this.fieldDefinitions[name];
             const fieldValue = (value as any)[name];
             if (fieldValue === undefined) {
-                if (!isOptional) throw new Error(`Missing mandatory field ${name}`);
+                if (!isOptional) {
+                    throw new Error(`Missing mandatory field ${name}`);
+                }
                 continue;
             }
             schema.encodeTlvInternal(writer, fieldValue, { id });
@@ -87,8 +89,9 @@ export class ObjectSchema<F extends TlvFields> extends TlvSchema<TypeFromFields<
             if (optional) continue;
             const value = result[name];
             if (value !== undefined) continue;
-            if (fallback === undefined) throw new Error(`Missing mandatory field ${name}`);
-            result[name] = fallback;
+            if (fallback !== undefined) {
+                result[name] = fallback;
+            }
         }
         return result as TypeFromFields<F>;
     }
@@ -96,8 +99,12 @@ export class ObjectSchema<F extends TlvFields> extends TlvSchema<TypeFromFields<
     override validate(value: TypeFromFields<F>): void {
         for (const name in this.fieldDefinitions) {
             const { optional, schema } = this.fieldDefinitions[name];
-            if (optional && (value as any)[name] === undefined) continue;
-            if (!optional && (value as any)[name] === undefined) throw new Error(`Missing mandatory field ${name}`);
+            if ((value as any)[name] === undefined) {
+                if (optional) {
+                    continue;
+                }
+                throw new Error(`Missing mandatory field ${name}`);
+            }
             schema.validate((value as any)[name]);
         }
     }

--- a/packages/matter.js/src/tlv/TlvObject.ts
+++ b/packages/matter.js/src/tlv/TlvObject.ts
@@ -39,7 +39,7 @@ export class ObjectSchema<F extends TlvFields> extends TlvSchema<TypeFromFields<
     private readonly fieldById = new Array<{ name: string, field: FieldType<any> }>();
 
     constructor(
-        private readonly fieldDefinitions: F,
+        readonly fieldDefinitions: F,
         private readonly type: TlvType.Structure | TlvType.List = TlvType.Structure,
     ) {
         super();

--- a/packages/matter.js/test/cluster/ClusterServerTest.ts
+++ b/packages/matter.js/test/cluster/ClusterServerTest.ts
@@ -366,14 +366,14 @@ describe("ClusterServer structure", () => {
                     setScopedClusterDataValueCalledCounter++;
                     assert.equal(cluster.id, BindingCluster.id);
                     assert.equal(clusterDataKey, "binding");
-                    assert.deepEqual(value, { value: [{}], version: 1 });
+                    assert.deepEqual(value, { value: [{ fabricIndex: { index: 1 } }], version: 1 });
                 }
             } as Fabric;
 
             assert.deepEqual(binding.attributes.binding.getLocal(fabric), []);
-            binding.attributes.binding.setLocal([{}], fabric);
+            binding.attributes.binding.setLocal([{ fabricIndex: { index: 1 } }], fabric);
             assert.deepEqual(binding.getBindingAttribute(fabric), []);
-            binding.setBindingAttribute([{}], fabric);
+            binding.setBindingAttribute([{ fabricIndex: { index: 1 } }], fabric);
 
             assert.equal(getScopedClusterDataValueCalledCounter, 4);
             assert.equal(setScopedClusterDataValueCalledCounter, 2);

--- a/packages/matter.js/test/protocol/interaction/AttributeDataDecoderTest.ts
+++ b/packages/matter.js/test/protocol/interaction/AttributeDataDecoderTest.ts
@@ -27,7 +27,7 @@ const TlvAclTestSchema = TlvObject({
     privilege: TlvField(1, TlvUInt8),
     authMode: TlvField(2, TlvUInt8),
     subjects: TlvField(3, TlvNullable(TlvUInt8)),
-    targets: TlvField(4, TlvNullable(TlvUInt8)),
+    targets: TlvField(4, TlvNullable(TlvUInt8))
 });
 
 const fakeTime = new TimeFake(0);

--- a/tools/mom/spec/translate-cluster.ts
+++ b/tools/mom/spec/translate-cluster.ts
@@ -205,7 +205,10 @@ function translateMetadata(definition: ClusterReference, children: Array<Cluster
 
 // For some reason, "default" fabric access appears in an informational row
 // instead of the access column in many of the core definitions.  Fix this.
-function applyAccessNotes(fields?: HtmlReference, records?: { access?: string }[]) {
+//
+// We also use the presence of this record to add the implicity FabrixIndex
+// field
+function applyAccessNotes(fields?: HtmlReference, records?: { id: number, access?: string }[]) {
     if (!fields?.table?.notes.length || !records) {
         return;
     }
@@ -236,15 +239,27 @@ function applyAccessNotes(fields?: HtmlReference, records?: { access?: string }[
         }
     }
 
-    // If we have the flag, apply it unless the row already has an access flag
+    // If we have the flag, apply it
     if (flag) {
+        // Update access for each record unless it already has a fabric flag
+        let haveFabricIndex = false;
         for (const r of records) {
+            if (r.id === Globals.FabricIndex.id) {
+                haveFabricIndex = true;
+            }
             const access = r.access;
             if (!access) {
                 r.access = flag;
             } else if (!access.match(/[SF]/i)) {
                 r.access += flag;
             }
+        }
+
+        // Add the FabricIndex field if not already present
+        if (!haveFabricIndex) {
+            const fabricIndex = { ...Globals.FabricIndex };
+            delete fabricIndex.global;
+            records.push(fabricIndex as { id: number, name: string });
         }
     }
 }
@@ -464,8 +479,6 @@ function translateInvokable(definition: ClusterReference, children: Array<Cluste
             children: Children(translateValueChildren)
         });
 
-        applyAccessNotes(definition.commands, records);
-
         const commands = translateRecordsToMatter("command", records, (r) => {
             let direction: CommandElement.Direction | undefined;
             if (r.direction.match(/client.*server/i)) {
@@ -504,8 +517,6 @@ function translateInvokable(definition: ClusterReference, children: Array<Cluste
             conformance: Optional(Code),
             children: Children(translateValueChildren)
         });
-
-        applyAccessNotes(definition.events, records);
 
         const events = translateRecordsToMatter("event", records, (r) => {
             let priority: EventElement.Priority;


### PR DESCRIPTION
Generates fabricIndex field for all structures that should have it.  Modifies AttributeServer and InteractionServer as necessary to set the field to the appropriate value.

fixes #239

Scan the individual commits for details.