### PR TITLE
WindowCovering tweaks & testing

### DIFF
--- a/models/local/DoorLockOverrides.ts
+++ b/models/local/DoorLockOverrides.ts
@@ -49,6 +49,9 @@ LocalMatter.children.push({
         // types for these guys.  Would be easy to detect but since we've
         // already got overrides going on just doing it here
         { tag: "attribute", id: 0x3, name: "DoorState", type: "DoorStateEnum" },
-        { tag: "attribute", id: 0x25, name: "OperatingMode", type: "OperatingModeEnum" }
+        { tag: "attribute", id: 0x25, name: "OperatingMode", type: "OperatingModeEnum" },
+
+        // This name gets mangled by spec importer
+        { tag: "attribute", id: 0x33, name: "RequirePinForRemoteOperation" }
     ]
 })

--- a/models/spec.ts
+++ b/models/spec.ts
@@ -8218,7 +8218,7 @@ export const SpecMatter: MatterElement = {
                 },
 
                 {
-                    tag: "attribute", name: "TargetPositionLiftPercent100Ths", id: 0xb, type: "percent100ths",
+                    tag: "attribute", name: "TargetPositionLiftPercent100ths", id: 0xb, type: "percent100ths",
                     access: "R V", conformance: "LF & PA_LF", constraint: "0 to 10000", default: null, quality: "X S P",
                     details: "The TargetPositionLiftPercent100ths attribute identifies the position where the Window Covering " +
                         "Lift will go or is moving to as a percentage.",
@@ -8226,7 +8226,7 @@ export const SpecMatter: MatterElement = {
                 },
 
                 {
-                    tag: "attribute", name: "TargetPositionTiltPercent100Ths", id: 0xc, type: "percent100ths",
+                    tag: "attribute", name: "TargetPositionTiltPercent100ths", id: 0xc, type: "percent100ths",
                     access: "R V", conformance: "TL & PA_TL", constraint: "0 to 10000", default: null, quality: "X S P",
                     details: "The TargetPositionTiltPercent100ths attribute identifies the position where the Window Covering " +
                         "Tilt will go or is moving to as a percentage.",
@@ -8271,7 +8271,7 @@ export const SpecMatter: MatterElement = {
                 },
 
                 {
-                    tag: "attribute", name: "CurrentPositionLiftPercent100Ths", id: 0xe, type: "percent100ths",
+                    tag: "attribute", name: "CurrentPositionLiftPercent100ths", id: 0xe, type: "percent100ths",
                     access: "R V", conformance: "LF & PA_LF", constraint: "0 to 10000", default: null, quality: "X N P",
                     details: "The CurrentPositionLiftPercent100ths attribute identifies the actual position as a percentage with " +
                         "a minimal step of 0.01%. E.g Max 10000 equals 100.00%.",
@@ -8279,7 +8279,7 @@ export const SpecMatter: MatterElement = {
                 },
 
                 {
-                    tag: "attribute", name: "CurrentPositionTiltPercent100Ths", id: 0xf, type: "percent100ths",
+                    tag: "attribute", name: "CurrentPositionTiltPercent100ths", id: 0xf, type: "percent100ths",
                     access: "R V", conformance: "TL & PA_TL", constraint: "0 to 10000", default: null, quality: "X N P",
                     details: "The CurrentPositionTiltPercent100ths attribute identifies the actual position as a percentage with " +
                         "a minimal step of 0.01%. E.g Max 10000 equals 100.00%.",
@@ -8561,7 +8561,7 @@ export const SpecMatter: MatterElement = {
                             constraint: "desc"
                         },
                         {
-                            tag: "datatype", name: "LiftPercent100ThsValue", id: 0x1, type: "percent100ths", conformance: "O.a",
+                            tag: "datatype", name: "LiftPercent100thsValue", id: 0x1, type: "percent100ths", conformance: "O.a",
                             constraint: "desc"
                         }
                     ]
@@ -8611,7 +8611,7 @@ export const SpecMatter: MatterElement = {
                             constraint: "desc"
                         },
                         {
-                            tag: "datatype", name: "TiltPercent100ThsValue", id: 0x1, type: "percent100ths", conformance: "O.a",
+                            tag: "datatype", name: "TiltPercent100thsValue", id: 0x1, type: "percent100ths", conformance: "O.a",
                             constraint: "desc"
                         }
                     ]

--- a/packages/matter.js/src/cluster/definitions/DoorLockCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/DoorLockCluster.ts
@@ -2024,9 +2024,9 @@ export namespace DoorLock {
     });
 
     /**
-     * A DoorLockCluster supports these elements if it supports feature CredentialOverTheAirAccess.
+     * A DoorLockCluster supports these elements if it supports features CredentialOverTheAirAccess and PinCredential.
      */
-    export const CredentialOverTheAirAccessComponent = ClusterComponent({
+    export const CredentialOverTheAirAccessAndPinCredentialComponent = ClusterComponent({
         attributes: {
             /**
              * Boolean set to True if the door lock server requires that an optional PINs be included in the payload of
@@ -2034,7 +2034,7 @@ export namespace DoorLock {
              *
              * @see {@link MatterApplicationClusterSpecificationV1_1} § 5.2.3.37
              */
-            requirePiNforRemoteOperation: OptionalWritableAttribute(
+            requirePinForRemoteOperation: WritableAttribute(
                 0x33,
                 TlvBoolean,
                 { default: true, writeAcl: AccessLevel.Administer }
@@ -2313,7 +2313,11 @@ export namespace DoorLock {
                 { rfidCredential: true }
             );
 
-            extendCluster(cluster, CredentialOverTheAirAccessComponent, { credentialOverTheAirAccess: true });
+            extendCluster(
+                cluster,
+                CredentialOverTheAirAccessAndPinCredentialComponent,
+                { credentialOverTheAirAccess: true, pinCredential: true }
+            );
             extendCluster(cluster, NotificationAndPinCredentialComponent, { notification: true, pinCredential: true });
             extendCluster(cluster, NotificationComponent, { notification: true });
             extendCluster(
@@ -2358,7 +2362,7 @@ export namespace DoorLock {
         & (SF extends { yearDayAccessSchedules: true } ? typeof YearDayAccessSchedulesComponent : {})
         & (SF extends { holidaySchedules: true } ? typeof HolidaySchedulesComponent : {})
         & (SF extends { pinCredential: true } | { rfidCredential: true } ? typeof PinCredentialOrRfidCredentialComponent : {})
-        & (SF extends { credentialOverTheAirAccess: true } ? typeof CredentialOverTheAirAccessComponent : {})
+        & (SF extends { credentialOverTheAirAccess: true, pinCredential: true } ? typeof CredentialOverTheAirAccessAndPinCredentialComponent : {})
         & (SF extends { notification: true, pinCredential: true } ? typeof NotificationAndPinCredentialComponent : {})
         & (SF extends { notification: true } ? typeof NotificationComponent : {})
         & (SF extends { notification: true, rfidCredential: true } ? typeof NotificationAndRfidCredentialComponent : {})
@@ -2376,7 +2380,7 @@ export namespace DoorLock {
     const WDSCH = { weekDayAccessSchedules: true };
     const YDSCH = { yearDayAccessSchedules: true };
     const HDSCH = { holidaySchedules: true };
-    const COTA = { credentialOverTheAirAccess: true };
+    const COTA_PIN = { credentialOverTheAirAccess: true, pinCredential: true };
     const NOT_PIN = { notification: true, pinCredential: true };
     const NOT = { notification: true };
     const NOT_RID = { notification: true, rfidCredential: true };
@@ -2464,9 +2468,9 @@ export namespace DoorLock {
                 PinCredentialComponent.attributes.sendPinOverTheAir,
                 { optionalIf: [PIN] }
             ),
-            requirePiNforRemoteOperation: AsConditional(
-                CredentialOverTheAirAccessComponent.attributes.requirePiNforRemoteOperation,
-                { optionalIf: [COTA] }
+            requirePinForRemoteOperation: AsConditional(
+                CredentialOverTheAirAccessAndPinCredentialComponent.attributes.requirePinForRemoteOperation,
+                { mandatoryIf: [COTA_PIN] }
             ),
             expiringUserTimeout: AsConditional(UserComponent.attributes.expiringUserTimeout, { optionalIf: [USR] }),
             keypadOperationEventMask: AsConditional(

--- a/packages/matter.js/src/cluster/definitions/ThermostatCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/ThermostatCluster.ts
@@ -1076,22 +1076,6 @@ export namespace Thermostat {
             ),
 
             /**
-             * This attribute specifies the heating mode setpoint when the room is unoccupied.
-             *
-             * Refer to Setpoint Limits for constraints. If an attempt is made to set this attribute such that these
-             * constraints are violated, a response with the status code CONSTRAINT_ERROR shall be returned.
-             *
-             * If the occupancy status of the room is unknown, this attribute shall not be used.
-             *
-             * @see {@link MatterApplicationClusterSpecificationV1_1} § 4.3.7.16
-             */
-            unoccupiedHeatingSetpoint: OptionalWritableAttribute(
-                0x14,
-                TlvInt16.bound({ min: -27315 }),
-                { persistent: true, default: 2000 }
-            ),
-
-            /**
              * This attribute specifies the minimum level that the heating setpoint may be set to.
              *
              * This attribute, and the following three attributes, allow the user to define setpoint limits more
@@ -1185,22 +1169,6 @@ export namespace Thermostat {
             ),
 
             /**
-             * This attribute specifies the cooling mode setpoint when the room is unoccupied.
-             *
-             * Refer to Setpoint Limits for constraints. If an attempt is made to set this attribute such that these
-             * constraints are violated, a response with the status code CONSTRAINT_ERROR shall be returned.
-             *
-             * If the occupancy status of the room is unknown, this attribute shall not be used.
-             *
-             * @see {@link MatterApplicationClusterSpecificationV1_1} § 4.3.7.15
-             */
-            unoccupiedCoolingSetpoint: OptionalWritableAttribute(
-                0x13,
-                TlvInt16.bound({ min: -27315 }),
-                { persistent: true, default: 2600 }
-            ),
-
-            /**
              * This attribute specifies the minimum level that the cooling setpoint may be set to.
              *
              * Refer to Setpoint Limits for constraints. If an attempt is made to set this attribute to a value which
@@ -1260,6 +1228,52 @@ export namespace Thermostat {
                 0x10,
                 TlvInt8.bound({ min: -25, max: 25 }),
                 { persistent: true, default: 0, writeAcl: AccessLevel.Manage }
+            )
+        }
+    });
+
+    /**
+     * A ThermostatCluster supports these elements if it supports features Cooling and Occupancy.
+     */
+    export const CoolingAndOccupancyComponent = ClusterComponent({
+        attributes: {
+            /**
+             * This attribute specifies the cooling mode setpoint when the room is unoccupied.
+             *
+             * Refer to Setpoint Limits for constraints. If an attempt is made to set this attribute such that these
+             * constraints are violated, a response with the status code CONSTRAINT_ERROR shall be returned.
+             *
+             * If the occupancy status of the room is unknown, this attribute shall not be used.
+             *
+             * @see {@link MatterApplicationClusterSpecificationV1_1} § 4.3.7.15
+             */
+            unoccupiedCoolingSetpoint: WritableAttribute(
+                0x13,
+                TlvInt16.bound({ min: -27315 }),
+                { persistent: true, default: 2600 }
+            )
+        }
+    });
+
+    /**
+     * A ThermostatCluster supports these elements if it supports features Heating and Occupancy.
+     */
+    export const HeatingAndOccupancyComponent = ClusterComponent({
+        attributes: {
+            /**
+             * This attribute specifies the heating mode setpoint when the room is unoccupied.
+             *
+             * Refer to Setpoint Limits for constraints. If an attempt is made to set this attribute such that these
+             * constraints are violated, a response with the status code CONSTRAINT_ERROR shall be returned.
+             *
+             * If the occupancy status of the room is unknown, this attribute shall not be used.
+             *
+             * @see {@link MatterApplicationClusterSpecificationV1_1} § 4.3.7.16
+             */
+            unoccupiedHeatingSetpoint: WritableAttribute(
+                0x14,
+                TlvInt16.bound({ min: -27315 }),
+                { persistent: true, default: 2000 }
             )
         }
     });
@@ -1406,8 +1420,15 @@ export namespace Thermostat {
              *
              * @see {@link MatterApplicationClusterSpecificationV1_1} § 4.3.7.39
              */
-            occupiedSetbackMax: FixedAttribute(0x36, TlvNullable(TlvUInt8.bound({ max: 254 })), { default: null }),
+            occupiedSetbackMax: FixedAttribute(0x36, TlvNullable(TlvUInt8.bound({ max: 254 })), { default: null })
+        }
+    });
 
+    /**
+     * A ThermostatCluster supports these elements if it supports features Setback and Occupancy.
+     */
+    export const SetbackAndOccupancyComponent = ClusterComponent({
+        attributes: {
             /**
              * This attribute specifies the amount that the Thermostat server will allow the LocalTemperature Value to
              * float above the UnoccupiedCooling setpoint (i.e., UnoccupiedCooling + UnoccupiedSetback) or below the
@@ -1432,7 +1453,7 @@ export namespace Thermostat {
              *
              * @see {@link MatterApplicationClusterSpecificationV1_1} § 4.3.7.40
              */
-            unoccupiedSetback: OptionalWritableAttribute(
+            unoccupiedSetback: WritableAttribute(
                 0x37,
                 TlvNullable(TlvUInt8.bound({ max: 254 })),
                 { persistent: true, default: null, writeAcl: AccessLevel.Manage }
@@ -1446,7 +1467,7 @@ export namespace Thermostat {
              *
              * @see {@link MatterApplicationClusterSpecificationV1_1} § 4.3.7.41
              */
-            unoccupiedSetbackMin: OptionalFixedAttribute(
+            unoccupiedSetbackMin: FixedAttribute(
                 0x38,
                 TlvNullable(TlvUInt8.bound({ min: 0, max: 254 })),
                 { default: null }
@@ -1460,11 +1481,7 @@ export namespace Thermostat {
              *
              * @see {@link MatterApplicationClusterSpecificationV1_1} § 4.3.7.42
              */
-            unoccupiedSetbackMax: OptionalFixedAttribute(
-                0x39,
-                TlvNullable(TlvUInt8.bound({ max: 254 })),
-                { default: null }
-            )
+            unoccupiedSetbackMax: FixedAttribute(0x39, TlvNullable(TlvUInt8.bound({ max: 254 })), { default: null })
         }
     });
 
@@ -1496,9 +1513,12 @@ export namespace Thermostat {
             extendCluster(cluster, HeatingComponent, { heating: true });
             extendCluster(cluster, CoolingComponent, { cooling: true });
             extendCluster(cluster, NotLocalTemperatureNotExposedComponent, { localTemperatureNotExposed: false });
+            extendCluster(cluster, CoolingAndOccupancyComponent, { cooling: true, occupancy: true });
+            extendCluster(cluster, HeatingAndOccupancyComponent, { heating: true, occupancy: true });
             extendCluster(cluster, AutoModeComponent, { autoMode: true });
             extendCluster(cluster, ScheduleConfigurationComponent, { scheduleConfiguration: true });
             extendCluster(cluster, SetbackComponent, { setback: true });
+            extendCluster(cluster, SetbackAndOccupancyComponent, { setback: true, occupancy: true });
 
             preventCluster(
                 cluster,
@@ -1518,9 +1538,12 @@ export namespace Thermostat {
         & (SF extends { heating: true } ? typeof HeatingComponent : {})
         & (SF extends { cooling: true } ? typeof CoolingComponent : {})
         & (SF extends { localTemperatureNotExposed: false } ? typeof NotLocalTemperatureNotExposedComponent : {})
+        & (SF extends { cooling: true, occupancy: true } ? typeof CoolingAndOccupancyComponent : {})
+        & (SF extends { heating: true, occupancy: true } ? typeof HeatingAndOccupancyComponent : {})
         & (SF extends { autoMode: true } ? typeof AutoModeComponent : {})
         & (SF extends { scheduleConfiguration: true } ? typeof ScheduleConfigurationComponent : {})
         & (SF extends { setback: true } ? typeof SetbackComponent : {})
+        & (SF extends { setback: true, occupancy: true } ? typeof SetbackAndOccupancyComponent : {})
         & (SF extends { autoMode: true, heating: false } ? never : {})
         & (SF extends { autoMode: true, cooling: false } ? never : {})
         & (SF extends { heating: false, cooling: false } ? never : {});
@@ -1528,9 +1551,12 @@ export namespace Thermostat {
     const OCC = { occupancy: true };
     const HEAT = { heating: true };
     const COOL = { cooling: true };
+    const COOL_OCC = { cooling: true, occupancy: true };
+    const HEAT_OCC = { heating: true, occupancy: true };
     const AUTO = { autoMode: true };
     const SCH = { scheduleConfiguration: true };
     const SB = { setback: true };
+    const SB_OCC = { setback: true, occupancy: true };
 
     /**
      * This cluster supports all Thermostat features. It may support illegal feature combinations.
@@ -1578,12 +1604,12 @@ export namespace Thermostat {
                 { mandatoryIf: [HEAT] }
             ),
             unoccupiedCoolingSetpoint: AsConditional(
-                CoolingComponent.attributes.unoccupiedCoolingSetpoint,
-                { optionalIf: [COOL] }
+                CoolingAndOccupancyComponent.attributes.unoccupiedCoolingSetpoint,
+                { mandatoryIf: [COOL_OCC] }
             ),
             unoccupiedHeatingSetpoint: AsConditional(
-                HeatingComponent.attributes.unoccupiedHeatingSetpoint,
-                { optionalIf: [HEAT] }
+                HeatingAndOccupancyComponent.attributes.unoccupiedHeatingSetpoint,
+                { mandatoryIf: [HEAT_OCC] }
             ),
             minHeatSetpointLimit: AsConditional(
                 HeatingComponent.attributes.minHeatSetpointLimit,
@@ -1621,9 +1647,18 @@ export namespace Thermostat {
             occupiedSetback: AsConditional(SetbackComponent.attributes.occupiedSetback, { mandatoryIf: [SB] }),
             occupiedSetbackMin: AsConditional(SetbackComponent.attributes.occupiedSetbackMin, { mandatoryIf: [SB] }),
             occupiedSetbackMax: AsConditional(SetbackComponent.attributes.occupiedSetbackMax, { mandatoryIf: [SB] }),
-            unoccupiedSetback: AsConditional(SetbackComponent.attributes.unoccupiedSetback, { optionalIf: [SB] }),
-            unoccupiedSetbackMin: AsConditional(SetbackComponent.attributes.unoccupiedSetbackMin, { optionalIf: [SB] }),
-            unoccupiedSetbackMax: AsConditional(SetbackComponent.attributes.unoccupiedSetbackMax, { optionalIf: [SB] })
+            unoccupiedSetback: AsConditional(
+                SetbackAndOccupancyComponent.attributes.unoccupiedSetback,
+                { mandatoryIf: [SB_OCC] }
+            ),
+            unoccupiedSetbackMin: AsConditional(
+                SetbackAndOccupancyComponent.attributes.unoccupiedSetbackMin,
+                { mandatoryIf: [SB_OCC] }
+            ),
+            unoccupiedSetbackMax: AsConditional(
+                SetbackAndOccupancyComponent.attributes.unoccupiedSetbackMax,
+                { mandatoryIf: [SB_OCC] }
+            )
         },
 
         commands: {

--- a/packages/matter.js/src/cluster/definitions/WindowCoveringCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/WindowCoveringCluster.ts
@@ -36,7 +36,7 @@ import {
     OptionalCommand,
     Cluster as CreateCluster
 } from "../../cluster/Cluster.js";
-import { TlvEnum, TlvUInt8, TlvBitmap, TlvUInt16, TlvPercent100ths, TlvPercent } from "../../tlv/TlvNumber.js";
+import { TlvEnum, TlvUInt8, TlvBitmap, TlvUInt16, TlvPercent, TlvPercent100ths } from "../../tlv/TlvNumber.js";
 import { TlvNoArguments } from "../../tlv/TlvNoArguments.js";
 import { TlvNullable } from "../../tlv/TlvNullable.js";
 import { TlvObject, TlvOptionalField, TlvField } from "../../tlv/TlvObject.js";
@@ -300,7 +300,7 @@ export namespace WindowCovering {
      */
     export const TlvGoToLiftPercentageRequest = TlvObject({
         liftPercentageValue: TlvOptionalField(0, TlvPercent),
-        liftPercent100ThsValue: TlvOptionalField(1, TlvPercent100ths)
+        liftPercent100thsValue: TlvOptionalField(1, TlvPercent100ths)
     });
 
     /**
@@ -310,7 +310,7 @@ export namespace WindowCovering {
      */
     export const TlvGoToTiltPercentageRequest = TlvObject({
         tiltPercentageValue: TlvOptionalField(0, TlvPercent),
-        tiltPercent100ThsValue: TlvOptionalField(1, TlvPercent100ths)
+        tiltPercent100thsValue: TlvOptionalField(1, TlvPercent100ths)
     });
 
     /**
@@ -672,31 +672,7 @@ export namespace WindowCovering {
              *
              * @see {@link MatterApplicationClusterSpecificationV1_1} § 5.3.5.6
              */
-            numberOfActuationsLift: OptionalAttribute(0x5, TlvUInt16, { persistent: true, default: 0 }),
-
-            /**
-             * The TargetPositionLiftPercent100ths attribute identifies the position where the Window Covering Lift
-             * will go or is moving to as a percentage.
-             *
-             * @see {@link MatterApplicationClusterSpecificationV1_1} § 5.3.5.13
-             */
-            targetPositionLiftPercent100Ths: OptionalAttribute(
-                0xb,
-                TlvNullable(TlvPercent100ths),
-                { scene: true, default: null }
-            ),
-
-            /**
-             * The CurrentPositionLiftPercent100ths attribute identifies the actual position as a percentage with a
-             * minimal step of 0.01%. E.g Max 10000 equals 100.00%.
-             *
-             * @see {@link MatterApplicationClusterSpecificationV1_1} § 5.3.5.9
-             */
-            currentPositionLiftPercent100Ths: OptionalAttribute(
-                0xe,
-                TlvNullable(TlvPercent100ths),
-                { persistent: true, default: null }
-            )
+            numberOfActuationsLift: OptionalAttribute(0x5, TlvUInt16, { persistent: true, default: 0 })
         },
 
         commands: {
@@ -734,31 +710,7 @@ export namespace WindowCovering {
              *
              * @see {@link MatterApplicationClusterSpecificationV1_1} § 5.3.5.7
              */
-            numberOfActuationsTilt: OptionalAttribute(0x6, TlvUInt16, { persistent: true, default: 0 }),
-
-            /**
-             * The TargetPositionTiltPercent100ths attribute identifies the position where the Window Covering Tilt
-             * will go or is moving to as a percentage.
-             *
-             * @see {@link MatterApplicationClusterSpecificationV1_1} § 5.3.5.14
-             */
-            targetPositionTiltPercent100Ths: OptionalAttribute(
-                0xc,
-                TlvNullable(TlvPercent100ths),
-                { scene: true, default: null }
-            ),
-
-            /**
-             * The CurrentPositionTiltPercent100ths attribute identifies the actual position as a percentage with a
-             * minimal step of 0.01%. E.g Max 10000 equals 100.00%.
-             *
-             * @see {@link MatterApplicationClusterSpecificationV1_1} § 5.3.5.10
-             */
-            currentPositionTiltPercent100Ths: OptionalAttribute(
-                0xf,
-                TlvNullable(TlvPercent100ths),
-                { persistent: true, default: null }
-            )
+            numberOfActuationsTilt: OptionalAttribute(0x6, TlvUInt16, { persistent: true, default: 0 })
         },
 
         commands: {
@@ -802,6 +754,30 @@ export namespace WindowCovering {
                 0x8,
                 TlvNullable(TlvPercent),
                 { scene: true, persistent: true, default: null }
+            ),
+
+            /**
+             * The TargetPositionLiftPercent100ths attribute identifies the position where the Window Covering Lift
+             * will go or is moving to as a percentage.
+             *
+             * @see {@link MatterApplicationClusterSpecificationV1_1} § 5.3.5.13
+             */
+            targetPositionLiftPercent100ths: Attribute(
+                0xb,
+                TlvNullable(TlvPercent100ths),
+                { scene: true, default: null }
+            ),
+
+            /**
+             * The CurrentPositionLiftPercent100ths attribute identifies the actual position as a percentage with a
+             * minimal step of 0.01%. E.g Max 10000 equals 100.00%.
+             *
+             * @see {@link MatterApplicationClusterSpecificationV1_1} § 5.3.5.9
+             */
+            currentPositionLiftPercent100ths: Attribute(
+                0xe,
+                TlvNullable(TlvPercent100ths),
+                { persistent: true, default: null }
             )
         },
 
@@ -845,6 +821,30 @@ export namespace WindowCovering {
                 0x9,
                 TlvNullable(TlvPercent),
                 { scene: true, persistent: true, default: null }
+            ),
+
+            /**
+             * The TargetPositionTiltPercent100ths attribute identifies the position where the Window Covering Tilt
+             * will go or is moving to as a percentage.
+             *
+             * @see {@link MatterApplicationClusterSpecificationV1_1} § 5.3.5.14
+             */
+            targetPositionTiltPercent100ths: Attribute(
+                0xc,
+                TlvNullable(TlvPercent100ths),
+                { scene: true, default: null }
+            ),
+
+            /**
+             * The CurrentPositionTiltPercent100ths attribute identifies the actual position as a percentage with a
+             * minimal step of 0.01%. E.g Max 10000 equals 100.00%.
+             *
+             * @see {@link MatterApplicationClusterSpecificationV1_1} § 5.3.5.10
+             */
+            currentPositionTiltPercent100ths: Attribute(
+                0xf,
+                TlvNullable(TlvPercent100ths),
+                { persistent: true, default: null }
             )
         },
 
@@ -1032,21 +1032,21 @@ export namespace WindowCovering {
                 TiltAndPositionAwareTiltComponent.attributes.currentPositionTiltPercentage,
                 { optionalIf: [TL_PA_TL] }
             ),
-            targetPositionLiftPercent100Ths: AsConditional(
-                LiftComponent.attributes.targetPositionLiftPercent100Ths,
-                { optionalIf: [LF] }
+            targetPositionLiftPercent100ths: AsConditional(
+                LiftAndPositionAwareLiftComponent.attributes.targetPositionLiftPercent100ths,
+                { mandatoryIf: [LF_PA_LF] }
             ),
-            targetPositionTiltPercent100Ths: AsConditional(
-                TiltComponent.attributes.targetPositionTiltPercent100Ths,
-                { optionalIf: [TL] }
+            targetPositionTiltPercent100ths: AsConditional(
+                TiltAndPositionAwareTiltComponent.attributes.targetPositionTiltPercent100ths,
+                { mandatoryIf: [TL_PA_TL] }
             ),
-            currentPositionLiftPercent100Ths: AsConditional(
-                LiftComponent.attributes.currentPositionLiftPercent100Ths,
-                { optionalIf: [LF] }
+            currentPositionLiftPercent100ths: AsConditional(
+                LiftAndPositionAwareLiftComponent.attributes.currentPositionLiftPercent100ths,
+                { mandatoryIf: [LF_PA_LF] }
             ),
-            currentPositionTiltPercent100Ths: AsConditional(
-                TiltComponent.attributes.currentPositionTiltPercent100Ths,
-                { optionalIf: [TL] }
+            currentPositionTiltPercent100ths: AsConditional(
+                TiltAndPositionAwareTiltComponent.attributes.currentPositionTiltPercent100ths,
+                { mandatoryIf: [TL_PA_TL] }
             ),
             installedOpenLimitLift: AsConditional(
                 LiftAndPositionAwareLiftAndAbsolutePositionComponent.attributes.installedOpenLimitLift,

--- a/packages/matter.js/src/model/logic/cluster-variance/InferredComponents.ts
+++ b/packages/matter.js/src/model/logic/cluster-variance/InferredComponents.ts
@@ -60,7 +60,7 @@ const FEATURE_NAME = "[A-Z_][A-Z_]+";
 const FEATURE = `(${FEATURE_NAME})`;
 const CONJUNCT_FEATURES = `(${FEATURE_NAME}(?: & ${FEATURE_NAME})*)`;
 const DISJUNCT_FEATURES = CONJUNCT_FEATURES.replace("&", "[|,]");
-const FIELD = "[A-Z][A-Za-z_$]+";
+const FIELD = "[A-Z][A-Za-z_$]*[a-z][A-Za-z_$]*";
 const AND = " & ";
 const NOT = "!";
 

--- a/packages/matter.js/src/model/standard/elements/DoorLock.ts
+++ b/packages/matter.js/src/model/standard/elements/DoorLock.ts
@@ -522,7 +522,7 @@ Matter.children.push({
         },
 
         {
-            tag: "attribute", name: "RequirePiNforRemoteOperation", id: 0x33, type: "bool", access: "R[W] VA",
+            tag: "attribute", name: "RequirePinForRemoteOperation", id: 0x33, type: "bool", access: "R[W] VA",
             conformance: "COTA & PIN", default: true, quality: "P",
             details: "Boolean set to True if the door lock server requires that an optional PINs be included in the " +
                 "payload of remote lock operation events like Lock, Unlock, Unlock with Timeout and Toggle in order " +

--- a/packages/matter.js/src/model/standard/elements/WindowCovering.ts
+++ b/packages/matter.js/src/model/standard/elements/WindowCovering.ts
@@ -200,7 +200,7 @@ Matter.children.push({
         },
 
         {
-            tag: "attribute", name: "TargetPositionLiftPercent100Ths", id: 0xb, type: "percent100ths",
+            tag: "attribute", name: "TargetPositionLiftPercent100ths", id: 0xb, type: "percent100ths",
             access: "R V", conformance: "LF & PA_LF", constraint: "0 to 10000", default: null, quality: "X S P",
             details: "The TargetPositionLiftPercent100ths attribute identifies the position where the Window Covering " +
                 "Lift will go or is moving to as a percentage.",
@@ -208,7 +208,7 @@ Matter.children.push({
         },
 
         {
-            tag: "attribute", name: "TargetPositionTiltPercent100Ths", id: 0xc, type: "percent100ths",
+            tag: "attribute", name: "TargetPositionTiltPercent100ths", id: 0xc, type: "percent100ths",
             access: "R V", conformance: "TL & PA_TL", constraint: "0 to 10000", default: null, quality: "X S P",
             details: "The TargetPositionTiltPercent100ths attribute identifies the position where the Window Covering " +
                 "Tilt will go or is moving to as a percentage.",
@@ -253,7 +253,7 @@ Matter.children.push({
         },
 
         {
-            tag: "attribute", name: "CurrentPositionLiftPercent100Ths", id: 0xe, type: "percent100ths",
+            tag: "attribute", name: "CurrentPositionLiftPercent100ths", id: 0xe, type: "percent100ths",
             access: "R V", conformance: "LF & PA_LF", constraint: "0 to 10000", default: null, quality: "X N P",
             details: "The CurrentPositionLiftPercent100ths attribute identifies the actual position as a percentage with " +
                 "a minimal step of 0.01%. E.g Max 10000 equals 100.00%.",
@@ -261,7 +261,7 @@ Matter.children.push({
         },
 
         {
-            tag: "attribute", name: "CurrentPositionTiltPercent100Ths", id: 0xf, type: "percent100ths",
+            tag: "attribute", name: "CurrentPositionTiltPercent100ths", id: 0xf, type: "percent100ths",
             access: "R V", conformance: "TL & PA_TL", constraint: "0 to 10000", default: null, quality: "X N P",
             details: "The CurrentPositionTiltPercent100ths attribute identifies the actual position as a percentage with " +
                 "a minimal step of 0.01%. E.g Max 10000 equals 100.00%.",
@@ -545,7 +545,7 @@ Matter.children.push({
                     constraint: "desc"
                 },
                 {
-                    tag: "datatype", name: "LiftPercent100ThsValue", id: 0x1, type: "percent100ths", conformance: "O.a",
+                    tag: "datatype", name: "LiftPercent100thsValue", id: 0x1, type: "percent100ths", conformance: "O.a",
                     constraint: "desc"
                 }
             ]
@@ -597,7 +597,7 @@ Matter.children.push({
                     constraint: "desc"
                 },
                 {
-                    tag: "datatype", name: "TiltPercent100ThsValue", id: 0x1, type: "percent100ths", conformance: "O.a",
+                    tag: "datatype", name: "TiltPercent100thsValue", id: 0x1, type: "percent100ths", conformance: "O.a",
                     constraint: "desc"
                 }
             ]

--- a/packages/matter.js/src/util/String.ts
+++ b/packages/matter.js/src/util/String.ts
@@ -57,7 +57,7 @@ export function camelize(name: string, upperFirst = true) {
     addPiece(i);
 
     let didFirst = false;
-    return pieces.map((piece) => {
+    let result = pieces.map((piece) => {
         let firstChar = piece[0];
         if (upperFirst || didFirst) {
             firstChar = firstChar.toUpperCase();
@@ -67,6 +67,11 @@ export function camelize(name: string, upperFirst = true) {
         }
         return `${firstChar}${piece.slice(1).toLowerCase()}`;
     }).join("");
+
+    // Special case so "100ths" doesn't become "100Ths" which is formally correct but goofy
+    result = result.replace(/(\d+)Ths/i, "$1ths");
+
+    return result;
 }
 
 /**

--- a/packages/matter.js/test/cluster/ClusterFactoryTest.ts
+++ b/packages/matter.js/test/cluster/ClusterFactoryTest.ts
@@ -303,8 +303,7 @@ describe("ClusterFactory", () => {
         }, {
             ev1: true,
             ev2: true,
-        }
-        );
+        });
     })
 
     /**
@@ -363,7 +362,7 @@ describe("ClusterFactory", () => {
         handlers;
 
         // Create the cluster server
-        ClusterServer(
+        const server = ClusterServer(
             MyCluster,
             {
                 attr1: 1,
@@ -383,7 +382,8 @@ describe("ClusterFactory", () => {
         }, {
             ev1: true,
             ev2: true,
-        }
-        );
+        });
+
+        server.attributes.attr2
     })
 })

--- a/packages/matter.js/test/cluster/ClusterServerTest.ts
+++ b/packages/matter.js/test/cluster/ClusterServerTest.ts
@@ -526,9 +526,9 @@ describe("ClusterServer structure", () => {
                         ledFeedback: false,
                     },
                     numberOfActuationsLift: 0,
-                    targetPositionLiftPercent100Ths: 0,
-                    currentPositionLiftPercent100Ths: 0,
-                    currentPositionTiltPercent100Ths: 0, // Should not be there because not valid for feature-combination
+                    targetPositionLiftPercent100ths: 0,
+                    currentPositionLiftPercent100ths: 0,
+                    currentPositionTiltPercent100ths: 0, // Should not be there because not valid for feature-combination
                 },
                 {
                     upOrOpen: async () => { /* dummy */ },
@@ -542,7 +542,7 @@ describe("ClusterServer structure", () => {
 
             assert.deepEqual(fakeLogSink, [
                 { level: Level.DEBUG, log: '1970-01-01 00:00:00.000 DEBUG InteractionProtocol InitialAttributeValue for "WindowCovering/currentPositionLiftPercentage" is optional by supportedFeatures: {"lift":true,"positionAwareLift":true} and is not set!' },
-                { level: Level.WARN, log: '1970-01-01 00:00:00.000 WARN InteractionProtocol InitialAttributeValue for "WindowCovering/currentPositionTiltPercent100Ths" is provided but it\'s neither optional or mandatory for supportedFeatures: {"lift":true,"positionAwareLift":true} but is set!' },
+                { level: Level.WARN, log: '1970-01-01 00:00:00.000 WARN InteractionProtocol InitialAttributeValue for "WindowCovering/currentPositionTiltPercent100ths" is provided but it\'s neither optional or mandatory for supportedFeatures: {"lift":true,"positionAwareLift":true} but is set!' },
                 { level: Level.WARN, log: '1970-01-01 00:00:00.000 WARN InteractionProtocol Command "WindowCovering/goToLiftPercentage" is REQUIRED by supportedFeatures: {"lift":true,"positionAwareLift":true} but is not set!' }
             ]);
         });

--- a/packages/matter.js/test/cluster/definitions/WindowCoveringClusterTest.ts
+++ b/packages/matter.js/test/cluster/definitions/WindowCoveringClusterTest.ts
@@ -1,0 +1,160 @@
+/**
+ * @license
+ * Copyright 2022-2023 Project CHIP Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { WindowCovering, WindowCoveringCluster } from "../../../src/cluster/definitions/WindowCoveringCluster.js";
+import { AttributeId } from "../../../src/datatype/AttributeId.js";
+import { CommandId } from "../../../src/datatype/CommandId.js";
+import { ClusterServer } from "../../../src/protocol/interaction/InteractionServer.js";
+import { BitFlags } from "../../../src/schema/BitmapSchema.js";
+
+function wrapIds<T>(factory: new (id: number) => T, ...ids: number[]) {
+    return ids.map(id => new factory(id));
+}
+
+describe("WindowCoveringCluster", () => {
+    const WindowCovering_LF_PALF = WindowCoveringCluster.with("Lift", "PositionAwareLift");
+
+    it("correctly initializes elements for LF & PA_LF", () => {
+        const NONE = [false, false, false, false];
+        const OPTIONAL = [true, false, false, false];
+        const WRITABLE = [false, true, false, false];
+        const FIXED = [false, false, true, false];
+
+        expect(
+            Object.fromEntries(Object.entries(WindowCovering_LF_PALF.attributes).map(
+                ([k, { optional, writable, fixed, fabricScoped }]) => [k, [optional, writable, fixed, fabricScoped]]
+            ))
+        ).toEqual({ // TODO - make strict after updating web tester
+            acceptedCommandList: NONE,
+            attributeList: NONE,
+            clusterRevision: NONE,
+            configStatus: NONE,
+            currentPositionLiftPercent100ths: NONE,
+            currentPositionLiftPercentage: OPTIONAL,
+            endProductType: FIXED,
+            eventList: NONE,
+            featureMap: NONE,
+            generatedCommandList: NONE,
+            mode: WRITABLE,
+            numberOfActuationsLift: OPTIONAL,
+            operationalStatus: NONE,
+            safetyStatus: OPTIONAL,
+            targetPositionLiftPercent100ths: NONE,
+            type: FIXED
+        });
+
+        expect(
+            Object.fromEntries(Object.entries(WindowCovering_LF_PALF.commands).map(
+                ([k, { optional }]) => [k, [optional, false, false, false]]
+            ))
+        ).toEqual({ // TODO - make strict after updating web tester
+            downOrClose: NONE,
+            goToLiftPercentage: NONE,
+            stopMotion: NONE,
+            upOrOpen: NONE
+        })
+    });
+
+    it("correctly configures ClusterServer for LF & PA_LF", () => {
+        const server = ClusterServer(
+            WindowCovering_LF_PALF,
+            {
+                type: WindowCovering.WindowCoveringType.ProjectorScreen,
+
+                // Hrm, should this accept a partial bitmap?
+                configStatus: BitFlags(
+                    WindowCovering.ConfigStatus,
+                    "Operational",
+                    "LiftPositionAware",
+                    "OnlineReserved"
+                ),
+
+                currentPositionLiftPercent100ths: 5000,
+                targetPositionLiftPercent100ths: 5000,
+                endProductType: WindowCovering.EndProductType.PleatedShade,
+                mode: BitFlags(
+                    WindowCovering.Mode
+                ),
+                operationalStatus: {
+                    global: WindowCovering.MovementStatus.Stopped,
+                    lift: WindowCovering.MovementStatus.Stopped,
+                    tilt: WindowCovering.MovementStatus.Stopped
+                },
+                safetyStatus: BitFlags(
+                    WindowCovering.SafetyStatus,
+                    "ObstacleDetected"
+                )
+            },
+            {
+                downOrClose: () => { },
+                stopMotion: () => { },
+                upOrOpen: () => { }
+            }
+        );
+
+        const attrValues = Object.fromEntries(
+            Object.entries(server.attributes)
+                .map(([k, v]) => [k, v.getLocal()])
+        );
+
+        expect(attrValues).toEqual({ // TODO - make strict after updating web tester
+            acceptedCommandList: wrapIds(CommandId,
+                0, 1, 2
+            ),
+            attributeList: wrapIds(AttributeId,
+                0, 7, 10, 13, 23, 26, 65533, 65532, 65531, 65530, 65529, 65528, 11, 14
+            ),
+            clusterRevision: 5,
+            configStatus: {
+                operational: true,
+                onlineReserved: true,
+                liftMovementReversed: false,
+                liftPositionAware: true,
+                tiltPositionAware: false,
+                liftEncoderControlled: false,
+                tiltEncoderControlled: false
+            },
+            currentPositionLiftPercent100ths: 5000,
+            endProductType: 4,
+            eventList: [],
+            featureMap: {
+                lift: true,
+                tilt: false,
+                positionAwareLift: true,
+                positionAwareTilt: false,
+                absolutePosition: false
+            },
+            generatedCommandList: [],
+            mode: {
+                motorDirectionReversed: false,
+                calibrationMode: false,
+                maintenanceMode: false,
+                ledFeedback: false
+            },
+            operationalStatus: {
+                global: 0,
+                lift: 0,
+                tilt: 0
+            },
+            safetyStatus: {
+                failedCommunication: false,
+                hardwareFailure: false,
+                manualOperation: false,
+                motorJammed: false,
+                obstacleDetected: true,
+                positionFailure: false,
+                power: false,
+                protection: false,
+                remoteLockout: false,
+                stopInput: false,
+                tamperDetection: false,
+                thermalProtection: false
+            },
+            targetPositionLiftPercent100ths: 5000,
+            type: 9
+        })
+    })
+})

--- a/packages/matter.js/test/model/logic/ClusterVarianceTest.ts
+++ b/packages/matter.js/test/model/logic/ClusterVarianceTest.ts
@@ -118,6 +118,26 @@ describe("ClusterVariance", () => {
                 }
             )
         })
+
+        it("parses FOO & BAR", () => {
+            expectComponents(
+                attrs(["FOO", "BAR"], { name: "attr", conformance: "FOO & BAR" }),
+                {
+                    mandatory: ["attr"],
+                    condition: { allOf: ["FOO", "BAR"] }
+                }
+            )
+        })
+
+        it("parses FOO & BarBar", () => {
+            expectComponents(
+                attrs(["FOO", "BAR"], { name: "attr", conformance: "FOO & BarBar" }),
+                {
+                    optional: ["attr"],
+                    condition: { allOf: ["FOO"] }
+                }
+            )
+        })
     })
 })
 


### PR DESCRIPTION
Tweaks a couple of names ("100ths" now camelizes as "100ths" and not "100Ths").

Fixes a conformance rule that was incorrectly matching pattern "FOO & BAR".  Makes a few attributes mandatory that were previously optional.

Adds a WindowCovering-specific test, fairly exhaustive but currently for a fairly limited feature set.