### PR TITLE
Simplify types and increase type checking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All Changes without a GitHub Username in brackets are from the core team: @Apoll
   * Breaking: Types of specific clusters are no longer exported flat on main level. Cluster exports are now namespaces that include their types.
   * Breaking: All collection files meant to be used for exports only are renamed to export.ts and should not be used for internal imports
   * Breaking: Attribute listener methods renamed: addListener -> addValueSetListener, addMatterListener -> addValueChangeListener (also remove methods) to make it more clear what they do
+  * Breaking: Change from object style to Branded types for special Datatype objects (e.g. "new VendorId(0xFFF1)" -> "VendorId(0xFFF1)")
   * Feature: Enhance CommissioningServer options to also specify GeneralCommissioningServer details and settings
   * Feature: Adjust RegulatoryConfig Handling in Device and Controller to match with specifications
   * Feature: Endpoint Structures use custom-unique-id (from EndpointOptions)/uniqueStorageKey (from BasicInformationCluster)/serialNumber (from BasicInformationCluster)/ Index (in this order) to store and restore the endpoint ID in structures
@@ -29,7 +30,7 @@ All Changes without a GitHub Username in brackets are from the core team: @Apoll
   * Feature: Refactor Controller Commissioning process and add network commissioning support
   * Feature: Correctly Handle FabricIndex fields for Read and Write requests
   * Feature: Handle subscription errors and destroy session if failing more than 3 times
-  * Feature: Add full event support (Device and Controller) including triggering some default events automatically (startup, shutdown, reachabilitycChanged, bootReason)
+  * Feature: Add full event support (Device and Controller) including triggering some default events automatically (startup, shutdown, reachabilityChanged, bootReason)
   * Feature: Add more parameters to several InteractionClient methods to allow to configure more parameters of the requests
   * Feature: Allows subscripts to be updated dynamically when the endpoint structure for bridges changes by adding or removing a device
   * Enhance: Device port in MDNSBroadcaster is now dynamically set and add UDC (User directed Commissioning) Announcements

--- a/packages/matter-node-ble.js/src/ble/BleBroadcaster.ts
+++ b/packages/matter-node-ble.js/src/ble/BleBroadcaster.ts
@@ -29,11 +29,11 @@ export class BleBroadcaster implements InstanceBroadcaster {
     async setCommissionMode(mode: number, { deviceName, deviceType, vendorId, productId, discriminator }: CommissioningModeInstanceData) {
         if (mode !== 1) {
             this.advertise = false;
-            logger.info(`skip BLE announce because of commissioning mode ${mode} ${deviceName} ${deviceType} ${vendorId.id} ${productId} ${discriminator}`);
+            logger.info(`skip BLE announce because of commissioning mode ${mode} ${deviceName} ${deviceType} ${vendorId} ${productId} ${discriminator}`);
             await this.blenoServer.stopAdvertising();
             return;
         }
-        logger.debug(`store data for commissioning mode ${mode} ${deviceName} ${deviceType} ${vendorId.id} ${productId} ${discriminator}`);
+        logger.debug(`store data for commissioning mode ${mode} ${deviceName} ${deviceType} ${vendorId} ${productId} ${discriminator}`);
         this.productId = productId;
         this.vendorId = vendorId;
         this.discriminator = discriminator;
@@ -48,7 +48,7 @@ export class BleBroadcaster implements InstanceBroadcaster {
         return; // Not needed because we only advertise un-commissioned devices
     }
 
-    setCommissionerInfo(_commissionerData: CommissionerInstanceData) {
+    async setCommissionerInfo(_commissionerData: CommissionerInstanceData) {
         this.advertise = false;
         logger.error(`skip BLE announce because announcing a commissioner is not supported`);
     }

--- a/packages/matter-node-ble.js/src/ble/BleScanner.ts
+++ b/packages/matter-node-ble.js/src/ble/BleScanner.ts
@@ -13,8 +13,8 @@ import { NobleBleClient } from "./NobleBleClient";
 import { BtpCodec } from "@project-chip/matter.js/codec";
 import { ByteArray, getPromiseResolver } from "@project-chip/matter.js/util";
 import { Time, Timer } from "@project-chip/matter.js/time";
-import { VendorId } from "@project-chip/matter.js/datatype";
 import { BleError } from "@project-chip/matter.js/ble";
+import { VendorId } from "@project-chip/matter.js/datatype";
 
 const logger = Logger.get("BleScanner");
 
@@ -83,7 +83,7 @@ export class BleScanner implements Scanner {
             const commissionableDevice: CommissionableDeviceData = {
                 D: discriminator,
                 SD: (discriminator >> 8) & 0x0F,
-                VP: `${vendorId.id}+${productId}`,
+                VP: `${vendorId}+${productId}`,
                 CM: 1, // Can be no other mode,
                 addresses: [{ type: "ble", peripheralAddress: peripheral.address }]
             };
@@ -112,12 +112,12 @@ export class BleScanner implements Scanner {
         }
 
         if (record.VP !== undefined) {
-            const vendorIdQueryId = this.buildCommissionableQueryIdentifier({ vendorId: new VendorId(parseInt(record.VP.split("+")[0])) });
+            const vendorIdQueryId = this.buildCommissionableQueryIdentifier({ vendorId: VendorId(parseInt(record.VP.split("+")[0])) });
             if (this.recordWaiters.has(vendorIdQueryId)) {
                 return vendorIdQueryId;
             }
             if (record.VP.includes("+")) {
-                const productIdQueryId = this.buildCommissionableQueryIdentifier({ vendorId: new VendorId(parseInt(record.VP.split("+")[1])) });
+                const productIdQueryId = this.buildCommissionableQueryIdentifier({ vendorId: VendorId(parseInt(record.VP.split("+")[1])) });
                 if (this.recordWaiters.has(productIdQueryId)) {
                     return productIdQueryId;
                 }
@@ -143,7 +143,7 @@ export class BleScanner implements Scanner {
             return `SD:${identifier.shortDiscriminator}`;
         }
         else if ("vendorId" in identifier) {
-            return `V:${identifier.vendorId.id}`;
+            return `V:${identifier.vendorId}`;
         }
         else if ("productId" in identifier) { // Custom identifier because normally productId is only included in TXT record
             return `P:${identifier.productId}`;
@@ -162,7 +162,7 @@ export class BleScanner implements Scanner {
             foundRecords.push(...storedRecords.filter(({ deviceData: { SD } }) => SD === identifier.shortDiscriminator));
         }
         else if ("vendorId" in identifier) {
-            foundRecords.push(...storedRecords.filter(({ deviceData: { VP } }) => VP === `${identifier.vendorId.id}` || VP?.startsWith(`${identifier.vendorId.id}+`)));
+            foundRecords.push(...storedRecords.filter(({ deviceData: { VP } }) => VP === `${identifier.vendorId}` || VP?.startsWith(`${identifier.vendorId}+`)));
         }
         else if ("productId" in identifier) {
             foundRecords.push(...storedRecords.filter(({ deviceData: { VP } }) => VP?.endsWith(`+${identifier.productId}`)));

--- a/packages/matter-node.js-examples/src/examples/BridgedDevicesNode.ts
+++ b/packages/matter-node.js-examples/src/examples/BridgedDevicesNode.ts
@@ -17,11 +17,11 @@
 import { CommissioningServer, MatterServer } from "@project-chip/matter-node.js";
 
 import { OnOffLightDevice, OnOffPluginUnitDevice, Aggregator, DeviceTypes } from "@project-chip/matter-node.js/device";
-import { VendorId } from "@project-chip/matter-node.js/datatype";
 import { Logger } from "@project-chip/matter-node.js/log";
 import { StorageManager, StorageBackendDisk } from "@project-chip/matter-node.js/storage";
 import { commandExecutor, getIntParameter, getParameter, requireMinNodeVersion, hasParameter } from "@project-chip/matter-node.js/util";
 import { Time } from "@project-chip/matter-node.js/time";
+import { VendorId } from "@project-chip/matter.js/datatype";
 
 const logger = Logger.get("Device");
 
@@ -67,7 +67,7 @@ class BridgedDevice {
         const passcode = getIntParameter("passcode") ?? deviceStorage.get("passcode", 20202021);
         const discriminator = getIntParameter("discriminator") ?? deviceStorage.get("discriminator", 3840);
         // product name / id and vendor id should match what is in the device certificate
-        const vendorId = new VendorId(getIntParameter("vendorid") ?? deviceStorage.get("vendorid", 0xFFF1));
+        const vendorId = getIntParameter("vendorid") ?? deviceStorage.get("vendorid", 0xFFF1);
         const productName = `node-matter OnOff-Bridge`;
         const productId = getIntParameter("productid") ?? deviceStorage.get("productid", 0x8000);
 
@@ -78,7 +78,7 @@ class BridgedDevice {
 
         deviceStorage.set("passcode", passcode);
         deviceStorage.set("discriminator", discriminator);
-        deviceStorage.set("vendorid", vendorId.id);
+        deviceStorage.set("vendorid", vendorId);
         deviceStorage.set("productid", productId);
         deviceStorage.set("uniqueid", uniqueId);
 
@@ -105,7 +105,7 @@ class BridgedDevice {
             discriminator,
             basicInformation: {
                 vendorName,
-                vendorId,
+                vendorId: VendorId(vendorId),
                 nodeLabel: productName,
                 productName,
                 productLabel: productName,

--- a/packages/matter-node.js-examples/src/examples/ComposedDeviceNode.ts
+++ b/packages/matter-node.js-examples/src/examples/ComposedDeviceNode.ts
@@ -21,9 +21,9 @@ import { CommissioningServer, MatterServer } from "@project-chip/matter-node.js"
 import { commandExecutor, getIntParameter, getParameter, requireMinNodeVersion, hasParameter } from "@project-chip/matter-node.js/util";
 import { Time } from "@project-chip/matter-node.js/time";
 import { OnOffLightDevice, OnOffPluginUnitDevice, DeviceTypes } from "@project-chip/matter-node.js/device";
-import { VendorId } from "@project-chip/matter-node.js/datatype";
 import { Logger } from "@project-chip/matter-node.js/log";
 import { StorageManager, StorageBackendDisk } from "@project-chip/matter-node.js/storage";
+import { VendorId } from "@project-chip/matter-node.js/datatype";
 
 const logger = Logger.get("Device");
 
@@ -73,7 +73,7 @@ class ComposedDevice {
         const passcode = getIntParameter("passcode") ?? deviceStorage.get("passcode", 20202021);
         const discriminator = getIntParameter("discriminator") ?? deviceStorage.get("discriminator", 3840);
         // product name / id and vendor id should match what is in the device certificate
-        const vendorId = new VendorId(getIntParameter("vendorid") ?? deviceStorage.get("vendorid", 0xFFF1));
+        const vendorId = getIntParameter("vendorid") ?? deviceStorage.get("vendorid", 0xFFF1);
         const productName = `node-matter OnOff-Bridge`;
         const productId = getIntParameter("productid") ?? deviceStorage.get("productid", 0x8000);
 
@@ -84,7 +84,7 @@ class ComposedDevice {
 
         deviceStorage.set("passcode", passcode);
         deviceStorage.set("discriminator", discriminator);
-        deviceStorage.set("vendorid", vendorId.id);
+        deviceStorage.set("vendorid", vendorId);
         deviceStorage.set("productid", productId);
         deviceStorage.set("isSocket", isSocket);
         deviceStorage.set("uniqueid", uniqueId);
@@ -112,7 +112,7 @@ class ComposedDevice {
             discriminator,
             basicInformation: {
                 vendorName,
-                vendorId,
+                vendorId: VendorId(vendorId),
                 nodeLabel: productName,
                 productName,
                 productLabel: productName,

--- a/packages/matter-node.js-examples/src/examples/DeviceNode.ts
+++ b/packages/matter-node.js-examples/src/examples/DeviceNode.ts
@@ -20,13 +20,13 @@ import {
 } from "@project-chip/matter-node.js/util";
 import { Time } from "@project-chip/matter-node.js/time";
 import { OnOffLightDevice, OnOffPluginUnitDevice } from "@project-chip/matter-node.js/device";
-import { VendorId } from "@project-chip/matter-node.js/datatype";
 import { Logger } from "@project-chip/matter-node.js/log";
 import { StorageManager, StorageBackendDisk } from "@project-chip/matter-node.js/storage";
 import { Ble } from "@project-chip/matter-node.js/ble";
 import { BleNode } from "@project-chip/matter-node-ble.js/ble";
 import { NetworkCommissioning, GeneralCommissioningCluster } from "@project-chip/matter-node.js/cluster";
 import { ClusterServer } from "@project-chip/matter-node.js/interaction";
+import { DeviceTypeId, VendorId } from "@project-chip/matter.js/datatype";
 
 if (hasParameter("ble")) {
     // Initialize Ble
@@ -80,7 +80,7 @@ class Device {
         const passcode = getIntParameter("passcode") ?? deviceStorage.get("passcode", 20202021);
         const discriminator = getIntParameter("discriminator") ?? deviceStorage.get("discriminator", 3840);
         // product name / id and vendor id should match what is in the device certificate
-        const vendorId = new VendorId(getIntParameter("vendorid") ?? deviceStorage.get("vendorid", 0xFFF1));
+        const vendorId = getIntParameter("vendorid") ?? deviceStorage.get("vendorid", 0xFFF1);
         const productName = `node-matter OnOff ${isSocket ? "Socket" : "Light"}`;
         const productId = getIntParameter("productid") ?? deviceStorage.get("productid", 0x8000);
 
@@ -91,7 +91,7 @@ class Device {
 
         deviceStorage.set("passcode", passcode);
         deviceStorage.set("discriminator", discriminator);
-        deviceStorage.set("vendorid", vendorId.id);
+        deviceStorage.set("vendorid", vendorId);
         deviceStorage.set("productid", productId);
         deviceStorage.set("isSocket", isSocket);
         deviceStorage.set("uniqueid", uniqueId);
@@ -131,12 +131,12 @@ class Device {
         const commissioningServer = new CommissioningServer({
             port,
             deviceName,
-            deviceType: onOffDevice.deviceType,
+            deviceType: DeviceTypeId(onOffDevice.deviceType),
             passcode,
             discriminator,
             basicInformation: {
                 vendorName,
-                vendorId,
+                vendorId: VendorId(vendorId),
                 nodeLabel: productName,
                 productName,
                 productLabel: productName,

--- a/packages/matter-node.js-examples/src/examples/MultiDeviceNode.ts
+++ b/packages/matter-node.js-examples/src/examples/MultiDeviceNode.ts
@@ -21,9 +21,9 @@ import { CommissioningServer, MatterServer } from "@project-chip/matter-node.js"
 import { commandExecutor, getIntParameter, getParameter, requireMinNodeVersion, hasParameter } from "@project-chip/matter-node.js/util";
 import { Time } from "@project-chip/matter-node.js/time";
 import { OnOffLightDevice, OnOffPluginUnitDevice, DeviceTypes } from "@project-chip/matter-node.js/device";
-import { VendorId } from "@project-chip/matter-node.js/datatype";
 import { Logger } from "@project-chip/matter-node.js/log";
 import { StorageManager, StorageBackendDisk } from "@project-chip/matter-node.js/storage";
+import { VendorId } from "@project-chip/matter.js/datatype";
 
 const logger = Logger.get("MultiDevice");
 
@@ -110,7 +110,7 @@ class Device {
             const passcode = getIntParameter(`passcode${i}`) ?? deviceStorage.get(`passcode${i}`, defaultPasscode++);
             const discriminator = getIntParameter(`discriminator${i}`) ?? deviceStorage.get(`discriminator${i}`, defaultDiscriminator++);
             // product name / id and vendor id should match what is in the device certificate
-            const vendorId = new VendorId(getIntParameter(`vendorid${i}`) ?? deviceStorage.get(`vendorid${i}`, 0xFFF1));
+            const vendorId = getIntParameter(`vendorid${i}`) ?? deviceStorage.get(`vendorid${i}`, 0xFFF1);
             const productName = `node-matter OnOff-Device ${i}`;
             const productId = getIntParameter(`productid${i}`) ?? deviceStorage.get(`productid${i}`, 0x8000);
 
@@ -120,7 +120,7 @@ class Device {
 
             deviceStorage.set(`passcode${i}`, passcode);
             deviceStorage.set(`discriminator${i}`, discriminator);
-            deviceStorage.set(`vendorid${i}`, vendorId.id);
+            deviceStorage.set(`vendorid${i}`, vendorId);
             deviceStorage.set(`productid${i}`, productId);
             deviceStorage.set(`isSocket${i}`, isSocket);
             deviceStorage.set(`uniqueid${i}`, uniqueId);
@@ -133,7 +133,7 @@ class Device {
                 discriminator,
                 basicInformation: {
                     vendorName,
-                    vendorId,
+                    vendorId: VendorId(vendorId),
                     nodeLabel: productName,
                     productName,
                     productLabel: productName,

--- a/packages/matter-node.js/test/cluster/ClusterServerTestingUtil.ts
+++ b/packages/matter-node.js/test/cluster/ClusterServerTestingUtil.ts
@@ -28,6 +28,6 @@ export async function callCommandOnClusterServer<A extends Attributes, C extends
 }
 
 export async function createTestSessionWithFabric() {
-    const testFabric = new Fabric(new FabricIndex(1), new FabricId(BigInt(1)), new NodeId(BigInt(1)), new NodeId(BigInt(2)), ZERO, ZERO, KEY, new VendorId(1), ZERO, ZERO, ZERO, ZERO, ZERO, "");
-    return await SecureSession.create({} as any, 1, testFabric, new NodeId(BigInt(1)), 1, ZERO, ZERO, false, false, () => { /* */ }, 1, 2);
+    const testFabric = new Fabric(FabricIndex(1), FabricId(BigInt(1)), NodeId(BigInt(1)), NodeId(BigInt(2)), ZERO, ZERO, KEY, VendorId(1), ZERO, ZERO, ZERO, ZERO, ZERO, "");
+    return await SecureSession.create({} as any, 1, testFabric, NodeId(BigInt(1)), 1, ZERO, ZERO, false, false, () => { /* */ }, 1, 2);
 }

--- a/packages/matter-node.js/test/cluster/GeneralCommissioningServerTest.ts
+++ b/packages/matter-node.js/test/cluster/GeneralCommissioningServerTest.ts
@@ -23,7 +23,7 @@ import {
 import { SessionType, Message } from "@project-chip/matter.js/codec";
 import { callCommandOnClusterServer, createTestSessionWithFabric } from "./ClusterServerTestingUtil";
 import { Endpoint, DeviceTypes } from "@project-chip/matter.js/device";
-import { VendorId } from "@project-chip/matter.js/datatype";
+import { EndpointNumber, VendorId } from "@project-chip/matter.js/datatype";
 
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 
@@ -49,7 +49,7 @@ describe("GeneralCommissioning Server test", () => {
             }, GeneralCommissioningClusterHandler({ allowCountryCodeChange, countryCodeWhitelist }));
         basicInformationServer = ClusterServer(BasicInformationCluster, {
             dataModelRevision: 1,
-            vendorId: new VendorId(1),
+            vendorId: VendorId(1),
             vendorName: "test",
             productId: 1,
             productName: "test",
@@ -71,7 +71,7 @@ describe("GeneralCommissioning Server test", () => {
 
         testSession = await createTestSessionWithFabric();
 
-        endpoint = new Endpoint([DeviceTypes.ON_OFF_LIGHT], { endpointId: 1 });
+        endpoint = new Endpoint([DeviceTypes.ON_OFF_LIGHT], { endpointId: EndpointNumber(1) });
         endpoint.addClusterServer(basicInformationServer);
         endpoint.addClusterServer(generalCommissioningServer);
     }

--- a/packages/matter-node.js/test/cluster/GroupsServerTest.ts
+++ b/packages/matter-node.js/test/cluster/GroupsServerTest.ts
@@ -22,7 +22,7 @@ import { Fabric, FabricJsonObject } from "@project-chip/matter.js/fabric";
 import {
     ClusterServerObjForCluster, GroupsCluster, GroupsClusterHandler, Identify
 } from "@project-chip/matter.js/cluster";
-import { GroupId } from "@project-chip/matter.js/datatype";
+import { EndpointNumber, GroupId } from "@project-chip/matter.js/datatype";
 import { getPromiseResolver } from "@project-chip/matter.js/util";
 import { SessionType, Message } from "@project-chip/matter.js/codec";
 import { callCommandOnClusterServer, createTestSessionWithFabric } from "./ClusterServerTestingUtil";
@@ -52,11 +52,11 @@ describe("Groups Server test", () => {
         testSession = await createTestSessionWithFabric();
         testFabric = testSession.getFabric();
 
-        endpoint = new Endpoint([DeviceTypes.ON_OFF_LIGHT], { endpointId: 1 });
+        endpoint = new Endpoint([DeviceTypes.ON_OFF_LIGHT], { endpointId: EndpointNumber(1) });
         endpoint.addClusterServer(groupsServer);
         endpoint.addClusterServer(identifyServer);
 
-        endpoint2 = new Endpoint([DeviceTypes.ON_OFF_LIGHT], { endpointId: 2 });
+        endpoint2 = new Endpoint([DeviceTypes.ON_OFF_LIGHT], { endpointId: EndpointNumber(2) });
     }
 
     describe("Basic groups actions", () => {
@@ -68,11 +68,11 @@ describe("Groups Server test", () => {
             const { promise: firstPromise, resolver: firstResolver } = await getPromiseResolver<FabricJsonObject>();
             testFabric?.setPersistCallback(() => firstResolver(testFabric!.toStorageObject()));
 
-            const result = await callCommandOnClusterServer(groupsServer!, "addGroup", { groupId: new GroupId(1), groupName: "Group 1" }, endpoint!, testSession, { packetHeader: { sessionType: SessionType.Unicast } } as Message);
+            const result = await callCommandOnClusterServer(groupsServer!, "addGroup", { groupId: GroupId(1), groupName: "Group 1" }, endpoint!, testSession, { packetHeader: { sessionType: SessionType.Unicast } } as Message);
 
             const persistedData = await firstPromise;
 
-            assert.deepEqual(result, { code: StatusCode.Success, responseId: 0, response: { status: StatusCode.Success, groupId: new GroupId(1) } });
+            assert.deepEqual(result, { code: StatusCode.Success, responseId: 0, response: { status: StatusCode.Success, groupId: GroupId(1) } });
             assert.ok(persistedData);
             assert.ok(persistedData.scopedClusterData);
             const groupData = persistedData.scopedClusterData.get(GroupsCluster.id);
@@ -84,11 +84,11 @@ describe("Groups Server test", () => {
             const { promise: firstPromise, resolver: firstResolver } = await getPromiseResolver<FabricJsonObject>();
             testFabric?.setPersistCallback(() => firstResolver(testFabric!.toStorageObject()));
 
-            const result = await callCommandOnClusterServer(groupsServer!, "addGroup", { groupId: new GroupId(2), groupName: "Group 2" }, endpoint!, testSession, { packetHeader: { sessionType: SessionType.Unicast } } as Message);
+            const result = await callCommandOnClusterServer(groupsServer!, "addGroup", { groupId: GroupId(2), groupName: "Group 2" }, endpoint!, testSession, { packetHeader: { sessionType: SessionType.Unicast } } as Message);
 
             const persistedData = await firstPromise;
 
-            assert.deepEqual(result, { code: StatusCode.Success, responseId: 0, response: { status: StatusCode.Success, groupId: new GroupId(2) } });
+            assert.deepEqual(result, { code: StatusCode.Success, responseId: 0, response: { status: StatusCode.Success, groupId: GroupId(2) } });
             assert.ok(persistedData);
             assert.ok(persistedData.scopedClusterData);
             const groupData = persistedData.scopedClusterData.get(GroupsCluster.id);
@@ -100,11 +100,11 @@ describe("Groups Server test", () => {
             const { promise: firstPromise, resolver: firstResolver } = await getPromiseResolver<FabricJsonObject>();
             testFabric?.setPersistCallback(() => firstResolver(testFabric!.toStorageObject()));
 
-            const result = await callCommandOnClusterServer(groupsServer!, "addGroup", { groupId: new GroupId(5), groupName: "Group 5" }, endpoint2!, testSession, { packetHeader: { sessionType: SessionType.Unicast } } as Message);
+            const result = await callCommandOnClusterServer(groupsServer!, "addGroup", { groupId: GroupId(5), groupName: "Group 5" }, endpoint2!, testSession, { packetHeader: { sessionType: SessionType.Unicast } } as Message);
 
             const persistedData = await firstPromise;
 
-            assert.deepEqual(result, { code: StatusCode.Success, responseId: 0, response: { status: StatusCode.Success, groupId: new GroupId(5) } });
+            assert.deepEqual(result, { code: StatusCode.Success, responseId: 0, response: { status: StatusCode.Success, groupId: GroupId(5) } });
             assert.ok(persistedData);
             assert.ok(persistedData.scopedClusterData);
             const groupData = persistedData.scopedClusterData.get(GroupsCluster.id);
@@ -113,31 +113,31 @@ describe("Groups Server test", () => {
         });
 
         it("get group name", async () => {
-            const result = await callCommandOnClusterServer(groupsServer!, "viewGroup", { groupId: new GroupId(1) }, endpoint!, testSession, { packetHeader: { sessionType: SessionType.Unicast } } as Message);
+            const result = await callCommandOnClusterServer(groupsServer!, "viewGroup", { groupId: GroupId(1) }, endpoint!, testSession, { packetHeader: { sessionType: SessionType.Unicast } } as Message);
 
-            assert.deepEqual(result, { code: StatusCode.Success, responseId: 1, response: { status: StatusCode.Success, groupId: new GroupId(1), groupName: "Group 1" } });
+            assert.deepEqual(result, { code: StatusCode.Success, responseId: 1, response: { status: StatusCode.Success, groupId: GroupId(1), groupName: "Group 1" } });
         });
 
         it("get group membership for no id", async () => {
             const result = await callCommandOnClusterServer(groupsServer!, "getGroupMembership", { groupList: [] }, endpoint!, testSession, { packetHeader: { sessionType: SessionType.Unicast } } as Message);
 
-            assert.deepEqual(result, { code: StatusCode.Success, responseId: 2, response: { capacity: 252, groupList: [new GroupId(1), new GroupId(2)] } });
+            assert.deepEqual(result, { code: StatusCode.Success, responseId: 2, response: { capacity: 252, groupList: [GroupId(1), GroupId(2)] } });
         });
 
         it("get group membership of a defined group", async () => {
-            const result = await callCommandOnClusterServer(groupsServer!, "getGroupMembership", { groupList: [new GroupId(1)] }, endpoint!, testSession, { packetHeader: { sessionType: SessionType.Unicast } } as Message);
+            const result = await callCommandOnClusterServer(groupsServer!, "getGroupMembership", { groupList: [GroupId(1)] }, endpoint!, testSession, { packetHeader: { sessionType: SessionType.Unicast } } as Message);
 
-            assert.deepEqual(result, { code: StatusCode.Success, responseId: 2, response: { capacity: 252, groupList: [new GroupId(1)] } });
+            assert.deepEqual(result, { code: StatusCode.Success, responseId: 2, response: { capacity: 252, groupList: [GroupId(1)] } });
         });
 
         it("get group membership of two defined groups", async () => {
-            const result = await callCommandOnClusterServer(groupsServer!, "getGroupMembership", { groupList: [new GroupId(1), new GroupId(2)] }, endpoint!, testSession, { packetHeader: { sessionType: SessionType.Unicast } } as Message);
+            const result = await callCommandOnClusterServer(groupsServer!, "getGroupMembership", { groupList: [GroupId(1), GroupId(2)] }, endpoint!, testSession, { packetHeader: { sessionType: SessionType.Unicast } } as Message);
 
-            assert.deepEqual(result, { code: StatusCode.Success, responseId: 2, response: { capacity: 252, groupList: [new GroupId(1), new GroupId(2)] } });
+            assert.deepEqual(result, { code: StatusCode.Success, responseId: 2, response: { capacity: 252, groupList: [GroupId(1), GroupId(2)] } });
         });
 
         it("get group membership of a unknown group", async () => {
-            const result = await callCommandOnClusterServer(groupsServer!, "getGroupMembership", { groupList: [new GroupId(3)] }, endpoint!, testSession, { packetHeader: { sessionType: SessionType.Unicast } } as Message);
+            const result = await callCommandOnClusterServer(groupsServer!, "getGroupMembership", { groupList: [GroupId(3)] }, endpoint!, testSession, { packetHeader: { sessionType: SessionType.Unicast } } as Message);
 
             assert.deepEqual(result, { code: StatusCode.Success, responseId: 2, response: { capacity: 252, groupList: [] } });
         });
@@ -146,11 +146,11 @@ describe("Groups Server test", () => {
             const { promise: firstPromise, resolver: firstResolver } = await getPromiseResolver<FabricJsonObject>();
             testFabric?.setPersistCallback(() => firstResolver(testFabric!.toStorageObject()));
 
-            const result = await callCommandOnClusterServer(groupsServer!, "removeGroup", { groupId: new GroupId(1) }, endpoint!, testSession, { packetHeader: { sessionType: SessionType.Unicast } } as Message);
+            const result = await callCommandOnClusterServer(groupsServer!, "removeGroup", { groupId: GroupId(1) }, endpoint!, testSession, { packetHeader: { sessionType: SessionType.Unicast } } as Message);
 
             const persistedData = await firstPromise;
 
-            assert.deepEqual(result, { code: StatusCode.Success, responseId: 3, response: { status: StatusCode.Success, groupId: new GroupId(1) } });
+            assert.deepEqual(result, { code: StatusCode.Success, responseId: 3, response: { status: StatusCode.Success, groupId: GroupId(1) } });
             assert.ok(persistedData);
             assert.ok(persistedData.scopedClusterData);
             const groupData = persistedData.scopedClusterData.get(GroupsCluster.id);
@@ -181,34 +181,34 @@ describe("Groups Server test", () => {
         });
 
         it("error on read non existing group", async () => {
-            const result = await callCommandOnClusterServer(groupsServer!, "viewGroup", { groupId: new GroupId(1) }, endpoint!, testSession, { packetHeader: { sessionType: SessionType.Unicast } } as Message);
+            const result = await callCommandOnClusterServer(groupsServer!, "viewGroup", { groupId: GroupId(1) }, endpoint!, testSession, { packetHeader: { sessionType: SessionType.Unicast } } as Message);
 
             assert.ok(result);
             assert.equal(result.code, StatusCode.Success);
             assert.equal(result.response.status, StatusCode.NotFound);
-            assert.deepEqual(result.response.groupId, new GroupId(1));
+            assert.deepEqual(result.response.groupId, GroupId(1));
         });
 
         it("error on delete non existing group", async () => {
-            const result = await callCommandOnClusterServer(groupsServer!, "removeGroup", { groupId: new GroupId(1) }, endpoint!, testSession, { packetHeader: { sessionType: SessionType.Unicast } } as Message);
+            const result = await callCommandOnClusterServer(groupsServer!, "removeGroup", { groupId: GroupId(1) }, endpoint!, testSession, { packetHeader: { sessionType: SessionType.Unicast } } as Message);
 
             assert.ok(result);
             assert.equal(result.code, StatusCode.Success);
             assert.equal(result.response.status, StatusCode.NotFound);
-            assert.deepEqual(result.response.groupId, new GroupId(1));
+            assert.deepEqual(result.response.groupId, GroupId(1));
         });
 
         it("error on adding group with too long name", async () => {
-            const result = await callCommandOnClusterServer(groupsServer!, "addGroup", { groupId: new GroupId(1), groupName: '12345678901234567' }, endpoint!, testSession, { packetHeader: { sessionType: SessionType.Unicast } } as Message);
+            const result = await callCommandOnClusterServer(groupsServer!, "addGroup", { groupId: GroupId(1), groupName: '12345678901234567' }, endpoint!, testSession, { packetHeader: { sessionType: SessionType.Unicast } } as Message);
 
             assert.ok(result);
             assert.equal(result.code, StatusCode.Success);
             assert.equal(result.response.status, StatusCode.ConstraintError);
-            assert.deepEqual(result.response.groupId, new GroupId(1));
+            assert.deepEqual(result.response.groupId, GroupId(1));
         });
 
         it("error on Groupcast message", async () => {
-            await assert.rejects(async () => await callCommandOnClusterServer(groupsServer!, "viewGroup", { groupId: new GroupId(1) }, endpoint!, testSession, { packetHeader: { sessionType: SessionType.Group } } as Message),
+            await assert.rejects(async () => await callCommandOnClusterServer(groupsServer!, "viewGroup", { groupId: GroupId(1) }, endpoint!, testSession, { packetHeader: { sessionType: SessionType.Group } } as Message),
                 {
                     message: "Groupcast not supported"
                 });
@@ -224,7 +224,7 @@ describe("Groups Server test", () => {
             const { promise: firstPromise, resolver: firstResolver } = await getPromiseResolver<FabricJsonObject>();
             testFabric?.setPersistCallback(() => firstResolver(testFabric!.toStorageObject()));
 
-            const result = await callCommandOnClusterServer(groupsServer!, "addGroupIfIdentifying", { groupId: new GroupId(3), groupName: "Group 3" }, endpoint!, testSession, { packetHeader: { sessionType: SessionType.Unicast } } as Message);
+            const result = await callCommandOnClusterServer(groupsServer!, "addGroupIfIdentifying", { groupId: GroupId(3), groupName: "Group 3" }, endpoint!, testSession, { packetHeader: { sessionType: SessionType.Unicast } } as Message);
 
             const persistedData = await firstPromise;
 
@@ -246,16 +246,16 @@ describe("Groups Server test", () => {
         });
 
         it("nothing is added because we are not identifying", async () => {
-            const result = await callCommandOnClusterServer(groupsServer!, "addGroupIfIdentifying", { groupId: new GroupId(3), groupName: "Group 3" }, endpoint!, testSession, { packetHeader: { sessionType: SessionType.Unicast } } as Message);
+            const result = await callCommandOnClusterServer(groupsServer!, "addGroupIfIdentifying", { groupId: GroupId(3), groupName: "Group 3" }, endpoint!, testSession, { packetHeader: { sessionType: SessionType.Unicast } } as Message);
 
             assert.deepEqual(result, { code: StatusCode.Success, responseId: 5, response: undefined });
 
-            const resultRead = await callCommandOnClusterServer(groupsServer!, "viewGroup", { groupId: new GroupId(3) }, endpoint!, testSession, { packetHeader: { sessionType: SessionType.Unicast } } as Message);
+            const resultRead = await callCommandOnClusterServer(groupsServer!, "viewGroup", { groupId: GroupId(3) }, endpoint!, testSession, { packetHeader: { sessionType: SessionType.Unicast } } as Message);
 
             assert.ok(resultRead);
             assert.equal(resultRead.code, StatusCode.Success);
             assert.equal(resultRead.response.status, StatusCode.NotFound);
-            assert.deepEqual(resultRead.response.groupId, new GroupId(3));
+            assert.deepEqual(resultRead.response.groupId, GroupId(3));
         });
     });
 });

--- a/packages/matter-node.js/test/cluster/ScenesServerTest.ts
+++ b/packages/matter-node.js/test/cluster/ScenesServerTest.ts
@@ -23,7 +23,7 @@ import {
     GroupsCluster, GroupsClusterHandler, ScenesCluster, ScenesClusterHandler, OnOffCluster, OnOffClusterHandler,
     ClusterServerObjForCluster
 } from "@project-chip/matter.js/cluster";
-import { GroupId, AttributeId, ClusterId } from "@project-chip/matter.js/datatype";
+import { GroupId, AttributeId, ClusterId, EndpointNumber } from "@project-chip/matter.js/datatype";
 import { getPromiseResolver } from "@project-chip/matter.js/util";
 import { SessionType, Message } from "@project-chip/matter.js/codec";
 import { callCommandOnClusterServer, createTestSessionWithFabric } from "./ClusterServerTestingUtil";
@@ -44,7 +44,7 @@ describe("Scenes Server test", () => {
         scenesServer = ClusterServer(ScenesCluster, {
             sceneCount: 0,
             currentScene: 0,
-            currentGroup: new GroupId(0),
+            currentGroup: GroupId(0),
             sceneValid: false,
             nameSupport: { nameSupport: true },
             lastConfiguredBy: null
@@ -53,7 +53,7 @@ describe("Scenes Server test", () => {
         testSession = await createTestSessionWithFabric();
         testFabric = testSession.getFabric();
 
-        endpoint = new Endpoint([DeviceTypes.ON_OFF_LIGHT], { endpointId: 1 });
+        endpoint = new Endpoint([DeviceTypes.ON_OFF_LIGHT], { endpointId: EndpointNumber(1) });
         endpoint.addClusterServer(groupsServer);
         endpoint.addClusterServer(scenesServer);
         endpoint.addClusterServer(onOffServer);
@@ -65,30 +65,30 @@ describe("Scenes Server test", () => {
         });
 
         it("add new group and scene and verify storage", async () => {
-            const groupResult = await callCommandOnClusterServer(groupsServer!, "addGroup", { groupId: new GroupId(1), groupName: "Group 1" }, endpoint!, testSession, { packetHeader: { sessionType: SessionType.Unicast } } as Message);
+            const groupResult = await callCommandOnClusterServer(groupsServer!, "addGroup", { groupId: GroupId(1), groupName: "Group 1" }, endpoint!, testSession, { packetHeader: { sessionType: SessionType.Unicast } } as Message);
             assert.ok(groupResult);
 
             const { promise: firstPromise, resolver: firstResolver } = await getPromiseResolver<FabricJsonObject>();
             testFabric?.setPersistCallback(() => firstResolver(testFabric!.toStorageObject()));
 
             const result = await callCommandOnClusterServer(scenesServer!, "addScene", {
-                groupId: new GroupId(1),
+                groupId: GroupId(1),
                 sceneId: 1,
                 sceneName: "Scene 1",
                 transitionTime: 10,
                 extensionFieldSets: [
-                    { clusterId: new ClusterId(OnOffCluster.id), attributeValueList: [{ attributeId: new AttributeId(0), attributeValue: TlvBoolean.encodeTlv(true) }] },
+                    { clusterId: ClusterId(OnOffCluster.id), attributeValueList: [{ attributeId: AttributeId(0), attributeValue: TlvBoolean.encodeTlv(true) }] },
                 ]
             }, endpoint!, testSession, { packetHeader: { sessionType: SessionType.Unicast } } as Message);
 
             const persistedData = await firstPromise;
 
-            assert.deepEqual(result, { code: StatusCode.Success, responseId: 0, response: { status: StatusCode.Success, groupId: new GroupId(1), sceneId: 1 } });
+            assert.deepEqual(result, { code: StatusCode.Success, responseId: 0, response: { status: StatusCode.Success, groupId: GroupId(1), sceneId: 1 } });
             assert.ok(persistedData);
             assert.ok(persistedData.scopedClusterData);
             const scenesData = persistedData.scopedClusterData.get(ScenesCluster.id);
             assert.ok(scenesData);
-            assert.deepEqual(scenesData, new Map([["1", new Map([[1, new Map([[1, { "extensionFieldSets": [{ "attributeValueList": [{ "attributeId": { "id": 0 }, "attributeValue": [{ "tag": undefined, "typeLength": { "type": 8, "value": true }, "value": undefined }] }], "clusterId": { "id": 6 } }], "sceneId": 1, "sceneName": "Scene 1", "sceneTransitionTime": 10, "scenesGroupId": 1, "transitionTime100ms": 0 }]])]])]]));
+            assert.deepEqual(scenesData, new Map([["1", new Map([[1, new Map([[1, { "extensionFieldSets": [{ "attributeValueList": [{ "attributeId": 0, "attributeValue": [{ "tag": undefined, "typeLength": { "type": 8, "value": true }, "value": undefined }] }], "clusterId": 6 }], "sceneId": 1, "sceneName": "Scene 1", "sceneTransitionTime": 10, "scenesGroupId": 1, "transitionTime100ms": 0 }]])]])]]));
 
             assert.equal(scenesServer!.attributes.sceneCount.get(testSession!, false), 1);
         });
@@ -98,80 +98,80 @@ describe("Scenes Server test", () => {
             testFabric?.setPersistCallback(() => firstResolver(testFabric!.toStorageObject()));
 
             const result = await callCommandOnClusterServer(scenesServer!, "addScene", {
-                groupId: new GroupId(1),
+                groupId: GroupId(1),
                 sceneId: 2,
                 sceneName: "Scene 2",
                 transitionTime: 10,
                 extensionFieldSets: [
-                    { clusterId: new ClusterId(OnOffCluster.id), attributeValueList: [{ attributeId: new AttributeId(0), attributeValue: TlvBoolean.encodeTlv(false) }] },
+                    { clusterId: ClusterId(OnOffCluster.id), attributeValueList: [{ attributeId: AttributeId(0), attributeValue: TlvBoolean.encodeTlv(false) }] },
                 ]
             }, endpoint!, testSession, { packetHeader: { sessionType: SessionType.Unicast } } as Message);
 
             const persistedData = await firstPromise;
 
-            assert.deepEqual(result, { code: StatusCode.Success, responseId: 0, response: { status: StatusCode.Success, groupId: new GroupId(1), sceneId: 2 } });
+            assert.deepEqual(result, { code: StatusCode.Success, responseId: 0, response: { status: StatusCode.Success, groupId: GroupId(1), sceneId: 2 } });
             assert.ok(persistedData);
             assert.ok(persistedData.scopedClusterData);
             const scenesData = persistedData.scopedClusterData.get(ScenesCluster.id);
             assert.ok(scenesData);
-            assert.deepEqual(scenesData, new Map([["1", new Map([[1, new Map([[1, { "extensionFieldSets": [{ "attributeValueList": [{ "attributeId": { "id": 0 }, "attributeValue": [{ "tag": undefined, "typeLength": { "type": 8, "value": true }, "value": undefined }] }], "clusterId": { "id": 6 } }], "sceneId": 1, "sceneName": "Scene 1", "sceneTransitionTime": 10, "scenesGroupId": 1, "transitionTime100ms": 0 }], [2, { "extensionFieldSets": [{ "attributeValueList": [{ "attributeId": { "id": 0 }, "attributeValue": [{ "tag": undefined, "typeLength": { "type": 8, "value": false }, "value": undefined }] }], "clusterId": { "id": 6 } }], "sceneId": 2, "sceneName": "Scene 2", "sceneTransitionTime": 10, "scenesGroupId": 1, "transitionTime100ms": 0 }]])]])]]));
+            assert.deepEqual(scenesData, new Map([["1", new Map([[1, new Map([[1, { "extensionFieldSets": [{ "attributeValueList": [{ "attributeId": 0, "attributeValue": [{ "tag": undefined, "typeLength": { "type": 8, "value": true }, "value": undefined }] }], "clusterId": 6 }], "sceneId": 1, "sceneName": "Scene 1", "sceneTransitionTime": 10, "scenesGroupId": 1, "transitionTime100ms": 0 }], [2, { "extensionFieldSets": [{ "attributeValueList": [{ "attributeId": 0, "attributeValue": [{ "tag": undefined, "typeLength": { "type": 8, "value": false }, "value": undefined }] }], "clusterId": 6 }], "sceneId": 2, "sceneName": "Scene 2", "sceneTransitionTime": 10, "scenesGroupId": 1, "transitionTime100ms": 0 }]])]])]]));
             assert.equal(scenesServer!.attributes.sceneCount.get(testSession!, false), 2);
         });
 
         it("add another new group and scene and verify storage", async () => {
-            const groupResult = await callCommandOnClusterServer(groupsServer!, "addGroup", { groupId: new GroupId(2), groupName: "Group 2" }, endpoint!, testSession, { packetHeader: { sessionType: SessionType.Unicast } } as Message);
+            const groupResult = await callCommandOnClusterServer(groupsServer!, "addGroup", { groupId: GroupId(2), groupName: "Group 2" }, endpoint!, testSession, { packetHeader: { sessionType: SessionType.Unicast } } as Message);
             assert.ok(groupResult);
 
             const { promise: firstPromise, resolver: firstResolver } = await getPromiseResolver<FabricJsonObject>();
             testFabric?.setPersistCallback(() => firstResolver(testFabric!.toStorageObject()));
 
             const result = await callCommandOnClusterServer(scenesServer!, "addScene", {
-                groupId: new GroupId(2),
+                groupId: GroupId(2),
                 sceneId: 3,
                 sceneName: "Scene 3",
                 transitionTime: 10,
                 extensionFieldSets: [
-                    { clusterId: new ClusterId(OnOffCluster.id), attributeValueList: [{ attributeId: new AttributeId(0), attributeValue: TlvBoolean.encodeTlv(true) }] },
+                    { clusterId: ClusterId(OnOffCluster.id), attributeValueList: [{ attributeId: AttributeId(0), attributeValue: TlvBoolean.encodeTlv(true) }] },
                 ]
             }, endpoint!, testSession, { packetHeader: { sessionType: SessionType.Unicast } } as Message);
 
             const persistedData = await firstPromise;
 
-            assert.deepEqual(result, { code: StatusCode.Success, responseId: 0, response: { status: StatusCode.Success, groupId: new GroupId(2), sceneId: 3 } });
+            assert.deepEqual(result, { code: StatusCode.Success, responseId: 0, response: { status: StatusCode.Success, groupId: GroupId(2), sceneId: 3 } });
             assert.ok(persistedData);
             assert.ok(persistedData.scopedClusterData);
             const scenesData = persistedData.scopedClusterData.get(ScenesCluster.id);
             assert.ok(scenesData);
-            assert.deepEqual(scenesData, new Map([["1", new Map([[1, new Map([[1, { "extensionFieldSets": [{ "attributeValueList": [{ "attributeId": { "id": 0 }, "attributeValue": [{ "tag": undefined, "typeLength": { "type": 8, "value": true }, "value": undefined }] }], "clusterId": { "id": 6 } }], "sceneId": 1, "sceneName": "Scene 1", "sceneTransitionTime": 10, "scenesGroupId": 1, "transitionTime100ms": 0 }], [2, { "extensionFieldSets": [{ "attributeValueList": [{ "attributeId": { "id": 0 }, "attributeValue": [{ "tag": undefined, "typeLength": { "type": 8, "value": false }, "value": undefined }] }], "clusterId": { "id": 6 } }], "sceneId": 2, "sceneName": "Scene 2", "sceneTransitionTime": 10, "scenesGroupId": 1, "transitionTime100ms": 0 }]])], [2, new Map([[3, { "extensionFieldSets": [{ "attributeValueList": [{ "attributeId": { "id": 0 }, "attributeValue": [{ "tag": undefined, "typeLength": { "type": 8, "value": true }, "value": undefined }] }], "clusterId": { "id": 6 } }], "sceneId": 3, "sceneName": "Scene 3", "sceneTransitionTime": 10, "scenesGroupId": 2, "transitionTime100ms": 0 }]])]])]]));
+            assert.deepEqual(scenesData, new Map([["1", new Map([[1, new Map([[1, { "extensionFieldSets": [{ "attributeValueList": [{ "attributeId": 0, "attributeValue": [{ "tag": undefined, "typeLength": { "type": 8, "value": true }, "value": undefined }] }], "clusterId": 6 }], "sceneId": 1, "sceneName": "Scene 1", "sceneTransitionTime": 10, "scenesGroupId": 1, "transitionTime100ms": 0 }], [2, { "extensionFieldSets": [{ "attributeValueList": [{ "attributeId": 0, "attributeValue": [{ "tag": undefined, "typeLength": { "type": 8, "value": false }, "value": undefined }] }], "clusterId": 6 }], "sceneId": 2, "sceneName": "Scene 2", "sceneTransitionTime": 10, "scenesGroupId": 1, "transitionTime100ms": 0 }]])], [2, new Map([[3, { "extensionFieldSets": [{ "attributeValueList": [{ "attributeId": 0, "attributeValue": [{ "tag": undefined, "typeLength": { "type": 8, "value": true }, "value": undefined }] }], "clusterId": 6 }], "sceneId": 3, "sceneName": "Scene 3", "sceneTransitionTime": 10, "scenesGroupId": 2, "transitionTime100ms": 0 }]])]])]]));
             assert.equal(scenesServer!.attributes.sceneCount.get(testSession!, false), 3);
         });
 
         it("get scene data", async () => {
-            const result = await callCommandOnClusterServer(scenesServer!, "viewScene", { groupId: new GroupId(1), sceneId: 1 }, endpoint!, testSession, { packetHeader: { sessionType: SessionType.Unicast } } as Message);
+            const result = await callCommandOnClusterServer(scenesServer!, "viewScene", { groupId: GroupId(1), sceneId: 1 }, endpoint!, testSession, { packetHeader: { sessionType: SessionType.Unicast } } as Message);
 
-            assert.deepEqual(result, { code: StatusCode.Success, response: { "extensionFieldSets": [{ "attributeValueList": [{ "attributeId": { "id": 0 }, "attributeValue": [{ "tag": undefined, "typeLength": { "type": 8, "value": true }, "value": undefined }] }], "clusterId": { "id": 6 } }], "groupId": { "id": 1 }, "sceneId": 1, "sceneName": "Scene 1", "status": 0, "transitionTime": 10 }, "responseId": 1 });
+            assert.deepEqual(result, { code: StatusCode.Success, response: { "extensionFieldSets": [{ "attributeValueList": [{ "attributeId": 0, "attributeValue": [{ "tag": undefined, "typeLength": { "type": 8, "value": true }, "value": undefined }] }], "clusterId": 6 }], "groupId": 1, "sceneId": 1, "sceneName": "Scene 1", "status": 0, "transitionTime": 10 }, "responseId": 1 });
         });
 
         it("get scene membership", async () => {
-            const result = await callCommandOnClusterServer(scenesServer!, "getSceneMembership", { groupId: new GroupId(1) }, endpoint!, testSession, { packetHeader: { sessionType: SessionType.Unicast } } as Message);
+            const result = await callCommandOnClusterServer(scenesServer!, "getSceneMembership", { groupId: GroupId(1) }, endpoint!, testSession, { packetHeader: { sessionType: SessionType.Unicast } } as Message);
 
-            assert.deepEqual(result, { code: StatusCode.Success, responseId: 6, response: { status: StatusCode.Success, capacity: 252, groupId: new GroupId(1), sceneList: [1, 2] } });
+            assert.deepEqual(result, { code: StatusCode.Success, responseId: 6, response: { status: StatusCode.Success, capacity: 252, groupId: GroupId(1), sceneList: [1, 2] } });
         });
 
         it("delete scene and verify storage", async () => {
             const { promise: firstPromise, resolver: firstResolver } = await getPromiseResolver<FabricJsonObject>();
             testFabric?.setPersistCallback(() => firstResolver(testFabric!.toStorageObject()));
 
-            const result = await callCommandOnClusterServer(scenesServer!, "removeScene", { groupId: new GroupId(1), sceneId: 2 }, endpoint!, testSession, { packetHeader: { sessionType: SessionType.Unicast } } as Message);
+            const result = await callCommandOnClusterServer(scenesServer!, "removeScene", { groupId: GroupId(1), sceneId: 2 }, endpoint!, testSession, { packetHeader: { sessionType: SessionType.Unicast } } as Message);
 
             const persistedData = await firstPromise;
 
-            assert.deepEqual(result, { code: StatusCode.Success, responseId: 2, response: { status: StatusCode.Success, groupId: new GroupId(1), sceneId: 2 } });
+            assert.deepEqual(result, { code: StatusCode.Success, responseId: 2, response: { status: StatusCode.Success, groupId: GroupId(1), sceneId: 2 } });
             assert.ok(persistedData);
             assert.ok(persistedData.scopedClusterData);
             const scenesData = persistedData.scopedClusterData.get(ScenesCluster.id);
             assert.ok(scenesData);
-            assert.deepEqual(scenesData, new Map([["1", new Map([[1, new Map([[1, { "extensionFieldSets": [{ "attributeValueList": [{ "attributeId": { "id": 0 }, "attributeValue": [{ "tag": undefined, "typeLength": { "type": 8, "value": true }, "value": undefined }] }], "clusterId": { "id": 6 } }], "sceneId": 1, "sceneName": "Scene 1", "sceneTransitionTime": 10, "scenesGroupId": 1, "transitionTime100ms": 0 }]])], [2, new Map([[3, { "extensionFieldSets": [{ "attributeValueList": [{ "attributeId": { "id": 0 }, "attributeValue": [{ "tag": undefined, "typeLength": { "type": 8, "value": true }, "value": undefined }] }], "clusterId": { "id": 6 } }], "sceneId": 3, "sceneName": "Scene 3", "sceneTransitionTime": 10, "scenesGroupId": 2, "transitionTime100ms": 0 }]])]])]]));
+            assert.deepEqual(scenesData, new Map([["1", new Map([[1, new Map([[1, { "extensionFieldSets": [{ "attributeValueList": [{ "attributeId": 0, "attributeValue": [{ "tag": undefined, "typeLength": { "type": 8, "value": true }, "value": undefined }] }], "clusterId": 6 }], "sceneId": 1, "sceneName": "Scene 1", "sceneTransitionTime": 10, "scenesGroupId": 1, "transitionTime100ms": 0 }]])], [2, new Map([[3, { "extensionFieldSets": [{ "attributeValueList": [{ "attributeId": 0, "attributeValue": [{ "tag": undefined, "typeLength": { "type": 8, "value": true }, "value": undefined }] }], "clusterId": 6 }], "sceneId": 3, "sceneName": "Scene 3", "sceneTransitionTime": 10, "scenesGroupId": 2, "transitionTime100ms": 0 }]])]])]]));
             assert.equal(scenesServer!.attributes.sceneCount.get(testSession!, false), 2);
         });
 
@@ -179,16 +179,16 @@ describe("Scenes Server test", () => {
             const { promise: firstPromise, resolver: firstResolver } = await getPromiseResolver<FabricJsonObject>();
             testFabric?.setPersistCallback(() => firstResolver(testFabric!.toStorageObject()));
 
-            const result = await callCommandOnClusterServer(scenesServer!, "removeAllScenes", { groupId: new GroupId(1) }, endpoint!, testSession, { packetHeader: { sessionType: SessionType.Unicast } } as Message);
+            const result = await callCommandOnClusterServer(scenesServer!, "removeAllScenes", { groupId: GroupId(1) }, endpoint!, testSession, { packetHeader: { sessionType: SessionType.Unicast } } as Message);
 
             const persistedData = await firstPromise;
 
-            assert.deepEqual(result, { code: StatusCode.Success, responseId: 3, response: { status: StatusCode.Success, groupId: new GroupId(1) } });
+            assert.deepEqual(result, { code: StatusCode.Success, responseId: 3, response: { status: StatusCode.Success, groupId: GroupId(1) } });
             assert.ok(persistedData);
             assert.ok(persistedData.scopedClusterData);
             const scenesData = persistedData.scopedClusterData.get(ScenesCluster.id);
             assert.ok(scenesData);
-            assert.deepEqual(scenesData, new Map([["1", new Map([[2, new Map([[3, { "extensionFieldSets": [{ "attributeValueList": [{ "attributeId": { "id": 0 }, "attributeValue": [{ "tag": undefined, "typeLength": { "type": 8, "value": true }, "value": undefined }] }], "clusterId": { "id": 6 } }], "sceneId": 3, "sceneName": "Scene 3", "sceneTransitionTime": 10, "scenesGroupId": 2, "transitionTime100ms": 0 }]])]])]]));
+            assert.deepEqual(scenesData, new Map([["1", new Map([[2, new Map([[3, { "extensionFieldSets": [{ "attributeValueList": [{ "attributeId": 0, "attributeValue": [{ "tag": undefined, "typeLength": { "type": 8, "value": true }, "value": undefined }] }], "clusterId": 6 }], "sceneId": 3, "sceneName": "Scene 3", "sceneTransitionTime": 10, "scenesGroupId": 2, "transitionTime100ms": 0 }]])]])]]));
             assert.equal(scenesServer!.attributes.sceneCount.get(testSession!, false), 1);
         });
 
@@ -196,11 +196,11 @@ describe("Scenes Server test", () => {
             const { promise: firstPromise, resolver: firstResolver } = await getPromiseResolver<FabricJsonObject>();
             testFabric?.setPersistCallback(() => firstResolver(testFabric!.toStorageObject()));
 
-            const result = await callCommandOnClusterServer(groupsServer!, "removeGroup", { groupId: new GroupId(2) }, endpoint!, testSession, { packetHeader: { sessionType: SessionType.Unicast } } as Message);
+            const result = await callCommandOnClusterServer(groupsServer!, "removeGroup", { groupId: GroupId(2) }, endpoint!, testSession, { packetHeader: { sessionType: SessionType.Unicast } } as Message);
 
             const persistedData = await firstPromise;
 
-            assert.deepEqual(result, { code: StatusCode.Success, responseId: 3, response: { status: StatusCode.Success, groupId: new GroupId(2) } });
+            assert.deepEqual(result, { code: StatusCode.Success, responseId: 3, response: { status: StatusCode.Success, groupId: GroupId(2) } });
             assert.ok(persistedData);
             assert.ok(persistedData.scopedClusterData);
             const scenesData = persistedData.scopedClusterData.get(ScenesCluster.id);
@@ -216,50 +216,50 @@ describe("Scenes Server test", () => {
         });
 
         it("error on read scene on non existence group", async () => {
-            const result = await callCommandOnClusterServer(scenesServer!, "viewScene", { groupId: new GroupId(1), sceneId: 1 }, endpoint!, testSession, { packetHeader: { sessionType: SessionType.Unicast } } as Message);
+            const result = await callCommandOnClusterServer(scenesServer!, "viewScene", { groupId: GroupId(1), sceneId: 1 }, endpoint!, testSession, { packetHeader: { sessionType: SessionType.Unicast } } as Message);
 
             assert.ok(result);
             assert.equal(result.code, StatusCode.Success);
             assert.equal(result.response.status, StatusCode.InvalidCommand);
-            assert.deepEqual(result.response.groupId, new GroupId(1));
+            assert.deepEqual(result.response.groupId, GroupId(1));
             assert.deepEqual(result.response.sceneId, 1);
         });
 
         it("error on read non existent scene", async () => {
-            const resultGroup = await callCommandOnClusterServer(groupsServer!, "addGroup", { groupId: new GroupId(1), groupName: "Group 1" }, endpoint!, testSession, { packetHeader: { sessionType: SessionType.Unicast } } as Message);
+            const resultGroup = await callCommandOnClusterServer(groupsServer!, "addGroup", { groupId: GroupId(1), groupName: "Group 1" }, endpoint!, testSession, { packetHeader: { sessionType: SessionType.Unicast } } as Message);
             assert.ok(resultGroup);
 
-            const result = await callCommandOnClusterServer(scenesServer!, "viewScene", { groupId: new GroupId(1), sceneId: 1 }, endpoint!, testSession, { packetHeader: { sessionType: SessionType.Unicast } } as Message);
+            const result = await callCommandOnClusterServer(scenesServer!, "viewScene", { groupId: GroupId(1), sceneId: 1 }, endpoint!, testSession, { packetHeader: { sessionType: SessionType.Unicast } } as Message);
 
             assert.ok(result);
             assert.equal(result.code, StatusCode.Success);
             assert.equal(result.response.status, StatusCode.NotFound);
-            assert.deepEqual(result.response.groupId, new GroupId(1));
+            assert.deepEqual(result.response.groupId, GroupId(1));
             assert.deepEqual(result.response.sceneId, 1);
         });
 
         it("error on delete non existing scene", async () => {
-            const result = await callCommandOnClusterServer(scenesServer!, "removeScene", { groupId: new GroupId(1), sceneId: 1 }, endpoint!, testSession, { packetHeader: { sessionType: SessionType.Unicast } } as Message);
+            const result = await callCommandOnClusterServer(scenesServer!, "removeScene", { groupId: GroupId(1), sceneId: 1 }, endpoint!, testSession, { packetHeader: { sessionType: SessionType.Unicast } } as Message);
 
             assert.ok(result);
             assert.equal(result.code, StatusCode.Success);
             assert.equal(result.response.status, StatusCode.NotFound);
-            assert.deepEqual(result.response.groupId, new GroupId(1));
+            assert.deepEqual(result.response.groupId, GroupId(1));
             assert.deepEqual(result.response.sceneId, 1);
         });
 
         it("error on adding scene with too long name", async () => {
-            const result = await callCommandOnClusterServer(scenesServer!, "addScene", { groupId: new GroupId(1), sceneId: 1, sceneName: '12345678901234567', transitionTime: 2, extensionFieldSets: [] }, endpoint!, testSession, { packetHeader: { sessionType: SessionType.Unicast } } as Message);
+            const result = await callCommandOnClusterServer(scenesServer!, "addScene", { groupId: GroupId(1), sceneId: 1, sceneName: '12345678901234567', transitionTime: 2, extensionFieldSets: [] }, endpoint!, testSession, { packetHeader: { sessionType: SessionType.Unicast } } as Message);
 
             assert.ok(result);
             assert.equal(result.code, StatusCode.Success);
             assert.equal(result.response.status, StatusCode.ConstraintError);
-            assert.deepEqual(result.response.groupId, new GroupId(1));
+            assert.deepEqual(result.response.groupId, GroupId(1));
             assert.deepEqual(result.response.sceneId, 1);
         });
 
         it("error on Groupcast message", async () => {
-            await assert.rejects(async () => await callCommandOnClusterServer(scenesServer!, "viewScene", { groupId: new GroupId(1), sceneId: 1 }, endpoint!, testSession, { packetHeader: { sessionType: SessionType.Group } } as Message),
+            await assert.rejects(async () => await callCommandOnClusterServer(scenesServer!, "viewScene", { groupId: GroupId(1), sceneId: 1 }, endpoint!, testSession, { packetHeader: { sessionType: SessionType.Group } } as Message),
                 {
                     message: "Groupcast not supported"
                 });
@@ -267,7 +267,7 @@ describe("Scenes Server test", () => {
 
         it("recallScene on not existing group id", async () => {
             await assert.rejects(async () => await callCommandOnClusterServer(scenesServer!, "recallScene", {
-                groupId: new GroupId(5),
+                groupId: GroupId(5),
                 sceneId: 1,
             }, endpoint!, testSession, { packetHeader: { sessionType: SessionType.Unicast } } as Message), {
                 message: '(133) Group 5 does not exist on this endpoint',
@@ -277,7 +277,7 @@ describe("Scenes Server test", () => {
 
         it("recallScene on not existing scene id", async () => {
             await assert.rejects(async () => await callCommandOnClusterServer(scenesServer!, "recallScene", {
-                groupId: new GroupId(1),
+                groupId: GroupId(1),
                 sceneId: 10,
             }, endpoint!, testSession, { packetHeader: { sessionType: SessionType.Unicast } } as Message), {
                 message: '(139) Scene 10 does not exist for group 1',
@@ -294,43 +294,43 @@ describe("Scenes Server test", () => {
 
         it("storeScene", async () => {
             assert.equal(scenesServer?.attributes.currentScene.getLocal(), 0);
-            assert.deepEqual(scenesServer?.attributes.currentGroup.getLocal(), new GroupId(0));
+            assert.deepEqual(scenesServer?.attributes.currentGroup.getLocal(), GroupId(0));
 
-            const groupResult = await callCommandOnClusterServer(groupsServer!, "addGroup", { groupId: new GroupId(1), groupName: "Group 1" }, endpoint!, testSession, { packetHeader: { sessionType: SessionType.Unicast } } as Message);
+            const groupResult = await callCommandOnClusterServer(groupsServer!, "addGroup", { groupId: GroupId(1), groupName: "Group 1" }, endpoint!, testSession, { packetHeader: { sessionType: SessionType.Unicast } } as Message);
             assert.ok(groupResult);
 
             const { promise: firstPromise, resolver: firstResolver } = await getPromiseResolver<FabricJsonObject>();
             testFabric?.setPersistCallback(() => firstResolver(testFabric!.toStorageObject()));
 
             const result = await callCommandOnClusterServer(scenesServer!, "storeScene", {
-                groupId: new GroupId(1),
+                groupId: GroupId(1),
                 sceneId: 1,
             }, endpoint!, testSession, { packetHeader: { sessionType: SessionType.Unicast } } as Message);
 
             const persistedData = await firstPromise;
 
-            assert.deepEqual(result, { code: StatusCode.Success, responseId: 4, response: { status: StatusCode.Success, groupId: new GroupId(1), sceneId: 1 } });
+            assert.deepEqual(result, { code: StatusCode.Success, responseId: 4, response: { status: StatusCode.Success, groupId: GroupId(1), sceneId: 1 } });
             assert.ok(persistedData);
             assert.ok(persistedData.scopedClusterData);
             const scenesData = persistedData.scopedClusterData.get(ScenesCluster.id);
             assert.ok(scenesData);
-            assert.deepEqual(scenesData, new Map([["1", new Map([[1, new Map([[1, { "extensionFieldSets": [{ "attributeValueList": [{ "attributeId": { "id": 0 }, "attributeValue": [{ "tag": undefined, "typeLength": { "type": 8, "value": true } }] }], "clusterId": { "id": 6 } }], "sceneId": 1, "sceneName": "", "sceneTransitionTime": 0, "scenesGroupId": 1, "transitionTime100ms": 0 }]])]])]]));
+            assert.deepEqual(scenesData, new Map([["1", new Map([[1, new Map([[1, { "extensionFieldSets": [{ "attributeValueList": [{ "attributeId": 0, "attributeValue": [{ "tag": undefined, "typeLength": { "type": 8, "value": true } }] }], "clusterId": 6 }], "sceneId": 1, "sceneName": "", "sceneTransitionTime": 0, "scenesGroupId": 1, "transitionTime100ms": 0 }]])]])]]));
 
             assert.equal(scenesServer?.attributes.sceneValid.get(testSession!, false), true);
             assert.equal(scenesServer?.attributes.currentScene.getLocal(), 1);
-            assert.deepEqual(scenesServer?.attributes.currentGroup.getLocal(), new GroupId(1));
+            assert.deepEqual(scenesServer?.attributes.currentGroup.getLocal(), GroupId(1));
         });
 
         it("copy one Scene error to group does not exist", async () => {
             const result = await callCommandOnClusterServer(scenesServer!, "copyScene", {
                 mode: 0,
-                groupIdentifierFrom: new GroupId(5),
+                groupIdentifierFrom: GroupId(5),
                 sceneIdentifierFrom: 1,
-                groupIdentifierTo: new GroupId(1),
+                groupIdentifierTo: GroupId(1),
                 sceneIdentifierTo: 2,
             }, endpoint!, testSession, { packetHeader: { sessionType: SessionType.Unicast } } as Message);
 
-            assert.deepEqual(result, { code: StatusCode.Success, responseId: 66, response: { status: StatusCode.InvalidCommand, groupIdentifierFrom: new GroupId(5), sceneIdentifierFrom: 1 } });
+            assert.deepEqual(result, { code: StatusCode.Success, responseId: 66, response: { status: StatusCode.InvalidCommand, groupIdentifierFrom: GroupId(5), sceneIdentifierFrom: 1 } });
         });
 
         it("copy one Scene same group", async () => {
@@ -339,13 +339,13 @@ describe("Scenes Server test", () => {
 
             const result = await callCommandOnClusterServer(scenesServer!, "copyScene", {
                 mode: 0,
-                groupIdentifierFrom: new GroupId(1),
+                groupIdentifierFrom: GroupId(1),
                 sceneIdentifierFrom: 1,
-                groupIdentifierTo: new GroupId(1),
+                groupIdentifierTo: GroupId(1),
                 sceneIdentifierTo: 2,
             }, endpoint!, testSession, { packetHeader: { sessionType: SessionType.Unicast } } as Message);
 
-            assert.deepEqual(result, { code: StatusCode.Success, responseId: 66, response: { status: StatusCode.Success, groupIdentifierFrom: new GroupId(1), sceneIdentifierFrom: 1 } });
+            assert.deepEqual(result, { code: StatusCode.Success, responseId: 66, response: { status: StatusCode.Success, groupIdentifierFrom: GroupId(1), sceneIdentifierFrom: 1 } });
 
             const persistedData = await firstPromise;
 
@@ -353,11 +353,11 @@ describe("Scenes Server test", () => {
             assert.ok(persistedData.scopedClusterData);
             const scenesData = persistedData.scopedClusterData.get(ScenesCluster.id);
             assert.ok(scenesData);
-            assert.deepEqual(scenesData, new Map([["1", new Map([[1, new Map([[1, { "extensionFieldSets": [{ "attributeValueList": [{ "attributeId": { "id": 0 }, "attributeValue": [{ "tag": undefined, "typeLength": { "type": 8, "value": true } }] }], "clusterId": { "id": 6 } }], "sceneId": 1, "sceneName": "", "sceneTransitionTime": 0, "scenesGroupId": 1, "transitionTime100ms": 0 }], [2, { "extensionFieldSets": [{ "attributeValueList": [{ "attributeId": { "id": 0 }, "attributeValue": [{ "tag": undefined, "typeLength": { "type": 8, "value": true } }] }], "clusterId": { "id": 6 } }], "sceneId": 2, "sceneName": "", "sceneTransitionTime": 0, "scenesGroupId": 1, "transitionTime100ms": 0 }]])]])]]));
+            assert.deepEqual(scenesData, new Map([["1", new Map([[1, new Map([[1, { "extensionFieldSets": [{ "attributeValueList": [{ "attributeId": 0, "attributeValue": [{ "tag": undefined, "typeLength": { "type": 8, "value": true } }] }], "clusterId": 6 }], "sceneId": 1, "sceneName": "", "sceneTransitionTime": 0, "scenesGroupId": 1, "transitionTime100ms": 0 }], [2, { "extensionFieldSets": [{ "attributeValueList": [{ "attributeId": 0, "attributeValue": [{ "tag": undefined, "typeLength": { "type": 8, "value": true } }] }], "clusterId": 6 }], "sceneId": 2, "sceneName": "", "sceneTransitionTime": 0, "scenesGroupId": 1, "transitionTime100ms": 0 }]])]])]]));
         });
 
         it("copy one Scene other group", async () => {
-            const groupResult = await callCommandOnClusterServer(groupsServer!, "addGroup", { groupId: new GroupId(2), groupName: "Group 2" }, endpoint!, testSession, { packetHeader: { sessionType: SessionType.Unicast } } as Message);
+            const groupResult = await callCommandOnClusterServer(groupsServer!, "addGroup", { groupId: GroupId(2), groupName: "Group 2" }, endpoint!, testSession, { packetHeader: { sessionType: SessionType.Unicast } } as Message);
             assert.ok(groupResult);
 
             const { promise: firstPromise, resolver: firstResolver } = await getPromiseResolver<FabricJsonObject>();
@@ -365,13 +365,13 @@ describe("Scenes Server test", () => {
 
             const result = await callCommandOnClusterServer(scenesServer!, "copyScene", {
                 mode: 0,
-                groupIdentifierFrom: new GroupId(1),
+                groupIdentifierFrom: GroupId(1),
                 sceneIdentifierFrom: 1,
-                groupIdentifierTo: new GroupId(2),
+                groupIdentifierTo: GroupId(2),
                 sceneIdentifierTo: 3,
             }, endpoint!, testSession, { packetHeader: { sessionType: SessionType.Unicast } } as Message);
 
-            assert.deepEqual(result, { code: StatusCode.Success, responseId: 66, response: { status: StatusCode.Success, groupIdentifierFrom: new GroupId(1), sceneIdentifierFrom: 1 } });
+            assert.deepEqual(result, { code: StatusCode.Success, responseId: 66, response: { status: StatusCode.Success, groupIdentifierFrom: GroupId(1), sceneIdentifierFrom: 1 } });
 
             const persistedData = await firstPromise;
 
@@ -379,11 +379,11 @@ describe("Scenes Server test", () => {
             assert.ok(persistedData.scopedClusterData);
             const scenesData = persistedData.scopedClusterData.get(ScenesCluster.id);
             assert.ok(scenesData);
-            assert.deepEqual(scenesData, new Map([["1", new Map([[1, new Map([[1, { "extensionFieldSets": [{ "attributeValueList": [{ "attributeId": { "id": 0 }, "attributeValue": [{ "tag": undefined, "typeLength": { "type": 8, "value": true } }] }], "clusterId": { "id": 6 } }], "sceneId": 1, "sceneName": "", "sceneTransitionTime": 0, "scenesGroupId": 1, "transitionTime100ms": 0 }], [2, { "extensionFieldSets": [{ "attributeValueList": [{ "attributeId": { "id": 0 }, "attributeValue": [{ "tag": undefined, "typeLength": { "type": 8, "value": true } }] }], "clusterId": { "id": 6 } }], "sceneId": 2, "sceneName": "", "sceneTransitionTime": 0, "scenesGroupId": 1, "transitionTime100ms": 0 }]])], [2, new Map([[3, { "extensionFieldSets": [{ "attributeValueList": [{ "attributeId": { "id": 0 }, "attributeValue": [{ "tag": undefined, "typeLength": { "type": 8, "value": true } }] }], "clusterId": { "id": 6 } }], "sceneId": 3, "sceneName": "", "sceneTransitionTime": 0, "scenesGroupId": 2, "transitionTime100ms": 0 }]])]])]]));
+            assert.deepEqual(scenesData, new Map([["1", new Map([[1, new Map([[1, { "extensionFieldSets": [{ "attributeValueList": [{ "attributeId": 0, "attributeValue": [{ "tag": undefined, "typeLength": { "type": 8, "value": true } }] }], "clusterId": 6 }], "sceneId": 1, "sceneName": "", "sceneTransitionTime": 0, "scenesGroupId": 1, "transitionTime100ms": 0 }], [2, { "extensionFieldSets": [{ "attributeValueList": [{ "attributeId": 0, "attributeValue": [{ "tag": undefined, "typeLength": { "type": 8, "value": true } }] }], "clusterId": 6 }], "sceneId": 2, "sceneName": "", "sceneTransitionTime": 0, "scenesGroupId": 1, "transitionTime100ms": 0 }]])], [2, new Map([[3, { "extensionFieldSets": [{ "attributeValueList": [{ "attributeId": 0, "attributeValue": [{ "tag": undefined, "typeLength": { "type": 8, "value": true } }] }], "clusterId": 6 }], "sceneId": 3, "sceneName": "", "sceneTransitionTime": 0, "scenesGroupId": 2, "transitionTime100ms": 0 }]])]])]]));
         });
 
         it("copy all Scenes to other group", async () => {
-            const groupResult = await callCommandOnClusterServer(groupsServer!, "addGroup", { groupId: new GroupId(3), groupName: "Group 3" }, endpoint!, testSession, { packetHeader: { sessionType: SessionType.Unicast } } as Message);
+            const groupResult = await callCommandOnClusterServer(groupsServer!, "addGroup", { groupId: GroupId(3), groupName: "Group 3" }, endpoint!, testSession, { packetHeader: { sessionType: SessionType.Unicast } } as Message);
             assert.ok(groupResult);
 
             const { promise: firstPromise, resolver: firstResolver } = await getPromiseResolver<FabricJsonObject>();
@@ -391,13 +391,13 @@ describe("Scenes Server test", () => {
 
             const result = await callCommandOnClusterServer(scenesServer!, "copyScene", {
                 mode: { copyAllScenes: true },
-                groupIdentifierFrom: new GroupId(1),
+                groupIdentifierFrom: GroupId(1),
                 sceneIdentifierFrom: 0,
-                groupIdentifierTo: new GroupId(3),
+                groupIdentifierTo: GroupId(3),
                 sceneIdentifierTo: 0,
             }, endpoint!, testSession, { packetHeader: { sessionType: SessionType.Unicast } } as Message);
 
-            assert.deepEqual(result, { code: StatusCode.Success, responseId: 66, response: { status: StatusCode.Success, groupIdentifierFrom: new GroupId(1), sceneIdentifierFrom: 0 } });
+            assert.deepEqual(result, { code: StatusCode.Success, responseId: 66, response: { status: StatusCode.Success, groupIdentifierFrom: GroupId(1), sceneIdentifierFrom: 0 } });
 
             const persistedData = await firstPromise;
 
@@ -405,25 +405,25 @@ describe("Scenes Server test", () => {
             assert.ok(persistedData.scopedClusterData);
             const scenesData = persistedData.scopedClusterData.get(ScenesCluster.id);
             assert.ok(scenesData);
-            assert.deepEqual(scenesData, new Map([["1", new Map([[1, new Map([[1, { "extensionFieldSets": [{ "attributeValueList": [{ "attributeId": { "id": 0 }, "attributeValue": [{ "tag": undefined, "typeLength": { "type": 8, "value": true } }] }], "clusterId": { "id": 6 } }], "sceneId": 1, "sceneName": "", "sceneTransitionTime": 0, "scenesGroupId": 1, "transitionTime100ms": 0 }], [2, { "extensionFieldSets": [{ "attributeValueList": [{ "attributeId": { "id": 0 }, "attributeValue": [{ "tag": undefined, "typeLength": { "type": 8, "value": true } }] }], "clusterId": { "id": 6 } }], "sceneId": 2, "sceneName": "", "sceneTransitionTime": 0, "scenesGroupId": 1, "transitionTime100ms": 0 }]])], [2, new Map([[3, { "extensionFieldSets": [{ "attributeValueList": [{ "attributeId": { "id": 0 }, "attributeValue": [{ "tag": undefined, "typeLength": { "type": 8, "value": true } }] }], "clusterId": { "id": 6 } }], "sceneId": 3, "sceneName": "", "sceneTransitionTime": 0, "scenesGroupId": 2, "transitionTime100ms": 0 }]])], [3, new Map([[1, { "extensionFieldSets": [{ "attributeValueList": [{ "attributeId": { "id": 0 }, "attributeValue": [{ "tag": undefined, "typeLength": { "type": 8, "value": true } }] }], "clusterId": { "id": 6 } }], "sceneId": 1, "sceneName": "", "sceneTransitionTime": 0, "scenesGroupId": 3, "transitionTime100ms": 0 }], [2, { "extensionFieldSets": [{ "attributeValueList": [{ "attributeId": { "id": 0 }, "attributeValue": [{ "tag": undefined, "typeLength": { "type": 8, "value": true } }] }], "clusterId": { "id": 6 } }], "sceneId": 2, "sceneName": "", "sceneTransitionTime": 0, "scenesGroupId": 3, "transitionTime100ms": 0 }]])]])]]));
+            assert.deepEqual(scenesData, new Map([["1", new Map([[1, new Map([[1, { "extensionFieldSets": [{ "attributeValueList": [{ "attributeId": 0, "attributeValue": [{ "tag": undefined, "typeLength": { "type": 8, "value": true } }] }], "clusterId": 6 }], "sceneId": 1, "sceneName": "", "sceneTransitionTime": 0, "scenesGroupId": 1, "transitionTime100ms": 0 }], [2, { "extensionFieldSets": [{ "attributeValueList": [{ "attributeId": 0, "attributeValue": [{ "tag": undefined, "typeLength": { "type": 8, "value": true } }] }], "clusterId": 6 }], "sceneId": 2, "sceneName": "", "sceneTransitionTime": 0, "scenesGroupId": 1, "transitionTime100ms": 0 }]])], [2, new Map([[3, { "extensionFieldSets": [{ "attributeValueList": [{ "attributeId": 0, "attributeValue": [{ "tag": undefined, "typeLength": { "type": 8, "value": true } }] }], "clusterId": 6 }], "sceneId": 3, "sceneName": "", "sceneTransitionTime": 0, "scenesGroupId": 2, "transitionTime100ms": 0 }]])], [3, new Map([[1, { "extensionFieldSets": [{ "attributeValueList": [{ "attributeId": 0, "attributeValue": [{ "tag": undefined, "typeLength": { "type": 8, "value": true } }] }], "clusterId": 6 }], "sceneId": 1, "sceneName": "", "sceneTransitionTime": 0, "scenesGroupId": 3, "transitionTime100ms": 0 }], [2, { "extensionFieldSets": [{ "attributeValueList": [{ "attributeId": 0, "attributeValue": [{ "tag": undefined, "typeLength": { "type": 8, "value": true } }] }], "clusterId": 6 }], "sceneId": 2, "sceneName": "", "sceneTransitionTime": 0, "scenesGroupId": 3, "transitionTime100ms": 0 }]])]])]]));
         });
 
         it("recallScene", async () => {
             onOffServer?.attributes.onOff.setLocal(false);
             assert.equal(onOffServer?.attributes.onOff.getLocal(), false);
-            assert.deepEqual(scenesServer?.attributes.currentGroup.getLocal(), new GroupId(1));
+            assert.deepEqual(scenesServer?.attributes.currentGroup.getLocal(), GroupId(1));
             assert.equal(scenesServer?.attributes.currentScene.getLocal(), 1);
 
             assert.equal(scenesServer?.attributes.sceneValid.get(testSession!, false), false);
 
             const result = await callCommandOnClusterServer(scenesServer!, "recallScene", {
-                groupId: new GroupId(3),
+                groupId: GroupId(3),
                 sceneId: 2,
             }, endpoint!, testSession, { packetHeader: { sessionType: SessionType.Unicast } } as Message);
 
             assert.deepEqual(result, { code: StatusCode.Success, responseId: 5, response: undefined });
             assert.equal(onOffServer?.attributes.onOff.getLocal(), true);
-            assert.deepEqual(scenesServer?.attributes.currentGroup.getLocal(), new GroupId(3));
+            assert.deepEqual(scenesServer?.attributes.currentGroup.getLocal(), GroupId(3));
             assert.equal(scenesServer?.attributes.currentScene.getLocal(), 2);
             assert.equal(scenesServer?.attributes.sceneValid.get(testSession!, false), true);
         });

--- a/packages/matter-node.js/test/fabric/FabricTest.ts
+++ b/packages/matter-node.js/test/fabric/FabricTest.ts
@@ -22,22 +22,22 @@ const ROOT_CERT = ByteArray.fromHex("1530010100240201370324140018260480125428260
 const NEW_OP_CERT = ByteArray.fromHex("153001010124020137032414001826048012542826058015203b370624150124110918240701240801300941049ac1dc9995e6897f2bf1420a6efdba30781ac3dcdb7bb15e993050ff0ce92c52727b029c30f11f163b177d3bfa37f015db156994801f0e0f9b64c72bf8a15153370a35012801182402013603040204011830041402cce0d7bfa29e98e454be38e27bfe6c0f162302300514e766069362d7e35b79687161644d222bdde93a6818300b4050e8183c290f438a57516faea006282d6d2b5178d5d15dfcc3ec8a9232db942894ff2d2ce941d3b42dd8a2cd51eea4f3f50b66757959368868c3a0a1b5fe665f18");
 const IPK_KEY = ByteArray.fromHex("74656d706f726172792069706b203031");
 const OPERATIONAL_ID = ByteArray.fromHex("d559af361549a9a2");
-const TEST_ROOT_NODE = new NodeId(BigInt(1));
+const TEST_ROOT_NODE = NodeId(BigInt(1));
 
-const TEST_FABRIC_INDEX = new FabricIndex(1);
-const TEST_FABRIC_ID = new FabricId(BigInt("0x2906C908D115D362"));
-const TEST_NODE_ID = new NodeId(BigInt("0xCD5544AA7B13EF14"));
+const TEST_FABRIC_INDEX = FabricIndex(1);
+const TEST_FABRIC_ID = FabricId(BigInt("0x2906C908D115D362"));
+const TEST_NODE_ID = NodeId(BigInt("0xCD5544AA7B13EF14"));
 const TEST_ROOT_PUBLIC_KEY = ByteArray.fromHex("044a9f42b1ca4840d37292bbc7f6a7e11e22200c976fc900dbc98a7a383a641cb8254a2e56d4e295a847943b4e3897c4a773e930277b4d9fbede8a052686bfacfa");
 const TEST_IDENTITY_PROTECTION_KEY = ByteArray.fromHex("9bc61cd9c62a2df6d64dfcaa9dc472d4");
 const TEST_RANDOM = ByteArray.fromHex("7e171231568dfa17206b3accf8faec2f4d21b580113196f47c7c4deb810a73dc");
 const EXPECTED_DESTINATION_ID = ByteArray.fromHex("dc35dd5fc9134cc5544538c9c3fc4297c1ec3370c839136a80e10796451d4c53");
 
 const TEST_RANDOM_2 = ByteArray.fromHex("147546b42b4212ae62e3b393b973e7892e02a86d387d8f4829b0861495b5743a");
-const TEST_NODE_ID_2 = new NodeId(BigInt("0x0000000000000009"));
+const TEST_NODE_ID_2 = NodeId(BigInt("0x0000000000000009"));
 const EXPECTED_DESTINATION_ID_2 = ByteArray.fromHex("e62053e0b5226773ab96833d79133c865ddb5a67c9ea932471c73405afcd68da");
 
-const TEST_FABRIC_ID_3 = new FabricId(BigInt("0x0000000000000001"));
-const TEST_NODE_ID_3 = new NodeId(BigInt("0x0000000000000055"));
+const TEST_FABRIC_ID_3 = FabricId(BigInt("0x0000000000000001"));
+const TEST_NODE_ID_3 = NodeId(BigInt("0x0000000000000055"));
 const TEST_ROOT_PUBLIC_KEY_3 = ByteArray.fromHex("04d89eb7e3f3226d0918f4b85832457bb9981bca7aaef58c18fb5ec07525e472b2bd1617fb75ee41bd388f94ae6a6070efc896777516a5c54aff74ec0804cdde9d");
 const TEST_IDENTITY_PROTECTION_KEY_3 = ByteArray.fromHex("0c677d9b5ac585827b577470bd9bd516");
 const TEST_RANDOM_3 = ByteArray.fromHex("0b2a71876d3d090d37cb5286168ab9be0d2e7e0ccbedc1f55331b8a8051ee02f");
@@ -46,7 +46,7 @@ const EXPECTED_DESTINATION_ID_3 = ByteArray.fromHex("f7f7009606c61927af625020675
 describe("FabricBuilder", () => {
     describe("build", () => {
         const builder = new FabricBuilder(TEST_FABRIC_INDEX);
-        builder.setRootVendorId(new VendorId(0));
+        builder.setRootVendorId(VendorId(0));
         builder.setRootNodeId(TEST_ROOT_NODE);
         builder.setRootCert(ROOT_CERT);
         builder.setOperationalCert(NEW_OP_CERT);
@@ -70,7 +70,7 @@ describe("Fabric", () => {
 
     describe("getDestinationId", () => {
         it("generates the correct destination ID", () => {
-            const fabric = new Fabric(TEST_FABRIC_INDEX, TEST_FABRIC_ID, TEST_NODE_ID, TEST_ROOT_NODE, Buffer.alloc(0), TEST_ROOT_PUBLIC_KEY, Crypto.createKeyPair(), new VendorId(0), Buffer.alloc(0), Buffer.alloc(0), TEST_IDENTITY_PROTECTION_KEY, undefined, Buffer.alloc(0), '');
+            const fabric = new Fabric(TEST_FABRIC_INDEX, TEST_FABRIC_ID, TEST_NODE_ID, TEST_ROOT_NODE, Buffer.alloc(0), TEST_ROOT_PUBLIC_KEY, Crypto.createKeyPair(), VendorId(0), Buffer.alloc(0), Buffer.alloc(0), TEST_IDENTITY_PROTECTION_KEY, undefined, Buffer.alloc(0), '');
 
             const result = fabric.getDestinationId(TEST_NODE_ID, TEST_RANDOM);
 
@@ -79,7 +79,7 @@ describe("Fabric", () => {
 
         it("generates the correct destination ID 2", async () => {
             const builder = new FabricBuilder(TEST_FABRIC_INDEX);
-            builder.setRootVendorId(new VendorId(0));
+            builder.setRootVendorId(VendorId(0));
             builder.setRootCert(ROOT_CERT);
             builder.setRootNodeId(TEST_ROOT_NODE);
             builder.setOperationalCert(NEW_OP_CERT);
@@ -92,7 +92,7 @@ describe("Fabric", () => {
         });
 
         it("generates the correct destination ID 3", () => {
-            const fabric = new Fabric(TEST_FABRIC_INDEX, TEST_FABRIC_ID_3, TEST_NODE_ID_3, TEST_ROOT_NODE, Buffer.alloc(0), TEST_ROOT_PUBLIC_KEY_3, Crypto.createKeyPair(), new VendorId(0), Buffer.alloc(0), Buffer.alloc(0), TEST_IDENTITY_PROTECTION_KEY_3, undefined, Buffer.alloc(0), "");
+            const fabric = new Fabric(TEST_FABRIC_INDEX, TEST_FABRIC_ID_3, TEST_NODE_ID_3, TEST_ROOT_NODE, Buffer.alloc(0), TEST_ROOT_PUBLIC_KEY_3, Crypto.createKeyPair(), VendorId(0), Buffer.alloc(0), Buffer.alloc(0), TEST_IDENTITY_PROTECTION_KEY_3, undefined, Buffer.alloc(0), "");
 
             const result = fabric.getDestinationId(TEST_NODE_ID_3, TEST_RANDOM_3);
 

--- a/packages/matter-node.js/test/interaction/InteractionProtocolTest.ts
+++ b/packages/matter-node.js/test/interaction/InteractionProtocolTest.ts
@@ -23,7 +23,9 @@ import {
 } from "@project-chip/matter.js/interaction";
 import { MessageExchange } from "@project-chip/matter.js/protocol";
 import { Endpoint, DeviceTypeDefinition, DeviceClasses } from "@project-chip/matter.js/device";
-import { FabricId, FabricIndex, NodeId, VendorId, TlvFabricIndex } from "@project-chip/matter.js/datatype";
+import {
+    FabricId, FabricIndex, NodeId, VendorId, TlvFabricIndex, EndpointNumber, ClusterId, AttributeId, CommandId
+} from "@project-chip/matter.js/datatype";
 import {
     TlvString, TlvUInt8, TlvNoArguments, TlvArray, TlvField, TlvObject, TlvNullable, TlvOptionalField
 } from "@project-chip/matter.js/tlv";
@@ -44,13 +46,13 @@ const READ_REQUEST: ReadRequest = {
     interactionModelRevision: 1,
     isFabricFiltered: true,
     attributeRequests: [
-        { endpointId: 0, clusterId: 0x28, attributeId: 2 },
-        { endpointId: 0, clusterId: 0x28, attributeId: 4 },
-        { endpointId: 0, clusterId: 0x28, attributeId: 400 }, // unsupported attribute
-        { endpointId: 0, clusterId: 0x99, attributeId: 4 }, // unsupported cluster
-        { endpointId: 1, clusterId: 0x28, attributeId: 1 }, // unsupported endpoint
-        { endpointId: undefined, clusterId: 0x28, attributeId: 3 },
-        { endpointId: undefined, clusterId: 0x99, attributeId: 3 }, // ignore
+        { endpointId: EndpointNumber(0), clusterId: ClusterId(0x28), attributeId: AttributeId(2) },
+        { endpointId: EndpointNumber(0), clusterId: ClusterId(0x28), attributeId: AttributeId(4) },
+        { endpointId: EndpointNumber(0), clusterId: ClusterId(0x28), attributeId: AttributeId(400) }, // unsupported attribute
+        { endpointId: EndpointNumber(0), clusterId: ClusterId(0x99), attributeId: AttributeId(4) }, // unsupported cluster
+        { endpointId: EndpointNumber(1), clusterId: ClusterId(0x28), attributeId: AttributeId(1) }, // unsupported endpoint
+        { endpointId: undefined, clusterId: ClusterId(0x28), attributeId: AttributeId(3) },
+        { endpointId: undefined, clusterId: ClusterId(0x99), attributeId: AttributeId(3) }, // ignore
     ],
 };
 
@@ -61,39 +63,39 @@ const READ_RESPONSE: DataReport = {
     attributeReports: [
         {
             attributeData: {
-                path: { endpointId: 0, clusterId: 0x28, attributeId: 2 },
+                path: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x28), attributeId: AttributeId(2) },
                 data: TlvUInt8.encodeTlv(1),
                 dataVersion: 0,
             }
         },
         {
             attributeData: {
-                path: { endpointId: 0, clusterId: 0x28, attributeId: 4 },
+                path: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x28), attributeId: AttributeId(4) },
                 data: TlvUInt8.encodeTlv(2),
                 dataVersion: 0,
             }
         },
         {
             attributeStatus: {
-                path: { endpointId: 0, clusterId: 0x28, attributeId: 400 },
+                path: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x28), attributeId: AttributeId(400) },
                 status: { status: 134 },
             }
         },
         {
             attributeStatus: {
-                path: { endpointId: 0, clusterId: 0x99, attributeId: 4 },
+                path: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x99), attributeId: AttributeId(4) },
                 status: { status: 195 },
             }
         },
         {
             attributeStatus: {
-                path: { endpointId: 1, clusterId: 0x28, attributeId: 1 },
+                path: { endpointId: EndpointNumber(1), clusterId: ClusterId(0x28), attributeId: AttributeId(1) },
                 status: { status: 127 },
             }
         },
         {
             attributeData: {
-                path: { endpointId: 0, clusterId: 0x28, attributeId: 3 },
+                path: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x28), attributeId: AttributeId(3) },
                 data: TlvString.encodeTlv("product"),
                 dataVersion: 0,
             }
@@ -107,22 +109,22 @@ const WRITE_REQUEST: WriteRequest = {
     timedRequest: false,
     writeRequests: [
         {
-            path: { endpointId: 0, clusterId: 0x28, attributeId: 100 },
+            path: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x28), attributeId: AttributeId(100) },
             data: TlvUInt8.encodeTlv(3),
             dataVersion: 0,
         },
         {
-            path: { endpointId: 0, clusterId: 0x99, attributeId: 4 },
+            path: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x99), attributeId: AttributeId(4) },
             data: TlvUInt8.encodeTlv(3),
             dataVersion: 0,
         },
         {
-            path: { endpointId: 1, clusterId: 0x28, attributeId: 4 },
+            path: { endpointId: EndpointNumber(1), clusterId: ClusterId(0x28), attributeId: AttributeId(4) },
             data: TlvUInt8.encodeTlv(3),
             dataVersion: 0,
         },
         {
-            path: { endpointId: 0, clusterId: 0x28, attributeId: 5 },
+            path: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x28), attributeId: AttributeId(5) },
             data: TlvString.encodeTlv("test"),
             dataVersion: 0,
         },
@@ -134,16 +136,16 @@ const WRITE_RESPONSE: WriteResponse = {
     interactionModelRevision: 1,
     writeResponses: [
         {
-            path: { attributeId: 100, clusterId: 40, endpointId: 0 }, status: { status: 134 }
+            path: { attributeId: AttributeId(100), clusterId: ClusterId(40), endpointId: EndpointNumber(0) }, status: { status: 134 }
         },
         {
-            path: { attributeId: 4, clusterId: 0x99, endpointId: 0 }, status: { status: 195 }
+            path: { attributeId: AttributeId(4), clusterId: ClusterId(0x99), endpointId: EndpointNumber(0) }, status: { status: 195 }
         },
         {
-            path: { attributeId: 4, clusterId: 40, endpointId: 1 }, status: { status: 127 }
+            path: { attributeId: AttributeId(4), clusterId: ClusterId(40), endpointId: EndpointNumber(1) }, status: { status: 127 }
         },
         {
-            path: { attributeId: 5, clusterId: 40, endpointId: 0 }, status: { status: 0 }
+            path: { attributeId: AttributeId(5), clusterId: ClusterId(40), endpointId: EndpointNumber(0) }, status: { status: 0 }
         }
     ]
 };
@@ -154,17 +156,17 @@ const MASS_WRITE_REQUEST: WriteRequest = {
     timedRequest: false,
     writeRequests: [
         {
-            path: { endpointId: 0, clusterId: 0x28 },
+            path: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x28) },
             data: TlvString.encodeTlv("test"),
             dataVersion: 0,
         },
         {
-            path: { endpointId: 0, clusterId: 0x99 },
+            path: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x99) },
             data: TlvString.encodeTlv("test"),
             dataVersion: 0,
         },
         {
-            path: { endpointId: 1, clusterId: 0x28 },
+            path: { endpointId: EndpointNumber(1), clusterId: ClusterId(0x28) },
             data: TlvString.encodeTlv("test"),
             dataVersion: 0,
         }
@@ -176,13 +178,13 @@ const MASS_WRITE_RESPONSE: WriteResponse = {
     interactionModelRevision: 1,
     writeResponses: [
         {
-            path: { attributeId: 5, clusterId: 40, endpointId: 0 }, status: { status: 0 }
+            path: { attributeId: AttributeId(5), clusterId: ClusterId(40), endpointId: EndpointNumber(0) }, status: { status: 0 }
         },
         {
-            path: { attributeId: 6, clusterId: 40, endpointId: 0 }, status: { status: 0 }
+            path: { attributeId: AttributeId(6), clusterId: ClusterId(40), endpointId: EndpointNumber(0) }, status: { status: 0 }
         },
         {
-            path: { attributeId: 16, clusterId: 40, endpointId: 0 }, status: { status: 0 }
+            path: { attributeId: AttributeId(16), clusterId: ClusterId(40), endpointId: EndpointNumber(0) }, status: { status: 0 }
         }
     ]
 };
@@ -201,12 +203,12 @@ const CHUNKED_ARRAY_WRITE_REQUEST: WriteRequest = {
     timedRequest: false,
     writeRequests: [
         {
-            path: { endpointId: 0, clusterId: 0x1f, attributeId: 0 },
+            path: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x1f), attributeId: AttributeId(0) },
             data: TlvArray(TlvAclTestSchema).encodeTlv([]),
             dataVersion: 0,
         },
         {
-            path: { endpointId: 0, clusterId: 0x1f, attributeId: 0, listIndex: null },
+            path: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x1f), attributeId: AttributeId(0), listIndex: null },
             data: TlvAclTestSchema.encodeTlv({
                 privilege: 1,
                 authMode: 1,
@@ -216,7 +218,7 @@ const CHUNKED_ARRAY_WRITE_REQUEST: WriteRequest = {
             dataVersion: 0,
         },
         {
-            path: { endpointId: 0, clusterId: 0x1f, attributeId: 0, listIndex: null },
+            path: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x1f), attributeId: AttributeId(0), listIndex: null },
             data: TlvAclTestSchema.encodeTlv({
                 privilege: 1,
                 authMode: 0,
@@ -227,13 +229,13 @@ const CHUNKED_ARRAY_WRITE_REQUEST: WriteRequest = {
             dataVersion: 0,
         },
         {
-            path: { endpointId: 0, clusterId: 0x1f, attributeId: 0, listIndex: null },
+            path: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x1f), attributeId: AttributeId(0), listIndex: null },
             data: TlvAclTestSchema.encodeTlv({
                 privilege: 1,
                 authMode: 2,
                 subjects: null,
                 targets: null,
-                fabricIndex: new FabricIndex(2),
+                fabricIndex: FabricIndex(2),
             }),
             dataVersion: 0,
         },
@@ -245,7 +247,7 @@ const CHUNKED_ARRAY_WRITE_RESPONSE: WriteResponse = {
     interactionModelRevision: 1,
     writeResponses: [
         {
-            path: { attributeId: 0, clusterId: 31, endpointId: 0 }, status: { status: 0 }
+            path: { attributeId: AttributeId(0), clusterId: ClusterId(31), endpointId: EndpointNumber(0) }, status: { status: 0 }
         }
     ]
 };
@@ -257,9 +259,9 @@ const INVOKE_COMMAND_REQUEST_WITH_EMPTY_ARGS: InvokeRequest = {
     invokeRequests: [
         {
             commandPath: {
-                endpointId: 0,
-                clusterId: 6,
-                commandId: 1,
+                endpointId: EndpointNumber(0),
+                clusterId: ClusterId(6),
+                commandId: CommandId(1),
             },
             commandFields: TlvNoArguments.encodeTlv(undefined),
         }
@@ -272,7 +274,7 @@ const INVOKE_COMMAND_REQUEST_WITH_NO_ARGS: InvokeRequest = {
     timedRequest: false,
     invokeRequests: [
         {
-            commandPath: { endpointId: 0, clusterId: 6, commandId: 1 },
+            commandPath: { endpointId: EndpointNumber(0), clusterId: ClusterId(6), commandId: CommandId(1) },
         }
     ]
 };
@@ -283,22 +285,22 @@ const INVOKE_COMMAND_REQUEST_MULTI: InvokeRequest = {
     timedRequest: false,
     invokeRequests: [
         {
-            commandPath: { endpointId: 0, clusterId: 6, commandId: 1 },
+            commandPath: { endpointId: EndpointNumber(0), clusterId: ClusterId(6), commandId: CommandId(1) },
         },
         {
-            commandPath: { endpointId: undefined, clusterId: 6, commandId: 0 },
+            commandPath: { endpointId: undefined, clusterId: ClusterId(6), commandId: CommandId(0) },
         },
         {
-            commandPath: { endpointId: undefined, clusterId: 6, commandId: 99 },
+            commandPath: { endpointId: undefined, clusterId: ClusterId(6), commandId: CommandId(99) },
         },
         {
-            commandPath: { endpointId: 0, clusterId: 6, commandId: 100 },
+            commandPath: { endpointId: EndpointNumber(0), clusterId: ClusterId(6), commandId: CommandId(100) },
         },
         {
-            commandPath: { endpointId: 0, clusterId: 90, commandId: 1 },
+            commandPath: { endpointId: EndpointNumber(0), clusterId: ClusterId(90), commandId: CommandId(1) },
         },
         {
-            commandPath: { endpointId: 99, clusterId: 6, commandId: 1 },
+            commandPath: { endpointId: EndpointNumber(99), clusterId: ClusterId(6), commandId: CommandId(1) },
         }
     ]
 };
@@ -309,7 +311,7 @@ const INVOKE_COMMAND_REQUEST_INVALID: InvokeRequest = {
     timedRequest: false,
     invokeRequests: [
         {
-            commandPath: { endpointId: 0, clusterId: 6, commandId: 10 },
+            commandPath: { endpointId: EndpointNumber(0), clusterId: ClusterId(6), commandId: CommandId(10) },
         }
     ]
 };
@@ -320,7 +322,7 @@ const INVOKE_COMMAND_RESPONSE: InvokeResponse = {
     invokeResponses: [
         {
             status: {
-                commandPath: { clusterId: 6, commandId: 1, endpointId: 0 }, status: { status: 0 }
+                commandPath: { clusterId: ClusterId(6), commandId: CommandId(1), endpointId: EndpointNumber(0) }, status: { status: 0 }
             }
         }
     ]
@@ -332,7 +334,7 @@ const INVOKE_COMMAND_RESPONSE_INVALID: InvokeResponse = {
     invokeResponses: [
         {
             status: {
-                commandPath: { clusterId: 6, commandId: 10, endpointId: 0 }, status: { status: 0x81 }
+                commandPath: { clusterId: ClusterId(6), commandId: CommandId(10), endpointId: EndpointNumber(0) }, status: { status: 0x81 }
             }
         }
     ]
@@ -344,27 +346,27 @@ const INVOKE_COMMAND_RESPONSE_MULTI: InvokeResponse = {
     invokeResponses: [
         {
             status: {
-                commandPath: { clusterId: 6, commandId: 100, endpointId: 0 }, status: { status: 129 }
+                commandPath: { clusterId: ClusterId(6), commandId: CommandId(100), endpointId: EndpointNumber(0) }, status: { status: 129 }
             }
         },
         {
             status: {
-                commandPath: { clusterId: 90, commandId: 1, endpointId: 0 }, status: { status: 195 }
+                commandPath: { clusterId: ClusterId(90), commandId: CommandId(1), endpointId: EndpointNumber(0) }, status: { status: 195 }
             }
         },
         {
             status: {
-                commandPath: { clusterId: 6, commandId: 1, endpointId: 99 }, status: { status: 127 }
+                commandPath: { clusterId: ClusterId(6), commandId: CommandId(1), endpointId: EndpointNumber(99) }, status: { status: 127 }
             }
         },
         {
             status: {
-                commandPath: { clusterId: 6, commandId: 1, endpointId: 0 }, status: { status: 0 }
+                commandPath: { clusterId: ClusterId(6), commandId: CommandId(1), endpointId: EndpointNumber(0) }, status: { status: 0 }
             }
         },
         {
             status: {
-                commandPath: { clusterId: 6, commandId: 0, endpointId: 0 }, status: { status: 0 }
+                commandPath: { clusterId: ClusterId(6), commandId: CommandId(0), endpointId: EndpointNumber(0) }, status: { status: 0 }
             }
         },
     ]
@@ -377,11 +379,11 @@ describe("InteractionProtocol", () => {
             const storageManager = new StorageManager(new StorageBackendMemory());
             await storageManager.initialize();
             const storageContext = storageManager.createContext("test");
-            const endpoint = new Endpoint([DummyTestDevice], { endpointId: 0 });
+            const endpoint = new Endpoint([DummyTestDevice], { endpointId: EndpointNumber(0) });
             endpoint.addClusterServer(ClusterServer(BasicInformationCluster, {
                 dataModelRevision: 1,
                 vendorName: "vendor",
-                vendorId: new VendorId(1),
+                vendorId: VendorId(1),
                 productName: "product",
                 productId: 2,
                 nodeLabel: "",
@@ -412,7 +414,7 @@ describe("InteractionProtocol", () => {
             const basicCluster = ClusterServer(BasicInformationCluster, {
                 dataModelRevision: 1,
                 vendorName: "vendor",
-                vendorId: new VendorId(1),
+                vendorId: VendorId(1),
                 productName: "product",
                 productId: 2,
                 nodeLabel: "",
@@ -433,7 +435,7 @@ describe("InteractionProtocol", () => {
             const storageManager = new StorageManager(new StorageBackendMemory());
             await storageManager.initialize();
             const storageContext = storageManager.createContext("test");
-            const endpoint = new Endpoint([DummyTestDevice], { endpointId: 0 });
+            const endpoint = new Endpoint([DummyTestDevice], { endpointId: EndpointNumber(0) });
             endpoint.addClusterServer(basicCluster);
             const interactionProtocol = new InteractionServer(storageContext);
             interactionProtocol.setRootEndpoint(endpoint);
@@ -459,13 +461,13 @@ describe("InteractionProtocol", () => {
             const storageManager = new StorageManager(new StorageBackendMemory());
             await storageManager.initialize();
             const storageContext = storageManager.createContext("test");
-            const endpoint = new Endpoint([DummyTestDevice], { endpointId: 0 });
+            const endpoint = new Endpoint([DummyTestDevice], { endpointId: EndpointNumber(0) });
             endpoint.addClusterServer(accessControlCluster);
             const interactionProtocol = new InteractionServer(storageContext);
             interactionProtocol.setRootEndpoint(endpoint);
 
-            const testFabric = new Fabric(new FabricIndex(1), new FabricId(BigInt(1)), new NodeId(BigInt(1)), new NodeId(BigInt(2)), ByteArray.fromHex("00"), ByteArray.fromHex("00"), KEY, new VendorId(1), ByteArray.fromHex("00"), ByteArray.fromHex("00"), ByteArray.fromHex("00"), ByteArray.fromHex("00"), ByteArray.fromHex("00"), "");
-            const testSession = await SecureSession.create({ getFabrics: () => [] } as any, 1, testFabric, new NodeId(BigInt(1)), 1, ByteArray.fromHex("00"), ByteArray.fromHex("00"), false, false, () => {/* nothing */ }, 1000, 1000);
+            const testFabric = new Fabric(FabricIndex(1), FabricId(1), NodeId(BigInt(1)), NodeId(1), ByteArray.fromHex("00"), ByteArray.fromHex("00"), KEY, VendorId(1), ByteArray.fromHex("00"), ByteArray.fromHex("00"), ByteArray.fromHex("00"), ByteArray.fromHex("00"), ByteArray.fromHex("00"), "");
+            const testSession = await SecureSession.create({ getFabrics: () => [] } as any, 1, testFabric, NodeId(1), 1, ByteArray.fromHex("00"), ByteArray.fromHex("00"), false, false, () => {/* nothing */ }, 1000, 1000);
             const result = interactionProtocol.handleWriteRequest(({ channel: { name: "test" }, session: testSession }) as unknown as MessageExchange<any>, CHUNKED_ARRAY_WRITE_REQUEST);
 
             assert.deepEqual(result, CHUNKED_ARRAY_WRITE_RESPONSE);
@@ -475,21 +477,21 @@ describe("InteractionProtocol", () => {
                     authMode: 1,
                     subjects: null,
                     targets: null,
-                    fabricIndex: new FabricIndex(1), // Set from session
+                    fabricIndex: FabricIndex(1), // Set from session
                 },
                 {
                     privilege: 1,
                     authMode: 0,
                     subjects: null,
                     targets: null,
-                    fabricIndex: new FabricIndex(0), // existing value 0
+                    fabricIndex: FabricIndex(0), // existing value 0
                 },
                 {
                     privilege: 1,
                     authMode: 2,
                     subjects: null,
                     targets: null,
-                    fabricIndex: new FabricIndex(2), // existing value 2
+                    fabricIndex: FabricIndex(2), // existing value 2
                 }
             ]);
         });
@@ -498,7 +500,7 @@ describe("InteractionProtocol", () => {
             const basicCluster = ClusterServer(BasicInformationCluster, {
                 dataModelRevision: 1,
                 vendorName: "vendor",
-                vendorId: new VendorId(1),
+                vendorId: VendorId(1),
                 productName: "product",
                 productId: 2,
                 nodeLabel: "",
@@ -519,7 +521,7 @@ describe("InteractionProtocol", () => {
             const storageManager = new StorageManager(new StorageBackendMemory());
             await storageManager.initialize();
             const storageContext = storageManager.createContext("test");
-            const endpoint = new Endpoint([DummyTestDevice], { endpointId: 0 });
+            const endpoint = new Endpoint([DummyTestDevice], { endpointId: EndpointNumber(0) });
             endpoint.addClusterServer(basicCluster);
             const interactionProtocol = new InteractionServer(storageContext);
             interactionProtocol.setRootEndpoint(endpoint);
@@ -554,7 +556,7 @@ describe("InteractionProtocol", () => {
             const storageManager = new StorageManager(new StorageBackendMemory());
             await storageManager.initialize();
             const storageContext = storageManager.createContext("test");
-            const endpoint = new Endpoint([DummyTestDevice], { endpointId: 0 });
+            const endpoint = new Endpoint([DummyTestDevice], { endpointId: EndpointNumber(0) });
             endpoint.addClusterServer(onOffCluster);
             const interactionProtocol = new InteractionServer(storageContext);
             interactionProtocol.setRootEndpoint(endpoint);
@@ -585,7 +587,7 @@ describe("InteractionProtocol", () => {
             const storageManager = new StorageManager(new StorageBackendMemory());
             await storageManager.initialize();
             const storageContext = storageManager.createContext("test");
-            const endpoint = new Endpoint([DummyTestDevice], { endpointId: 0 });
+            const endpoint = new Endpoint([DummyTestDevice], { endpointId: EndpointNumber(0) });
             endpoint.addClusterServer(onOffCluster);
             const interactionProtocol = new InteractionServer(storageContext);
             interactionProtocol.setRootEndpoint(endpoint);
@@ -615,7 +617,7 @@ describe("InteractionProtocol", () => {
             const storageManager = new StorageManager(new StorageBackendMemory());
             await storageManager.initialize();
             const storageContext = storageManager.createContext("test");
-            const endpoint = new Endpoint([DummyTestDevice], { endpointId: 0 });
+            const endpoint = new Endpoint([DummyTestDevice], { endpointId: EndpointNumber(0) });
             endpoint.addClusterServer(onOffCluster);
             const interactionProtocol = new InteractionServer(storageContext);
             interactionProtocol.setRootEndpoint(endpoint);
@@ -649,7 +651,7 @@ describe("InteractionProtocol", () => {
             const storageManager = new StorageManager(new StorageBackendMemory());
             await storageManager.initialize();
             const storageContext = storageManager.createContext("test");
-            const endpoint = new Endpoint([DummyTestDevice], { endpointId: 0 });
+            const endpoint = new Endpoint([DummyTestDevice], { endpointId: EndpointNumber(0) });
             endpoint.addClusterServer(onOffCluster);
             const interactionProtocol = new InteractionServer(storageContext);
             interactionProtocol.setRootEndpoint(endpoint);

--- a/packages/matter.js/src/MatterController.ts
+++ b/packages/matter.js/src/MatterController.ts
@@ -44,6 +44,7 @@ import { TlvEnum } from "./tlv/TlvNumber.js";
 import { TlvString } from "./tlv/TlvString.js";
 import { CommissioningError, CommissioningOptions, ControllerCommissioner } from "./protocol/ControllerCommissioner.js";
 import { NetworkError } from "./net/Network.js";
+import { FabricId } from "./datatype/FabricId.js";
 
 const TlvCommissioningSuccessFailureResponse = TlvObject({
     /** Contain the result of the operation. */
@@ -54,9 +55,9 @@ const TlvCommissioningSuccessFailureResponse = TlvObject({
 });
 export type CommissioningSuccessFailureResponse = TypeFromSchema<typeof TlvCommissioningSuccessFailureResponse>;
 
-const FABRIC_INDEX = new FabricIndex(1);
-const FABRIC_ID = BigInt(1);
-const DEFAULT_ADMIN_VENDOR_ID = new VendorId(0xFFF1); // TODO combine into ControllerCommissioner!
+const FABRIC_INDEX = FabricIndex(1);
+const FABRIC_ID = FabricId(1);
+const DEFAULT_ADMIN_VENDOR_ID = VendorId(0xFFF1); // TODO combine into ControllerCommissioner!
 
 const logger = Logger.get("MatterController");
 
@@ -69,7 +70,7 @@ export class PairRetransmissionLimitReachedError extends RetransmissionLimitReac
 export class MatterController {
     public static async create(scanner: Scanner, netInterfaceIpv4: NetInterface | undefined, netInterfaceIpv6: NetInterface, storage: StorageContext, operationalServerAddress?: ServerAddressIp, commissioningOptions?: CommissioningOptions): Promise<MatterController> {
         // TODO move to ControllerCommissioner
-        const CONTROLLER_NODE_ID = new NodeId(Crypto.getRandomBigUInt64());
+        const CONTROLLER_NODE_ID = NodeId(Crypto.getRandomBigUInt64());
         const certificateManager = new RootCertificateManager(storage);
 
         const ipkValue = Crypto.getRandomData(16);
@@ -77,7 +78,7 @@ export class MatterController {
             .setRootCert(certificateManager.getRootCert())
             .setRootNodeId(CONTROLLER_NODE_ID)
             .setIdentityProtectionKey(ipkValue)
-            .setRootVendorId(commissioningOptions?.adminVendorId ?? DEFAULT_ADMIN_VENDOR_ID)
+            .setRootVendorId(VendorId(commissioningOptions?.adminVendorId ?? DEFAULT_ADMIN_VENDOR_ID))
         fabricBuilder.setOperationalCert(certificateManager.generateNoc(fabricBuilder.getPublicKey(), FABRIC_ID, CONTROLLER_NODE_ID));
 
         // Check if we have a fabric stored in the storage, if yes initialize this one, else build a new one

--- a/packages/matter.js/src/MatterNode.ts
+++ b/packages/matter.js/src/MatterNode.ts
@@ -13,6 +13,7 @@ import { ClusterServerObj } from "./cluster/server/ClusterServer.js";
 import { InteractionClient } from "./protocol/interaction/InteractionClient.js";
 import { MdnsBroadcaster } from "./mdns/MdnsBroadcaster.js";
 import { MdnsScanner } from "./mdns/MdnsScanner.js"
+import { EndpointNumber } from "./datatype/EndpointNumber.js";
 
 /**
  * Abstract base class that represents a node in the matter ecosystem.
@@ -86,7 +87,7 @@ export abstract class MatterNode {
      * @param endpointId Endpoint ID of the child endpoint to get
      * @protected
      */
-    protected getChildEndpoint(endpointId: number): Endpoint | undefined {
+    protected getChildEndpoint(endpointId: EndpointNumber): Endpoint | undefined {
         return this.rootEndpoint.getChildEndpoint(endpointId);
     }
 

--- a/packages/matter.js/src/certificate/AttestationCertificateManager.ts
+++ b/packages/matter.js/src/certificate/AttestationCertificateManager.ts
@@ -13,11 +13,11 @@ import { VendorId } from "../datatype/VendorId.js";
 import { PrivateKey } from "../crypto/Key.js";
 
 function getPaiCommonName(vendorId: VendorId, productId?: number) {
-    return `node-matter Dev PAI 0x${vendorId.id.toString(16).toUpperCase()} ${productId === undefined ? 'no PID' : `0x${productId.toString(16).toUpperCase()}`}`;
+    return `node-matter Dev PAI 0x${vendorId.toString(16).toUpperCase()} ${productId === undefined ? 'no PID' : `0x${productId.toString(16).toUpperCase()}`}`;
 }
 
 function getDacCommonName(vendorId: VendorId, productId: number) {
-    return `node-matter Dev DAC 0x${vendorId.id.toString(16).toUpperCase()}/0x${productId.toString(16).toUpperCase()}`;
+    return `node-matter Dev DAC 0x${vendorId.toString(16).toUpperCase()}/0x${productId.toString(16).toUpperCase()}`;
 }
 
 function getPaaCommonName() {

--- a/packages/matter.js/src/certificate/CertificateManager.ts
+++ b/packages/matter.js/src/certificate/CertificateManager.ts
@@ -22,6 +22,7 @@ import { TlvBoolean } from "../tlv/TlvBoolean.js";
 import { TypeFromSchema } from "../tlv/TlvSchema.js";
 import { Key, PublicKey } from "../crypto/Key.js";
 import { MatterError } from "../common/MatterError.js";
+import { FabricId, TlvFabricId } from "../datatype/FabricId.js";
 
 export class CertificateError extends MatterError { }
 
@@ -56,16 +57,16 @@ function uInt16To4Chars(value: number) {
 export const CommonName_X520 = (name: string) => [DerObject("550403", { value: name })];
 
 /** matter-node-id = ASN.1 OID 1.3.6.1.4.1.37244.1.1 */
-export const NodeId_Matter = (nodeId: NodeId) => [DerObject("2b0601040182a27c0101", { value: intTo16Chars(nodeId.id) })];
+export const NodeId_Matter = (nodeId: NodeId) => [DerObject("2b0601040182a27c0101", { value: intTo16Chars(nodeId) })];
 
 /** matter-rcac-id = ASN.1 OID 1.3.6.1.4.1.37244.1.4 */
 export const RcacId_Matter = (id: bigint | number) => [DerObject("2b0601040182a27c0104", { value: intTo16Chars(id) })];
 
 /** matter-fabric-id = ASN.1 OID 1.3.6.1.4.1.37244.1.5 */
-export const FabricId_Matter = (id: bigint | number) => [DerObject("2b0601040182a27c0105", { value: intTo16Chars(id) })];
+export const FabricId_Matter = (id: FabricId) => [DerObject("2b0601040182a27c0105", { value: intTo16Chars(id) })];
 
 /** matter-oid-vid = ASN.1 OID 1.3.6.1.4.1.37244.2.1 */
-export const VendorId_Matter = (vendorId: VendorId) => [DerObject("2b0601040182a27c0201", { value: uInt16To4Chars(vendorId.id) })];
+export const VendorId_Matter = (vendorId: VendorId) => [DerObject("2b0601040182a27c0201", { value: uInt16To4Chars(vendorId) })];
 
 /** matter-oid-pid = ASN.1 OID 1.3.6.1.4.1.3724 4.2.2 */
 export const ProductId_Matter = (id: number) => [DerObject("2b0601040182a27c0202", { value: uInt16To4Chars(id) })];
@@ -107,7 +108,7 @@ export const TlvOperationalCertificate = TlvObject({
     notBefore: TlvField(4, TlvUInt32),
     notAfter: TlvField(5, TlvUInt32),
     subject: TlvField(6, TlvList({
-        fabricId: TlvField(21, TlvUInt64),
+        fabricId: TlvField(21, TlvFabricId),
         nodeId: TlvField(17, TlvNodeId),
     })),
     publicKeyAlgorithm: TlvField(7, TlvUInt8),
@@ -279,7 +280,7 @@ export class CertificateManager {
             },
             subject: {
                 fabricId: FabricId_Matter(fabricId),
-                nodeId: NodeId_Matter(nodeId),
+                nodeId: NodeId_Matter(NodeId(nodeId)),
             },
             publicKey: PublicKeyEcPrime256v1_X962(ellipticCurvePublicKey),
             extensions: ContextTagged(3, {

--- a/packages/matter.js/src/certificate/RootCertificateManager.ts
+++ b/packages/matter.js/src/certificate/RootCertificateManager.ts
@@ -11,6 +11,7 @@ import { NodeId } from "../datatype/NodeId.js";
 import { Time } from "../time/Time.js";
 import { StorageContext } from "../storage/StorageContext.js";
 import { BinaryKeyPair, PrivateKey } from "../crypto/Key.js";
+import { FabricId } from "../datatype/FabricId.js";
 
 export class RootCertificateManager {
     private rootCertId = BigInt(0);
@@ -76,7 +77,7 @@ export class RootCertificateManager {
         return TlvRootCertificate.encode({ ...unsignedCertificate, signature });
     }
 
-    generateNoc(publicKey: ByteArray, fabricId: bigint, nodeId: NodeId) {
+    generateNoc(publicKey: ByteArray, fabricId: FabricId, nodeId: NodeId) {
         const now = Time.get().now();
         const certId = this.nextCertificateId++;
         const unsignedCertificate = {

--- a/packages/matter.js/src/cluster/Cluster.ts
+++ b/packages/matter.js/src/cluster/Cluster.ts
@@ -15,6 +15,7 @@ import { TlvBitmap, TlvUInt16, TlvUInt32 } from "../tlv/TlvNumber.js";
 import { TlvArray } from "../tlv/TlvArray.js";
 import { MatterCoreSpecificationV1_0 } from "../spec/Specifications.js";
 import { MatterError } from "../common/MatterError.js";
+import { ClusterId } from "../datatype/ClusterId.js";
 
 export class AttributeError extends MatterError { }
 
@@ -31,7 +32,7 @@ export type ConditionalFeatureList<F extends BitSchema> = TypeFromPartialBitSche
 
 /* Interfaces and helper methods to define a cluster attribute */
 export interface Attribute<T, F extends BitSchema> {
-    id: number,
+    id: AttributeId,
     schema: TlvSchema<T>,
     optional: boolean,
     readAcl: AccessLevel,
@@ -109,7 +110,7 @@ export const Attribute = <T, V extends T, F extends BitSchema>(id: number, schem
     default: conformanceValue,
     readAcl = AccessLevel.View,
 }: AttributeOptions<V> = {}): Attribute<T, F> => ({
-    id,
+    id: AttributeId(id),
     schema,
     optional: false,
     writable: false,
@@ -132,7 +133,7 @@ export const OptionalAttribute = <T, V extends T, F extends BitSchema>(id: numbe
     default: conformanceValue,
     readAcl = AccessLevel.View,
 }: AttributeOptions<V> = {}): OptionalAttribute<T, F> => ({
-    id,
+    id: AttributeId(id),
     schema,
     optional: true,
     writable: false,
@@ -157,7 +158,7 @@ export const ConditionalAttribute = <T, V extends T, F extends BitSchema>(id: nu
     optionalIf = [],
     mandatoryIf = [],
 }: ConditionalAttributeOptions<V, F>): ConditionalAttribute<T, F> => ({
-    id,
+    id: AttributeId(id),
     schema,
     optional: true,
     writable: false,
@@ -181,7 +182,7 @@ export const WritableAttribute = <T, V extends T, F extends BitSchema>(id: numbe
     readAcl = AccessLevel.View,
     writeAcl = AccessLevel.View,
 }: AttributeOptions<V> = {}): WritableAttribute<T, F> => ({
-    id,
+    id: AttributeId(id),
     schema,
     optional: false,
     writable: true,
@@ -206,7 +207,7 @@ export const OptionalWritableAttribute = <T, V extends T, F extends BitSchema>(i
     readAcl = AccessLevel.View,
     writeAcl = AccessLevel.View,
 }: AttributeOptions<V> = {}): OptionalWritableAttribute<T, F> => ({
-    id,
+    id: AttributeId(id),
     schema,
     optional: true,
     writable: true,
@@ -233,7 +234,7 @@ export const ConditionalWritableAttribute = <T, V extends T, F extends BitSchema
     optionalIf = [],
     mandatoryIf = [],
 }: ConditionalAttributeOptions<V, F>): ConditionalWritableAttribute<T, F> => ({
-    id,
+    id: AttributeId(id),
     schema,
     optional: true,
     writable: true,
@@ -257,7 +258,7 @@ export const FabricScopedAttribute = <T, V extends T, F extends BitSchema>(id: n
     default: conformanceValue,
     readAcl = AccessLevel.View
 }: AttributeOptions<V> = {}): FabricScopedAttribute<T, F> => ({
-    id,
+    id: AttributeId(id),
     schema,
     optional: false,
     writable: false,
@@ -281,7 +282,7 @@ export const WritableFabricScopedAttribute = <T, V extends T, F extends BitSchem
     readAcl = AccessLevel.View,
     writeAcl = AccessLevel.View,
 }: AttributeOptions<V> = {}): WritableFabricScopedAttribute<T, F> => ({
-    id,
+    id: AttributeId(id),
     schema,
     optional: false,
     writable: true,
@@ -306,7 +307,7 @@ export const OptionalWritableFabricScopedAttribute = <T, V extends T, F extends 
     readAcl = AccessLevel.View,
     writeAcl = AccessLevel.View,
 }: AttributeOptions<V> = {}): OptionalWritableFabricScopedAttribute<T, F> => ({
-    id,
+    id: AttributeId(id),
     schema,
     optional: true,
     writable: true,
@@ -333,7 +334,7 @@ export const ConditionalWritableFabricScopedAttribute = <T, V extends T, F exten
     optionalIf = [],
     mandatoryIf = [],
 }: ConditionalAttributeOptions<V, F> = {}): ConditionalWritableFabricScopedAttribute<T, F> => ({
-    id,
+    id: AttributeId(id),
     schema,
     optional: true,
     writable: true,
@@ -357,7 +358,7 @@ export const FixedAttribute = <T, V extends T, F extends BitSchema>(id: number, 
     default: conformanceValue,
     readAcl = AccessLevel.View,
 }: AttributeOptions<V> = {}): FixedAttribute<T, F> => ({
-    id,
+    id: AttributeId(id),
     schema,
     optional: false,
     writable: false,
@@ -380,7 +381,7 @@ export const WritableFixedAttribute = <T, V extends T, F extends BitSchema>(id: 
     default: conformanceValue,
     readAcl = AccessLevel.View,
 }: AttributeOptions<V> = {}): FixedAttribute<T, F> => ({
-    id,
+    id: AttributeId(id),
     schema,
     optional: false,
     writable: true,
@@ -403,7 +404,7 @@ export const OptionalFixedAttribute = <T, V extends T, F extends BitSchema>(id: 
     default: conformanceValue,
     readAcl = AccessLevel.View,
 }: AttributeOptions<V> = {}): OptionalFixedAttribute<T, F> => ({
-    id,
+    id: AttributeId(id),
     schema,
     optional: true,
     writable: false,
@@ -428,7 +429,7 @@ export const ConditionalFixedAttribute = <T, V extends T, F extends BitSchema>(i
     optionalIf = [],
     mandatoryIf = [],
 }: ConditionalAttributeOptions<V, F>): ConditionalFixedAttribute<T, F> => ({
-    id,
+    id: AttributeId(id),
     schema,
     optional: true,
     writable: false,
@@ -453,9 +454,9 @@ export const TlvNoResponse = TlvVoid;
 
 export interface Command<RequestT, ResponseT, F extends BitSchema> {
     optional: boolean,
-    requestId: number,
+    requestId: CommandId,
     requestSchema: TlvSchema<RequestT>,
-    responseId: number,
+    responseId: CommandId,
     responseSchema: TlvSchema<ResponseT>,
     isConditional: boolean,
     mandatoryIf: ConditionalFeatureList<F>,
@@ -485,9 +486,9 @@ export const Command = <RequestT, ResponseT, F extends BitSchema>(
     responseSchema: TlvSchema<ResponseT>
 ): Command<RequestT, ResponseT, F> => ({
     optional: false,
-    requestId,
+    requestId: CommandId(requestId),
     requestSchema,
-    responseId,
+    responseId: CommandId(responseId),
     responseSchema,
     isConditional: false,
     optionalIf: [],
@@ -501,9 +502,9 @@ export const OptionalCommand = <RequestT, ResponseT, F extends BitSchema>(
     responseSchema: TlvSchema<ResponseT>,
 ): OptionalCommand<RequestT, ResponseT, F> => ({
     optional: true,
-    requestId,
+    requestId: CommandId(requestId),
     requestSchema,
-    responseId,
+    responseId: CommandId(responseId),
     responseSchema,
     isConditional: false,
     optionalIf: [],
@@ -521,9 +522,9 @@ export const ConditionalCommand = <RequestT, ResponseT, F extends BitSchema>(
     }: ConditionalCommandOptions<F>
 ): ConditionalCommand<RequestT, ResponseT, F> => ({
     optional: true,
-    requestId,
+    requestId: CommandId(requestId),
     requestSchema,
-    responseId,
+    responseId: CommandId(responseId),
     responseSchema,
     isConditional: true,
     optionalIf,
@@ -538,7 +539,7 @@ export const enum EventPriority {
 }
 
 export interface Event<T, F extends BitSchema> {
-    id: number,
+    id: EventId,
     schema: TlvSchema<T>,
     priority: EventPriority,
     optional: boolean,
@@ -561,7 +562,7 @@ export interface ConditionalEvent<T, F extends BitSchema> extends OptionalEvent<
 }
 
 export const Event = <T, F extends BitSchema>(id: number, priority: EventPriority, schema: TlvSchema<T>): Event<T, F> => ({
-    id,
+    id: EventId(id),
     schema,
     priority,
     optional: false,
@@ -571,7 +572,7 @@ export const Event = <T, F extends BitSchema>(id: number, priority: EventPriorit
 });
 
 export const OptionalEvent = <T, F extends BitSchema>(id: number, priority: EventPriority, schema: TlvSchema<T>): OptionalEvent<T, F> => ({
-    id,
+    id: EventId(id),
     schema,
     priority,
     optional: true,
@@ -581,7 +582,7 @@ export const OptionalEvent = <T, F extends BitSchema>(id: number, priority: Even
 });
 
 export const ConditionalEvent = <T, F extends BitSchema>(
-    id: number,
+    id: EventId,
     priority: EventPriority,
     schema: TlvSchema<T>,
     {
@@ -589,7 +590,7 @@ export const ConditionalEvent = <T, F extends BitSchema>(
         mandatoryIf = []
     }: ConditionalEventOptions<F>
 ): ConditionalEvent<T, F> => ({
-    id,
+    id: EventId(id),
     schema,
     priority,
     optional: true,
@@ -647,7 +648,7 @@ export const GlobalAttributes = <F extends BitSchema>(features: F) => ({
 } as GlobalAttributes<F>);
 
 export interface Cluster<F extends BitSchema, SF extends TypeFromPartialBitSchema<F>, A extends Attributes, C extends Commands, E extends Events> {
-    id: number,
+    id: ClusterId,
     name: string,
     revision: number,
     features: F,
@@ -676,7 +677,7 @@ export const Cluster = <F extends BitSchema, SF extends TypeFromPartialBitSchema
     commands?: C,
     events?: E,
 }): Cluster<F, SF, Merge<A, GlobalAttributes<F>>, C, E> => ({
-    id,
+    id: ClusterId(id),
     name,
     revision,
     features,

--- a/packages/matter.js/src/cluster/ClusterHelper.ts
+++ b/packages/matter.js/src/cluster/ClusterHelper.ts
@@ -6,8 +6,13 @@
 import { Attribute, Cluster, Event, Command } from "./Cluster.js";
 import * as Clusters from "./definitions/index.js";
 import { NodeId } from "../datatype/NodeId.js";
+import { ClusterId } from "../datatype/ClusterId.js";
 import { TlvAttributePath, TlvCommandPath, TlvEventPath } from "../protocol/interaction/InteractionProtocol.js";
 import { TypeFromSchema } from "../tlv/TlvSchema.js";
+import { EndpointNumber } from "../datatype/EndpointNumber.js";
+import { AttributeId } from "../datatype/AttributeId.js";
+import { EventId } from "../datatype/EventId.js";
+import { CommandId } from "../datatype/CommandId.js";
 
 export const AllClustersMap: { [key: Cluster<any, any, any, any, any>["id"]]: Cluster<any, any, any, any, any> } = {
     [Clusters.AccessControlCluster.id]: Clusters.AccessControlCluster,
@@ -97,17 +102,17 @@ interface CachedCommandInfo {
     command: Command<any, any, any>;
     name: string;
 }
-const clusterAttributeCache = new Map<number, Map<number, CachedAttributeInfo>>();
-const clusterEventCache = new Map<number, Map<number, CachedEventInfo>>();
-const clusterCommandCache = new Map<number, Map<number, CachedCommandInfo>>();
+const clusterAttributeCache = new Map<ClusterId, Map<AttributeId, CachedAttributeInfo>>();
+const clusterEventCache = new Map<ClusterId, Map<EventId, CachedEventInfo>>();
+const clusterCommandCache = new Map<ClusterId, Map<CommandId, CachedCommandInfo>>();
 
-export function getClusterById(clusterId: number): Cluster<any, any, any, any, any> {
+export function getClusterById(clusterId: ClusterId): Cluster<any, any, any, any, any> {
     return AllClustersMap[clusterId];
 }
 
-export function getClusterAttributeById(clusterDef: Cluster<any, any, any, any, any>, attributeId: number): CachedAttributeInfo | undefined {
+export function getClusterAttributeById(clusterDef: Cluster<any, any, any, any, any>, attributeId: AttributeId): CachedAttributeInfo | undefined {
     if (!clusterAttributeCache.has(clusterDef.id)) {
-        const attributeMap = new Map<number, CachedAttributeInfo>();
+        const attributeMap = new Map<AttributeId, CachedAttributeInfo>();
 
         const { attributes } = clusterDef;
 
@@ -127,9 +132,9 @@ export function getClusterAttributeById(clusterDef: Cluster<any, any, any, any, 
     return attributeMap.get(attributeId);
 }
 
-export function getClusterEventById(clusterDef: Cluster<any, any, any, any, any>, eventId: number): CachedEventInfo | undefined {
+export function getClusterEventById(clusterDef: Cluster<any, any, any, any, any>, eventId: EventId): CachedEventInfo | undefined {
     if (!clusterEventCache.has(clusterDef.id)) {
-        const eventMap = new Map<number, CachedEventInfo>();
+        const eventMap = new Map<EventId, CachedEventInfo>();
 
         const { events } = clusterDef;
 
@@ -149,9 +154,9 @@ export function getClusterEventById(clusterDef: Cluster<any, any, any, any, any>
     return eventMap.get(eventId);
 }
 
-export function getClusterCommandById(clusterDef: Cluster<any, any, any, any, any>, commandId: number): CachedCommandInfo | undefined {
+export function getClusterCommandById(clusterDef: Cluster<any, any, any, any, any>, commandId: CommandId): CachedCommandInfo | undefined {
     if (!clusterCommandCache.has(clusterDef.id)) {
-        const commandMap = new Map<number, CachedCommandInfo>();
+        const commandMap = new Map<CommandId, CachedCommandInfo>();
 
         const { commands } = clusterDef;
 
@@ -175,8 +180,8 @@ function toHex(value: number | bigint | undefined) {
     return value === undefined ? "*" : `0x${value.toString(16)}`;
 }
 
-function resolveEndpointClusterName(nodeId: NodeId | undefined, endpointId: number | undefined, clusterId: number | undefined) {
-    let elementName = nodeId === undefined ? "" : `${toHex(nodeId.id)}/`;
+function resolveEndpointClusterName(nodeId: NodeId | undefined, endpointId: EndpointNumber | undefined, clusterId: ClusterId | undefined) {
+    let elementName = nodeId === undefined ? "" : `${toHex(nodeId)}/`;
     if (endpointId === undefined) {
         elementName += "*";
     } else {

--- a/packages/matter.js/src/cluster/client/AttributeClient.ts
+++ b/packages/matter.js/src/cluster/client/AttributeClient.ts
@@ -12,6 +12,8 @@ import { FabricIndex } from "../../datatype/FabricIndex.js";
 import { NoAssociatedFabricError } from "../../session/SecureSession.js";
 import { tryCatch } from "../../common/TryCatchHandler.js";
 import { InternalError } from "../../common/MatterError.js";
+import { EndpointNumber } from "../../datatype/EndpointNumber.js";
+import { ClusterId } from "../../datatype/ClusterId.js";
 
 export class AttributeClient<T> {
     private readonly isWritable: boolean;
@@ -22,8 +24,8 @@ export class AttributeClient<T> {
     constructor(
         readonly attribute: Attribute<T, any>,
         readonly name: string,
-        readonly endpointId: number,
-        readonly clusterId: number,
+        readonly endpointId: EndpointNumber,
+        readonly clusterId: ClusterId,
         private getInteractionClientCallback: () => Promise<InteractionClient>,
     ) {
         const { schema, writable, fabricScoped } = attribute;
@@ -55,7 +57,7 @@ export class AttributeClient<T> {
                 return this.schema.removeField(
                     value,
                     <number>Globals.FabricIndex.id,
-                    (existingFieldIndex) => existingFieldIndex.index === sessionFabric.fabricIndex.index
+                    (existingFieldIndex) => existingFieldIndex.index === sessionFabric.fabricIndex
                 );
             }, NoAssociatedFabricError, value);
         }

--- a/packages/matter.js/src/cluster/client/ClusterClient.ts
+++ b/packages/matter.js/src/cluster/client/ClusterClient.ts
@@ -15,6 +15,7 @@ import { ClusterServerObj } from "../server/ClusterServer.js";
 import { EventClient } from "./EventClient.js";
 import { BitSchema } from "../../schema/BitmapSchema.js";
 import { DecodedEventData } from "../../protocol/interaction/EventDataDecoder.js";
+import { ClusterId } from "../../datatype/ClusterId.js";
 
 export type AttributeClients<F extends BitSchema, A extends Attributes> = Merge<
     Merge<
@@ -77,7 +78,7 @@ export type ClusterClientObjForCluster<C extends Cluster<any, any, any, any, any
 /** Strongly typed interface of a cluster client */
 export type ClusterClientObj<F extends BitSchema, A extends Attributes, C extends Commands, E extends Events> =
     {
-        id: number;
+        id: ClusterId;
         _type: "ClusterClient";
         name: string;
         endpointId: number;

--- a/packages/matter.js/src/cluster/client/EventClient.ts
+++ b/packages/matter.js/src/cluster/client/EventClient.ts
@@ -8,6 +8,8 @@ import { InteractionClient } from "../../protocol/interaction/InteractionClient.
 import { Event } from "../Cluster.js";
 import { InternalError } from "../../common/MatterError.js";
 import { DecodedEventData } from "../../protocol/interaction/EventDataDecoder.js";
+import { EndpointNumber } from "../../datatype/EndpointNumber.js";
+import { ClusterId } from "../../datatype/ClusterId.js";
 
 export class EventClient<T> {
     private readonly listeners = new Array<(event: DecodedEventData<T>) => void>();
@@ -15,8 +17,8 @@ export class EventClient<T> {
     constructor(
         readonly event: Event<T, any>,
         readonly name: string,
-        readonly endpointId: number,
-        readonly clusterId: number,
+        readonly endpointId: EndpointNumber,
+        readonly clusterId: ClusterId,
         private getInteractionClientCallback: () => Promise<InteractionClient>,
     ) { }
 

--- a/packages/matter.js/src/cluster/definitions/ApplicationBasicCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/ApplicationBasicCluster.ts
@@ -102,7 +102,7 @@ export namespace ApplicationBasic {
              *
              * @see {@link MatterApplicationClusterSpecificationV1_1} § 6.3.3.2
              */
-            vendorId: OptionalFixedAttribute(0x1, TlvVendorId, { default: new VendorId(0) }),
+            vendorId: OptionalFixedAttribute(0x1, TlvVendorId, { default: VendorId(0) }),
 
             /**
              * This attribute shall specify a human readable (displayable) name of the Content App assigned by the

--- a/packages/matter.js/src/cluster/definitions/OperationalCredentialsCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/OperationalCredentialsCluster.ts
@@ -614,7 +614,7 @@ export namespace OperationalCredentials {
              *
              * @see {@link MatterCoreSpecificationV1_1} § 11.17.5.6
              */
-            currentFabricIndex: Attribute(0x5, TlvFabricIndex, { default: new FabricIndex(0) })
+            currentFabricIndex: Attribute(0x5, TlvFabricIndex, { default: FabricIndex(0) })
         },
 
         commands: {

--- a/packages/matter.js/src/cluster/definitions/ScenesCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/ScenesCluster.ts
@@ -375,7 +375,7 @@ export namespace Scenes {
              *
              * @see {@link MatterApplicationClusterSpecificationV1_1} § 1.4.7.3
              */
-            currentGroup: Attribute(0x2, TlvGroupId, { default: new GroupId(0) }),
+            currentGroup: Attribute(0x2, TlvGroupId, { default: GroupId(0) }),
 
             /**
              * The SceneValid attribute indicates whether the state of the server corresponds to that associated with

--- a/packages/matter.js/src/cluster/server/AttributeServer.ts
+++ b/packages/matter.js/src/cluster/server/AttributeServer.ts
@@ -16,6 +16,7 @@ import { StatusResponseError } from "../../protocol/interaction/InteractionMesse
 import { StatusCode } from "../../protocol/interaction/InteractionProtocol.js";
 import { ImplementationError, InternalError, MatterError, ValidationError } from "../../common/MatterError.js";
 import { Globals } from "../../model/index.js";
+import { AttributeId } from "../../datatype/AttributeId.js";
 
 /**
  * Thrown when an operation cannot complete because fabric information is
@@ -37,7 +38,7 @@ export abstract class BaseAttributeServer<T> {
     protected endpoint?: Endpoint;
 
     constructor(
-        readonly id: number,
+        readonly id: AttributeId,
         readonly name: string,
         readonly schema: TlvSchema<T>,
         readonly isWritable: boolean,
@@ -79,7 +80,7 @@ export class FixedAttributeServer<T> extends BaseAttributeServer<T> {
     protected readonly getter: (session?: Session<MatterDevice>, endpoint?: Endpoint, isFabricFiltered?: boolean) => T;
 
     constructor(
-        id: number,
+        id: AttributeId,
         name: string,
         schema: TlvSchema<T>,
         isWritable: boolean,
@@ -205,7 +206,7 @@ export class AttributeServer<T> extends FixedAttributeServer<T> {
     protected readonly validator: (value: T, session?: Session<MatterDevice>, endpoint?: Endpoint) => void;
 
     constructor(
-        id: number,
+        id: AttributeId,
         name: string,
         schema: TlvSchema<T>,
         isWritable: boolean,
@@ -402,7 +403,7 @@ export class FabricScopedAttributeServer<T> extends AttributeServer<T>{
     private readonly isCustomSetter: boolean;
 
     constructor(
-        id: number,
+        id: AttributeId,
         name: string,
         schema: TlvSchema<T>,
         isWritable: boolean,

--- a/packages/matter.js/src/cluster/server/ClusterServer.ts
+++ b/packages/matter.js/src/cluster/server/ClusterServer.ts
@@ -25,6 +25,7 @@ import { Fabric } from "../../fabric/Fabric.js";
 import { EventServer } from "./EventServer.js";
 import { EventHandler } from "../../protocol/interaction/EventHandler.js";
 import { BitSchema } from "../../schema/BitmapSchema.js";
+import { ClusterId } from "../../datatype/ClusterId.js";
 
 /** Cluster attributes accessible on the cluster server */
 type MandatoryAttributeServers<A extends Attributes> = Omit<{ [P in MandatoryAttributeNames<A>]: A[P] extends FabricScopedAttribute<any, any> ? FabricScopedAttributeServer<AttributeJsType<A[P]>> : (A[P] extends WritableFabricScopedAttribute<any, any> ? FabricScopedAttributeServer<AttributeJsType<A[P]>> : (A[P] extends FixedAttribute<any, any> ? FixedAttributeServer<AttributeJsType<A[P]>> : AttributeServer<AttributeJsType<A[P]>>)) }, keyof GlobalAttributes<any>>;
@@ -92,7 +93,7 @@ export type ClusterServerObjForCluster<C extends Cluster<any, any, any, any, any
 export type ClusterServerObj<A extends Attributes, C extends Commands, E extends Events> =
     {
         /** Cluster ID */
-        id: number;
+        id: ClusterId;
 
         /** Cluster name */
         name: string;

--- a/packages/matter.js/src/cluster/server/CommandServer.ts
+++ b/packages/matter.js/src/cluster/server/CommandServer.ts
@@ -11,20 +11,21 @@ import { Message } from "../../codec/MessageCodec.js";
 import { Logger } from "../../log/Logger.js";
 import { StatusCode } from "../../protocol/interaction/InteractionProtocol.js";
 import { Endpoint } from "../../device/Endpoint.js";
+import { CommandId } from "../../datatype/CommandId.js";
 
 const logger = Logger.get("CommandServer");
 
 export class CommandServer<RequestT, ResponseT> {
     constructor(
-        readonly invokeId: number,
-        readonly responseId: number,
+        readonly invokeId: CommandId,
+        readonly responseId: CommandId,
         readonly name: string,
         readonly requestSchema: TlvSchema<RequestT>,
         readonly responseSchema: TlvSchema<ResponseT>,
         protected readonly handler: (request: RequestT, session: Session<MatterDevice>, message: Message, endpoint: Endpoint) => Promise<ResponseT> | ResponseT,
     ) { }
 
-    async invoke(session: Session<MatterDevice>, args: TlvStream, message: Message, endpoint: Endpoint): Promise<{ code: StatusCode, responseId: number, response: TlvStream }> {
+    async invoke(session: Session<MatterDevice>, args: TlvStream, message: Message, endpoint: Endpoint): Promise<{ code: StatusCode, responseId: CommandId, response: TlvStream }> {
         const request = this.requestSchema.decodeTlv(args);
         logger.debug(`Invoke ${this.name} with data ${Logger.toJSON(request)}`);
         const response = await this.handler(request, session, message, endpoint);

--- a/packages/matter.js/src/cluster/server/EventServer.ts
+++ b/packages/matter.js/src/cluster/server/EventServer.ts
@@ -10,6 +10,8 @@ import { EventPriority } from "../Cluster.js";
 import { EventData, EventHandler, EventStorageData } from "../../protocol/interaction/EventHandler.js";
 import { Time } from "../../time/Time.js";
 import { InternalError } from "../../common/MatterError.js";
+import { EventId } from "../../datatype/EventId.js";
+import { ClusterId } from "../../datatype/ClusterId.js";
 
 // TODO Add Fabric Scoped EventServer when needed
 
@@ -20,8 +22,8 @@ export class EventServer<T> {
     protected eventHandler?: EventHandler;
 
     constructor(
-        readonly id: number,
-        readonly clusterId: number,
+        readonly id: EventId,
+        readonly clusterId: ClusterId,
         readonly name: string,
         readonly schema: TlvSchema<T>,
         readonly priority: EventPriority,

--- a/packages/matter.js/src/cluster/server/GeneralCommissioningServer.ts
+++ b/packages/matter.js/src/cluster/server/GeneralCommissioningServer.ts
@@ -98,7 +98,7 @@ export const GeneralCommissioningClusterHandler: (options?: {
         const fabric = session.getFabric();
         if (fabric === undefined) throw new MatterFlowError("commissioningComplete is called but the fabric has not been defined yet");
         breadcrumb.setLocal(BigInt(0));
-        logger.info(`Commissioning completed on fabric #${fabric.fabricId.id} as node #${fabric.nodeId}.`);
+        logger.info(`Commissioning completed on fabric #${fabric.fabricId} as node #${fabric.nodeId}.`);
 
         session.getContext().completeCommission();
 

--- a/packages/matter.js/src/cluster/server/OperationalCredentialsServer.ts
+++ b/packages/matter.js/src/cluster/server/OperationalCredentialsServer.ts
@@ -164,7 +164,7 @@ export const OperationalCredentialsClusterHandler: (conf: OperationalCredentials
         const fabric = device.getFabricByIndex(fabricIndex);
 
         if (fabric === undefined) {
-            return { statusCode: OperationalCredentials.NodeOperationalCertStatus.InvalidFabricIndex, debugText: `Fabric ${fabricIndex.index} not found` };
+            return { statusCode: OperationalCredentials.NodeOperationalCertStatus.InvalidFabricIndex, debugText: `Fabric ${fabricIndex} not found` };
         }
 
         fabric.remove();

--- a/packages/matter.js/src/codec/BtpCodec.ts
+++ b/packages/matter.js/src/codec/BtpCodec.ts
@@ -269,7 +269,7 @@ export class BtpCodec {
         writer.writeUInt16(0xFFF6);
         writer.writeUInt8(0x00);
         writer.writeUInt16(discriminator);
-        writer.writeUInt16(vendorId.id);
+        writer.writeUInt16(vendorId);
         writer.writeUInt16(productId);
         writer.writeUInt8(hasAdditionalAdvertisementData ? 0x01 : 0x00);
         return writer.toByteArray();
@@ -297,6 +297,6 @@ export class BtpCodec {
         const vendorId = reader.readUInt16();
         const productId = reader.readUInt16();
         const hasAdditionalAdvertisementData = !!reader.readUInt8();
-        return { discriminator, vendorId: new VendorId(vendorId), productId, hasAdditionalAdvertisementData };
+        return { discriminator, vendorId, productId, hasAdditionalAdvertisementData };
     }
 }

--- a/packages/matter.js/src/codec/MessageCodec.ts
+++ b/packages/matter.js/src/codec/MessageCodec.ts
@@ -10,6 +10,7 @@ import { DataReader } from "../util/DataReader.js";
 import { DataWriter } from "../util/DataWriter.js";
 import { DiagnosticDictionary } from "../log/Logger.js";
 import { NotImplementedError, UnexpectedDataError } from "../common/MatterError.js";
+import { GroupId } from "../datatype/GroupId.js";
 
 export interface PacketHeader {
     sessionId: number,
@@ -126,9 +127,9 @@ export class MessageCodec {
         const sessionId = reader.readUInt16();
         const securityFlags = reader.readUInt8();
         const messageId = reader.readUInt32();
-        const sourceNodeId = hasSourceNodeId ? new NodeId(reader.readUInt64()) : undefined;
-        const destNodeId = hasDestNodeId ? new NodeId(reader.readUInt64()) : undefined;
-        const destGroupId = hasDestGroupId ? reader.readUInt16() : undefined;
+        const sourceNodeId = hasSourceNodeId ? NodeId(reader.readUInt64()) : undefined;
+        const destNodeId = hasDestNodeId ? NodeId(reader.readUInt64()) : undefined;
+        const destGroupId = hasDestGroupId ? GroupId(reader.readUInt16()) : undefined;
 
         const sessionType = securityFlags & 0b00000011;
         if (sessionType !== SessionType.Group && sessionType !== SessionType.Unicast) throw new UnexpectedDataError(`Unsupported session type ${sessionType}`);
@@ -172,8 +173,8 @@ export class MessageCodec {
         writer.writeUInt16(sessionId);
         writer.writeUInt8(securityFlags);
         writer.writeUInt32(messageCounter);
-        if (sourceNodeId !== undefined) writer.writeUInt64(sourceNodeId.id);
-        if (destNodeId !== undefined) writer.writeUInt64(destNodeId.id);
+        if (sourceNodeId !== undefined) writer.writeUInt64(sourceNodeId);
+        if (destNodeId !== undefined) writer.writeUInt64(destNodeId);
         if (destGroupId !== undefined) writer.writeUInt32(destGroupId);
         return writer.toByteArray();
     }

--- a/packages/matter.js/src/common/InstanceBroadcaster.ts
+++ b/packages/matter.js/src/common/InstanceBroadcaster.ts
@@ -193,13 +193,13 @@ export type OperationalInstanceData = {
 export interface InstanceBroadcaster {
 
     /** Set a commissionable mode and details to announce a commissionable device. */
-    setCommissionMode(mode: number, deviceData: CommissioningModeInstanceData): void;
+    setCommissionMode(mode: number, deviceData: CommissioningModeInstanceData): Promise<void>;
 
     /** Set operational details to Announce an operational device which is already commissioned. */
-    setFabrics(fabrics: Fabric[]): void;
+    setFabrics(fabrics: Fabric[]): Promise<void>;
 
     /** Set commissioner details to announce a commissioner service for User directed commissioning (UDC). */
-    setCommissionerInfo(commissionerData: CommissionerInstanceData): void;
+    setCommissionerInfo(commissionerData: CommissionerInstanceData): Promise<void>;
 
     /** Send out announcements for this instance. */
     announce(): Promise<void>;

--- a/packages/matter.js/src/datatype/AttributeId.ts
+++ b/packages/matter.js/src/datatype/AttributeId.ts
@@ -5,23 +5,24 @@
  */
 
 import { TlvUInt32 } from "../tlv/TlvNumber.js";
-import { TlvWrapper } from "../tlv/TlvWrapper.js";
 import { MatterCoreSpecificationV1_0 } from "../spec/Specifications.js";
+import { Branded } from "../util/Type.js";
+import { TlvWrapper } from "../tlv/TlvWrapper.js";
 
 /**
  * An Attribute ID is a 32 bit number and indicates an attribute defined in a cluster specification.
  *
  * @see {@link MatterCoreSpecificationV1_0} § 7.18.2.15
  */
-export class AttributeId {
-    constructor(
-        readonly id: number
-    ) { }
+export type AttributeId = Branded<number, "AttributeId">;
+
+export function AttributeId(id: number): AttributeId {
+    return id as AttributeId;
 }
 
 /** Tlv schema for an Attribute Id. */
 export const TlvAttributeId = new TlvWrapper<AttributeId, number>(
     TlvUInt32,
-    attributeId => attributeId.id,
-    value => new AttributeId(value),
+    attributeId => attributeId,
+    value => AttributeId(value),
 );

--- a/packages/matter.js/src/datatype/ClusterId.ts
+++ b/packages/matter.js/src/datatype/ClusterId.ts
@@ -5,8 +5,9 @@
  */
 
 import { TlvUInt32 } from "../tlv/TlvNumber.js";
-import { TlvWrapper } from "../tlv/TlvWrapper.js";
 import { MatterCoreSpecificationV1_0 } from "../spec/Specifications.js";
+import { Branded } from "../util/Type.js";
+import { TlvWrapper } from "../tlv/TlvWrapper.js";
 
 /**
  * A Cluster Identifier is a 32 bit number and SHALL reference a single cluster specification and
@@ -14,15 +15,15 @@ import { MatterCoreSpecificationV1_0 } from "../spec/Specifications.js";
  *
  * @see {@link MatterCoreSpecificationV1_0} § 7.10
  */
-export class ClusterId {
-    constructor(
-        readonly id: number
-    ) { }
+export type ClusterId = Branded<number, "ClusterId">;
+
+export function ClusterId(v: number): ClusterId {
+    return v as ClusterId;
 }
 
 /** Tlv schema for a cluster Id. */
 export const TlvClusterId = new TlvWrapper<ClusterId, number>(
     TlvUInt32,
-    clusterId => clusterId.id,
-    value => new ClusterId(value),
+    clusterId => clusterId,
+    value => ClusterId(value),
 );

--- a/packages/matter.js/src/datatype/CommandId.ts
+++ b/packages/matter.js/src/datatype/CommandId.ts
@@ -5,23 +5,24 @@
  */
 
 import { TlvUInt32 } from "../tlv/TlvNumber.js";
-import { TlvWrapper } from "../tlv/TlvWrapper.js";
 import { MatterCoreSpecificationV1_0 } from "../spec/Specifications.js";
+import { Branded } from "../util/Type.js";
+import { TlvWrapper } from "../tlv/TlvWrapper.js";
 
 /**
  * A Command ID is a 32 bit number and indicates a command defined in a cluster specification.
  *
  * @see {@link MatterCoreSpecificationV1_0} § 7.18.2.18
  */
-export class CommandId {
-    constructor(
-        readonly id: number
-    ) { }
+export type CommandId = Branded<number, "CommandId">;
+
+export function CommandId(v: number): CommandId {
+    return v as CommandId;
 }
 
 /** Tlv schema for an Command Id. */
 export const TlvCommandId = new TlvWrapper<CommandId, number>(
     TlvUInt32,
-    commandId => commandId.id,
-    value => new CommandId(value),
+    commandId => commandId,
+    value => CommandId(value),
 );

--- a/packages/matter.js/src/datatype/DeviceTypeId.ts
+++ b/packages/matter.js/src/datatype/DeviceTypeId.ts
@@ -5,23 +5,24 @@
  */
 
 import { TlvUInt32 } from "../tlv/TlvNumber.js";
-import { TlvWrapper } from "../tlv/TlvWrapper.js";
 import { MatterCoreSpecificationV1_0 } from "../spec/Specifications.js";
+import { Branded } from "../util/Type.js";
+import { TlvWrapper } from "../tlv/TlvWrapper.js";
 
 /**
  * A Device type ID is a 32-bit number that defines the type of the device.
  *
  * @see {@link MatterCoreSpecificationV1_0} § 7.15
  */
-export class DeviceTypeId {
-    constructor(
-        readonly id: number
-    ) { }
+export type DeviceTypeId = Branded<number, "DeviceTypeId">;
+
+export function DeviceTypeId(v: number): DeviceTypeId {
+    return v as DeviceTypeId;
 }
 
 /** Tlv schema for a Device type ID. */
 export const TlvDeviceTypeId = new TlvWrapper<DeviceTypeId, number>(
     TlvUInt32,
-    deviceTypeId => deviceTypeId.id,
-    value => new DeviceTypeId(value),
+    deviceTypeId => deviceTypeId,
+    value => DeviceTypeId(value),
 );

--- a/packages/matter.js/src/datatype/EndpointNumber.ts
+++ b/packages/matter.js/src/datatype/EndpointNumber.ts
@@ -5,23 +5,24 @@
  */
 
 import { TlvUInt16 } from "../tlv/TlvNumber.js";
-import { TlvWrapper } from "../tlv/TlvWrapper.js";
 import { MatterCoreSpecificationV1_0 } from "../spec/Specifications.js";
+import { Branded } from "../util/Type.js";
+import { TlvWrapper } from "../tlv/TlvWrapper.js";
 
 /**
  * A Endpoint Number is a 16-bit number that that indicates an instance of a device type.
  *
  * @see {@link MatterCoreSpecificationV1_0} § 7.18.2.11
  */
-export class EndpointNumber {
-    constructor(
-        readonly number: number
-    ) { }
+export type EndpointNumber = Branded<number, "EndpointNumber">;
+
+export function EndpointNumber(n: number): EndpointNumber {
+    return n as EndpointNumber;
 }
 
 /** Tlv schema for an Endpoint number. */
 export const TlvEndpointNumber = new TlvWrapper<EndpointNumber, number>(
     TlvUInt16,
-    endpointNumber => endpointNumber.number,
-    value => new EndpointNumber(value),
+    endpointNumber => endpointNumber,
+    value => EndpointNumber(value),
 );

--- a/packages/matter.js/src/datatype/EventId.ts
+++ b/packages/matter.js/src/datatype/EventId.ts
@@ -5,23 +5,24 @@
  */
 
 import { TlvUInt32 } from "../tlv/TlvNumber.js";
-import { TlvWrapper } from "../tlv/TlvWrapper.js";
 import { MatterCoreSpecificationV1_0 } from "../spec/Specifications.js";
+import { Branded } from "../util/Type.js";
+import { TlvWrapper } from "../tlv/TlvWrapper.js";
 
 /**
  * An EVent ID is a 32 bit number and indicates an event defined in a cluster specification.
  *
  * @see {@link MatterCoreSpecificationV1_0} § 7.18.2.17
  */
-export class EventId {
-    constructor(
-        readonly id: number
-    ) { }
+export type EventId = Branded<number, "EventId">;
+
+export function EventId(v: number): EventId {
+    return v as EventId;
 }
 
 /** Tlv schema for an Event Id. */
 export const TlvEventId = new TlvWrapper<EventId, number>(
     TlvUInt32,
-    eventId => eventId.id,
-    value => new EventId(value),
+    eventId => eventId,
+    value => EventId(value),
 );

--- a/packages/matter.js/src/datatype/FabricId.ts
+++ b/packages/matter.js/src/datatype/FabricId.ts
@@ -5,8 +5,10 @@
  */
 
 import { TlvUInt64 } from "../tlv/TlvNumber.js";
-import { TlvWrapper } from "../tlv/TlvWrapper.js";
 import { MatterCoreSpecificationV1_0 } from "../spec/Specifications.js";
+import { TlvWrapper } from "../tlv/TlvWrapper.js";
+import { Branded } from "../util/Type.js";
+import { toBigInt } from "../util/Number.js";
 
 /**
  * A Fabric ID is a 64-bit number that uniquely identifies the Fabric within the scope of
@@ -14,15 +16,15 @@ import { MatterCoreSpecificationV1_0 } from "../spec/Specifications.js";
  *
  * @see {@link MatterCoreSpecificationV1_0} § 2.5.1
  */
-export class FabricId {
-    constructor(
-        readonly id: bigint,
-    ) { }
+export type FabricId = Branded<bigint, "FabricId">;
+
+export function FabricId(value: bigint | number): FabricId {
+    return toBigInt(value) as FabricId;
 }
 
 /** Tlv schema for a Node Identifier. */
 export const TlvFabricId = new TlvWrapper<FabricId, number | bigint>(
     TlvUInt64,
-    fabricId => fabricId.id,
-    value => new FabricId(BigInt(value)),
+    fabricId => fabricId,
+    value => FabricId(value)
 );

--- a/packages/matter.js/src/datatype/FabricIndex.ts
+++ b/packages/matter.js/src/datatype/FabricIndex.ts
@@ -7,6 +7,7 @@
 import { TlvUInt8 } from "../tlv/TlvNumber.js";
 import { TlvWrapper } from "../tlv/TlvWrapper.js";
 import { MatterCoreSpecificationV1_0 } from "../spec/Specifications.js";
+import { Branded } from "../util/Type.js";
 
 /**
  * Each fabric supported on a node is referenced by fabric-index that is unique on the node. This
@@ -18,19 +19,21 @@ import { MatterCoreSpecificationV1_0 } from "../spec/Specifications.js";
  *
  * @see {@link MatterCoreSpecificationV1_0} § 7.5.2
  */
-export class FabricIndex {
-    static NO_FABRIC = new FabricIndex(0);
-    static OMIT_FABRIC = new FabricIndex(-1);
+export type FabricIndex = Branded<number, "FabricIndex">;
 
-    constructor(
-        readonly index: number,
-    ) { }
+export function FabricIndex(value: number): FabricIndex {
+    return value as FabricIndex;
+}
+
+export namespace FabricIndex {
+    export const NO_FABRIC = 0 as FabricIndex;
+    export const OMIT_FABRIC = -1 as FabricIndex;
 }
 
 /** Tlv Schema for a Fabric Index. */
 export const TlvFabricIndex = new TlvWrapper<FabricIndex, number | undefined>(
     TlvUInt8.bound({ min: 0, max: 254 }),
-    fabricIndex => fabricIndex.index === -1 ? undefined : fabricIndex.index,
+    fabricIndex => fabricIndex === -1 ? undefined : fabricIndex,
     value => {
         switch (value) {
             case undefined:
@@ -38,7 +41,7 @@ export const TlvFabricIndex = new TlvWrapper<FabricIndex, number | undefined>(
             case 0:
                 return FabricIndex.NO_FABRIC;
             default:
-                return new FabricIndex(value);
+                return value as FabricIndex;
         }
-    },
+    }
 );

--- a/packages/matter.js/src/datatype/GroupId.ts
+++ b/packages/matter.js/src/datatype/GroupId.ts
@@ -5,8 +5,9 @@
  */
 
 import { TlvUInt16 } from "../tlv/TlvNumber.js";
-import { TlvWrapper } from "../tlv/TlvWrapper.js";
 import { MatterCoreSpecificationV1_0 } from "../spec/Specifications.js";
+import { Branded } from "../util/Type.js";
+import { TlvWrapper } from "../tlv/TlvWrapper.js";
 
 /**
  * A Group Identifier (Group ID or GID) is a 16-bit number that identifies a set of Nodes across a
@@ -20,15 +21,15 @@ import { MatterCoreSpecificationV1_0 } from "../spec/Specifications.js";
  *
  * @see {@link MatterCoreSpecificationV1_0} § 2.5.4
  */
-export class GroupId {
-    constructor(
-        readonly id: number,
-    ) { }
+export type GroupId = Branded<number, "GroupId">;
+
+export function GroupId(v: number): GroupId {
+    return v as GroupId;
 }
 
 /** Tlv Schema for a Group Id. */
 export const TlvGroupId = new TlvWrapper<GroupId, number>(
     TlvUInt16,
-    groupId => groupId.id,
-    value => new GroupId(value),
+    groupId => groupId,
+    value => GroupId(value),
 );

--- a/packages/matter.js/src/datatype/NodeId.ts
+++ b/packages/matter.js/src/datatype/NodeId.ts
@@ -5,15 +5,14 @@
  */
 
 import { TlvUInt64 } from "../tlv/TlvNumber.js";
-import { TlvWrapper } from "../tlv/TlvWrapper.js";
 import { Crypto } from "../crypto/Crypto.js";
 import { DataWriter } from "../util/DataWriter.js";
 import { Endian } from "../util/ByteArray.js";
 import { UnexpectedDataError } from "../common/MatterError.js";
 import { MatterCoreSpecificationV1_0 } from "../spec/Specifications.js";
-
-const OPERATIONAL_NODE_MIN = BigInt('0x0000000000000001');
-const OPERATIONAL_NODE_MAX = BigInt('0xFFFFFFEFFFFFFFFF');
+import { TlvWrapper } from "../tlv/TlvWrapper.js";
+import { Branded } from "../util/Type.js";
+import { toBigInt } from "../util/Number.js";
 
 /**
  * A Node Identifier (Node ID) is a 64-bit number that uniquely identifies an individual Node or a
@@ -21,37 +20,42 @@ const OPERATIONAL_NODE_MAX = BigInt('0xFFFFFFEFFFFFFFFF');
  *
  * @see {@link MatterCoreSpecificationV1_0} § 2.5.5
  */
-export class NodeId {
-    constructor(
-        readonly id: bigint,
-    ) { }
+export type NodeId = Branded<bigint, "NodeId">;
 
-    toString() {
+export function NodeId(v: bigint | number): NodeId {
+    return toBigInt(v) as NodeId;
+}
+
+export namespace NodeId {
+    const OPERATIONAL_NODE_MIN = BigInt('0x0000000000000001');
+    const OPERATIONAL_NODE_MAX = BigInt('0xFFFFFFEFFFFFFFFF');
+
+    export const toHexString = (nodeId: NodeId) => {
         const writer = new DataWriter(Endian.Big);
-        writer.writeUInt64(this.id);
+        writer.writeUInt64(nodeId);
         return writer.toByteArray().toHex().toUpperCase();
     }
 
-    static getRandomOperationalNodeId() {
+    export const getRandomOperationalNodeId = () => {
         while (true) {
             const randomBigInt = BigInt('0x' + Crypto.getRandomData(8).toHex());
             if (randomBigInt >= OPERATIONAL_NODE_MIN && randomBigInt <= OPERATIONAL_NODE_MAX) {
-                return new NodeId(randomBigInt);
+                return NodeId(randomBigInt);
             }
         }
     }
 
-    static getGroupNodeId(groupId: number) {
+    export const getGroupNodeId = (groupId: number) => {
         if (groupId < 0 || groupId > 0xFFFF) {
             throw new UnexpectedDataError(`Invalid group ID: ${groupId}`);
         }
-        return new NodeId(BigInt('0xFFFFFFFFFFFF' + groupId.toString(16).padStart(4, "0")));
+        return NodeId(BigInt('0xFFFFFFFFFFFF' + groupId.toString(16).padStart(4, "0")));
     }
 }
 
 /** Tlv schema for a Node Identifier. */
 export const TlvNodeId = new TlvWrapper<NodeId, number | bigint>(
     TlvUInt64,
-    nodeId => nodeId.id,
-    value => new NodeId(BigInt(value)),
+    nodeId => nodeId,
+    value => NodeId(BigInt(value))
 );

--- a/packages/matter.js/src/datatype/VendorId.ts
+++ b/packages/matter.js/src/datatype/VendorId.ts
@@ -5,8 +5,9 @@
  */
 
 import { TlvUInt16 } from "../tlv/TlvNumber.js";
-import { TlvWrapper } from "../tlv/TlvWrapper.js";
 import { MatterCoreSpecificationV1_0 } from "../spec/Specifications.js";
+import { Branded } from "../util/Type.js";
+import { TlvWrapper } from "../tlv/TlvWrapper.js";
 
 /**
  * A Vendor Identifier (Vendor ID or VID) is a 16-bit number that uniquely identifies a particular
@@ -15,15 +16,15 @@ import { MatterCoreSpecificationV1_0 } from "../spec/Specifications.js";
  *
  * @see {@link MatterCoreSpecificationV1_0} § 2.5.2
  */
-export class VendorId {
-    constructor(
-        readonly id: number,
-    ) { }
+export type VendorId = Branded<number, "VendorId">;
+
+export function VendorId(v: number): VendorId {
+    return v as VendorId;
 }
 
 /** Data model for a Vendor Identifier. */
 export const TlvVendorId = new TlvWrapper<VendorId, number>(
     TlvUInt16,
-    vendorId => vendorId.id,
-    value => new VendorId(value),
+    vendorId => vendorId,
+    value => VendorId(value),
 );

--- a/packages/matter.js/src/device/Device.ts
+++ b/packages/matter.js/src/device/Device.ts
@@ -15,6 +15,8 @@ import { BitSchema, TypeFromPartialBitSchema } from "../schema/BitmapSchema.js";
 import { BindingCluster } from "../cluster/definitions/BindingCluster.js";
 import { ClusterServer } from "../protocol/interaction/InteractionServer.js";
 import { ImplementationError, NotImplementedError } from "../common/MatterError.js";
+import { EndpointNumber } from "../datatype/EndpointNumber.js";
+import { DeviceTypeId } from "../datatype/DeviceTypeId.js";
 
 /**
  * Temporary used device class for paired devices until we added a layer to choose the right specialized device class
@@ -32,7 +34,7 @@ export class PairedDevice extends Endpoint {
     constructor(
         definition: AtLeastOne<DeviceTypeDefinition>,
         clusters: (ClusterServerObj<Attributes, Commands, Events> | ClusterClientObj<any, Attributes, Commands, Events>)[] = [],
-        endpointId: number
+        endpointId: EndpointNumber
     ) {
         super(definition, { endpointId });
         clusters.forEach(cluster => {
@@ -71,14 +73,14 @@ export class PairedDevice extends Endpoint {
  * Root endpoint of a device. This is used internally and not needed to be instanced by the user.
  */
 export class RootEndpoint extends Endpoint {
-    readonly deviceType: number;
+    readonly deviceType: DeviceTypeId;
 
     /**
      * Create a new RootEndpoint instance. This is automatically instanced by the CommissioningServer class.
      */
     constructor(
     ) {
-        super([DeviceTypes.ROOT], { endpointId: 0 });
+        super([DeviceTypes.ROOT], { endpointId: EndpointNumber(0) });
         this.deviceType = DeviceTypes.ROOT.code;
     }
 }

--- a/packages/matter.js/src/device/DeviceTypes.ts
+++ b/packages/matter.js/src/device/DeviceTypes.ts
@@ -6,6 +6,8 @@
 
 import * as MatterClusters from "../cluster/definitions/index.js";
 import { MatterDeviceLibrarySpecificationV1_0 } from "../spec/Specifications.js";
+import { DeviceTypeId } from "../datatype/DeviceTypeId.js";
+import { ClusterId } from "../datatype/ClusterId.js";
 
 /**
  * This represents a Root Node for devices.
@@ -62,14 +64,14 @@ export enum DeviceClasses {
 
 export interface DeviceTypeDefinition {
     name: string;
-    code: number;
+    code: DeviceTypeId;
     deviceClass: DeviceClasses;
     superSet?: string;
     revision: number;
-    requiredServerClusters: number[];
-    optionalServerClusters: number[];
-    requiredClientClusters: number[];
-    optionalClientClusters: number[];
+    requiredServerClusters: ClusterId[];
+    optionalServerClusters: ClusterId[];
+    requiredClientClusters: ClusterId[];
+    optionalClientClusters: ClusterId[];
 }
 
 export const DeviceTypeDefinition = ({
@@ -88,13 +90,13 @@ export const DeviceTypeDefinition = ({
     deviceClass: DeviceClasses;
     superSet?: string;
     revision: number;
-    requiredServerClusters?: number[];
-    optionalServerClusters?: number[];
-    requiredClientClusters?: number[];
-    optionalClientClusters?: number[];
+    requiredServerClusters?: ClusterId[];
+    optionalServerClusters?: ClusterId[];
+    requiredClientClusters?: ClusterId[];
+    optionalClientClusters?: ClusterId[];
 }): DeviceTypeDefinition => ({
     name,
-    code,
+    code: DeviceTypeId(code),
     deviceClass,
     superSet,
     revision,

--- a/packages/matter.js/src/fabric/FabricManager.ts
+++ b/packages/matter.js/src/fabric/FabricManager.ts
@@ -38,7 +38,7 @@ export class FabricManager {
     }
 
     removeFabric(fabricIndex: FabricIndex) {
-        const index = this.fabrics.findIndex(fabric => fabric.fabricIndex.index === fabricIndex.index);
+        const index = this.fabrics.findIndex(fabric => fabric.fabricIndex === fabricIndex);
         if (index === -1) throw new FabricNotFoundError(`Fabric with index ${fabricIndex} cannot be removed because it does not exist.`);
         this.fabrics.splice(index, 1);
         this.persistFabrics();
@@ -59,7 +59,7 @@ export class FabricManager {
     }
 
     armFailSafe() {
-        this.fabricBuilder = new FabricBuilder(new FabricIndex(this.nextFabricIndex++));
+        this.fabricBuilder = new FabricBuilder(FabricIndex(this.nextFabricIndex++));
     }
 
     getFabricBuilder() {

--- a/packages/matter.js/src/mdns/MdnsBroadcaster.ts
+++ b/packages/matter.js/src/mdns/MdnsBroadcaster.ts
@@ -22,6 +22,7 @@ import {
 } from "../common/InstanceBroadcaster.js";
 import { TypeFromPartialBitSchema } from "../schema/BitmapSchema.js";
 import { ImplementationError } from "../common/MatterError.js";
+import { NodeId } from "../datatype/NodeId.js";
 
 const logger = Logger.get("MdnsBroadcaster");
 
@@ -72,7 +73,7 @@ export class MdnsBroadcaster {
             pairingInstructions = ""
         }: CommissioningModeInstanceData
     ) {
-        logger.debug(`announce commissioning mode ${mode} ${deviceName} ${deviceType} ${vendorId.id} ${productId} ${discriminator}`);
+        logger.debug(`announce commissioning mode ${mode} ${deviceName} ${deviceType} ${vendorId} ${productId} ${discriminator}`);
 
         const shortDiscriminator = (discriminator >> 8) & 0x0F;
         const instanceId = Crypto.getRandomData(8).toHex().toUpperCase();
@@ -113,7 +114,7 @@ export class MdnsBroadcaster {
                 PtrRecord(commissionModeQname, deviceQname),
                 SrvRecord(deviceQname, { priority: 0, weight: 0, port: announcedNetPort, target: hostname }),
                 TxtRecord(deviceQname, [
-                    `VP=${vendorId.id}+${productId}`,                    /* Vendor / Product */
+                    `VP=${vendorId}+${productId}`,                    /* Vendor / Product */
                     `DT=${deviceType}`,                                  /* Device Type */
                     `DN=${deviceName}`,                                  /* Device Name */
                     `SII=${sleepIdleInterval}`,                          /* Sleepy Idle Interval */
@@ -157,10 +158,10 @@ export class MdnsBroadcaster {
                 const { operationalId, nodeId } = fabric;
                 const operationalIdString = operationalId.toHex().toUpperCase();
                 const fabricQname = getFabricQname(operationalIdString);
-                const deviceMatterQname = getDeviceMatterQname(operationalIdString, nodeId.toString());
+                const deviceMatterQname = getDeviceMatterQname(operationalIdString, NodeId.toHexString(nodeId));
 
                 logger.debug("Announcement: Fabric", Logger.dict({
-                    id: `${operationalId.toHex()}/${nodeId.id}`,
+                    id: `${operationalId.toHex()}/${nodeId}`,
                     qname: deviceMatterQname,
                     port: announcedNetPort,
                     interface: netInterface
@@ -204,7 +205,7 @@ export class MdnsBroadcaster {
 
         const instanceId = Crypto.getRandomData(8).toHex().toUpperCase();
         const deviceTypeQname = `_T${deviceType}._sub.${MATTER_COMMISSIONER_SERVICE_QNAME}`;
-        const vendorQname = `_V${vendorId.id}._sub.${MATTER_COMMISSIONER_SERVICE_QNAME}`;
+        const vendorQname = `_V${vendorId}._sub.${MATTER_COMMISSIONER_SERVICE_QNAME}`;
         const deviceQname = `${instanceId}.${MATTER_COMMISSIONER_SERVICE_QNAME}`;
 
         this.mdnsServer.setRecordsGenerator(announcedNetPort, netInterface => {
@@ -218,7 +219,7 @@ export class MdnsBroadcaster {
                 PtrRecord(vendorQname, deviceQname),
                 SrvRecord(deviceQname, { priority: 0, weight: 0, port: announcedNetPort, target: hostname }),
                 TxtRecord(deviceQname, [
-                    `VP=${vendorId.id}+${productId}`, /* Vendor / Product */
+                    `VP=${vendorId}+${productId}`, /* Vendor / Product */
                     `DT=${deviceType}`,               /* Device Type */
                     `DN=${deviceName}`,               /* Device Name */
                     `SII=${sleepIdleInterval}`,       /* Sleepy Idle Interval */

--- a/packages/matter.js/src/mdns/MdnsConsts.ts
+++ b/packages/matter.js/src/mdns/MdnsConsts.ts
@@ -13,7 +13,7 @@ export const MATTER_SERVICE_QNAME = "_matter._tcp.local";
 
 export const getFabricQname = (operationalIdString: string) => `_I${operationalIdString}._sub.${MATTER_SERVICE_QNAME}`;
 export const getDeviceMatterQname = (operationalIdString: string, nodeIdString: string) => `${operationalIdString}-${nodeIdString}.${MATTER_SERVICE_QNAME}`;
-export const getVendorQname = (vendorId: VendorId) => `_V${vendorId.id}._sub.${MATTER_COMMISSION_SERVICE_QNAME}`;
+export const getVendorQname = (vendorId: VendorId) => `_V${vendorId}._sub.${MATTER_COMMISSION_SERVICE_QNAME}`;
 export const getDeviceTypeQname = (deviceType: number) => `_T${deviceType}._sub.${MATTER_COMMISSION_SERVICE_QNAME}`;
 export const getShortDiscriminatorQname = (shortDiscriminator: number) => `_S${shortDiscriminator}._sub.${MATTER_COMMISSION_SERVICE_QNAME}`;
 export const getLongDiscriminatorQname = (longDiscriminator: number) => `_L${longDiscriminator}._sub.${MATTER_COMMISSION_SERVICE_QNAME}`;

--- a/packages/matter.js/src/mdns/MdnsInstanceBroadcaster.ts
+++ b/packages/matter.js/src/mdns/MdnsInstanceBroadcaster.ts
@@ -17,17 +17,17 @@ export class MdnsInstanceBroadcaster implements InstanceBroadcaster {
         private readonly mdnsBroadcaster: MdnsBroadcaster,
     ) { }
 
-    setCommissionMode(mode: number, deviceData: CommissioningModeInstanceData) {
+    async setCommissionMode(mode: number, deviceData: CommissioningModeInstanceData) {
         this.mdnsBroadcaster.setCommissionMode(this.instancePort, mode, deviceData);
     }
 
     /** Set the Broadcaster Data to announce a device for operative discovery (aka "already paired") */
-    setFabrics(fabrics: Fabric[]) {
+    async setFabrics(fabrics: Fabric[]) {
         this.mdnsBroadcaster.setFabrics(this.instancePort, fabrics);
     }
 
     /** Set the Broadcaster data to announce a Commissioner (aka Commissioner discovery) */
-    setCommissionerInfo(commissionerData: CommissionerInstanceData) {
+    async setCommissionerInfo(commissionerData: CommissionerInstanceData) {
         this.mdnsBroadcaster.setCommissionerInfo(this.instancePort, commissionerData);
     }
 

--- a/packages/matter.js/src/mdns/MdnsScanner.ts
+++ b/packages/matter.js/src/mdns/MdnsScanner.ts
@@ -20,9 +20,9 @@ import { Fabric } from "../fabric/Fabric.js";
 import { NodeId } from "../datatype/NodeId.js";
 import { isIPv6 } from "../util/Ip.js";
 import { Logger } from "../log/Logger.js";
-import { VendorId } from "../datatype/VendorId.js";
 import { ServerAddress, ServerAddressIp } from "../common/ServerAddress.js";
 import { ImplementationError } from "../common/MatterError.js";
+import { VendorId } from "../datatype/VendorId.js";
 
 const logger = Logger.get("MdnsScanner");
 
@@ -257,7 +257,7 @@ export class MdnsScanner implements Scanner {
 
     private createOperationalMatterQName(operationalId: ByteArray, nodeId: NodeId) {
         const operationalIdString = operationalId.toHex().toUpperCase();
-        return getDeviceMatterQname(operationalIdString, nodeId.toString());
+        return getDeviceMatterQname(operationalIdString, NodeId.toHexString(nodeId));
     }
 
     /**
@@ -306,7 +306,7 @@ export class MdnsScanner implements Scanner {
             foundRecords.push(...storedRecords.filter(({ SD }) => SD === identifier.shortDiscriminator));
         }
         else if ("vendorId" in identifier) {
-            foundRecords.push(...storedRecords.filter(({ V }) => V === identifier.vendorId.id));
+            foundRecords.push(...storedRecords.filter(({ V }) => V === identifier.vendorId));
         }
         else if ("deviceType" in identifier) {
             foundRecords.push(...storedRecords.filter(({ DT }) => DT === identifier.deviceType));
@@ -384,7 +384,7 @@ export class MdnsScanner implements Scanner {
         }
 
         if (record.V !== undefined) {
-            const vendorIdQueryId = this.buildCommissionableQueryIdentifier({ vendorId: new VendorId(record.V) });
+            const vendorIdQueryId = this.buildCommissionableQueryIdentifier({ vendorId: VendorId(record.V) });
             if (this.activeAnnounceQueries.has(vendorIdQueryId)) {
                 return vendorIdQueryId;
             }

--- a/packages/matter.js/src/protocol/interaction/AttributeDataDecoder.ts
+++ b/packages/matter.js/src/protocol/interaction/AttributeDataDecoder.ts
@@ -12,15 +12,18 @@ import { TlvSchema, TypeFromSchema } from "../../tlv/TlvSchema.js";
 import { Logger } from "../../log/Logger.js";
 import { TlvAttributeData, TlvAttributeReport } from "./InteractionProtocol.js";
 import { UnexpectedDataError } from "../../common/MatterError.js";
+import { EndpointNumber } from "../../datatype/EndpointNumber.js";
+import { ClusterId } from "../../datatype/ClusterId.js";
+import { AttributeId } from "../../datatype/AttributeId.js";
 
 const logger = Logger.get("AttributeDataDecoder");
 
 export interface DecodedAttributeReportValue<T> {
     path: {
         nodeId?: NodeId,
-        endpointId: number,
-        clusterId: number,
-        attributeId: number,
+        endpointId: EndpointNumber,
+        clusterId: ClusterId,
+        attributeId: AttributeId,
         attributeName: string
     },
     version: number,
@@ -30,9 +33,9 @@ export interface DecodedAttributeReportValue<T> {
 export interface DecodedAttributeValue<T> {
     path: {
         nodeId?: NodeId,
-        endpointId: number,
-        clusterId: number,
-        attributeId: number,
+        endpointId: EndpointNumber,
+        clusterId: ClusterId,
+        attributeId: AttributeId,
         attributeName: string
     },
     version?: number,
@@ -48,7 +51,7 @@ export function normalizeAndDecodeReadAttributeReport(data: TypeFromSchema<typeo
 
 export function normalizeAttributeData(data: TypeFromSchema<typeof TlvAttributeData>[], acceptWildcardPaths = false): TypeFromSchema<typeof TlvAttributeData>[][] {
     // Fill in missing path elements when tag compression is used
-    let lastPath: { nodeId?: NodeId, endpointId: number, clusterId: number, attributeId: number } | undefined;
+    let lastPath: { nodeId?: NodeId, endpointId: EndpointNumber, clusterId: ClusterId, attributeId: AttributeId } | undefined;
     data.forEach(value => {
         if (value === undefined) return;
         const { path } = value;

--- a/packages/matter.js/src/protocol/interaction/EventDataDecoder.ts
+++ b/packages/matter.js/src/protocol/interaction/EventDataDecoder.ts
@@ -11,6 +11,9 @@ import { TypeFromSchema } from "../../tlv/TlvSchema.js";
 import { Logger } from "../../log/Logger.js";
 import { TlvEventData, TlvEventReport } from "./InteractionProtocol.js";
 import { UnexpectedDataError } from "../../common/MatterError.js";
+import { EndpointNumber } from "../../datatype/EndpointNumber.js";
+import { ClusterId } from "../../datatype/ClusterId.js";
+import { EventId } from "../../datatype/EventId.js";
 
 const logger = Logger.get("EventDataDecoder");
 
@@ -27,9 +30,9 @@ export type DecodedEventData<T> = {
 export type DecodedEventReportValue<T> = {
     path: {
         nodeId?: NodeId,
-        endpointId: number,
-        clusterId: number,
-        eventId: number,
+        endpointId: EndpointNumber,
+        clusterId: ClusterId,
+        eventId: EventId,
         eventName: string
     },
     events: DecodedEventData<T>[],

--- a/packages/matter.js/src/protocol/interaction/EventHandler.ts
+++ b/packages/matter.js/src/protocol/interaction/EventHandler.ts
@@ -10,6 +10,9 @@ import { TypeFromSchema } from "../../tlv/TlvSchema.js";
 import { TlvEventFilter, TlvEventPath } from "./InteractionProtocol.js";
 import { Logger } from "../../log/Logger.js";
 import { resolveEventName } from "../../cluster/ClusterHelper.js";
+import { EndpointNumber } from "../../datatype/EndpointNumber.js";
+import { ClusterId } from "../../datatype/ClusterId.js";
+import { EventId } from "../../datatype/EventId.js";
 
 const logger = Logger.get("EventHandler");
 
@@ -19,9 +22,9 @@ const MAX_EVENTS = 10_000;
  * Data of one Event
  */
 export interface EventData<T> {
-    endpointId: number;
-    clusterId: number;
-    eventId: number
+    endpointId: EndpointNumber;
+    clusterId: ClusterId;
+    eventId: EventId
     epochTimestamp: number;
     priority: EventPriority;
     data: T;

--- a/packages/matter.js/src/protocol/interaction/InteractionEndpointStructure.ts
+++ b/packages/matter.js/src/protocol/interaction/InteractionEndpointStructure.ts
@@ -19,9 +19,14 @@ import {
     eventPathToId, EventWithPath, genericElementPathToId
 } from "./InteractionServer.js";
 import { ImplementationError, InternalError } from "../../common/MatterError.js";
+import { ClusterId } from "../../datatype/ClusterId.js";
+import { EndpointNumber } from "../../datatype/EndpointNumber.js";
+import { CommandId } from "../../datatype/CommandId.js";
+import { EventId } from "../../datatype/EventId.js";
+import { AttributeId } from "../../datatype/AttributeId.js";
 
 export class InteractionEndpointStructure {
-    endpoints = new Map<number, Endpoint>();
+    endpoints = new Map<EndpointNumber, Endpoint>();
     attributes = new Map<string, (AttributeServer<any> | FabricScopedAttributeServer<any> | FixedAttributeServer<any>)>();
     attributePaths = new Array<AttributePath>();
     events = new Map<string, EventServer<any>>();
@@ -97,8 +102,8 @@ export class InteractionEndpointStructure {
         return value === undefined ? "*" : `0x${value.toString(16)}`;
     }
 
-    resolveGenericElementName(nodeId: NodeId | undefined, endpointId: number | undefined, clusterId: number | undefined, elementId: number | undefined, elementMap: Map<string, any>) {
-        const nodeIdPrefix = nodeId === undefined ? "" : `${this.toHex(nodeId.id)}/`;
+    resolveGenericElementName(nodeId: NodeId | undefined, endpointId: EndpointNumber | undefined, clusterId: ClusterId | undefined, elementId: number | undefined, elementMap: Map<string, any>) {
+        const nodeIdPrefix = nodeId === undefined ? "" : `${this.toHex(nodeId)}/`;
         if (endpointId === undefined) {
             return `${nodeIdPrefix}*/${this.toHex(clusterId)}/${this.toHex(elementId)}`;
         }
@@ -137,43 +142,43 @@ export class InteractionEndpointStructure {
         return this.resolveGenericElementName(undefined, endpointId, clusterId, commandId, this.commands);
     }
 
-    getEndpoint(endpointId: number): Endpoint | undefined {
+    getEndpoint(endpointId: EndpointNumber): Endpoint | undefined {
         return this.endpoints.get(endpointId);
     }
 
-    hasEndpoint(endpointId: number): boolean {
+    hasEndpoint(endpointId: EndpointNumber): boolean {
         return this.endpoints.has(endpointId);
     }
 
-    getClusterServer(endpointId: number, clusterId: number): ClusterServerObj<any, any, any> | undefined {
+    getClusterServer(endpointId: EndpointNumber, clusterId: ClusterId): ClusterServerObj<any, any, any> | undefined {
         return this.endpoints.get(endpointId)?.getClusterServerById(clusterId);
     }
 
-    hasClusterServer(endpointId: number, clusterId: number): boolean {
+    hasClusterServer(endpointId: EndpointNumber, clusterId: ClusterId): boolean {
         return !!this.getClusterServer(endpointId, clusterId);
     }
 
-    getAttribute(endpointId: number, clusterId: number, attributeId: number): AttributeServer<any> | FabricScopedAttributeServer<any> | FixedAttributeServer<any> | undefined {
+    getAttribute(endpointId: EndpointNumber, clusterId: ClusterId, attributeId: AttributeId): AttributeServer<any> | FabricScopedAttributeServer<any> | FixedAttributeServer<any> | undefined {
         return this.attributes.get(attributePathToId({ endpointId, clusterId, attributeId }));
     }
 
-    hasAttribute(endpointId: number, clusterId: number, attributeId: number): boolean {
+    hasAttribute(endpointId: EndpointNumber, clusterId: ClusterId, attributeId: AttributeId): boolean {
         return !!this.getAttribute(endpointId, clusterId, attributeId);
     }
 
-    getEvent(endpointId: number, clusterId: number, eventId: number): EventServer<any> | undefined {
+    getEvent(endpointId: EndpointNumber, clusterId: ClusterId, eventId: EventId): EventServer<any> | undefined {
         return this.events.get(eventPathToId({ endpointId, clusterId, eventId }));
     }
 
-    hasEvent(endpointId: number, clusterId: number, eventId: number): boolean {
+    hasEvent(endpointId: EndpointNumber, clusterId: ClusterId, eventId: EventId): boolean {
         return !!this.getEvent(endpointId, clusterId, eventId);
     }
 
-    getCommand(endpointId: number, clusterId: number, commandId: number): CommandServer<any, any> | undefined {
+    getCommand(endpointId: EndpointNumber, clusterId: ClusterId, commandId: CommandId): CommandServer<any, any> | undefined {
         return this.commands.get(commandPathToId({ endpointId, clusterId, commandId }));
     }
 
-    hasCommand(endpointId: number, clusterId: number, commandId: number): boolean {
+    hasCommand(endpointId: EndpointNumber, clusterId: ClusterId, commandId: CommandId): boolean {
         return !!this.getCommand(endpointId, clusterId, commandId);
     }
 

--- a/packages/matter.js/src/protocol/interaction/InteractionProtocol.ts
+++ b/packages/matter.js/src/protocol/interaction/InteractionProtocol.ts
@@ -9,9 +9,15 @@ import { TlvAny } from "../../tlv/TlvAny.js";
 import { TlvArray } from "../../tlv/TlvArray.js";
 import { TlvBoolean } from "../../tlv/TlvBoolean.js";
 import { TlvNullable } from "../../tlv/TlvNullable.js";
-import { TlvEnum, TlvUInt16, TlvUInt32, TlvUInt64, TlvUInt8 } from "../../tlv/TlvNumber.js";
+import { TlvEnum, TlvPosixMs, TlvSysTimeMS, TlvUInt16, TlvUInt32, TlvUInt64, TlvUInt8 } from "../../tlv/TlvNumber.js";
 import { TlvField, TlvList, TlvObject, TlvOptionalField } from "../../tlv/TlvObject.js";
 import { MatterCoreSpecificationV1_0 } from "../../spec/Specifications.js";
+import { TlvClusterId } from "../../datatype/ClusterId.js";
+import { TlvEventId } from "../../datatype/EventId.js";
+import { TlvAttributeId } from "../../datatype/AttributeId.js";
+import { TlvEndpointNumber } from "../../datatype/EndpointNumber.js";
+import { TlvCommandId } from "../../datatype/CommandId.js";
+import { EventPriority } from "../../cluster/Cluster.js";
 
 /** @see {@link MatterCoreSpecificationV1_0}, section 8.10 */
 export const enum StatusCode {
@@ -50,18 +56,18 @@ export const enum StatusCode {
 export const TlvAttributePath = TlvList({ // AttributePathIB
     enableTagCompression: TlvOptionalField(0, TlvBoolean),
     nodeId: TlvOptionalField(1, TlvNodeId),
-    endpointId: TlvOptionalField(2, TlvUInt16),
-    clusterId: TlvOptionalField(3, TlvUInt32),
-    attributeId: TlvOptionalField(4, TlvUInt32),
+    endpointId: TlvOptionalField(2, TlvEndpointNumber),
+    clusterId: TlvOptionalField(3, TlvClusterId),
+    attributeId: TlvOptionalField(4, TlvAttributeId),
     listIndex: TlvOptionalField(5, TlvNullable(TlvUInt16)),
 });
 
 /** @see {@link MatterCoreSpecificationV1_0}, section 10.5.8 */
 export const TlvEventPath = TlvList({ // EventPathIB
     nodeId: TlvOptionalField(0, TlvNodeId),
-    endpointId: TlvOptionalField(1, TlvUInt16),
-    clusterId: TlvOptionalField(2, TlvUInt32),
-    eventId: TlvOptionalField(3, TlvUInt32),
+    endpointId: TlvOptionalField(1, TlvEndpointNumber),
+    clusterId: TlvOptionalField(2, TlvClusterId),
+    eventId: TlvOptionalField(3, TlvEventId),
     isUrgent: TlvOptionalField(4, TlvBoolean),
 });
 
@@ -69,11 +75,11 @@ export const TlvEventPath = TlvList({ // EventPathIB
 export const TlvEventData = TlvObject({ // EventDataIB
     path: TlvField(0, TlvEventPath),
     eventNumber: TlvField(1, TlvUInt64),
-    priority: TlvField(2, TlvUInt8),
-    epochTimestamp: TlvOptionalField(3, TlvUInt64),
-    systemTimestamp: TlvOptionalField(4, TlvUInt64),
-    deltaEpochTimestamp: TlvOptionalField(5, TlvUInt64),
-    deltaSystemTimestamp: TlvOptionalField(6, TlvUInt64),
+    priority: TlvField(2, TlvEnum<EventPriority>()),
+    epochTimestamp: TlvOptionalField(3, TlvPosixMs),
+    systemTimestamp: TlvOptionalField(4, TlvSysTimeMS),
+    deltaEpochTimestamp: TlvOptionalField(5, TlvPosixMs),
+    deltaSystemTimestamp: TlvOptionalField(6, TlvSysTimeMS),
     data: TlvOptionalField(7, TlvAny),
 });
 
@@ -86,8 +92,8 @@ export const TlvEventFilter = TlvObject({ // EventFilterIB
 /** @see {@link MatterCoreSpecificationV1_0}, section 10.5.7 */
 export const TlvClusterPath = TlvList({ // ClusterPathIB
     nodeId: TlvOptionalField(0, TlvNodeId),
-    endpointId: TlvField(1, TlvUInt16),
-    clusterId: TlvField(2, TlvUInt32),
+    endpointId: TlvField(1, TlvEndpointNumber),
+    clusterId: TlvField(2, TlvClusterId),
 });
 
 /** @see {@link MatterCoreSpecificationV1_0}, section 10.5.3 */
@@ -141,9 +147,9 @@ export const TlvEventReport = TlvObject({ // EventReportIB
 
 /** @see {@link MatterCoreSpecificationV1_0}, section 10.5.11 */
 export const TlvCommandPath = TlvList({ // CommandPathIB
-    endpointId: TlvOptionalField(0, TlvUInt16),
-    clusterId: TlvField(1, TlvUInt32),
-    commandId: TlvField(2, TlvUInt32),
+    endpointId: TlvOptionalField(0, TlvEndpointNumber),
+    clusterId: TlvField(1, TlvClusterId),
+    commandId: TlvField(2, TlvCommandId),
 });
 
 /** @see {@link MatterCoreSpecificationV1_0}, section 10.5.12 */

--- a/packages/matter.js/src/session/SecureSession.ts
+++ b/packages/matter.js/src/session/SecureSession.ts
@@ -156,7 +156,7 @@ export class SecureSession<T> implements Session<T> {
         const writer = new DataWriter(Endian.Little);
         writer.writeUInt8(securityFlags);
         writer.writeUInt32(messageId);
-        writer.writeUInt64(nodeId.id);
+        writer.writeUInt64(nodeId);
         return writer.toByteArray();
     }
 }

--- a/packages/matter.js/src/session/case/CaseClient.ts
+++ b/packages/matter.js/src/session/case/CaseClient.ts
@@ -72,7 +72,7 @@ export class CaseClient {
             const { nodeOpCert: peerNewOpCert, intermediateCACert: peerIntermediateCACert, signature: peerSignature, resumptionId: peerResumptionId } = TlvEncryptedDataSigma2.decode(peerEncryptedData);
             const peerSignatureData = TlvSignedData.encode({ nodeOpCert: peerNewOpCert, intermediateCACert: peerIntermediateCACert, ecdhPublicKey: peerEcdhPublicKey, peerEcdhPublicKey: ecdhPublicKey });
             const { ellipticCurvePublicKey: peerPublicKey, subject: { nodeId: peerNodeIdCert } } = TlvOperationalCertificate.decode(peerNewOpCert);
-            if (peerNodeIdCert.id !== peerNodeId.id) throw new UnexpectedDataError("The node ID in the peer certificate doesn't match the expected peer node ID");
+            if (peerNodeIdCert !== peerNodeId) throw new UnexpectedDataError("The node ID in the peer certificate doesn't match the expected peer node ID");
             Crypto.verify(PublicKey(peerPublicKey), peerSignatureData, peerSignature);
 
             // Generate and send sigma3

--- a/packages/matter.js/src/session/case/CaseServer.ts
+++ b/packages/matter.js/src/session/case/CaseServer.ts
@@ -15,6 +15,7 @@ import { SECURE_CHANNEL_PROTOCOL_ID } from "../../protocol/securechannel/SecureC
 import { ByteArray } from "../../util/ByteArray.js";
 import { Logger } from "../../log/Logger.js";
 import { PublicKey } from "../../crypto/Key.js";
+import { NodeId } from "../../datatype/NodeId.js";
 
 const logger = Logger.get("CaseServer");
 
@@ -69,7 +70,7 @@ export class CaseServer implements ProtocolHandler<MatterDevice> {
                 throw error;
             }
 
-            logger.info(`session ${secureSession.getId()} resumed with ${messenger.getChannelName()} for Fabric ${fabric.nodeId.id.toString(16)}(index ${fabric.fabricIndex.index}) and PeerNode ${peerNodeId.id.toString(16)}`);
+            logger.info(`session ${secureSession.getId()} resumed with ${messenger.getChannelName()} for Fabric ${NodeId.toHexString(fabric.nodeId)}(index ${fabric.fabricIndex}) and PeerNode ${NodeId.toHexString(peerNodeId)}`);
             resumptionRecord.resumptionId = resumptionId; /* Update the ID */
 
             // Wait for success on the peer side
@@ -104,7 +105,7 @@ export class CaseServer implements ProtocolHandler<MatterDevice> {
             // All good! Create secure session
             const secureSessionSalt = ByteArray.concat(operationalIdentityProtectionKey, Crypto.hash([sigma1Bytes, sigma2Bytes, sigma3Bytes]));
             const secureSession = await server.createSecureSession(sessionId, fabric, peerNodeId, peerSessionId, sharedSecret, secureSessionSalt, false, false, mrpParams?.idleRetransTimeoutMs, mrpParams?.activeRetransTimeoutMs);
-            logger.info(`session ${secureSession.getId()} created with ${messenger.getChannelName()} for Fabric ${fabric.nodeId.id.toString(16)}(index ${fabric.fabricIndex.index}) and PeerNode ${peerNodeId.id.toString(16)}`);
+            logger.info(`session ${secureSession.getId()} created with ${messenger.getChannelName()} for Fabric ${NodeId.toHexString(fabric.nodeId)}(index ${fabric.fabricIndex}) and PeerNode ${NodeId.toHexString(peerNodeId)}`);
             await messenger.sendSuccess();
 
             resumptionRecord = { peerNodeId, fabric, sharedSecret, resumptionId };

--- a/packages/matter.js/src/storage/StringifyTools.ts
+++ b/packages/matter.js/src/storage/StringifyTools.ts
@@ -65,36 +65,6 @@ export function toJson(object: SupportedStorageTypes, spaces?: number): string {
         if (value instanceof Map) {
             return `{"${JSON_SPECIAL_KEY_TYPE}":"Map","${JSON_SPECIAL_KEY_VALUE}":${JSON.stringify(toJson(Array.from(value.entries())))}}`;
         }
-        if (value instanceof AttributeId) {
-            return `{"${JSON_SPECIAL_KEY_TYPE}":"AttributeId","${JSON_SPECIAL_KEY_VALUE}":${value.id}}`;
-        }
-        if (value instanceof ClusterId) {
-            return `{"${JSON_SPECIAL_KEY_TYPE}":"ClusterId","${JSON_SPECIAL_KEY_VALUE}":${value.id}}`;
-        }
-        if (value instanceof CommandId) {
-            return `{"${JSON_SPECIAL_KEY_TYPE}":"CommandId","${JSON_SPECIAL_KEY_VALUE}":${value.id}}`;
-        }
-        if (value instanceof EndpointNumber) {
-            return `{"${JSON_SPECIAL_KEY_TYPE}":"EndpointNumber","${JSON_SPECIAL_KEY_VALUE}":${value.number}}`;
-        }
-        if (value instanceof EventId) {
-            return `{"${JSON_SPECIAL_KEY_TYPE}":"EventId","${JSON_SPECIAL_KEY_VALUE}":${value.id}}`;
-        }
-        if (value instanceof FabricId) {
-            return `{"${JSON_SPECIAL_KEY_TYPE}":"FabricId","${JSON_SPECIAL_KEY_VALUE}":"${value.id.toString()}"}`;
-        }
-        if (value instanceof FabricIndex) {
-            return `{"${JSON_SPECIAL_KEY_TYPE}":"FabricIndex","${JSON_SPECIAL_KEY_VALUE}":${value.index}}`;
-        }
-        if (value instanceof GroupId) {
-            return `{"${JSON_SPECIAL_KEY_TYPE}":"GroupId","${JSON_SPECIAL_KEY_VALUE}":${value.id}}`;
-        }
-        if (value instanceof NodeId) {
-            return `{"${JSON_SPECIAL_KEY_TYPE}":"NodeId","${JSON_SPECIAL_KEY_VALUE}":"${value.id.toString()}"}`;
-        }
-        if (value instanceof VendorId) {
-            return `{"${JSON_SPECIAL_KEY_TYPE}":"VendorId","${JSON_SPECIAL_KEY_VALUE}":${value.id}}`;
-        }
         return value;
     }, spaces);
 }
@@ -111,26 +81,20 @@ export function fromJson(json: string): SupportedStorageTypes {
                     return ByteArray.fromHex(data[JSON_SPECIAL_KEY_VALUE]);
                 case "Map":
                     return new Map(fromJson(data[JSON_SPECIAL_KEY_VALUE]) as [SupportedStorageBaseTypes, SupportedStorageBaseTypes][]);
+
+                // TODO Remove in the future, leave here for now for backward compatibility?
                 case "AttributeId":
-                    return new AttributeId(data[JSON_SPECIAL_KEY_VALUE]);
                 case "ClusterId":
-                    return new ClusterId(data[JSON_SPECIAL_KEY_VALUE]);
                 case "CommandId":
-                    return new CommandId(data[JSON_SPECIAL_KEY_VALUE]);
                 case "EndpointNumber":
-                    return new EndpointNumber(data[JSON_SPECIAL_KEY_VALUE]);
                 case "EventId":
-                    return new EventId(data[JSON_SPECIAL_KEY_VALUE]);
-                case "FabricId":
-                    return new FabricId(BigInt(data[JSON_SPECIAL_KEY_VALUE]));
                 case "FabricIndex":
-                    return new FabricIndex(data[JSON_SPECIAL_KEY_VALUE]);
                 case "GroupId":
-                    return new GroupId(data[JSON_SPECIAL_KEY_VALUE]);
-                case "NodeId":
-                    return new NodeId(BigInt(data[JSON_SPECIAL_KEY_VALUE]));
                 case "VendorId":
-                    return new VendorId(data[JSON_SPECIAL_KEY_VALUE]);
+                    return data[JSON_SPECIAL_KEY_VALUE];
+                case "FabricId":
+                case "NodeId":
+                    return BigInt(data[JSON_SPECIAL_KEY_VALUE]);
 
                 default:
                     throw new UnexpectedDataError(`Unknown object type: ${object}`);

--- a/packages/matter.js/src/util/Type.ts
+++ b/packages/matter.js/src/util/Type.ts
@@ -53,3 +53,8 @@ export function isNullish(a: any) {
 }
 
 export type MakeMandatory<T> = Exclude<T, undefined>;
+
+/** Create a branded type */
+declare const __brand: unique symbol
+type Brand<B> = { [__brand]: B }
+export type Branded<T, B> = T & Brand<B>

--- a/packages/matter.js/test/cluster/AttributeServerTest.ts
+++ b/packages/matter.js/test/cluster/AttributeServerTest.ts
@@ -17,6 +17,7 @@ import { VendorId } from "../../src/datatype/VendorId.js";
 import { MatterDevice } from "../../src/MatterDevice.js";
 import { SecureSession } from "../../src/session/SecureSession.js";
 import { PrivateKey } from "../../src/crypto/Key.js";
+import { AttributeId } from "../../src/datatype/AttributeId.js";
 
 const ZERO = new ByteArray(1);
 const PRIVATE_KEY = new ByteArray(32);
@@ -27,30 +28,30 @@ describe("AttributeServerTest", () => {
 
     describe("FixedAttributeServer", () => {
         it("should return the value set in the constructor", () => {
-            const server = new FixedAttributeServer(1, "test", TlvUInt8, false, false, 3);
+            const server = new FixedAttributeServer(AttributeId(1), "test", TlvUInt8, false, false, 3);
             assert.strictEqual(server.getLocal(), 3);
         });
 
         it("should return the value from getter", () => {
-            const server = new FixedAttributeServer(1, "test", TlvUInt8, false, false, 3, () => 4);
+            const server = new FixedAttributeServer(AttributeId(1), "test", TlvUInt8, false, false, 3, () => 4);
             assert.strictEqual(server.getLocal(), 4);
         });
 
         it("should successfully initialize with a value", () => {
-            const server = new FixedAttributeServer(1, "test", TlvUInt8, false, false, 3);
+            const server = new FixedAttributeServer(AttributeId(1), "test", TlvUInt8, false, false, 3);
             server.init(5);
             assert.strictEqual(server.getLocal(), 5);
         });
 
         it("should throw an error if initialized with a version", () => {
-            const server = new FixedAttributeServer(1, "test", TlvUInt8, false, false, 3);
+            const server = new FixedAttributeServer(AttributeId(1), "test", TlvUInt8, false, false, 3);
             assert.throws(() => server.init(2, 1), { message: 'Version is not supported on fixed attribute "test".' });
         });
     });
 
     describe("AttributeServer", () => {
         it("should return the value set in the constructor", () => {
-            const server = new AttributeServer(1, "test", TlvUInt8, true, false, 3);
+            const server = new AttributeServer(AttributeId(1), "test", TlvUInt8, true, false, 3);
             assert.strictEqual(server.getLocal(), 3);
         });
 
@@ -59,7 +60,7 @@ describe("AttributeServerTest", () => {
             let versionTriggered: number | undefined = undefined;
             let valueTriggered2: number | undefined = undefined;
             let oldValueTriggered2: number | undefined = undefined;
-            const server = new AttributeServer(1, "test", TlvUInt8, false, false, 3,);
+            const server = new AttributeServer(AttributeId(1), "test", TlvUInt8, false, false, 3,);
             server.addValueChangeListener((value, version) => { valueTriggered = value; versionTriggered = version; });
             server.addValueSetListener((newValue, oldValue) => { valueTriggered2 = newValue; oldValueTriggered2 = oldValue; });
 
@@ -75,7 +76,7 @@ describe("AttributeServerTest", () => {
         it("should set the value locally and trigger listeners on non change", () => {
             let valueTriggered2: number | undefined = undefined;
             let oldValueTriggered2: number | undefined = undefined;
-            const server = new AttributeServer(1, "test", TlvUInt8, false, false, 3,);
+            const server = new AttributeServer(AttributeId(1), "test", TlvUInt8, false, false, 3,);
             server.addValueChangeListener(() => { throw new Error("Should not be triggered."); });
             server.addValueSetListener((newValue, oldValue) => { valueTriggered2 = newValue; oldValueTriggered2 = oldValue; });
 
@@ -87,19 +88,19 @@ describe("AttributeServerTest", () => {
         });
 
         it("should throw an error if the value is set non locally and not writable", () => {
-            const server = new AttributeServer(1, "test", TlvUInt8, false, false, 3,);
+            const server = new AttributeServer(AttributeId(1), "test", TlvUInt8, false, false, 3,);
             assert.strictEqual(server.getLocal(), 3);
             assert.throws(() => server.set(4, {} as SecureSession<MatterDevice>), { message: '(136) Attribute "test" is not writable.' });
         });
 
         it("should return the value from getter", () => {
-            const server = new AttributeServer(1, "test", TlvUInt8, false, false, 3, () => 4);
+            const server = new AttributeServer(AttributeId(1), "test", TlvUInt8, false, false, 3, () => 4);
             assert.strictEqual(server.getLocal(), 4);
         });
 
         it("should return the value from getter also with setter but increased version on change", () => {
             let valueSet: number | undefined = undefined;
-            const server = new AttributeServer(1, "test", TlvUInt8, false, false, 3, () => 4, (value) => { valueSet = value; return true; });
+            const server = new AttributeServer(AttributeId(1), "test", TlvUInt8, false, false, 3, () => 4, (value) => { valueSet = value; return true; });
             assert.deepEqual(server.getWithVersion({} as SecureSession<MatterDevice>, false), { value: 4, version: 0 });
             server.setLocal(5);
             assert.deepEqual(server.getWithVersion({} as SecureSession<MatterDevice>, false), { value: 4, version: 1 });
@@ -108,7 +109,7 @@ describe("AttributeServerTest", () => {
 
         it("should return the value from getter also with setter but not increased version when no change", () => {
             let valueSet: number | undefined = undefined;
-            const server = new AttributeServer(1, "test", TlvUInt8, false, false, 3, () => 4, (value) => { valueSet = value; return false; });
+            const server = new AttributeServer(AttributeId(1), "test", TlvUInt8, false, false, 3, () => 4, (value) => { valueSet = value; return false; });
             assert.deepEqual(server.getWithVersion({} as SecureSession<MatterDevice>, false), { value: 4, version: 0 });
             server.setLocal(5);
             assert.deepEqual(server.getWithVersion({} as SecureSession<MatterDevice>, false), { value: 4, version: 0 });
@@ -117,7 +118,7 @@ describe("AttributeServerTest", () => {
 
         it("should return the value from getter and increased version after update", () => {
             let valueSet: number | undefined = undefined;
-            const server = new AttributeServer(1, "test", TlvUInt8, false, false, 3, () => 4, (value) => { valueSet = value; return false; });
+            const server = new AttributeServer(AttributeId(1), "test", TlvUInt8, false, false, 3, () => 4, (value) => { valueSet = value; return false; });
             assert.deepEqual(server.getWithVersion({} as SecureSession<MatterDevice>, false), { value: 4, version: 0 });
             server.updated({} as SecureSession<MatterDevice>);
             assert.deepEqual(server.getWithVersion({} as SecureSession<MatterDevice>, false), { value: 4, version: 1 });
@@ -130,7 +131,7 @@ describe("AttributeServerTest", () => {
             let versionTriggered: number | undefined = undefined;
             let valueTriggered2: number | undefined = undefined;
             let oldValueTriggered2: number | undefined = undefined;
-            const server = new AttributeServer(1, "test", TlvUInt8, false, false, 3, () => 4, (value) => { valueSet = value; return true; });
+            const server = new AttributeServer(AttributeId(1), "test", TlvUInt8, false, false, 3, () => 4, (value) => { valueSet = value; return true; });
             server.addValueChangeListener((value, version) => { valueTriggered = value; versionTriggered = version; });
             server.addValueSetListener((newValue, oldValue) => { valueTriggered2 = newValue; oldValueTriggered2 = oldValue; });
             assert.deepEqual(server.getWithVersion({} as SecureSession<MatterDevice>, false), { value: 4, version: 0 });
@@ -147,7 +148,7 @@ describe("AttributeServerTest", () => {
             let valueSet: number | undefined = undefined;
             let valueTriggered2: number | undefined = undefined;
             let oldValueTriggered2: number | undefined = undefined;
-            const server = new AttributeServer(1, "test", TlvUInt8, false, false, 3, () => 4, (value) => { valueSet = value; return false; });
+            const server = new AttributeServer(AttributeId(1), "test", TlvUInt8, false, false, 3, () => 4, (value) => { valueSet = value; return false; });
             server.addValueChangeListener(() => { throw new Error("Should not be triggered"); });
             server.addValueSetListener((newValue, oldValue) => { valueTriggered2 = newValue; oldValueTriggered2 = oldValue; });
             assert.deepEqual(server.getWithVersion({} as SecureSession<MatterDevice>, false), { value: 4, version: 0 });
@@ -160,7 +161,7 @@ describe("AttributeServerTest", () => {
 
         it("should return the value from getter and increased version after update", () => {
             let valueSet: number | undefined = undefined;
-            const server = new AttributeServer(1, "test", TlvUInt8, false, false, 3, () => 4, (value) => { valueSet = value; return false; });
+            const server = new AttributeServer(AttributeId(1), "test", TlvUInt8, false, false, 3, () => 4, (value) => { valueSet = value; return false; });
             assert.deepEqual(server.getWithVersion({} as SecureSession<MatterDevice>, false), { value: 4, version: 0 });
             server.updated({} as SecureSession<MatterDevice>);
             assert.deepEqual(server.getWithVersion({} as SecureSession<MatterDevice>, false), { value: 4, version: 1 });
@@ -168,65 +169,65 @@ describe("AttributeServerTest", () => {
         });
 
         it("should successfully initialize with a value", () => {
-            const server = new AttributeServer(1, "test", TlvUInt8, false, false, 3);
+            const server = new AttributeServer(AttributeId(1), "test", TlvUInt8, false, false, 3);
             server.init(5, 1);
             assert.strictEqual(server.getLocal(), 5);
         });
 
         it("if initialized with undefined value the default value uis used", () => {
-            const server = new AttributeServer(1, "test", TlvUInt8, false, false, 3);
+            const server = new AttributeServer(AttributeId(1), "test", TlvUInt8, false, false, 3);
             server.init(undefined, 1);
             assert.strictEqual(server.getLocal(), 3);
         });
 
         it("use getter value if initialized with undefined", () => {
-            const server = new AttributeServer(1, "test", TlvUInt8, false, false, 3, () => 4);
+            const server = new AttributeServer(AttributeId(1), "test", TlvUInt8, false, false, 3, () => 4);
             server.init(1, 1);
             assert.strictEqual(server.getLocal(), 4);
         });
 
         it("setter is not called when initialized", () => {
             let setterCalled = false;
-            const server = new AttributeServer(1, "test", TlvUInt8, false, false, 3, undefined, () => { setterCalled = true; return true; });
+            const server = new AttributeServer(AttributeId(1), "test", TlvUInt8, false, false, 3, undefined, () => { setterCalled = true; return true; });
             server.init(1, 1);
             assert.strictEqual(setterCalled, false);
         });
 
         it("should throw an error if default value is invalid", () => {
-            assert.throws(() => new AttributeServer(1, "test", TlvUInt8.bound({ min: 0, max: 2 }), false, false, 3), { message: 'Validation error for attribute "test": Invalid value: 3 is above the maximum, 2.' });
+            assert.throws(() => new AttributeServer(AttributeId(1), "test", TlvUInt8.bound({ min: 0, max: 2 }), false, false, 3), { message: 'Validation error for attribute "test": Invalid value: 3 is above the maximum, 2.' });
         });
 
         it("should throw an error if set value is invalid according to schema validator", () => {
-            const server = new AttributeServer(1, "test", TlvUInt8.bound({ min: 0, max: 3 }), false, false, 3, undefined, () => true);
+            const server = new AttributeServer(AttributeId(1), "test", TlvUInt8.bound({ min: 0, max: 3 }), false, false, 3, undefined, () => true);
             assert.throws(() => server.setLocal(11), { message: 'Validation error for attribute "test": Invalid value: 11 is above the maximum, 3.' });
         });
 
         it("should throw an error if set value is invalid according to custom validator only on set", () => {
-            const server = new AttributeServer(1, "test", TlvUInt8, false, false, 3, undefined, undefined, () => { throw new Error("Validator error") });
+            const server = new AttributeServer(AttributeId(1), "test", TlvUInt8, false, false, 3, undefined, undefined, () => { throw new Error("Validator error") });
             assert.throws(() => server.setLocal(11), { message: "Validator error" });
         });
     });
 
     describe("FabricScopedAttributeServer", () => {
         it("should return the value set in the constructor if fabric context is empty", () => {
-            const testFabric = new Fabric(new FabricIndex(1), new FabricId(BigInt(1)), new NodeId(BigInt(1)), new NodeId(BigInt(2)), ZERO, ZERO, KEY, new VendorId(1), ZERO, ZERO, ZERO, ZERO, ZERO, "");
+            const testFabric = new Fabric(FabricIndex(1), FabricId(BigInt(1)), NodeId(BigInt(1)), NodeId(BigInt(2)), ZERO, ZERO, KEY, VendorId(1), ZERO, ZERO, ZERO, ZERO, ZERO, "");
 
-            const server = new FabricScopedAttributeServer(1, "test", TlvUInt8, true, false, 3, BasicInformationCluster);
+            const server = new FabricScopedAttributeServer(AttributeId(1), "test", TlvUInt8, true, false, 3, BasicInformationCluster);
             assert.strictEqual(server.getLocalForFabric(testFabric), 3);
         });
 
         it("should return the value from fabric context if set", () => {
-            const testFabric = new Fabric(new FabricIndex(1), new FabricId(BigInt(1)), new NodeId(BigInt(1)), new NodeId(BigInt(2)), ZERO, ZERO, KEY, new VendorId(1), ZERO, ZERO, ZERO, ZERO, ZERO, "");
+            const testFabric = new Fabric(FabricIndex(1), FabricId(BigInt(1)), NodeId(BigInt(1)), NodeId(BigInt(2)), ZERO, ZERO, KEY, VendorId(1), ZERO, ZERO, ZERO, ZERO, ZERO, "");
             testFabric.setScopedClusterDataValue(BasicInformationCluster, "test", { value: 5 });
 
-            const server = new FabricScopedAttributeServer(1, "test", TlvUInt8, true, false, 3, BasicInformationCluster);
+            const server = new FabricScopedAttributeServer(AttributeId(1), "test", TlvUInt8, true, false, 3, BasicInformationCluster);
             assert.strictEqual(server.getLocalForFabric(testFabric), 5);
         });
 
         it("should return the value from fabric scoped storage when changed", () => {
-            const testFabric = new Fabric(new FabricIndex(1), new FabricId(BigInt(1)), new NodeId(BigInt(1)), new NodeId(BigInt(2)), ZERO, ZERO, KEY, new VendorId(1), ZERO, ZERO, ZERO, ZERO, ZERO, "");
+            const testFabric = new Fabric(FabricIndex(1), FabricId(BigInt(1)), NodeId(BigInt(1)), NodeId(BigInt(2)), ZERO, ZERO, KEY, VendorId(1), ZERO, ZERO, ZERO, ZERO, ZERO, "");
 
-            const server = new FabricScopedAttributeServer(1, "test", TlvUInt8, true, false, 3, BasicInformationCluster);
+            const server = new FabricScopedAttributeServer(AttributeId(1), "test", TlvUInt8, true, false, 3, BasicInformationCluster);
             testFabric.setScopedClusterDataValue(BasicInformationCluster, "test", { value: 5 });
             assert.strictEqual(server.getLocalForFabric(testFabric), 5);
         });
@@ -236,10 +237,10 @@ describe("AttributeServerTest", () => {
             let versionTriggered: number | undefined = undefined;
             let valueTriggered2: number | undefined = undefined;
             let oldValueTriggered2: number | undefined = undefined;
-            const testFabric = new Fabric(new FabricIndex(1), new FabricId(BigInt(1)), new NodeId(BigInt(1)), new NodeId(BigInt(2)), ZERO, ZERO, KEY, new VendorId(1), ZERO, ZERO, ZERO, ZERO, ZERO, "");
+            const testFabric = new Fabric(FabricIndex(1), FabricId(BigInt(1)), NodeId(BigInt(1)), NodeId(BigInt(2)), ZERO, ZERO, KEY, VendorId(1), ZERO, ZERO, ZERO, ZERO, ZERO, "");
             testFabric.setScopedClusterDataValue(BasicInformationCluster, "test", { value: 5 });
 
-            const server = new FabricScopedAttributeServer(1, "test", TlvUInt8, true, false, 3, BasicInformationCluster);
+            const server = new FabricScopedAttributeServer(AttributeId(1), "test", TlvUInt8, true, false, 3, BasicInformationCluster);
             server.addValueChangeListener((value, version) => { valueTriggered = value; versionTriggered = version; });
             server.addValueSetListener((newValue, oldValue) => { valueTriggered2 = newValue; oldValueTriggered2 = oldValue; });
 
@@ -255,10 +256,10 @@ describe("AttributeServerTest", () => {
         it("should handle the value from fabric scoped storage when set and trigger ony external listeners", () => {
             let valueTriggered2: number | undefined = undefined;
             let oldValueTriggered2: number | undefined = undefined;
-            const testFabric = new Fabric(new FabricIndex(1), new FabricId(BigInt(1)), new NodeId(BigInt(1)), new NodeId(BigInt(2)), ZERO, ZERO, KEY, new VendorId(1), ZERO, ZERO, ZERO, ZERO, ZERO, "");
+            const testFabric = new Fabric(FabricIndex(1), FabricId(BigInt(1)), NodeId(BigInt(1)), NodeId(BigInt(2)), ZERO, ZERO, KEY, VendorId(1), ZERO, ZERO, ZERO, ZERO, ZERO, "");
             testFabric.setScopedClusterDataValue(BasicInformationCluster, "test", { value: 5 });
 
-            const server = new FabricScopedAttributeServer(1, "test", TlvUInt8, true, false, 3, BasicInformationCluster);
+            const server = new FabricScopedAttributeServer(AttributeId(1), "test", TlvUInt8, true, false, 3, BasicInformationCluster);
             server.addValueChangeListener(() => { throw new Error("Should not be triggered"); });
             server.addValueSetListener((newValue, oldValue) => { valueTriggered2 = newValue; oldValueTriggered2 = oldValue; });
 
@@ -270,23 +271,23 @@ describe("AttributeServerTest", () => {
         });
 
         it("should throw an error if only getter is implemented but writable", () => {
-            assert.throws(() => new FabricScopedAttributeServer(1, "test", TlvUInt8, true, false, 3, BasicInformationCluster, () => 7), { message: 'Getter and setter must be implemented together writeable fabric scoped attribute "test".' });
+            assert.throws(() => new FabricScopedAttributeServer(AttributeId(1), "test", TlvUInt8, true, false, 3, BasicInformationCluster, () => 7), { message: 'Getter and setter must be implemented together writeable fabric scoped attribute "test".' });
         });
 
         it("should throw an error when trying to get getter method value locally", () => {
-            const testFabric = new Fabric(new FabricIndex(1), new FabricId(BigInt(1)), new NodeId(BigInt(1)), new NodeId(BigInt(2)), ZERO, ZERO, KEY, new VendorId(1), ZERO, ZERO, ZERO, ZERO, ZERO, "");
+            const testFabric = new Fabric(FabricIndex(1), FabricId(BigInt(1)), NodeId(BigInt(1)), NodeId(BigInt(2)), ZERO, ZERO, KEY, VendorId(1), ZERO, ZERO, ZERO, ZERO, ZERO, "");
             testFabric.setScopedClusterDataValue(BasicInformationCluster, "test", { value: 5 });
 
-            const server = new FabricScopedAttributeServer(1, "test", TlvUInt8, false, false, 3, BasicInformationCluster, () => 7);
+            const server = new FabricScopedAttributeServer(AttributeId(1), "test", TlvUInt8, false, false, 3, BasicInformationCluster, () => 7);
             assert.throws(() => server.getLocalForFabric(testFabric), { message: 'Fabric scoped attribute "test" can not be read locally when a custom getter is defined.' });
         });
 
         it("should return value from getter when used non-locally", () => {
-            const testFabric = new Fabric(new FabricIndex(1), new FabricId(BigInt(1)), new NodeId(BigInt(1)), new NodeId(BigInt(2)), ZERO, ZERO, KEY, new VendorId(1), ZERO, ZERO, ZERO, ZERO, ZERO, "");
+            const testFabric = new Fabric(FabricIndex(1), FabricId(BigInt(1)), NodeId(BigInt(1)), NodeId(BigInt(2)), ZERO, ZERO, KEY, VendorId(1), ZERO, ZERO, ZERO, ZERO, ZERO, "");
             const testSession = { getAssociatedFabric: () => testFabric } as SecureSession<MatterDevice>;
             testFabric.setScopedClusterDataValue(BasicInformationCluster, "test", { value: 5 });
 
-            const server = new FabricScopedAttributeServer(1, "test", TlvUInt8, false, false, 3, BasicInformationCluster, () => 7);
+            const server = new FabricScopedAttributeServer(AttributeId(1), "test", TlvUInt8, false, false, 3, BasicInformationCluster, () => 7);
             assert.strictEqual(server.get(testSession, true), 7);
         });
 
@@ -295,10 +296,10 @@ describe("AttributeServerTest", () => {
             let versionTriggered: number | undefined = undefined;
             let valueTriggered2: number | undefined = undefined;
             let oldValueTriggered2: number | undefined = undefined;
-            const testFabric = new Fabric(new FabricIndex(1), new FabricId(BigInt(1)), new NodeId(BigInt(1)), new NodeId(BigInt(2)), ZERO, ZERO, KEY, new VendorId(1), ZERO, ZERO, ZERO, ZERO, ZERO, "");
+            const testFabric = new Fabric(FabricIndex(1), FabricId(BigInt(1)), NodeId(BigInt(1)), NodeId(BigInt(2)), ZERO, ZERO, KEY, VendorId(1), ZERO, ZERO, ZERO, ZERO, ZERO, "");
             const testSession = { getAssociatedFabric: () => testFabric } as SecureSession<MatterDevice>;
 
-            const server = new FabricScopedAttributeServer(1, "test", TlvUInt8, true, false, 3, BasicInformationCluster, () => 7, () => true);
+            const server = new FabricScopedAttributeServer(AttributeId(1), "test", TlvUInt8, true, false, 3, BasicInformationCluster, () => 7, () => true);
             server.init(undefined, 2);
             server.addValueChangeListener((value, version) => { valueTriggered = value; versionTriggered = version; });
             server.addValueSetListener((newValue, oldValue) => { valueTriggered2 = newValue; oldValueTriggered2 = oldValue; });

--- a/packages/matter.js/test/cluster/ClusterServerTest.ts
+++ b/packages/matter.js/test/cluster/ClusterServerTest.ts
@@ -22,6 +22,7 @@ import { BindingCluster } from "../../src/cluster/definitions/BindingCluster.js"
 import { IdentifyCluster, Identify } from "../../src/cluster/definitions/IdentifyCluster.js";
 import { Cluster, ClusterExtend } from "../../src/cluster/Cluster.js";
 import { ImplementationError } from "../../src/common/MatterError.js";
+import { EndpointNumber } from "../../src/datatype/EndpointNumber.js";
 
 describe("ClusterServer structure", () => {
     describe("correct attribute servers are used and exposed", () => {
@@ -30,7 +31,7 @@ describe("ClusterServer structure", () => {
                 {
                     dataModelRevision: 1,
                     vendorName: "test",
-                    vendorId: new VendorId(0),
+                    vendorId: VendorId(0),
                     productName: "test",
                     productId: 1,
                     nodeLabel: "",
@@ -63,7 +64,7 @@ describe("ClusterServer structure", () => {
             expect(basic.subscribeSoftwareVersionAttribute).not.toBeDefined();
 
             // Now we set this Cluster into Endpoint and retrieve it again and verify it is the same
-            const endpoint = new Endpoint([DeviceTypes.ON_OFF_LIGHT], { endpointId: 1 });
+            const endpoint = new Endpoint([DeviceTypes.ON_OFF_LIGHT], { endpointId: EndpointNumber(1) });
             endpoint.addClusterServer(basic);
 
             const basic2 = endpoint.getClusterServer(BasicInformationCluster);
@@ -88,7 +89,7 @@ describe("ClusterServer structure", () => {
                 {
                     dataModelRevision: 1,
                     vendorName: "test",
-                    vendorId: new VendorId(0),
+                    vendorId: VendorId(0),
                     productName: "test",
                     productId: 1,
                     nodeLabel: "",
@@ -114,7 +115,7 @@ describe("ClusterServer structure", () => {
             expect(basic.getNodeLabelAttribute()).toBe("new 2")
 
             // Now we set this Cluster into Endpoint and retrieve it again and verify it is the same
-            const endpoint = new Endpoint([DeviceTypes.ON_OFF_LIGHT], { endpointId: 1 });
+            const endpoint = new Endpoint([DeviceTypes.ON_OFF_LIGHT], { endpointId: EndpointNumber(1) });
             endpoint.addClusterServer(basic);
 
             const basic2 = endpoint.getClusterServer(BasicInformationCluster);
@@ -134,7 +135,7 @@ describe("ClusterServer structure", () => {
                 {
                     dataModelRevision: 1,
                     vendorName: "test",
-                    vendorId: new VendorId(0),
+                    vendorId: VendorId(0),
                     productName: "test",
                     productId: 1,
                     nodeLabel: "",
@@ -170,7 +171,7 @@ describe("ClusterServer structure", () => {
             expect(basic.subscribeManufacturingDateAttribute).not.toBeDefined();
 
             // Now we set this Cluster into Endpoint and retrieve it again and verify it is the same
-            const endpoint = new Endpoint([DeviceTypes.ON_OFF_LIGHT], { endpointId: 1 });
+            const endpoint = new Endpoint([DeviceTypes.ON_OFF_LIGHT], { endpointId: EndpointNumber(1) });
             endpoint.addClusterServer(basic);
 
             const basic2 = endpoint.getClusterServer(BasicInformationCluster);
@@ -197,7 +198,7 @@ describe("ClusterServer structure", () => {
                 {
                     dataModelRevision: 1,
                     vendorName: "test",
-                    vendorId: new VendorId(0),
+                    vendorId: VendorId(0),
                     productName: "test",
                     productId: 1,
                     nodeLabel: "",
@@ -225,7 +226,7 @@ describe("ClusterServer structure", () => {
             basic.setReachableAttribute(true);
 
             // Now we set this Cluster into Endpoint and retrieve it again and verify it is the same
-            const endpoint = new Endpoint([DeviceTypes.ON_OFF_LIGHT], { endpointId: 1 });
+            const endpoint = new Endpoint([DeviceTypes.ON_OFF_LIGHT], { endpointId: EndpointNumber(1) });
             endpoint.addClusterServer(basic);
 
             const basic2 = endpoint.getClusterServer(BasicInformationCluster);
@@ -246,7 +247,7 @@ describe("ClusterServer structure", () => {
                 {
                     dataModelRevision: 1,
                     vendorName: "test",
-                    vendorId: new VendorId(0),
+                    vendorId: VendorId(0),
                     productName: "test",
                     productId: 1,
                     nodeLabel: "",
@@ -275,7 +276,7 @@ describe("ClusterServer structure", () => {
             expect(basic.subscribeSerialNumberAttribute).not.toBeDefined();
 
             // Now we set this Cluster into Endpoint and retrieve it again and verify it is the same
-            const endpoint = new Endpoint([DeviceTypes.ON_OFF_LIGHT], { endpointId: 1 });
+            const endpoint = new Endpoint([DeviceTypes.ON_OFF_LIGHT], { endpointId: EndpointNumber(1) });
             endpoint.addClusterServer(basic);
 
             const basic2 = endpoint.getClusterServer(BasicInformationCluster);
@@ -298,7 +299,7 @@ describe("ClusterServer structure", () => {
                 {
                     dataModelRevision: 1,
                     vendorName: "test",
-                    vendorId: new VendorId(0),
+                    vendorId: VendorId(0),
                     productName: "test",
                     productId: 1,
                     nodeLabel: "",
@@ -326,7 +327,7 @@ describe("ClusterServer structure", () => {
             );
 
             // Now we set this Cluster into Endpoint and retrieve it again and verify it is the same
-            const endpoint = new Endpoint([DeviceTypes.ON_OFF_LIGHT], { endpointId: 1 });
+            const endpoint = new Endpoint([DeviceTypes.ON_OFF_LIGHT], { endpointId: EndpointNumber(1) });
             endpoint.addClusterServer(basic);
 
             const basic2 = endpoint.getClusterServer(BasicInformationCluster);
@@ -362,14 +363,14 @@ describe("ClusterServer structure", () => {
                     setScopedClusterDataValueCalledCounter++;
                     expect(cluster.id).toBe(BindingCluster.id)
                     expect(clusterDataKey).toBe("binding")
-                    expect(value).toEqual({ value: [{ fabricIndex: new FabricIndex(1) }] });
+                    expect(value).toEqual({ value: [{ fabricIndex: FabricIndex(1) }] });
                 }
             } as Fabric;
 
             expect(binding.attributes.binding.getLocalForFabric(fabric)).toEqual([])
-            binding.attributes.binding.setLocalForFabric([{ fabricIndex: new FabricIndex(1) }], fabric);
+            binding.attributes.binding.setLocalForFabric([{ fabricIndex: FabricIndex(1) }], fabric);
             expect(binding.getBindingAttribute(fabric, true)).toEqual([])
-            binding.setBindingAttribute([{ fabricIndex: new FabricIndex(1) }], fabric);
+            binding.setBindingAttribute([{ fabricIndex: FabricIndex(1) }], fabric);
 
             expect(getScopedClusterDataValueCalledCounter).toBe(4)
             expect(setScopedClusterDataValueCalledCounter).toBe(2)
@@ -382,7 +383,7 @@ describe("ClusterServer structure", () => {
                 AdministratorCommissioningCluster,
                 {
                     windowStatus: 0,
-                    adminFabricIndex: new FabricIndex(1),
+                    adminFabricIndex: FabricIndex(1),
                     adminVendorId: null
                 },
                 {
@@ -394,19 +395,19 @@ describe("ClusterServer structure", () => {
             // as any is trick because these attributes are not officially exposed by typings
             expect((server.attributes as any).featureMap.get()).toEqual({})
             expect((server.attributes as any).attributeList.get()).toEqual([
-                new AttributeId(0),
-                new AttributeId(1),
-                new AttributeId(2),
-                new AttributeId(65533),
-                new AttributeId(65532),
-                new AttributeId(65531),
-                new AttributeId(65530),
-                new AttributeId(65529),
-                new AttributeId(65528)
+                AttributeId(0),
+                AttributeId(1),
+                AttributeId(2),
+                AttributeId(65533),
+                AttributeId(65532),
+                AttributeId(65531),
+                AttributeId(65530),
+                AttributeId(65529),
+                AttributeId(65528)
             ]);
             expect((server.attributes as any).acceptedCommandList.get()).toEqual([
-                new CommandId(0),
-                new CommandId(2)
+                CommandId(0),
+                CommandId(2)
             ]);
             expect((server.attributes as any).generatedCommandList.get()).toEqual([])
             expect((server.attributes as any).eventList.get()).toEqual([])
@@ -428,18 +429,18 @@ describe("ClusterServer structure", () => {
             // as any is trick because these attributes are not officially exposed by typings
             expect((server.attributes as any).featureMap.get()).toEqual({})
             expect((server.attributes as any).attributeList.get()).toEqual([
-                new AttributeId(0),
-                new AttributeId(1),
-                new AttributeId(65533),
-                new AttributeId(65532),
-                new AttributeId(65531),
-                new AttributeId(65530),
-                new AttributeId(65529),
-                new AttributeId(65528)
+                AttributeId(0),
+                AttributeId(1),
+                AttributeId(65533),
+                AttributeId(65532),
+                AttributeId(65531),
+                AttributeId(65530),
+                AttributeId(65529),
+                AttributeId(65528)
             ]);
             expect((server.attributes as any).acceptedCommandList.get()).toEqual([
-                new CommandId(0),
-                new CommandId(0x40)
+                CommandId(0),
+                CommandId(0x40)
             ]);
             expect((server.attributes as any).generatedCommandList.get()).toEqual([])
             expect((server.attributes as any).eventList.get()).toEqual([])
@@ -461,18 +462,18 @@ describe("ClusterServer structure", () => {
             // as any is trick because these attributes are not officially exposed by typings
             expect((server.attributes as any).featureMap.get()).toEqual({})
             expect((server.attributes as any).attributeList.get()).toEqual([
-                new AttributeId(0),
-                new AttributeId(1),
-                new AttributeId(65533),
-                new AttributeId(65532),
-                new AttributeId(65531),
-                new AttributeId(65530),
-                new AttributeId(65529),
-                new AttributeId(65528)
+                AttributeId(0),
+                AttributeId(1),
+                AttributeId(65533),
+                AttributeId(65532),
+                AttributeId(65531),
+                AttributeId(65530),
+                AttributeId(65529),
+                AttributeId(65528)
             ]);
             expect((server.attributes as any).acceptedCommandList.get()).toEqual([
-                new CommandId(0),
-                new CommandId(0x40)
+                CommandId(0),
+                CommandId(0x40)
             ]);
             expect((server.attributes as any).generatedCommandList.get()).toEqual([])
             expect((server.attributes as any).eventList.get()).toEqual([])
@@ -493,16 +494,16 @@ describe("ClusterServer structure", () => {
             // as any is trick because these attributes are not officially exposed by typings
             expect((server.attributes as any).featureMap.get()).toEqual({})
             expect((server.attributes as any).attributeList.get()).toEqual([
-                new AttributeId(0),
-                new AttributeId(1),
-                new AttributeId(65533),
-                new AttributeId(65532),
-                new AttributeId(65531),
-                new AttributeId(65530),
-                new AttributeId(65529),
-                new AttributeId(65528)
+                AttributeId(0),
+                AttributeId(1),
+                AttributeId(65533),
+                AttributeId(65532),
+                AttributeId(65531),
+                AttributeId(65530),
+                AttributeId(65529),
+                AttributeId(65528)
             ]);
-            expect((server.attributes as any).acceptedCommandList.get()).toEqual([new CommandId(0)])
+            expect((server.attributes as any).acceptedCommandList.get()).toEqual([CommandId(0)])
             expect((server.attributes as any).generatedCommandList.get()).toEqual([])
         });
 
@@ -525,27 +526,27 @@ describe("ClusterServer structure", () => {
             // as any is trick because these attributes are not officially exposed by typings
             expect((server.attributes as any).featureMap.get()).toEqual({ groupNames: true })
             expect((server.attributes as any).attributeList.get()).toEqual([
-                new AttributeId(0),
-                new AttributeId(65533),
-                new AttributeId(65532),
-                new AttributeId(65531),
-                new AttributeId(65530),
-                new AttributeId(65529),
-                new AttributeId(65528)
+                AttributeId(0),
+                AttributeId(65533),
+                AttributeId(65532),
+                AttributeId(65531),
+                AttributeId(65530),
+                AttributeId(65529),
+                AttributeId(65528)
             ]);
             expect((server.attributes as any).acceptedCommandList.get()).toEqual([
-                new CommandId(0),
-                new CommandId(1),
-                new CommandId(2),
-                new CommandId(3),
-                new CommandId(4),
-                new CommandId(5)
+                CommandId(0),
+                CommandId(1),
+                CommandId(2),
+                CommandId(3),
+                CommandId(4),
+                CommandId(5)
             ]);
             expect((server.attributes as any).generatedCommandList.get()).toEqual([
-                new CommandId(0),
-                new CommandId(1),
-                new CommandId(2),
-                new CommandId(3)
+                CommandId(0),
+                CommandId(1),
+                CommandId(2),
+                CommandId(3)
             ]);
             expect((server.attributes as any).eventList.get()).toEqual([])
         });

--- a/packages/matter.js/test/cluster/definitions/WindowCoveringClusterTest.ts
+++ b/packages/matter.js/test/cluster/definitions/WindowCoveringClusterTest.ts
@@ -5,14 +5,8 @@
  */
 
 import { WindowCovering, WindowCoveringCluster } from "../../../src/cluster/definitions/WindowCoveringCluster.js";
-import { AttributeId } from "../../../src/datatype/AttributeId.js";
-import { CommandId } from "../../../src/datatype/CommandId.js";
 import { ClusterServer } from "../../../src/protocol/interaction/InteractionServer.js";
 import { BitFlags } from "../../../src/schema/BitmapSchema.js";
-
-function wrapIds<T>(factory: new (id: number) => T, ...ids: number[]) {
-    return ids.map(id => new factory(id));
-}
 
 describe("WindowCoveringCluster", () => {
     const WindowCovering_LF_PALF = WindowCoveringCluster.with("Lift", "PositionAwareLift");
@@ -102,12 +96,8 @@ describe("WindowCoveringCluster", () => {
         );
 
         expect(attrValues).toEqual({ // TODO - make strict after updating web tester
-            acceptedCommandList: wrapIds(CommandId,
-                0, 1, 2
-            ),
-            attributeList: wrapIds(AttributeId,
-                0, 7, 10, 13, 23, 26, 65533, 65532, 65531, 65530, 65529, 65528, 11, 14
-            ),
+            acceptedCommandList: [0, 1, 2],
+            attributeList: [0, 7, 10, 13, 23, 26, 65533, 65532, 65531, 65530, 65529, 65528, 11, 14],
             clusterRevision: 5,
             configStatus: {
                 operational: true,

--- a/packages/matter.js/test/codec/MessageTest.ts
+++ b/packages/matter.js/test/codec/MessageTest.ts
@@ -14,7 +14,7 @@ const DECODED = {
     packetHeader: {
         sessionId: 0,
         sessionType: 0,
-        sourceNodeId: new NodeId(BigInt("5936706156730294398")),
+        sourceNodeId: NodeId(BigInt("5936706156730294398")),
         messageId: 401755914,
         destGroupId: undefined,
         destNodeId: undefined,
@@ -42,7 +42,7 @@ const DECODED_2 = {
         sourceNodeId: undefined,
         messageId: 2031257377,
         destGroupId: undefined,
-        destNodeId: new NodeId(BigInt("5936706156730294398")),
+        destNodeId: NodeId(BigInt("5936706156730294398")),
         hasPrivacyEnhancements: false,
         isControlMessage: false,
         hasMessageExtensions: false,

--- a/packages/matter.js/test/device/MatterNodeStructureTest.ts
+++ b/packages/matter.js/test/device/MatterNodeStructureTest.ts
@@ -90,7 +90,7 @@ function addRequiredRootClusters(node: MatterNode, includeAdminCommissioningClus
                 {
                     dataModelRevision: 1,
                     vendorName: "vendor",
-                    vendorId: new VendorId(1),
+                    vendorId: VendorId(1),
                     productName: "product",
                     productId: 2,
                     nodeLabel: "",
@@ -253,13 +253,13 @@ describe("Endpoint Structures", () => {
             const node = new CommissioningServer({
                 port: 5540,
                 deviceName: "Test Device",
-                deviceType: 0x16,
+                deviceType: DeviceTypeId(0x16),
                 passcode: 123,
                 discriminator: 1234,
                 basicInformation: {
                     dataModelRevision: 1,
                     vendorName: "vendor",
-                    vendorId: new VendorId(1),
+                    vendorId: VendorId(1),
                     productName: "product",
                     productId: 2,
                     nodeLabel: "",
@@ -297,14 +297,14 @@ describe("Endpoint Structures", () => {
             } = endpointStructure;
 
             const rootPartsListAttribute = attributes.get(attributePathToId({
-                endpointId: 0,
+                endpointId: EndpointNumber(0),
                 clusterId: DescriptorCluster.id,
                 attributeId: DescriptorCluster.attributes.partsList.id
             })) as AttributeServer<EndpointNumber[]>;
             expect(rootPartsListAttribute?.getLocal()).toEqual([])
 
             const rootPartsListAttribute2 = endpointStructure.getAttributes([{
-                endpointId: 0,
+                endpointId: EndpointNumber(0),
                 clusterId: DescriptorCluster.id,
                 attributeId: DescriptorCluster.attributes.partsList.id
             }]);
@@ -312,16 +312,16 @@ describe("Endpoint Structures", () => {
             expect(rootPartsListAttribute).toBe(rootPartsListAttribute2[0].attribute)
 
             expect(endpoints.size).toBe(1)
-            expect(endpoints.get(0)?.getAllClusterServers().length).toBe(9)
-            expect(endpoints.get(0)?.hasClusterServer(DescriptorCluster)).toBeTruthy();
-            expect(endpoints.get(0)?.hasClusterServer(BasicInformationCluster)).toBeTruthy();
-            expect(endpoints.get(0)?.hasClusterServer(OperationalCredentialsCluster)).toBeTruthy();
-            expect(endpoints.get(0)?.hasClusterServer(GeneralCommissioning.Cluster)).toBeTruthy();
-            expect(endpoints.get(0)?.hasClusterServer(NetworkCommissioning.Cluster)).toBeTruthy();
-            expect(endpoints.get(0)?.hasClusterServer(AccessControlCluster)).toBeTruthy();
-            expect(endpoints.get(0)?.hasClusterServer(AdministratorCommissioning.Cluster)).toBeTruthy();
-            expect(endpoints.get(0)?.hasClusterServer(GroupKeyManagementCluster)).toBeTruthy();
-            expect(endpoints.get(0)?.hasClusterServer(GeneralCommissioning.Cluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.getAllClusterServers().length).toBe(9)
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(DescriptorCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(BasicInformationCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(OperationalCredentialsCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(GeneralCommissioning.Cluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(NetworkCommissioning.Cluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(AccessControlCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(AdministratorCommissioning.Cluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(GroupKeyManagementCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(GeneralCommissioning.Cluster)).toBeTruthy();
 
             expect(attributePaths.length).toBe(110);
             expect(commandPaths.length).toBe(18);
@@ -338,13 +338,13 @@ describe("Endpoint Structures", () => {
             const node = new CommissioningServer({
                 port: 5540,
                 deviceName: "Test Device",
-                deviceType: 0x16,
+                deviceType: DeviceTypeId(0x16),
                 passcode: 123,
                 discriminator: 1234,
                 basicInformation: {
                     dataModelRevision: 1,
                     vendorName: "vendor",
-                    vendorId: new VendorId(1),
+                    vendorId: VendorId(1),
                     productName: "product",
                     productId: 2,
                     nodeLabel: "",
@@ -392,31 +392,31 @@ describe("Endpoint Structures", () => {
             expect(endpointStorage.get("serial_node-matter-0000-index_0")).toBe(1)
 
             expect(endpoints.size).toBe(2)
-            expect(endpoints.get(0)?.getAllClusterServers().length).toBe(9)
-            expect(endpoints.get(0)?.hasClusterServer(DescriptorCluster)).toBeTruthy();
-            expect(endpoints.get(0)?.hasClusterServer(BasicInformationCluster)).toBeTruthy();
-            expect(endpoints.get(0)?.hasClusterServer(OperationalCredentialsCluster)).toBeTruthy();
-            expect(endpoints.get(0)?.hasClusterServer(GeneralCommissioning.Cluster)).toBeTruthy();
-            expect(endpoints.get(0)?.hasClusterServer(NetworkCommissioning.Cluster)).toBeTruthy();
-            expect(endpoints.get(0)?.hasClusterServer(AccessControlCluster)).toBeTruthy();
-            expect(endpoints.get(0)?.hasClusterServer(AdministratorCommissioning.Cluster)).toBeTruthy();
-            expect(endpoints.get(0)?.hasClusterServer(GroupKeyManagementCluster)).toBeTruthy();
-            expect(endpoints.get(0)?.hasClusterServer(GeneralCommissioning.Cluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.getAllClusterServers().length).toBe(9)
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(DescriptorCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(BasicInformationCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(OperationalCredentialsCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(GeneralCommissioning.Cluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(NetworkCommissioning.Cluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(AccessControlCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(AdministratorCommissioning.Cluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(GroupKeyManagementCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(GeneralCommissioning.Cluster)).toBeTruthy();
 
-            expect(endpoints.get(1)?.getAllClusterServers().length).toBe(6)
-            expect(endpoints.get(1)?.hasClusterServer(DescriptorCluster)).toBeTruthy();
-            expect(endpoints.get(1)?.hasClusterServer(IdentifyCluster)).toBeTruthy();
-            expect(endpoints.get(1)?.hasClusterServer(GroupsCluster)).toBeTruthy();
-            expect(endpoints.get(1)?.hasClusterServer(ScenesCluster)).toBeTruthy();
-            expect(endpoints.get(1)?.hasClusterServer(OnOffCluster)).toBeTruthy();
-            expect(endpoints.get(1)?.hasClusterServer(BindingCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(1))?.getAllClusterServers().length).toBe(6)
+            expect(endpoints.get(EndpointNumber(1))?.hasClusterServer(DescriptorCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(1))?.hasClusterServer(IdentifyCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(1))?.hasClusterServer(GroupsCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(1))?.hasClusterServer(ScenesCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(1))?.hasClusterServer(OnOffCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(1))?.hasClusterServer(BindingCluster)).toBeTruthy();
 
             const rootPartsListAttribute = attributes.get(attributePathToId({
-                endpointId: 0,
+                endpointId: EndpointNumber(0),
                 clusterId: DescriptorCluster.id,
                 attributeId: DescriptorCluster.attributes.partsList.id
             })) as AttributeServer<EndpointNumber[]>;
-            expect(rootPartsListAttribute?.getLocal()).toEqual([new EndpointNumber(1)]);
+            expect(rootPartsListAttribute?.getLocal()).toEqual([EndpointNumber(1)]);
 
             expect(attributePaths.length).toBe(161);
             expect(commandPaths.length).toBe(38);
@@ -433,13 +433,13 @@ describe("Endpoint Structures", () => {
             const node = new CommissioningServer({
                 port: 5540,
                 deviceName: "Test Device",
-                deviceType: 0x16,
+                deviceType: DeviceTypeId(0x16),
                 passcode: 123,
                 discriminator: 1234,
                 basicInformation: {
                     dataModelRevision: 1,
                     vendorName: "vendor",
-                    vendorId: new VendorId(1),
+                    vendorId: VendorId(1),
                     productName: "product",
                     productId: 2,
                     nodeLabel: "",
@@ -487,31 +487,31 @@ describe("Endpoint Structures", () => {
             expect(endpointStorage.get("serial_node-matter-0000-custom_test-unique-id")).toBe(1)
 
             expect(endpoints.size).toBe(2)
-            expect(endpoints.get(0)?.getAllClusterServers().length).toBe(9)
-            expect(endpoints.get(0)?.hasClusterServer(DescriptorCluster)).toBeTruthy();
-            expect(endpoints.get(0)?.hasClusterServer(BasicInformationCluster)).toBeTruthy();
-            expect(endpoints.get(0)?.hasClusterServer(OperationalCredentialsCluster)).toBeTruthy();
-            expect(endpoints.get(0)?.hasClusterServer(GeneralCommissioning.Cluster)).toBeTruthy();
-            expect(endpoints.get(0)?.hasClusterServer(NetworkCommissioning.Cluster)).toBeTruthy();
-            expect(endpoints.get(0)?.hasClusterServer(AccessControlCluster)).toBeTruthy();
-            expect(endpoints.get(0)?.hasClusterServer(AdministratorCommissioning.Cluster)).toBeTruthy();
-            expect(endpoints.get(0)?.hasClusterServer(GroupKeyManagementCluster)).toBeTruthy();
-            expect(endpoints.get(0)?.hasClusterServer(GeneralCommissioning.Cluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.getAllClusterServers().length).toBe(9)
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(DescriptorCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(BasicInformationCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(OperationalCredentialsCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(GeneralCommissioning.Cluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(NetworkCommissioning.Cluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(AccessControlCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(AdministratorCommissioning.Cluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(GroupKeyManagementCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(GeneralCommissioning.Cluster)).toBeTruthy();
 
-            expect(endpoints.get(1)?.getAllClusterServers().length).toBe(6)
-            expect(endpoints.get(1)?.hasClusterServer(DescriptorCluster)).toBeTruthy();
-            expect(endpoints.get(1)?.hasClusterServer(IdentifyCluster)).toBeTruthy();
-            expect(endpoints.get(1)?.hasClusterServer(GroupsCluster)).toBeTruthy();
-            expect(endpoints.get(1)?.hasClusterServer(ScenesCluster)).toBeTruthy();
-            expect(endpoints.get(1)?.hasClusterServer(OnOffCluster)).toBeTruthy();
-            expect(endpoints.get(1)?.hasClusterServer(BindingCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(1))?.getAllClusterServers().length).toBe(6)
+            expect(endpoints.get(EndpointNumber(1))?.hasClusterServer(DescriptorCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(1))?.hasClusterServer(IdentifyCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(1))?.hasClusterServer(GroupsCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(1))?.hasClusterServer(ScenesCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(1))?.hasClusterServer(OnOffCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(1))?.hasClusterServer(BindingCluster)).toBeTruthy();
 
             const rootPartsListAttribute = attributes.get(attributePathToId({
-                endpointId: 0,
+                endpointId: EndpointNumber(0),
                 clusterId: DescriptorCluster.id,
                 attributeId: DescriptorCluster.attributes.partsList.id
             })) as AttributeServer<EndpointNumber[]>;
-            expect(rootPartsListAttribute?.getLocal()).toEqual([new EndpointNumber(1)]);
+            expect(rootPartsListAttribute?.getLocal()).toEqual([EndpointNumber(1)]);
 
             expect(attributePaths.length).toBe(161);
             expect(commandPaths.length).toBe(38);
@@ -529,13 +529,13 @@ describe("Endpoint Structures", () => {
             const node = new CommissioningServer({
                 port: 5540,
                 deviceName: "Test Device",
-                deviceType: 0x16,
+                deviceType: DeviceTypeId(0x16),
                 passcode: 123,
                 discriminator: 1234,
                 basicInformation: {
                     dataModelRevision: 1,
                     vendorName: "vendor",
-                    vendorId: new VendorId(1),
+                    vendorId: VendorId(1),
                     productName: "product",
                     productId: 2,
                     nodeLabel: "",
@@ -583,31 +583,31 @@ describe("Endpoint Structures", () => {
             expect(endpointStorage.get("serial_node-matter-0000-index_0")).toBe(10)
 
             expect(endpoints.size).toBe(2)
-            expect(endpoints.get(0)?.getAllClusterServers().length).toBe(9)
-            expect(endpoints.get(0)?.hasClusterServer(DescriptorCluster)).toBeTruthy();
-            expect(endpoints.get(0)?.hasClusterServer(BasicInformationCluster)).toBeTruthy();
-            expect(endpoints.get(0)?.hasClusterServer(OperationalCredentialsCluster)).toBeTruthy();
-            expect(endpoints.get(0)?.hasClusterServer(GeneralCommissioning.Cluster)).toBeTruthy();
-            expect(endpoints.get(0)?.hasClusterServer(NetworkCommissioning.Cluster)).toBeTruthy();
-            expect(endpoints.get(0)?.hasClusterServer(AccessControlCluster)).toBeTruthy();
-            expect(endpoints.get(0)?.hasClusterServer(AdministratorCommissioning.Cluster)).toBeTruthy();
-            expect(endpoints.get(0)?.hasClusterServer(GroupKeyManagementCluster)).toBeTruthy();
-            expect(endpoints.get(0)?.hasClusterServer(GeneralCommissioning.Cluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.getAllClusterServers().length).toBe(9)
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(DescriptorCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(BasicInformationCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(OperationalCredentialsCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(GeneralCommissioning.Cluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(NetworkCommissioning.Cluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(AccessControlCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(AdministratorCommissioning.Cluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(GroupKeyManagementCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(GeneralCommissioning.Cluster)).toBeTruthy();
 
-            expect(endpoints.get(10)?.getAllClusterServers().length).toBe(6)
-            expect(endpoints.get(10)?.hasClusterServer(DescriptorCluster)).toBeTruthy();
-            expect(endpoints.get(10)?.hasClusterServer(IdentifyCluster)).toBeTruthy();
-            expect(endpoints.get(10)?.hasClusterServer(GroupsCluster)).toBeTruthy();
-            expect(endpoints.get(10)?.hasClusterServer(ScenesCluster)).toBeTruthy();
-            expect(endpoints.get(10)?.hasClusterServer(OnOffCluster)).toBeTruthy();
-            expect(endpoints.get(10)?.hasClusterServer(BindingCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(10))?.getAllClusterServers().length).toBe(6)
+            expect(endpoints.get(EndpointNumber(10))?.hasClusterServer(DescriptorCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(10))?.hasClusterServer(IdentifyCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(10))?.hasClusterServer(GroupsCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(10))?.hasClusterServer(ScenesCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(10))?.hasClusterServer(OnOffCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(10))?.hasClusterServer(BindingCluster)).toBeTruthy();
 
             const rootPartsListAttribute = attributes.get(attributePathToId({
-                endpointId: 0,
+                endpointId: EndpointNumber(0),
                 clusterId: DescriptorCluster.id,
                 attributeId: DescriptorCluster.attributes.partsList.id
             })) as AttributeServer<EndpointNumber[]>;
-            expect(rootPartsListAttribute?.getLocal()).toEqual([new EndpointNumber(10)]);
+            expect(rootPartsListAttribute?.getLocal()).toEqual([EndpointNumber(10)]);
 
             expect(attributePaths.length).toBe(161);
             expect(commandPaths.length).toBe(38);
@@ -625,13 +625,13 @@ describe("Endpoint Structures", () => {
             const node = new CommissioningServer({
                 port: 5540,
                 deviceName: "Test Device",
-                deviceType: 0x16,
+                deviceType: DeviceTypeId(0x16),
                 passcode: 123,
                 discriminator: 1234,
                 basicInformation: {
                     dataModelRevision: 1,
                     vendorName: "vendor",
-                    vendorId: new VendorId(1),
+                    vendorId: VendorId(1),
                     productName: "product",
                     productId: 2,
                     nodeLabel: "",
@@ -679,31 +679,31 @@ describe("Endpoint Structures", () => {
             expect(endpointStorage.get("serial_node-matter-0000-custom_test-unique-id")).toBe(10)
 
             expect(endpoints.size).toBe(2)
-            expect(endpoints.get(0)?.getAllClusterServers().length).toBe(9)
-            expect(endpoints.get(0)?.hasClusterServer(DescriptorCluster)).toBeTruthy();
-            expect(endpoints.get(0)?.hasClusterServer(BasicInformationCluster)).toBeTruthy();
-            expect(endpoints.get(0)?.hasClusterServer(OperationalCredentialsCluster)).toBeTruthy();
-            expect(endpoints.get(0)?.hasClusterServer(GeneralCommissioning.Cluster)).toBeTruthy();
-            expect(endpoints.get(0)?.hasClusterServer(NetworkCommissioning.Cluster)).toBeTruthy();
-            expect(endpoints.get(0)?.hasClusterServer(AccessControlCluster)).toBeTruthy();
-            expect(endpoints.get(0)?.hasClusterServer(AdministratorCommissioning.Cluster)).toBeTruthy();
-            expect(endpoints.get(0)?.hasClusterServer(GroupKeyManagementCluster)).toBeTruthy();
-            expect(endpoints.get(0)?.hasClusterServer(GeneralCommissioning.Cluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.getAllClusterServers().length).toBe(9)
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(DescriptorCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(BasicInformationCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(OperationalCredentialsCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(GeneralCommissioning.Cluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(NetworkCommissioning.Cluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(AccessControlCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(AdministratorCommissioning.Cluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(GroupKeyManagementCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(GeneralCommissioning.Cluster)).toBeTruthy();
 
-            expect(endpoints.get(10)?.getAllClusterServers().length).toBe(6)
-            expect(endpoints.get(10)?.hasClusterServer(DescriptorCluster)).toBeTruthy();
-            expect(endpoints.get(10)?.hasClusterServer(IdentifyCluster)).toBeTruthy();
-            expect(endpoints.get(10)?.hasClusterServer(GroupsCluster)).toBeTruthy();
-            expect(endpoints.get(10)?.hasClusterServer(ScenesCluster)).toBeTruthy();
-            expect(endpoints.get(10)?.hasClusterServer(OnOffCluster)).toBeTruthy();
-            expect(endpoints.get(10)?.hasClusterServer(BindingCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(10))?.getAllClusterServers().length).toBe(6)
+            expect(endpoints.get(EndpointNumber(10))?.hasClusterServer(DescriptorCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(10))?.hasClusterServer(IdentifyCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(10))?.hasClusterServer(GroupsCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(10))?.hasClusterServer(ScenesCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(10))?.hasClusterServer(OnOffCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(10))?.hasClusterServer(BindingCluster)).toBeTruthy();
 
             const rootPartsListAttribute = attributes.get(attributePathToId({
-                endpointId: 0,
+                endpointId: EndpointNumber(0),
                 clusterId: DescriptorCluster.id,
                 attributeId: DescriptorCluster.attributes.partsList.id
             })) as AttributeServer<EndpointNumber[]>;
-            expect(rootPartsListAttribute?.getLocal()).toEqual([new EndpointNumber(10)]);
+            expect(rootPartsListAttribute?.getLocal()).toEqual([EndpointNumber(10)]);
 
             expect(attributePaths.length).toBe(161);
             expect(commandPaths.length).toBe(38);
@@ -716,9 +716,9 @@ describe("Endpoint Structures", () => {
             const node = new TestNode();
             addRequiredRootClusters(node);
 
-            const aggregator = new Aggregator([], { endpointId: 1 });
+            const aggregator = new Aggregator([], { endpointId: EndpointNumber(1) });
 
-            const onoffLightDevice = new OnOffLightDevice(undefined, { endpointId: 11 });
+            const onoffLightDevice = new OnOffLightDevice(undefined, { endpointId: EndpointNumber(11) });
             onoffLightDevice.addClusterServer(ClusterServer(BridgedDeviceBasicInformationCluster, {
                 nodeLabel: "Socket 1",
                 reachable: true
@@ -742,54 +742,54 @@ describe("Endpoint Structures", () => {
             } = endpointStructure;
 
             expect(endpoints.size).toBe(3)
-            expect(endpoints.get(0)?.getAllClusterServers().length).toBe(9)
-            expect(endpoints.get(0)?.hasClusterServer(DescriptorCluster)).toBeTruthy();
-            expect(endpoints.get(0)?.hasClusterServer(BasicInformationCluster)).toBeTruthy();
-            expect(endpoints.get(0)?.hasClusterServer(OperationalCredentialsCluster)).toBeTruthy();
-            expect(endpoints.get(0)?.hasClusterServer(GeneralCommissioning.Cluster)).toBeTruthy();
-            expect(endpoints.get(0)?.hasClusterServer(NetworkCommissioning.Cluster)).toBeTruthy();
-            expect(endpoints.get(0)?.hasClusterServer(AccessControlCluster)).toBeTruthy();
-            expect(endpoints.get(0)?.hasClusterServer(AdministratorCommissioning.Cluster)).toBeTruthy();
-            expect(endpoints.get(0)?.hasClusterServer(GroupKeyManagementCluster)).toBeTruthy();
-            expect(endpoints.get(0)?.hasClusterServer(GeneralCommissioning.Cluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.getAllClusterServers().length).toBe(9)
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(DescriptorCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(BasicInformationCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(OperationalCredentialsCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(GeneralCommissioning.Cluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(NetworkCommissioning.Cluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(AccessControlCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(AdministratorCommissioning.Cluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(GroupKeyManagementCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(GeneralCommissioning.Cluster)).toBeTruthy();
 
-            expect(endpoints.get(1)?.getAllClusterServers().length).toBe(1)
-            expect(endpoints.get(1)?.hasClusterServer(DescriptorCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(1))?.getAllClusterServers().length).toBe(1)
+            expect(endpoints.get(EndpointNumber(1))?.hasClusterServer(DescriptorCluster)).toBeTruthy();
 
-            expect(endpoints.get(11)?.getAllClusterServers().length).toBe(7)
-            expect(endpoints.get(11)?.hasClusterServer(DescriptorCluster)).toBeTruthy();
-            expect(endpoints.get(11)?.hasClusterServer(IdentifyCluster)).toBeTruthy();
-            expect(endpoints.get(11)?.hasClusterServer(GroupsCluster)).toBeTruthy();
-            expect(endpoints.get(11)?.hasClusterServer(ScenesCluster)).toBeTruthy();
-            expect(endpoints.get(11)?.hasClusterServer(OnOffCluster)).toBeTruthy();
-            expect(endpoints.get(11)?.hasClusterServer(BridgedDeviceBasicInformationCluster)).toBeTruthy();
-            expect(endpoints.get(11)?.hasClusterServer(BindingCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(11))?.getAllClusterServers().length).toBe(7)
+            expect(endpoints.get(EndpointNumber(11))?.hasClusterServer(DescriptorCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(11))?.hasClusterServer(IdentifyCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(11))?.hasClusterServer(GroupsCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(11))?.hasClusterServer(ScenesCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(11))?.hasClusterServer(OnOffCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(11))?.hasClusterServer(BridgedDeviceBasicInformationCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(11))?.hasClusterServer(BindingCluster)).toBeTruthy();
 
-            const rootPartsListAttribute = attributes.get(attributePathToId({ endpointId: 0, clusterId: DescriptorCluster.id, attributeId: DescriptorCluster.attributes.partsList.id })) as AttributeServer<EndpointNumber[]>;
+            const rootPartsListAttribute = attributes.get(attributePathToId({ endpointId: EndpointNumber(0), clusterId: DescriptorCluster.id, attributeId: DescriptorCluster.attributes.partsList.id })) as AttributeServer<EndpointNumber[]>;
             expect(rootPartsListAttribute?.getLocal()).toEqual([
-                new EndpointNumber(1),
-                new EndpointNumber(11)]
+                EndpointNumber(1),
+                EndpointNumber(11)]
             );
 
-            const aggregatorPartsListAttribute = attributes.get(attributePathToId({ endpointId: 1, clusterId: DescriptorCluster.id, attributeId: DescriptorCluster.attributes.partsList.id })) as AttributeServer<EndpointNumber[]>;
-            expect(aggregatorPartsListAttribute?.getLocal()).toEqual([new EndpointNumber(11)])
+            const aggregatorPartsListAttribute = attributes.get(attributePathToId({ endpointId: EndpointNumber(1), clusterId: DescriptorCluster.id, attributeId: DescriptorCluster.attributes.partsList.id })) as AttributeServer<EndpointNumber[]>;
+            expect(aggregatorPartsListAttribute?.getLocal()).toEqual([EndpointNumber(11)])
 
-            const aggregatorDeviceTypeListAttribute = attributes.get(attributePathToId({ endpointId: 1, clusterId: DescriptorCluster.id, attributeId: DescriptorCluster.attributes.deviceTypeList.id })) as AttributeServer<EndpointNumber[]>;
+            const aggregatorDeviceTypeListAttribute = attributes.get(attributePathToId({ endpointId: EndpointNumber(1), clusterId: DescriptorCluster.id, attributeId: DescriptorCluster.attributes.deviceTypeList.id })) as AttributeServer<EndpointNumber[]>;
             expect(aggregatorDeviceTypeListAttribute?.getLocal()).toEqual([{
-                deviceType: new DeviceTypeId(DeviceTypes.AGGREGATOR.code),
+                deviceType: DeviceTypeId(DeviceTypes.AGGREGATOR.code),
                 revision: 1
             }]);
 
-            const devicePartsListAttribute = attributes.get(attributePathToId({ endpointId: 11, clusterId: DescriptorCluster.id, attributeId: DescriptorCluster.attributes.partsList.id })) as AttributeServer<EndpointNumber[]>;
+            const devicePartsListAttribute = attributes.get(attributePathToId({ endpointId: EndpointNumber(11), clusterId: DescriptorCluster.id, attributeId: DescriptorCluster.attributes.partsList.id })) as AttributeServer<EndpointNumber[]>;
             expect(devicePartsListAttribute?.getLocal()).toEqual([])
 
-            const deviceTypeListAttribute = attributes.get(attributePathToId({ endpointId: 11, clusterId: DescriptorCluster.id, attributeId: DescriptorCluster.attributes.deviceTypeList.id })) as AttributeServer<EndpointNumber[]>;
+            const deviceTypeListAttribute = attributes.get(attributePathToId({ endpointId: EndpointNumber(11), clusterId: DescriptorCluster.id, attributeId: DescriptorCluster.attributes.deviceTypeList.id })) as AttributeServer<EndpointNumber[]>;
             expect(deviceTypeListAttribute?.getLocal()).toEqual([
                 {
-                    deviceType: new DeviceTypeId(DeviceTypes.ON_OFF_LIGHT.code),
+                    deviceType: DeviceTypeId(DeviceTypes.ON_OFF_LIGHT.code),
                     revision: 2
                 }, {
-                    deviceType: new DeviceTypeId(DeviceTypes.BRIDGED_NODE.code),
+                    deviceType: DeviceTypeId(DeviceTypes.BRIDGED_NODE.code),
                     revision: 1
                 }
             ]);
@@ -803,10 +803,10 @@ describe("Endpoint Structures", () => {
             const node = new TestNode();
             addRequiredRootClusters(node);
 
-            const aggregator = new Aggregator([], { endpointId: 1 });
+            const aggregator = new Aggregator([], { endpointId: EndpointNumber(1) });
 
-            const onoffLightDevice11 = new OnOffLightDevice(undefined, { endpointId: 11 });
-            const onoffLightDevice12 = new OnOffLightDevice(undefined, { endpointId: 12 });
+            const onoffLightDevice11 = new OnOffLightDevice(undefined, { endpointId: EndpointNumber(11) });
+            const onoffLightDevice12 = new OnOffLightDevice(undefined, { endpointId: EndpointNumber(12) });
 
             aggregator.addBridgedDevice(onoffLightDevice11, {
                 nodeLabel: "Socket 1",
@@ -831,68 +831,68 @@ describe("Endpoint Structures", () => {
             } = endpointStructure;
 
             expect(endpoints.size).toBe(4)
-            expect(endpoints.get(0)?.getAllClusterServers().length).toBe(9)
-            expect(endpoints.get(0)?.hasClusterServer(DescriptorCluster)).toBeTruthy();
-            expect(endpoints.get(0)?.hasClusterServer(BasicInformationCluster)).toBeTruthy();
-            expect(endpoints.get(0)?.hasClusterServer(OperationalCredentialsCluster)).toBeTruthy();
-            expect(endpoints.get(0)?.hasClusterServer(GeneralCommissioning.Cluster)).toBeTruthy();
-            expect(endpoints.get(0)?.hasClusterServer(NetworkCommissioning.Cluster)).toBeTruthy();
-            expect(endpoints.get(0)?.hasClusterServer(AccessControlCluster)).toBeTruthy();
-            expect(endpoints.get(0)?.hasClusterServer(AdministratorCommissioning.Cluster)).toBeTruthy();
-            expect(endpoints.get(0)?.hasClusterServer(GroupKeyManagementCluster)).toBeTruthy();
-            expect(endpoints.get(0)?.hasClusterServer(GeneralCommissioning.Cluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.getAllClusterServers().length).toBe(9)
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(DescriptorCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(BasicInformationCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(OperationalCredentialsCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(GeneralCommissioning.Cluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(NetworkCommissioning.Cluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(AccessControlCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(AdministratorCommissioning.Cluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(GroupKeyManagementCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(GeneralCommissioning.Cluster)).toBeTruthy();
 
-            expect(endpoints.get(1)?.getAllClusterServers().length).toBe(1)
-            expect(endpoints.get(1)?.hasClusterServer(DescriptorCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(1))?.getAllClusterServers().length).toBe(1)
+            expect(endpoints.get(EndpointNumber(1))?.hasClusterServer(DescriptorCluster)).toBeTruthy();
 
-            expect(endpoints.get(11)?.getAllClusterServers().length).toBe(7)
-            expect(endpoints.get(11)?.hasClusterServer(DescriptorCluster)).toBeTruthy();
-            expect(endpoints.get(11)?.hasClusterServer(IdentifyCluster)).toBeTruthy();
-            expect(endpoints.get(11)?.hasClusterServer(GroupsCluster)).toBeTruthy();
-            expect(endpoints.get(11)?.hasClusterServer(ScenesCluster)).toBeTruthy();
-            expect(endpoints.get(11)?.hasClusterServer(BridgedDeviceBasicInformationCluster)).toBeTruthy();
-            expect(endpoints.get(11)?.hasClusterServer(OnOffCluster)).toBeTruthy();
-            expect(endpoints.get(11)?.hasClusterServer(BindingCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(11))?.getAllClusterServers().length).toBe(7)
+            expect(endpoints.get(EndpointNumber(11))?.hasClusterServer(DescriptorCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(11))?.hasClusterServer(IdentifyCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(11))?.hasClusterServer(GroupsCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(11))?.hasClusterServer(ScenesCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(11))?.hasClusterServer(BridgedDeviceBasicInformationCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(11))?.hasClusterServer(OnOffCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(11))?.hasClusterServer(BindingCluster)).toBeTruthy();
 
-            expect(endpoints.get(12)?.getAllClusterServers().length).toBe(7)
-            expect(endpoints.get(12)?.hasClusterServer(DescriptorCluster)).toBeTruthy();
-            expect(endpoints.get(12)?.hasClusterServer(IdentifyCluster)).toBeTruthy();
-            expect(endpoints.get(12)?.hasClusterServer(GroupsCluster)).toBeTruthy();
-            expect(endpoints.get(12)?.hasClusterServer(ScenesCluster)).toBeTruthy();
-            expect(endpoints.get(12)?.hasClusterServer(BridgedDeviceBasicInformationCluster)).toBeTruthy();
-            expect(endpoints.get(12)?.hasClusterServer(OnOffCluster)).toBeTruthy();
-            expect(endpoints.get(12)?.hasClusterServer(BindingCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(12))?.getAllClusterServers().length).toBe(7)
+            expect(endpoints.get(EndpointNumber(12))?.hasClusterServer(DescriptorCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(12))?.hasClusterServer(IdentifyCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(12))?.hasClusterServer(GroupsCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(12))?.hasClusterServer(ScenesCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(12))?.hasClusterServer(BridgedDeviceBasicInformationCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(12))?.hasClusterServer(OnOffCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(12))?.hasClusterServer(BindingCluster)).toBeTruthy();
 
-            const rootPartsListAttribute = attributes.get(attributePathToId({ endpointId: 0, clusterId: DescriptorCluster.id, attributeId: DescriptorCluster.attributes.partsList.id })) as AttributeServer<EndpointNumber[]>;
+            const rootPartsListAttribute = attributes.get(attributePathToId({ endpointId: EndpointNumber(0), clusterId: DescriptorCluster.id, attributeId: DescriptorCluster.attributes.partsList.id })) as AttributeServer<EndpointNumber[]>;
             expect(rootPartsListAttribute?.getLocal()).toEqual([
-                new EndpointNumber(1),
-                new EndpointNumber(11),
-                new EndpointNumber(12)
+                EndpointNumber(1),
+                EndpointNumber(11),
+                EndpointNumber(12)
             ]);
 
-            const aggregatorPartsListAttribute = attributes.get(attributePathToId({ endpointId: 1, clusterId: DescriptorCluster.id, attributeId: DescriptorCluster.attributes.partsList.id })) as AttributeServer<EndpointNumber[]>;
+            const aggregatorPartsListAttribute = attributes.get(attributePathToId({ endpointId: EndpointNumber(1), clusterId: DescriptorCluster.id, attributeId: DescriptorCluster.attributes.partsList.id })) as AttributeServer<EndpointNumber[]>;
             expect(aggregatorPartsListAttribute?.getLocal()).toEqual([
-                new EndpointNumber(11),
-                new EndpointNumber(12)
+                EndpointNumber(11),
+                EndpointNumber(12)
             ]);
 
-            const aggregatorDeviceTypeListAttribute = attributes.get(attributePathToId({ endpointId: 1, clusterId: DescriptorCluster.id, attributeId: DescriptorCluster.attributes.deviceTypeList.id })) as AttributeServer<EndpointNumber[]>;
+            const aggregatorDeviceTypeListAttribute = attributes.get(attributePathToId({ endpointId: EndpointNumber(1), clusterId: DescriptorCluster.id, attributeId: DescriptorCluster.attributes.deviceTypeList.id })) as AttributeServer<EndpointNumber[]>;
             expect(aggregatorDeviceTypeListAttribute?.getLocal()).toEqual([{
-                deviceType: new DeviceTypeId(DeviceTypes.AGGREGATOR.code),
+                deviceType: DeviceTypeId(DeviceTypes.AGGREGATOR.code),
                 revision: 1
             }]);
 
 
-            const devicePartsListAttribute = attributes.get(attributePathToId({ endpointId: 11, clusterId: DescriptorCluster.id, attributeId: DescriptorCluster.attributes.partsList.id })) as AttributeServer<EndpointNumber[]>;
+            const devicePartsListAttribute = attributes.get(attributePathToId({ endpointId: EndpointNumber(11), clusterId: DescriptorCluster.id, attributeId: DescriptorCluster.attributes.partsList.id })) as AttributeServer<EndpointNumber[]>;
             expect(devicePartsListAttribute?.getLocal()).toEqual([])
 
-            const deviceTypeListAttribute = attributes.get(attributePathToId({ endpointId: 11, clusterId: DescriptorCluster.id, attributeId: DescriptorCluster.attributes.deviceTypeList.id })) as AttributeServer<EndpointNumber[]>;
+            const deviceTypeListAttribute = attributes.get(attributePathToId({ endpointId: EndpointNumber(11), clusterId: DescriptorCluster.id, attributeId: DescriptorCluster.attributes.deviceTypeList.id })) as AttributeServer<EndpointNumber[]>;
             expect(deviceTypeListAttribute?.getLocal()).toEqual([
                 {
-                    deviceType: new DeviceTypeId(DeviceTypes.ON_OFF_LIGHT.code),
+                    deviceType: DeviceTypeId(DeviceTypes.ON_OFF_LIGHT.code),
                     revision: 2
                 }, {
-                    deviceType: new DeviceTypeId(DeviceTypes.BRIDGED_NODE.code),
+                    deviceType: DeviceTypeId(DeviceTypes.BRIDGED_NODE.code),
                     revision: 1
                 }
             ]);
@@ -906,7 +906,7 @@ describe("Endpoint Structures", () => {
             const node = new TestNode();
             addRequiredRootClusters(node);
 
-            const aggregator1 = new Aggregator([], { endpointId: 1 });
+            const aggregator1 = new Aggregator([], { endpointId: EndpointNumber(1) });
             aggregator1.addClusterServer(ClusterServer(
                 FixedLabelCluster,
                 {
@@ -915,8 +915,8 @@ describe("Endpoint Structures", () => {
                 {}
             ));
 
-            const onoffLightDevice11 = new OnOffLightDevice(undefined, { endpointId: 11 });
-            const onoffLightDevice12 = new OnOffLightDevice(undefined, { endpointId: 12 });
+            const onoffLightDevice11 = new OnOffLightDevice(undefined, { endpointId: EndpointNumber(11) });
+            const onoffLightDevice12 = new OnOffLightDevice(undefined, { endpointId: EndpointNumber(12) });
 
             aggregator1.addBridgedDevice(onoffLightDevice11, {
                 nodeLabel: "Socket 1-1",
@@ -928,7 +928,7 @@ describe("Endpoint Structures", () => {
             });
             node.addEndpoint(aggregator1);
 
-            const aggregator2 = new Aggregator([], { endpointId: 2 });
+            const aggregator2 = new Aggregator([], { endpointId: EndpointNumber(2) });
             aggregator2.addClusterServer(ClusterServer(
                 FixedLabelCluster,
                 {
@@ -937,8 +937,8 @@ describe("Endpoint Structures", () => {
                 {}
             ));
 
-            const onoffLightDevice21 = new OnOffLightDevice(undefined, { endpointId: 21 });
-            const onoffLightDevice22 = new OnOffLightDevice(undefined, { endpointId: 22 });
+            const onoffLightDevice21 = new OnOffLightDevice(undefined, { endpointId: EndpointNumber(21) });
+            const onoffLightDevice22 = new OnOffLightDevice(undefined, { endpointId: EndpointNumber(22) });
 
             aggregator2.addBridgedDevice(onoffLightDevice21, {
                 nodeLabel: "Socket 2-1",
@@ -963,81 +963,81 @@ describe("Endpoint Structures", () => {
             } = endpointStructure;
 
             expect(endpoints.size).toBe(7)
-            expect(endpoints.get(0)?.getAllClusterServers().length).toBe(9)
-            expect(endpoints.get(0)?.hasClusterServer(DescriptorCluster)).toBeTruthy();
-            expect(endpoints.get(0)?.hasClusterServer(BasicInformationCluster)).toBeTruthy();
-            expect(endpoints.get(0)?.hasClusterServer(OperationalCredentialsCluster)).toBeTruthy();
-            expect(endpoints.get(0)?.hasClusterServer(GeneralCommissioning.Cluster)).toBeTruthy();
-            expect(endpoints.get(0)?.hasClusterServer(NetworkCommissioning.Cluster)).toBeTruthy();
-            expect(endpoints.get(0)?.hasClusterServer(AccessControlCluster)).toBeTruthy();
-            expect(endpoints.get(0)?.hasClusterServer(AdministratorCommissioning.Cluster)).toBeTruthy();
-            expect(endpoints.get(0)?.hasClusterServer(GroupKeyManagementCluster)).toBeTruthy();
-            expect(endpoints.get(0)?.hasClusterServer(GeneralCommissioning.Cluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.getAllClusterServers().length).toBe(9)
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(DescriptorCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(BasicInformationCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(OperationalCredentialsCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(GeneralCommissioning.Cluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(NetworkCommissioning.Cluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(AccessControlCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(AdministratorCommissioning.Cluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(GroupKeyManagementCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(GeneralCommissioning.Cluster)).toBeTruthy();
 
-            expect(endpoints.get(1)?.getAllClusterServers().length).toBe(2)
-            expect(endpoints.get(1)?.hasClusterServer(DescriptorCluster)).toBeTruthy();
-            expect(endpoints.get(1)?.hasClusterServer(FixedLabelCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(1))?.getAllClusterServers().length).toBe(2)
+            expect(endpoints.get(EndpointNumber(1))?.hasClusterServer(DescriptorCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(1))?.hasClusterServer(FixedLabelCluster)).toBeTruthy();
 
-            expect(endpoints.get(11)?.getAllClusterServers().length).toBe(7)
-            expect(endpoints.get(11)?.hasClusterServer(DescriptorCluster)).toBeTruthy();
-            expect(endpoints.get(11)?.hasClusterServer(IdentifyCluster)).toBeTruthy();
-            expect(endpoints.get(11)?.hasClusterServer(GroupsCluster)).toBeTruthy();
-            expect(endpoints.get(11)?.hasClusterServer(ScenesCluster)).toBeTruthy();
-            expect(endpoints.get(11)?.hasClusterServer(BridgedDeviceBasicInformationCluster)).toBeTruthy();
-            expect(endpoints.get(11)?.hasClusterServer(OnOffCluster)).toBeTruthy();
-            expect(endpoints.get(11)?.hasClusterServer(BindingCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(11))?.getAllClusterServers().length).toBe(7)
+            expect(endpoints.get(EndpointNumber(11))?.hasClusterServer(DescriptorCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(11))?.hasClusterServer(IdentifyCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(11))?.hasClusterServer(GroupsCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(11))?.hasClusterServer(ScenesCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(11))?.hasClusterServer(BridgedDeviceBasicInformationCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(11))?.hasClusterServer(OnOffCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(11))?.hasClusterServer(BindingCluster)).toBeTruthy();
 
-            expect(endpoints.get(12)?.getAllClusterServers().length).toBe(7)
-            expect(endpoints.get(12)?.hasClusterServer(DescriptorCluster)).toBeTruthy();
-            expect(endpoints.get(12)?.hasClusterServer(IdentifyCluster)).toBeTruthy();
-            expect(endpoints.get(12)?.hasClusterServer(GroupsCluster)).toBeTruthy();
-            expect(endpoints.get(12)?.hasClusterServer(ScenesCluster)).toBeTruthy();
-            expect(endpoints.get(12)?.hasClusterServer(BridgedDeviceBasicInformationCluster)).toBeTruthy();
-            expect(endpoints.get(12)?.hasClusterServer(OnOffCluster)).toBeTruthy();
-            expect(endpoints.get(12)?.hasClusterServer(BindingCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(12))?.getAllClusterServers().length).toBe(7)
+            expect(endpoints.get(EndpointNumber(12))?.hasClusterServer(DescriptorCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(12))?.hasClusterServer(IdentifyCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(12))?.hasClusterServer(GroupsCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(12))?.hasClusterServer(ScenesCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(12))?.hasClusterServer(BridgedDeviceBasicInformationCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(12))?.hasClusterServer(OnOffCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(12))?.hasClusterServer(BindingCluster)).toBeTruthy();
 
-            expect(endpoints.get(2)?.getAllClusterServers().length).toBe(2)
-            expect(endpoints.get(2)?.hasClusterServer(DescriptorCluster)).toBeTruthy();
-            expect(endpoints.get(2)?.hasClusterServer(FixedLabelCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(2))?.getAllClusterServers().length).toBe(2)
+            expect(endpoints.get(EndpointNumber(2))?.hasClusterServer(DescriptorCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(2))?.hasClusterServer(FixedLabelCluster)).toBeTruthy();
 
-            expect(endpoints.get(21)?.getAllClusterServers().length).toBe(7)
-            expect(endpoints.get(21)?.hasClusterServer(DescriptorCluster)).toBeTruthy();
-            expect(endpoints.get(21)?.hasClusterServer(IdentifyCluster)).toBeTruthy();
-            expect(endpoints.get(21)?.hasClusterServer(GroupsCluster)).toBeTruthy();
-            expect(endpoints.get(21)?.hasClusterServer(ScenesCluster)).toBeTruthy();
-            expect(endpoints.get(21)?.hasClusterServer(BridgedDeviceBasicInformationCluster)).toBeTruthy();
-            expect(endpoints.get(21)?.hasClusterServer(OnOffCluster)).toBeTruthy();
-            expect(endpoints.get(21)?.hasClusterServer(BindingCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(21))?.getAllClusterServers().length).toBe(7)
+            expect(endpoints.get(EndpointNumber(21))?.hasClusterServer(DescriptorCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(21))?.hasClusterServer(IdentifyCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(21))?.hasClusterServer(GroupsCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(21))?.hasClusterServer(ScenesCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(21))?.hasClusterServer(BridgedDeviceBasicInformationCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(21))?.hasClusterServer(OnOffCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(21))?.hasClusterServer(BindingCluster)).toBeTruthy();
 
-            expect(endpoints.get(22)?.getAllClusterServers().length).toBe(7)
-            expect(endpoints.get(22)?.hasClusterServer(DescriptorCluster)).toBeTruthy();
-            expect(endpoints.get(22)?.hasClusterServer(IdentifyCluster)).toBeTruthy();
-            expect(endpoints.get(22)?.hasClusterServer(GroupsCluster)).toBeTruthy();
-            expect(endpoints.get(22)?.hasClusterServer(ScenesCluster)).toBeTruthy();
-            expect(endpoints.get(22)?.hasClusterServer(BridgedDeviceBasicInformationCluster)).toBeTruthy();
-            expect(endpoints.get(22)?.hasClusterServer(OnOffCluster)).toBeTruthy();
-            expect(endpoints.get(22)?.hasClusterServer(BindingCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(22))?.getAllClusterServers().length).toBe(7)
+            expect(endpoints.get(EndpointNumber(22))?.hasClusterServer(DescriptorCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(22))?.hasClusterServer(IdentifyCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(22))?.hasClusterServer(GroupsCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(22))?.hasClusterServer(ScenesCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(22))?.hasClusterServer(BridgedDeviceBasicInformationCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(22))?.hasClusterServer(OnOffCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(22))?.hasClusterServer(BindingCluster)).toBeTruthy();
 
-            const aggregator1PartsListAttribute = attributes.get(attributePathToId({ endpointId: 1, clusterId: DescriptorCluster.id, attributeId: DescriptorCluster.attributes.partsList.id })) as AttributeServer<EndpointNumber[]>;
+            const aggregator1PartsListAttribute = attributes.get(attributePathToId({ endpointId: EndpointNumber(1), clusterId: DescriptorCluster.id, attributeId: DescriptorCluster.attributes.partsList.id })) as AttributeServer<EndpointNumber[]>;
             expect(aggregator1PartsListAttribute?.getLocal()).toEqual([
-                new EndpointNumber(11),
-                new EndpointNumber(12)]
+                EndpointNumber(11),
+                EndpointNumber(12)]
             );
 
-            const aggregator2PartsListAttribute = attributes.get(attributePathToId({ endpointId: 2, clusterId: DescriptorCluster.id, attributeId: DescriptorCluster.attributes.partsList.id })) as AttributeServer<EndpointNumber[]>;
+            const aggregator2PartsListAttribute = attributes.get(attributePathToId({ endpointId: EndpointNumber(2), clusterId: DescriptorCluster.id, attributeId: DescriptorCluster.attributes.partsList.id })) as AttributeServer<EndpointNumber[]>;
             expect(aggregator2PartsListAttribute?.getLocal()).toEqual([
-                new EndpointNumber(21),
-                new EndpointNumber(22)
+                EndpointNumber(21),
+                EndpointNumber(22)
             ]);
 
-            const rootPartsListAttribute = attributes.get(attributePathToId({ endpointId: 0, clusterId: DescriptorCluster.id, attributeId: DescriptorCluster.attributes.partsList.id })) as AttributeServer<EndpointNumber[]>;
+            const rootPartsListAttribute = attributes.get(attributePathToId({ endpointId: EndpointNumber(0), clusterId: DescriptorCluster.id, attributeId: DescriptorCluster.attributes.partsList.id })) as AttributeServer<EndpointNumber[]>;
             expect(rootPartsListAttribute?.getLocal()).toEqual([
-                new EndpointNumber(1),
-                new EndpointNumber(11),
-                new EndpointNumber(12),
-                new EndpointNumber(2),
-                new EndpointNumber(21),
-                new EndpointNumber(22)
+                EndpointNumber(1),
+                EndpointNumber(11),
+                EndpointNumber(12),
+                EndpointNumber(2),
+                EndpointNumber(21),
+                EndpointNumber(22)
             ]);
 
             expect(attributePaths.length).toBe(380)
@@ -1054,13 +1054,13 @@ describe("Endpoint Structures", () => {
             const node = new CommissioningServer({
                 port: 5540,
                 deviceName: "Test Device",
-                deviceType: 0x16,
+                deviceType: DeviceTypeId(0x16),
                 passcode: 123,
                 discriminator: 1234,
                 basicInformation: {
                     dataModelRevision: 1,
                     vendorName: "vendor",
-                    vendorId: new VendorId(1),
+                    vendorId: VendorId(1),
                     productName: "product",
                     productId: 2,
                     nodeLabel: "",
@@ -1142,81 +1142,81 @@ describe("Endpoint Structures", () => {
             } = endpointStructure;
 
             expect(endpoints.size).toBe(7)
-            expect(endpoints.get(0)?.getAllClusterServers().length).toBe(9)
-            expect(endpoints.get(0)?.hasClusterServer(DescriptorCluster)).toBeTruthy();
-            expect(endpoints.get(0)?.hasClusterServer(BasicInformationCluster)).toBeTruthy();
-            expect(endpoints.get(0)?.hasClusterServer(OperationalCredentialsCluster)).toBeTruthy();
-            expect(endpoints.get(0)?.hasClusterServer(GeneralCommissioning.Cluster)).toBeTruthy();
-            expect(endpoints.get(0)?.hasClusterServer(NetworkCommissioning.Cluster)).toBeTruthy();
-            expect(endpoints.get(0)?.hasClusterServer(AccessControlCluster)).toBeTruthy();
-            expect(endpoints.get(0)?.hasClusterServer(AdministratorCommissioning.Cluster)).toBeTruthy();
-            expect(endpoints.get(0)?.hasClusterServer(GroupKeyManagementCluster)).toBeTruthy();
-            expect(endpoints.get(0)?.hasClusterServer(GeneralCommissioning.Cluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.getAllClusterServers().length).toBe(9)
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(DescriptorCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(BasicInformationCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(OperationalCredentialsCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(GeneralCommissioning.Cluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(NetworkCommissioning.Cluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(AccessControlCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(AdministratorCommissioning.Cluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(GroupKeyManagementCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(GeneralCommissioning.Cluster)).toBeTruthy();
 
-            expect(endpoints.get(1)?.getAllClusterServers().length).toBe(2)
-            expect(endpoints.get(1)?.hasClusterServer(DescriptorCluster)).toBeTruthy();
-            expect(endpoints.get(1)?.hasClusterServer(FixedLabelCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(1))?.getAllClusterServers().length).toBe(2)
+            expect(endpoints.get(EndpointNumber(1))?.hasClusterServer(DescriptorCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(1))?.hasClusterServer(FixedLabelCluster)).toBeTruthy();
 
-            expect(endpoints.get(2)?.getAllClusterServers().length).toBe(7)
-            expect(endpoints.get(2)?.hasClusterServer(DescriptorCluster)).toBeTruthy();
-            expect(endpoints.get(2)?.hasClusterServer(IdentifyCluster)).toBeTruthy();
-            expect(endpoints.get(2)?.hasClusterServer(GroupsCluster)).toBeTruthy();
-            expect(endpoints.get(2)?.hasClusterServer(ScenesCluster)).toBeTruthy();
-            expect(endpoints.get(2)?.hasClusterServer(BridgedDeviceBasicInformationCluster)).toBeTruthy();
-            expect(endpoints.get(2)?.hasClusterServer(OnOffCluster)).toBeTruthy();
-            expect(endpoints.get(2)?.hasClusterServer(BindingCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(2))?.getAllClusterServers().length).toBe(7)
+            expect(endpoints.get(EndpointNumber(2))?.hasClusterServer(DescriptorCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(2))?.hasClusterServer(IdentifyCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(2))?.hasClusterServer(GroupsCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(2))?.hasClusterServer(ScenesCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(2))?.hasClusterServer(BridgedDeviceBasicInformationCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(2))?.hasClusterServer(OnOffCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(2))?.hasClusterServer(BindingCluster)).toBeTruthy();
 
-            expect(endpoints.get(3)?.getAllClusterServers().length).toBe(7)
-            expect(endpoints.get(3)?.hasClusterServer(DescriptorCluster)).toBeTruthy();
-            expect(endpoints.get(3)?.hasClusterServer(IdentifyCluster)).toBeTruthy();
-            expect(endpoints.get(3)?.hasClusterServer(GroupsCluster)).toBeTruthy();
-            expect(endpoints.get(3)?.hasClusterServer(ScenesCluster)).toBeTruthy();
-            expect(endpoints.get(3)?.hasClusterServer(BridgedDeviceBasicInformationCluster)).toBeTruthy();
-            expect(endpoints.get(3)?.hasClusterServer(OnOffCluster)).toBeTruthy();
-            expect(endpoints.get(3)?.hasClusterServer(BindingCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(3))?.getAllClusterServers().length).toBe(7)
+            expect(endpoints.get(EndpointNumber(3))?.hasClusterServer(DescriptorCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(3))?.hasClusterServer(IdentifyCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(3))?.hasClusterServer(GroupsCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(3))?.hasClusterServer(ScenesCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(3))?.hasClusterServer(BridgedDeviceBasicInformationCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(3))?.hasClusterServer(OnOffCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(3))?.hasClusterServer(BindingCluster)).toBeTruthy();
 
-            expect(endpoints.get(4)?.getAllClusterServers().length).toBe(2)
-            expect(endpoints.get(4)?.hasClusterServer(DescriptorCluster)).toBeTruthy();
-            expect(endpoints.get(4)?.hasClusterServer(FixedLabelCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(4))?.getAllClusterServers().length).toBe(2)
+            expect(endpoints.get(EndpointNumber(4))?.hasClusterServer(DescriptorCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(4))?.hasClusterServer(FixedLabelCluster)).toBeTruthy();
 
-            expect(endpoints.get(5)?.getAllClusterServers().length).toBe(7)
-            expect(endpoints.get(5)?.hasClusterServer(DescriptorCluster)).toBeTruthy();
-            expect(endpoints.get(5)?.hasClusterServer(IdentifyCluster)).toBeTruthy();
-            expect(endpoints.get(5)?.hasClusterServer(GroupsCluster)).toBeTruthy();
-            expect(endpoints.get(5)?.hasClusterServer(ScenesCluster)).toBeTruthy();
-            expect(endpoints.get(5)?.hasClusterServer(BridgedDeviceBasicInformationCluster)).toBeTruthy();
-            expect(endpoints.get(5)?.hasClusterServer(OnOffCluster)).toBeTruthy();
-            expect(endpoints.get(5)?.hasClusterServer(BindingCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(5))?.getAllClusterServers().length).toBe(7)
+            expect(endpoints.get(EndpointNumber(5))?.hasClusterServer(DescriptorCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(5))?.hasClusterServer(IdentifyCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(5))?.hasClusterServer(GroupsCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(5))?.hasClusterServer(ScenesCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(5))?.hasClusterServer(BridgedDeviceBasicInformationCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(5))?.hasClusterServer(OnOffCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(5))?.hasClusterServer(BindingCluster)).toBeTruthy();
 
-            expect(endpoints.get(6)?.getAllClusterServers().length).toBe(7)
-            expect(endpoints.get(6)?.hasClusterServer(DescriptorCluster)).toBeTruthy();
-            expect(endpoints.get(6)?.hasClusterServer(IdentifyCluster)).toBeTruthy();
-            expect(endpoints.get(6)?.hasClusterServer(GroupsCluster)).toBeTruthy();
-            expect(endpoints.get(6)?.hasClusterServer(ScenesCluster)).toBeTruthy();
-            expect(endpoints.get(6)?.hasClusterServer(BridgedDeviceBasicInformationCluster)).toBeTruthy();
-            expect(endpoints.get(6)?.hasClusterServer(OnOffCluster)).toBeTruthy();
-            expect(endpoints.get(6)?.hasClusterServer(BindingCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(6))?.getAllClusterServers().length).toBe(7)
+            expect(endpoints.get(EndpointNumber(6))?.hasClusterServer(DescriptorCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(6))?.hasClusterServer(IdentifyCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(6))?.hasClusterServer(GroupsCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(6))?.hasClusterServer(ScenesCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(6))?.hasClusterServer(BridgedDeviceBasicInformationCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(6))?.hasClusterServer(OnOffCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(6))?.hasClusterServer(BindingCluster)).toBeTruthy();
 
-            const aggregator1PartsListAttribute = attributes.get(attributePathToId({ endpointId: 1, clusterId: DescriptorCluster.id, attributeId: DescriptorCluster.attributes.partsList.id })) as AttributeServer<EndpointNumber[]>;
+            const aggregator1PartsListAttribute = attributes.get(attributePathToId({ endpointId: EndpointNumber(1), clusterId: DescriptorCluster.id, attributeId: DescriptorCluster.attributes.partsList.id })) as AttributeServer<EndpointNumber[]>;
             expect(aggregator1PartsListAttribute?.getLocal()).toEqual([
-                new EndpointNumber(2),
-                new EndpointNumber(3)
+                EndpointNumber(2),
+                EndpointNumber(3)
             ]);
 
-            const aggregator2PartsListAttribute = attributes.get(attributePathToId({ endpointId: 4, clusterId: DescriptorCluster.id, attributeId: DescriptorCluster.attributes.partsList.id })) as AttributeServer<EndpointNumber[]>;
+            const aggregator2PartsListAttribute = attributes.get(attributePathToId({ endpointId: EndpointNumber(4), clusterId: DescriptorCluster.id, attributeId: DescriptorCluster.attributes.partsList.id })) as AttributeServer<EndpointNumber[]>;
             expect(aggregator2PartsListAttribute?.getLocal()).toEqual([
-                new EndpointNumber(5),
-                new EndpointNumber(6)
+                EndpointNumber(5),
+                EndpointNumber(6)
             ]);
 
-            const rootPartsListAttribute = attributes.get(attributePathToId({ endpointId: 0, clusterId: DescriptorCluster.id, attributeId: DescriptorCluster.attributes.partsList.id })) as AttributeServer<EndpointNumber[]>;
+            const rootPartsListAttribute = attributes.get(attributePathToId({ endpointId: EndpointNumber(0), clusterId: DescriptorCluster.id, attributeId: DescriptorCluster.attributes.partsList.id })) as AttributeServer<EndpointNumber[]>;
             expect(rootPartsListAttribute?.getLocal()).toEqual([
-                new EndpointNumber(1),
-                new EndpointNumber(2),
-                new EndpointNumber(3),
-                new EndpointNumber(4),
-                new EndpointNumber(5),
-                new EndpointNumber(6)
+                EndpointNumber(1),
+                EndpointNumber(2),
+                EndpointNumber(3),
+                EndpointNumber(4),
+                EndpointNumber(5),
+                EndpointNumber(6)
             ]);
 
             expect(attributePaths.length).toBe(380);
@@ -1234,13 +1234,13 @@ describe("Endpoint Structures", () => {
             const node = new CommissioningServer({
                 port: 5540,
                 deviceName: "Test Device",
-                deviceType: 0x16,
+                deviceType: DeviceTypeId(0x16),
                 passcode: 123,
                 discriminator: 1234,
                 basicInformation: {
                     dataModelRevision: 1,
                     vendorName: "vendor",
-                    vendorId: new VendorId(1),
+                    vendorId: VendorId(1),
                     productName: "product",
                     productId: 2,
                     nodeLabel: "",
@@ -1266,7 +1266,7 @@ describe("Endpoint Structures", () => {
             node.setStorage(testStorageContext);
             addRequiredRootClusters(node);
 
-            const aggregator1 = new Aggregator([], { endpointId: 37 });
+            const aggregator1 = new Aggregator([], { endpointId: EndpointNumber(37) });
             aggregator1.addClusterServer(ClusterServer(
                 FixedLabelCluster,
                 {
@@ -1275,7 +1275,7 @@ describe("Endpoint Structures", () => {
                 {}
             ));
 
-            const onoffLightDevice11 = new OnOffLightDevice(undefined, { endpointId: 3 });
+            const onoffLightDevice11 = new OnOffLightDevice(undefined, { endpointId: EndpointNumber(3) });
             const onoffLightDevice12 = new OnOffLightDevice();
 
             aggregator1.addBridgedDevice(onoffLightDevice11, {
@@ -1298,7 +1298,7 @@ describe("Endpoint Structures", () => {
             ));
 
             const onoffLightDevice21 = new OnOffLightDevice();
-            const onoffLightDevice22 = new OnOffLightDevice(undefined, { endpointId: 18 });
+            const onoffLightDevice22 = new OnOffLightDevice(undefined, { endpointId: EndpointNumber(18) });
 
             aggregator2.addBridgedDevice(onoffLightDevice21, {
                 nodeLabel: "Socket 2-1",
@@ -1338,113 +1338,113 @@ describe("Endpoint Structures", () => {
             } = endpointStructure;
 
             expect(endpoints.size).toBe(10)
-            expect(endpoints.get(0)?.getAllClusterServers().length).toBe(9)
-            expect(endpoints.get(0)?.hasClusterServer(DescriptorCluster)).toBeTruthy();
-            expect(endpoints.get(0)?.hasClusterServer(BasicInformationCluster)).toBeTruthy();
-            expect(endpoints.get(0)?.hasClusterServer(OperationalCredentialsCluster)).toBeTruthy();
-            expect(endpoints.get(0)?.hasClusterServer(GeneralCommissioning.Cluster)).toBeTruthy();
-            expect(endpoints.get(0)?.hasClusterServer(NetworkCommissioning.Cluster)).toBeTruthy();
-            expect(endpoints.get(0)?.hasClusterServer(AccessControlCluster)).toBeTruthy();
-            expect(endpoints.get(0)?.hasClusterServer(AdministratorCommissioning.Cluster)).toBeTruthy();
-            expect(endpoints.get(0)?.hasClusterServer(GroupKeyManagementCluster)).toBeTruthy();
-            expect(endpoints.get(0)?.hasClusterServer(GeneralCommissioning.Cluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.getAllClusterServers().length).toBe(9)
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(DescriptorCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(BasicInformationCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(OperationalCredentialsCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(GeneralCommissioning.Cluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(NetworkCommissioning.Cluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(AccessControlCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(AdministratorCommissioning.Cluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(GroupKeyManagementCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(GeneralCommissioning.Cluster)).toBeTruthy();
 
-            expect(endpoints.get(37)?.getAllClusterServers().length).toBe(2)
-            expect(endpoints.get(37)?.hasClusterServer(DescriptorCluster)).toBeTruthy();
-            expect(endpoints.get(37)?.hasClusterServer(FixedLabelCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(37))?.getAllClusterServers().length).toBe(2)
+            expect(endpoints.get(EndpointNumber(37))?.hasClusterServer(DescriptorCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(37))?.hasClusterServer(FixedLabelCluster)).toBeTruthy();
 
-            expect(endpoints.get(3)?.getAllClusterServers().length).toBe(7)
-            expect(endpoints.get(3)?.hasClusterServer(DescriptorCluster)).toBeTruthy();
-            expect(endpoints.get(3)?.hasClusterServer(IdentifyCluster)).toBeTruthy();
-            expect(endpoints.get(3)?.hasClusterServer(GroupsCluster)).toBeTruthy();
-            expect(endpoints.get(3)?.hasClusterServer(ScenesCluster)).toBeTruthy();
-            expect(endpoints.get(3)?.hasClusterServer(BridgedDeviceBasicInformationCluster)).toBeTruthy();
-            expect(endpoints.get(3)?.hasClusterServer(OnOffCluster)).toBeTruthy();
-            expect(endpoints.get(3)?.hasClusterServer(BindingCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(3))?.getAllClusterServers().length).toBe(7)
+            expect(endpoints.get(EndpointNumber(3))?.hasClusterServer(DescriptorCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(3))?.hasClusterServer(IdentifyCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(3))?.hasClusterServer(GroupsCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(3))?.hasClusterServer(ScenesCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(3))?.hasClusterServer(BridgedDeviceBasicInformationCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(3))?.hasClusterServer(OnOffCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(3))?.hasClusterServer(BindingCluster)).toBeTruthy();
 
-            expect(endpoints.get(38)?.getAllClusterServers().length).toBe(7)
-            expect(endpoints.get(38)?.hasClusterServer(DescriptorCluster)).toBeTruthy();
-            expect(endpoints.get(38)?.hasClusterServer(IdentifyCluster)).toBeTruthy();
-            expect(endpoints.get(38)?.hasClusterServer(GroupsCluster)).toBeTruthy();
-            expect(endpoints.get(38)?.hasClusterServer(ScenesCluster)).toBeTruthy();
-            expect(endpoints.get(38)?.hasClusterServer(BridgedDeviceBasicInformationCluster)).toBeTruthy();
-            expect(endpoints.get(38)?.hasClusterServer(OnOffCluster)).toBeTruthy();
-            expect(endpoints.get(38)?.hasClusterServer(BindingCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(38))?.getAllClusterServers().length).toBe(7)
+            expect(endpoints.get(EndpointNumber(38))?.hasClusterServer(DescriptorCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(38))?.hasClusterServer(IdentifyCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(38))?.hasClusterServer(GroupsCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(38))?.hasClusterServer(ScenesCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(38))?.hasClusterServer(BridgedDeviceBasicInformationCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(38))?.hasClusterServer(OnOffCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(38))?.hasClusterServer(BindingCluster)).toBeTruthy();
 
-            expect(endpoints.get(39)?.getAllClusterServers().length).toBe(2)
-            expect(endpoints.get(39)?.hasClusterServer(DescriptorCluster)).toBeTruthy();
-            expect(endpoints.get(39)?.hasClusterServer(FixedLabelCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(39))?.getAllClusterServers().length).toBe(2)
+            expect(endpoints.get(EndpointNumber(39))?.hasClusterServer(DescriptorCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(39))?.hasClusterServer(FixedLabelCluster)).toBeTruthy();
 
-            expect(endpoints.get(40)?.getAllClusterServers().length).toBe(7)
-            expect(endpoints.get(40)?.hasClusterServer(DescriptorCluster)).toBeTruthy();
-            expect(endpoints.get(40)?.hasClusterServer(IdentifyCluster)).toBeTruthy();
-            expect(endpoints.get(40)?.hasClusterServer(GroupsCluster)).toBeTruthy();
-            expect(endpoints.get(40)?.hasClusterServer(ScenesCluster)).toBeTruthy();
-            expect(endpoints.get(40)?.hasClusterServer(BridgedDeviceBasicInformationCluster)).toBeTruthy();
-            expect(endpoints.get(40)?.hasClusterServer(OnOffCluster)).toBeTruthy();
-            expect(endpoints.get(40)?.hasClusterServer(BindingCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(40))?.getAllClusterServers().length).toBe(7)
+            expect(endpoints.get(EndpointNumber(40))?.hasClusterServer(DescriptorCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(40))?.hasClusterServer(IdentifyCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(40))?.hasClusterServer(GroupsCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(40))?.hasClusterServer(ScenesCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(40))?.hasClusterServer(BridgedDeviceBasicInformationCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(40))?.hasClusterServer(OnOffCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(40))?.hasClusterServer(BindingCluster)).toBeTruthy();
 
-            expect(endpoints.get(18)?.getAllClusterServers().length).toBe(7)
-            expect(endpoints.get(18)?.hasClusterServer(DescriptorCluster)).toBeTruthy();
-            expect(endpoints.get(18)?.hasClusterServer(IdentifyCluster)).toBeTruthy();
-            expect(endpoints.get(18)?.hasClusterServer(GroupsCluster)).toBeTruthy();
-            expect(endpoints.get(18)?.hasClusterServer(ScenesCluster)).toBeTruthy();
-            expect(endpoints.get(18)?.hasClusterServer(BridgedDeviceBasicInformationCluster)).toBeTruthy();
-            expect(endpoints.get(18)?.hasClusterServer(OnOffCluster)).toBeTruthy();
-            expect(endpoints.get(18)?.hasClusterServer(BindingCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(18))?.getAllClusterServers().length).toBe(7)
+            expect(endpoints.get(EndpointNumber(18))?.hasClusterServer(DescriptorCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(18))?.hasClusterServer(IdentifyCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(18))?.hasClusterServer(GroupsCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(18))?.hasClusterServer(ScenesCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(18))?.hasClusterServer(BridgedDeviceBasicInformationCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(18))?.hasClusterServer(OnOffCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(18))?.hasClusterServer(BindingCluster)).toBeTruthy();
 
-            expect(endpoints.get(41)?.getAllClusterServers().length).toBe(2)
-            expect(endpoints.get(41)?.hasClusterServer(DescriptorCluster)).toBeTruthy();
-            expect(endpoints.get(41)?.hasClusterServer(BridgedDeviceBasicInformationCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(41))?.getAllClusterServers().length).toBe(2)
+            expect(endpoints.get(EndpointNumber(41))?.hasClusterServer(DescriptorCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(41))?.hasClusterServer(BridgedDeviceBasicInformationCluster)).toBeTruthy();
 
-            expect(endpoints.get(42)?.getAllClusterServers().length).toBe(6)
-            expect(endpoints.get(42)?.hasClusterServer(DescriptorCluster)).toBeTruthy();
-            expect(endpoints.get(42)?.hasClusterServer(IdentifyCluster)).toBeTruthy();
-            expect(endpoints.get(42)?.hasClusterServer(GroupsCluster)).toBeTruthy();
-            expect(endpoints.get(42)?.hasClusterServer(ScenesCluster)).toBeTruthy();
-            expect(endpoints.get(42)?.hasClusterServer(OnOffCluster)).toBeTruthy();
-            expect(endpoints.get(42)?.hasClusterServer(BindingCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(42))?.getAllClusterServers().length).toBe(6)
+            expect(endpoints.get(EndpointNumber(42))?.hasClusterServer(DescriptorCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(42))?.hasClusterServer(IdentifyCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(42))?.hasClusterServer(GroupsCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(42))?.hasClusterServer(ScenesCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(42))?.hasClusterServer(OnOffCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(42))?.hasClusterServer(BindingCluster)).toBeTruthy();
 
-            expect(endpoints.get(43)?.getAllClusterServers().length).toBe(6)
-            expect(endpoints.get(43)?.hasClusterServer(DescriptorCluster)).toBeTruthy();
-            expect(endpoints.get(43)?.hasClusterServer(IdentifyCluster)).toBeTruthy();
-            expect(endpoints.get(43)?.hasClusterServer(GroupsCluster)).toBeTruthy();
-            expect(endpoints.get(43)?.hasClusterServer(ScenesCluster)).toBeTruthy();
-            expect(endpoints.get(43)?.hasClusterServer(OnOffCluster)).toBeTruthy();
-            expect(endpoints.get(43)?.hasClusterServer(BindingCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(43))?.getAllClusterServers().length).toBe(6)
+            expect(endpoints.get(EndpointNumber(43))?.hasClusterServer(DescriptorCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(43))?.hasClusterServer(IdentifyCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(43))?.hasClusterServer(GroupsCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(43))?.hasClusterServer(ScenesCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(43))?.hasClusterServer(OnOffCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(43))?.hasClusterServer(BindingCluster)).toBeTruthy();
 
-            const aggregator1PartsListAttribute = attributes.get(attributePathToId({ endpointId: 37, clusterId: DescriptorCluster.id, attributeId: DescriptorCluster.attributes.partsList.id })) as AttributeServer<EndpointNumber[]>;
+            const aggregator1PartsListAttribute = attributes.get(attributePathToId({ endpointId: EndpointNumber(37), clusterId: DescriptorCluster.id, attributeId: DescriptorCluster.attributes.partsList.id })) as AttributeServer<EndpointNumber[]>;
             expect(aggregator1PartsListAttribute?.getLocal()).toEqual([
-                new EndpointNumber(3),
-                new EndpointNumber(38)
+                EndpointNumber(3),
+                EndpointNumber(38)
             ]);
 
-            const aggregator2PartsListAttribute = attributes.get(attributePathToId({ endpointId: 39, clusterId: DescriptorCluster.id, attributeId: DescriptorCluster.attributes.partsList.id })) as AttributeServer<EndpointNumber[]>;
+            const aggregator2PartsListAttribute = attributes.get(attributePathToId({ endpointId: EndpointNumber(39), clusterId: DescriptorCluster.id, attributeId: DescriptorCluster.attributes.partsList.id })) as AttributeServer<EndpointNumber[]>;
             expect(aggregator2PartsListAttribute?.getLocal()).toEqual([
-                new EndpointNumber(40),
-                new EndpointNumber(18),
-                new EndpointNumber(41),
-                new EndpointNumber(42),
-                new EndpointNumber(43)
+                EndpointNumber(40),
+                EndpointNumber(18),
+                EndpointNumber(41),
+                EndpointNumber(42),
+                EndpointNumber(43)
             ]);
 
-            const aggregator2PartsListAttribute2 = attributes.get(attributePathToId({ endpointId: 41, clusterId: DescriptorCluster.id, attributeId: DescriptorCluster.attributes.partsList.id })) as AttributeServer<EndpointNumber[]>;
+            const aggregator2PartsListAttribute2 = attributes.get(attributePathToId({ endpointId: EndpointNumber(41), clusterId: DescriptorCluster.id, attributeId: DescriptorCluster.attributes.partsList.id })) as AttributeServer<EndpointNumber[]>;
             expect(aggregator2PartsListAttribute2?.getLocal()).toEqual([
-                new EndpointNumber(42),
-                new EndpointNumber(43)
+                EndpointNumber(42),
+                EndpointNumber(43)
             ]);
 
-            const rootPartsListAttribute = attributes.get(attributePathToId({ endpointId: 0, clusterId: DescriptorCluster.id, attributeId: DescriptorCluster.attributes.partsList.id })) as AttributeServer<EndpointNumber[]>;
+            const rootPartsListAttribute = attributes.get(attributePathToId({ endpointId: EndpointNumber(0), clusterId: DescriptorCluster.id, attributeId: DescriptorCluster.attributes.partsList.id })) as AttributeServer<EndpointNumber[]>;
             expect(rootPartsListAttribute?.getLocal()).toEqual([
-                new EndpointNumber(37),
-                new EndpointNumber(3),
-                new EndpointNumber(38),
-                new EndpointNumber(39),
-                new EndpointNumber(40),
-                new EndpointNumber(18),
-                new EndpointNumber(41),
-                new EndpointNumber(42),
-                new EndpointNumber(43)
+                EndpointNumber(37),
+                EndpointNumber(3),
+                EndpointNumber(38),
+                EndpointNumber(39),
+                EndpointNumber(40),
+                EndpointNumber(18),
+                EndpointNumber(41),
+                EndpointNumber(42),
+                EndpointNumber(43)
             ]);
 
             expect(endpointStorage.get("serial_node-matter-0000-index_0-index_1")).toBe(38);
@@ -1467,13 +1467,13 @@ describe("Endpoint Structures", () => {
             const node = new CommissioningServer({
                 port: 5540,
                 deviceName: "Test Device",
-                deviceType: 0x16,
+                deviceType: DeviceTypeId(0x16),
                 passcode: 123,
                 discriminator: 1234,
                 basicInformation: {
                     dataModelRevision: 1,
                     vendorName: "vendor",
-                    vendorId: new VendorId(1),
+                    vendorId: VendorId(1),
                     productName: "product",
                     productId: 2,
                     nodeLabel: "",
@@ -1499,7 +1499,7 @@ describe("Endpoint Structures", () => {
             node.setStorage(testStorageContext);
             addRequiredRootClusters(node);
 
-            const aggregator1 = new Aggregator([], { endpointId: 37 });
+            const aggregator1 = new Aggregator([], { endpointId: EndpointNumber(37) });
             aggregator1.addClusterServer(ClusterServer(
                 FixedLabelCluster,
                 {
@@ -1531,7 +1531,7 @@ describe("Endpoint Structures", () => {
             ));
 
             const onoffLightDevice21 = new OnOffLightDevice();
-            const onoffLightDevice22 = new OnOffLightDevice(undefined, { endpointId: 18 });
+            const onoffLightDevice22 = new OnOffLightDevice(undefined, { endpointId: EndpointNumber(18) });
 
             aggregator2.addBridgedDevice(onoffLightDevice21, {
                 nodeLabel: "Socket 2-1",
@@ -1571,113 +1571,113 @@ describe("Endpoint Structures", () => {
             } = endpointStructure;
 
             expect(endpoints.size).toBe(10)
-            expect(endpoints.get(0)?.getAllClusterServers().length).toBe(9)
-            expect(endpoints.get(0)?.hasClusterServer(DescriptorCluster)).toBeTruthy();
-            expect(endpoints.get(0)?.hasClusterServer(BasicInformationCluster)).toBeTruthy();
-            expect(endpoints.get(0)?.hasClusterServer(OperationalCredentialsCluster)).toBeTruthy();
-            expect(endpoints.get(0)?.hasClusterServer(GeneralCommissioning.Cluster)).toBeTruthy();
-            expect(endpoints.get(0)?.hasClusterServer(NetworkCommissioning.Cluster)).toBeTruthy();
-            expect(endpoints.get(0)?.hasClusterServer(AccessControlCluster)).toBeTruthy();
-            expect(endpoints.get(0)?.hasClusterServer(AdministratorCommissioning.Cluster)).toBeTruthy();
-            expect(endpoints.get(0)?.hasClusterServer(GroupKeyManagementCluster)).toBeTruthy();
-            expect(endpoints.get(0)?.hasClusterServer(GeneralCommissioning.Cluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.getAllClusterServers().length).toBe(9)
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(DescriptorCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(BasicInformationCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(OperationalCredentialsCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(GeneralCommissioning.Cluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(NetworkCommissioning.Cluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(AccessControlCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(AdministratorCommissioning.Cluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(GroupKeyManagementCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(0))?.hasClusterServer(GeneralCommissioning.Cluster)).toBeTruthy();
 
-            expect(endpoints.get(37)?.getAllClusterServers().length).toBe(2)
-            expect(endpoints.get(37)?.hasClusterServer(DescriptorCluster)).toBeTruthy();
-            expect(endpoints.get(37)?.hasClusterServer(FixedLabelCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(37))?.getAllClusterServers().length).toBe(2)
+            expect(endpoints.get(EndpointNumber(37))?.hasClusterServer(DescriptorCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(37))?.hasClusterServer(FixedLabelCluster)).toBeTruthy();
 
-            expect(endpoints.get(3)?.getAllClusterServers().length).toBe(7)
-            expect(endpoints.get(3)?.hasClusterServer(DescriptorCluster)).toBeTruthy();
-            expect(endpoints.get(3)?.hasClusterServer(IdentifyCluster)).toBeTruthy();
-            expect(endpoints.get(3)?.hasClusterServer(GroupsCluster)).toBeTruthy();
-            expect(endpoints.get(3)?.hasClusterServer(ScenesCluster)).toBeTruthy();
-            expect(endpoints.get(3)?.hasClusterServer(BridgedDeviceBasicInformationCluster)).toBeTruthy();
-            expect(endpoints.get(3)?.hasClusterServer(OnOffCluster)).toBeTruthy();
-            expect(endpoints.get(3)?.hasClusterServer(BindingCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(3))?.getAllClusterServers().length).toBe(7)
+            expect(endpoints.get(EndpointNumber(3))?.hasClusterServer(DescriptorCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(3))?.hasClusterServer(IdentifyCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(3))?.hasClusterServer(GroupsCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(3))?.hasClusterServer(ScenesCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(3))?.hasClusterServer(BridgedDeviceBasicInformationCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(3))?.hasClusterServer(OnOffCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(3))?.hasClusterServer(BindingCluster)).toBeTruthy();
 
-            expect(endpoints.get(38)?.getAllClusterServers().length).toBe(7)
-            expect(endpoints.get(38)?.hasClusterServer(DescriptorCluster)).toBeTruthy();
-            expect(endpoints.get(38)?.hasClusterServer(IdentifyCluster)).toBeTruthy();
-            expect(endpoints.get(38)?.hasClusterServer(GroupsCluster)).toBeTruthy();
-            expect(endpoints.get(38)?.hasClusterServer(ScenesCluster)).toBeTruthy();
-            expect(endpoints.get(38)?.hasClusterServer(BridgedDeviceBasicInformationCluster)).toBeTruthy();
-            expect(endpoints.get(38)?.hasClusterServer(OnOffCluster)).toBeTruthy();
-            expect(endpoints.get(38)?.hasClusterServer(BindingCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(38))?.getAllClusterServers().length).toBe(7)
+            expect(endpoints.get(EndpointNumber(38))?.hasClusterServer(DescriptorCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(38))?.hasClusterServer(IdentifyCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(38))?.hasClusterServer(GroupsCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(38))?.hasClusterServer(ScenesCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(38))?.hasClusterServer(BridgedDeviceBasicInformationCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(38))?.hasClusterServer(OnOffCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(38))?.hasClusterServer(BindingCluster)).toBeTruthy();
 
-            expect(endpoints.get(39)?.getAllClusterServers().length).toBe(2)
-            expect(endpoints.get(39)?.hasClusterServer(DescriptorCluster)).toBeTruthy();
-            expect(endpoints.get(39)?.hasClusterServer(FixedLabelCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(39))?.getAllClusterServers().length).toBe(2)
+            expect(endpoints.get(EndpointNumber(39))?.hasClusterServer(DescriptorCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(39))?.hasClusterServer(FixedLabelCluster)).toBeTruthy();
 
-            expect(endpoints.get(40)?.getAllClusterServers().length).toBe(7)
-            expect(endpoints.get(40)?.hasClusterServer(DescriptorCluster)).toBeTruthy();
-            expect(endpoints.get(40)?.hasClusterServer(IdentifyCluster)).toBeTruthy();
-            expect(endpoints.get(40)?.hasClusterServer(GroupsCluster)).toBeTruthy();
-            expect(endpoints.get(40)?.hasClusterServer(ScenesCluster)).toBeTruthy();
-            expect(endpoints.get(40)?.hasClusterServer(BridgedDeviceBasicInformationCluster)).toBeTruthy();
-            expect(endpoints.get(40)?.hasClusterServer(OnOffCluster)).toBeTruthy();
-            expect(endpoints.get(40)?.hasClusterServer(BindingCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(40))?.getAllClusterServers().length).toBe(7)
+            expect(endpoints.get(EndpointNumber(40))?.hasClusterServer(DescriptorCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(40))?.hasClusterServer(IdentifyCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(40))?.hasClusterServer(GroupsCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(40))?.hasClusterServer(ScenesCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(40))?.hasClusterServer(BridgedDeviceBasicInformationCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(40))?.hasClusterServer(OnOffCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(40))?.hasClusterServer(BindingCluster)).toBeTruthy();
 
-            expect(endpoints.get(18)?.getAllClusterServers().length).toBe(7)
-            expect(endpoints.get(18)?.hasClusterServer(DescriptorCluster)).toBeTruthy();
-            expect(endpoints.get(18)?.hasClusterServer(IdentifyCluster)).toBeTruthy();
-            expect(endpoints.get(18)?.hasClusterServer(GroupsCluster)).toBeTruthy();
-            expect(endpoints.get(18)?.hasClusterServer(ScenesCluster)).toBeTruthy();
-            expect(endpoints.get(18)?.hasClusterServer(BridgedDeviceBasicInformationCluster)).toBeTruthy();
-            expect(endpoints.get(18)?.hasClusterServer(OnOffCluster)).toBeTruthy();
-            expect(endpoints.get(18)?.hasClusterServer(BindingCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(18))?.getAllClusterServers().length).toBe(7)
+            expect(endpoints.get(EndpointNumber(18))?.hasClusterServer(DescriptorCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(18))?.hasClusterServer(IdentifyCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(18))?.hasClusterServer(GroupsCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(18))?.hasClusterServer(ScenesCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(18))?.hasClusterServer(BridgedDeviceBasicInformationCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(18))?.hasClusterServer(OnOffCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(18))?.hasClusterServer(BindingCluster)).toBeTruthy();
 
-            expect(endpoints.get(41)?.getAllClusterServers().length).toBe(2)
-            expect(endpoints.get(41)?.hasClusterServer(DescriptorCluster)).toBeTruthy();
-            expect(endpoints.get(41)?.hasClusterServer(BridgedDeviceBasicInformationCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(41))?.getAllClusterServers().length).toBe(2)
+            expect(endpoints.get(EndpointNumber(41))?.hasClusterServer(DescriptorCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(41))?.hasClusterServer(BridgedDeviceBasicInformationCluster)).toBeTruthy();
 
-            expect(endpoints.get(42)?.getAllClusterServers().length).toBe(6)
-            expect(endpoints.get(42)?.hasClusterServer(DescriptorCluster)).toBeTruthy();
-            expect(endpoints.get(42)?.hasClusterServer(IdentifyCluster)).toBeTruthy();
-            expect(endpoints.get(42)?.hasClusterServer(GroupsCluster)).toBeTruthy();
-            expect(endpoints.get(42)?.hasClusterServer(ScenesCluster)).toBeTruthy();
-            expect(endpoints.get(42)?.hasClusterServer(OnOffCluster)).toBeTruthy();
-            expect(endpoints.get(42)?.hasClusterServer(BindingCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(42))?.getAllClusterServers().length).toBe(6)
+            expect(endpoints.get(EndpointNumber(42))?.hasClusterServer(DescriptorCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(42))?.hasClusterServer(IdentifyCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(42))?.hasClusterServer(GroupsCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(42))?.hasClusterServer(ScenesCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(42))?.hasClusterServer(OnOffCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(42))?.hasClusterServer(BindingCluster)).toBeTruthy();
 
-            expect(endpoints.get(43)?.getAllClusterServers().length).toBe(6)
-            expect(endpoints.get(43)?.hasClusterServer(DescriptorCluster)).toBeTruthy();
-            expect(endpoints.get(43)?.hasClusterServer(IdentifyCluster)).toBeTruthy();
-            expect(endpoints.get(43)?.hasClusterServer(GroupsCluster)).toBeTruthy();
-            expect(endpoints.get(43)?.hasClusterServer(ScenesCluster)).toBeTruthy();
-            expect(endpoints.get(43)?.hasClusterServer(OnOffCluster)).toBeTruthy();
-            expect(endpoints.get(43)?.hasClusterServer(BindingCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(43))?.getAllClusterServers().length).toBe(6)
+            expect(endpoints.get(EndpointNumber(43))?.hasClusterServer(DescriptorCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(43))?.hasClusterServer(IdentifyCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(43))?.hasClusterServer(GroupsCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(43))?.hasClusterServer(ScenesCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(43))?.hasClusterServer(OnOffCluster)).toBeTruthy();
+            expect(endpoints.get(EndpointNumber(43))?.hasClusterServer(BindingCluster)).toBeTruthy();
 
-            const aggregator1PartsListAttribute = attributes.get(attributePathToId({ endpointId: 37, clusterId: DescriptorCluster.id, attributeId: DescriptorCluster.attributes.partsList.id })) as AttributeServer<EndpointNumber[]>;
+            const aggregator1PartsListAttribute = attributes.get(attributePathToId({ endpointId: EndpointNumber(37), clusterId: DescriptorCluster.id, attributeId: DescriptorCluster.attributes.partsList.id })) as AttributeServer<EndpointNumber[]>;
             expect(aggregator1PartsListAttribute?.getLocal()).toEqual([
-                new EndpointNumber(3),
-                new EndpointNumber(38)
+                EndpointNumber(3),
+                EndpointNumber(38)
             ]);
 
-            const aggregator2PartsListAttribute = attributes.get(attributePathToId({ endpointId: 39, clusterId: DescriptorCluster.id, attributeId: DescriptorCluster.attributes.partsList.id })) as AttributeServer<EndpointNumber[]>;
+            const aggregator2PartsListAttribute = attributes.get(attributePathToId({ endpointId: EndpointNumber(39), clusterId: DescriptorCluster.id, attributeId: DescriptorCluster.attributes.partsList.id })) as AttributeServer<EndpointNumber[]>;
             expect(aggregator2PartsListAttribute?.getLocal()).toEqual([
-                new EndpointNumber(40),
-                new EndpointNumber(18),
-                new EndpointNumber(41),
-                new EndpointNumber(42),
-                new EndpointNumber(43)
+                EndpointNumber(40),
+                EndpointNumber(18),
+                EndpointNumber(41),
+                EndpointNumber(42),
+                EndpointNumber(43)
             ]);
 
-            const aggregator2PartsListAttribute2 = attributes.get(attributePathToId({ endpointId: 41, clusterId: DescriptorCluster.id, attributeId: DescriptorCluster.attributes.partsList.id })) as AttributeServer<EndpointNumber[]>;
+            const aggregator2PartsListAttribute2 = attributes.get(attributePathToId({ endpointId: EndpointNumber(41), clusterId: DescriptorCluster.id, attributeId: DescriptorCluster.attributes.partsList.id })) as AttributeServer<EndpointNumber[]>;
             expect(aggregator2PartsListAttribute2?.getLocal()).toEqual([
-                new EndpointNumber(42),
-                new EndpointNumber(43)
+                EndpointNumber(42),
+                EndpointNumber(43)
             ]);
 
-            const rootPartsListAttribute = attributes.get(attributePathToId({ endpointId: 0, clusterId: DescriptorCluster.id, attributeId: DescriptorCluster.attributes.partsList.id })) as AttributeServer<EndpointNumber[]>;
+            const rootPartsListAttribute = attributes.get(attributePathToId({ endpointId: EndpointNumber(0), clusterId: DescriptorCluster.id, attributeId: DescriptorCluster.attributes.partsList.id })) as AttributeServer<EndpointNumber[]>;
             expect(rootPartsListAttribute?.getLocal()).toEqual([
-                new EndpointNumber(37),
-                new EndpointNumber(3),
-                new EndpointNumber(38),
-                new EndpointNumber(39),
-                new EndpointNumber(40),
-                new EndpointNumber(18),
-                new EndpointNumber(41),
-                new EndpointNumber(42),
-                new EndpointNumber(43)
+                EndpointNumber(37),
+                EndpointNumber(3),
+                EndpointNumber(38),
+                EndpointNumber(39),
+                EndpointNumber(40),
+                EndpointNumber(18),
+                EndpointNumber(41),
+                EndpointNumber(42),
+                EndpointNumber(43)
             ]);
 
             expect(endpointStorage.get("serial_node-matter-0000-index_0-index_1")).toBe(38)
@@ -1718,16 +1718,16 @@ describe("Endpoint Structures", () => {
             } = endpointStructure2;
 
             expect(endpoints2.size).toBe(10)
-            expect(endpoints2.has(3)).toBe(false)
+            expect(endpoints2.has(EndpointNumber(3))).toBe(false)
 
-            expect(endpoints2.get(44)?.getAllClusterServers().length).toBe(7)
-            expect(endpoints2.get(44)?.hasClusterServer(DescriptorCluster)).toBeTruthy();
-            expect(endpoints2.get(44)?.hasClusterServer(IdentifyCluster)).toBeTruthy();
-            expect(endpoints2.get(44)?.hasClusterServer(GroupsCluster)).toBeTruthy();
-            expect(endpoints2.get(44)?.hasClusterServer(ScenesCluster)).toBeTruthy();
-            expect(endpoints2.get(44)?.hasClusterServer(OnOffCluster)).toBeTruthy();
-            expect(endpoints2.get(44)?.hasClusterServer(BindingCluster)).toBeTruthy();
-            expect(endpoints2.get(44)?.hasClusterServer(BridgedDeviceBasicInformationCluster)).toBeTruthy();
+            expect(endpoints2.get(EndpointNumber(44))?.getAllClusterServers().length).toBe(7)
+            expect(endpoints2.get(EndpointNumber(44))?.hasClusterServer(DescriptorCluster)).toBeTruthy();
+            expect(endpoints2.get(EndpointNumber(44))?.hasClusterServer(IdentifyCluster)).toBeTruthy();
+            expect(endpoints2.get(EndpointNumber(44))?.hasClusterServer(GroupsCluster)).toBeTruthy();
+            expect(endpoints2.get(EndpointNumber(44))?.hasClusterServer(ScenesCluster)).toBeTruthy();
+            expect(endpoints2.get(EndpointNumber(44))?.hasClusterServer(OnOffCluster)).toBeTruthy();
+            expect(endpoints2.get(EndpointNumber(44))?.hasClusterServer(BindingCluster)).toBeTruthy();
+            expect(endpoints2.get(EndpointNumber(44))?.hasClusterServer(BridgedDeviceBasicInformationCluster)).toBeTruthy();
 
             // Add the removed back and verify it gets same endpointID as before
             const onoffLightDevice11New = new OnOffLightDevice(undefined, { uniqueStorageKey: "3333" });
@@ -1746,7 +1746,7 @@ describe("Endpoint Structures", () => {
             } = endpointStructure3;
 
             expect(endpoints3.size).toBe(11)
-            expect(endpoints3.get(3)?.getAllClusterServers().length).toBe(7)
+            expect(endpoints3.get(EndpointNumber(3))?.getAllClusterServers().length).toBe(7)
         });
     });
 });

--- a/packages/matter.js/test/mdns/MdnsTest.ts
+++ b/packages/matter.js/test/mdns/MdnsTest.ts
@@ -18,9 +18,9 @@ import { ByteArray } from "../../src/util/ByteArray.js";
 import { FAKE_INTERFACE_NAME } from "../../src/net/fake/SimulatedNetwork.js";
 import { Time } from "../../src/time/Time.js";
 import { TimeFake } from "../../src/time/TimeFake.js";
-import { VendorId } from "../../src/datatype/VendorId.js";
 import { Crypto } from "../../src/crypto/Crypto.js";
 import { singleton } from "../../src/util/Singleton.js";
+import { VendorId } from "../../src/datatype/VendorId.js";
 
 Time.get = singleton(() => new TimeFake(0));
 
@@ -43,7 +43,7 @@ const serverNetwork = new NetworkFake(SERVER_MAC, [SERVER_IPv4, SERVER_IPv6]);
 const clientNetwork = new NetworkFake(CLIENT_MAC, [CLIENT_IP]);
 
 const OPERATIONAL_ID = ByteArray.fromHex("0000000000000018")
-const NODE_ID = new NodeId(BigInt(1));
+const NODE_ID = NodeId(BigInt(1));
 
 describe("MDNS Scanner and Broadcaster", () => {
     let broadcaster: MdnsBroadcaster;
@@ -109,7 +109,7 @@ describe("MDNS Scanner and Broadcaster", () => {
             broadcaster.setCommissionMode(PORT, 1, {
                 deviceName: "Test Device",
                 deviceType: 1,
-                vendorId: new VendorId(1),
+                vendorId: VendorId(1),
                 productId: 0x8000,
                 discriminator: 1234
             });
@@ -152,7 +152,7 @@ describe("MDNS Scanner and Broadcaster", () => {
             broadcaster.setCommissionerInfo(PORT, {
                 deviceName: "Test Commissioner",
                 deviceType: 1,
-                vendorId: new VendorId(1),
+                vendorId: VendorId(1),
                 productId: 0x8000,
             });
             await broadcaster.announce(PORT);
@@ -192,14 +192,14 @@ describe("MDNS Scanner and Broadcaster", () => {
             broadcaster.setCommissionMode(PORT2, 1, {
                 deviceName: "Test Device",
                 deviceType: 1,
-                vendorId: new VendorId(1),
+                vendorId: VendorId(1),
                 productId: 0x8000,
                 discriminator: 1234
             });
             broadcaster.setCommissionerInfo(PORT3, {
                 deviceName: "Test Commissioner",
                 deviceType: 1,
-                vendorId: new VendorId(1),
+                vendorId: VendorId(1),
                 productId: 0x8000,
             });
             await broadcaster.announce(PORT);
@@ -351,7 +351,7 @@ describe("MDNS Scanner and Broadcaster", () => {
             broadcaster.setCommissionMode(PORT, 1, {
                 deviceName: "Test Device",
                 deviceType: 1,
-                vendorId: new VendorId(1),
+                vendorId: VendorId(1),
                 productId: 0x8000,
                 discriminator: 1234
             });
@@ -438,7 +438,7 @@ describe("MDNS Scanner and Broadcaster", () => {
             broadcaster.setCommissionMode(PORT, 1, {
                 deviceName: "Test Device",
                 deviceType: 1,
-                vendorId: new VendorId(1),
+                vendorId: VendorId(1),
                 productId: 0x8000,
                 discriminator: 1234
             });

--- a/packages/matter.js/test/protocol/interaction/AttributeDataDecoderTest.ts
+++ b/packages/matter.js/test/protocol/interaction/AttributeDataDecoderTest.ts
@@ -16,6 +16,7 @@ import { VendorId } from "../../../src/datatype/VendorId.js";
 import { AttributeId } from "../../../src/datatype/AttributeId.js";
 import { EventId } from "../../../src/datatype/EventId.js";
 import { TypeFromSchema } from "../../../src/tlv/TlvSchema.js";
+import { EndpointNumber } from "../../../src/datatype/EndpointNumber.js";
 
 const TlvAclTestSchema = TlvObject({
     privilege: TlvField(1, TlvUInt8),
@@ -31,14 +32,14 @@ describe("AttributeDataDecoder", () => {
             const data: TypeFromSchema<typeof TlvAttributeReport>[] = [
                 {
                     attributeData: {
-                        path: { endpointId: 0, clusterId: 0x1f, attributeId: 0 },
+                        path: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x1f), attributeId: AttributeId(0) },
                         data: TlvArray(TlvAclTestSchema).encodeTlv([]),
                         dataVersion: 0,
                     }
                 },
                 {
                     attributeData: {
-                        path: { endpointId: 0, clusterId: 0x1f, attributeId: 0, listIndex: null },
+                        path: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x1f), attributeId: AttributeId(0), listIndex: null },
                         data: TlvAclTestSchema.encodeTlv({
                             privilege: 1,
                             authMode: 2,
@@ -50,7 +51,7 @@ describe("AttributeDataDecoder", () => {
                 },
                 {
                     attributeData: {
-                        path: { endpointId: 0, clusterId: 0x1f, attributeId: 0, listIndex: null },
+                        path: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x1f), attributeId: AttributeId(0), listIndex: null },
                         data: TlvAclTestSchema.encodeTlv({
                             privilege: 2,
                             authMode: 2,
@@ -65,10 +66,10 @@ describe("AttributeDataDecoder", () => {
 
             expect(normalizedData.length).toBe(1)
             expect(normalizedData[0].path).toEqual({
-                attributeId: 0,
+                attributeId: AttributeId(0),
                 attributeName: "acl",
-                clusterId: 0x1f,
-                endpointId: 0,
+                clusterId: ClusterId(0x1f),
+                endpointId: EndpointNumber(0),
                 nodeId: undefined
             });
             expect(normalizedData[0].value).toEqual([
@@ -91,14 +92,14 @@ describe("AttributeDataDecoder", () => {
             const data: TypeFromSchema<typeof TlvAttributeReport>[] = [
                 {
                     attributeData: {
-                        path: { endpointId: 0, clusterId: 0x1f, attributeId: 0 },
+                        path: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x1f), attributeId: AttributeId(0) },
                         data: TlvArray(TlvAclTestSchema).encodeTlv([]),
                         dataVersion: 0,
                     }
                 },
                 {
                     attributeData: {
-                        path: { endpointId: 0, clusterId: 0x1f, attributeId: 0, listIndex: 0 },
+                        path: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x1f), attributeId: AttributeId(0), listIndex: 0 },
                         data: TlvAclTestSchema.encodeTlv({
                             privilege: 1,
                             authMode: 2,
@@ -110,7 +111,7 @@ describe("AttributeDataDecoder", () => {
                 },
                 {
                     attributeData: {
-                        path: { endpointId: 0, clusterId: 0x1f, attributeId: 0, listIndex: 1 },
+                        path: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x1f), attributeId: AttributeId(0), listIndex: 1 },
                         data: TlvAclTestSchema.encodeTlv({
                             privilege: 2,
                             authMode: 2,
@@ -125,10 +126,10 @@ describe("AttributeDataDecoder", () => {
 
             expect(normalizedData.length).toBe(1)
             expect(normalizedData[0].path).toEqual({
-                attributeId: 0,
+                attributeId: AttributeId(0),
                 attributeName: "acl",
-                clusterId: 0x1f,
-                endpointId: 0,
+                clusterId: ClusterId(0x1f),
+                endpointId: EndpointNumber(0),
                 nodeId: undefined
             });
             expect(normalizedData[0].value).toEqual([
@@ -151,14 +152,14 @@ describe("AttributeDataDecoder", () => {
             const data: TypeFromSchema<typeof TlvAttributeReport>[] = [
                 {
                     attributeData: {
-                        path: { endpointId: 0, clusterId: 0x1f, attributeId: 0 },
+                        path: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x1f), attributeId: AttributeId(0) },
                         data: TlvArray(TlvAclTestSchema).encodeTlv([]),
                         dataVersion: 0,
                     }
                 },
                 {
                     attributeData: {
-                        path: { endpointId: 0, clusterId: 0x1f, attributeId: 0, listIndex: 0 },
+                        path: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x1f), attributeId: AttributeId(0), listIndex: 0 },
                         data: TlvAclTestSchema.encodeTlv({
                             privilege: 1,
                             authMode: 2,
@@ -170,7 +171,7 @@ describe("AttributeDataDecoder", () => {
                 },
                 {
                     attributeData: {
-                        path: { endpointId: 0, clusterId: 0x1f, attributeId: 0, listIndex: 1 },
+                        path: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x1f), attributeId: AttributeId(0), listIndex: 1 },
                         data: TlvAclTestSchema.encodeTlv({
                             privilege: 2,
                             authMode: 2,
@@ -182,7 +183,7 @@ describe("AttributeDataDecoder", () => {
                 },
                 {
                     attributeData: {
-                        path: { endpointId: 0, clusterId: 0x1f, attributeId: 0, listIndex: 2 },
+                        path: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x1f), attributeId: AttributeId(0), listIndex: 2 },
                         data: TlvAclTestSchema.encodeTlv({
                             privilege: 3,
                             authMode: 2,
@@ -194,7 +195,7 @@ describe("AttributeDataDecoder", () => {
                 },
                 {
                     attributeData: {
-                        path: { endpointId: 0, clusterId: 0x1f, attributeId: 0, listIndex: 1 },
+                        path: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x1f), attributeId: AttributeId(0), listIndex: 1 },
                         data: TlvNullable(TlvAclTestSchema).encodeTlv(null),
                         dataVersion: 0,
                     }
@@ -204,10 +205,10 @@ describe("AttributeDataDecoder", () => {
 
             expect(normalizedData.length).toBe(1)
             expect(normalizedData[0].path).toEqual({
-                attributeId: 0,
+                attributeId: AttributeId(0),
                 attributeName: "acl",
-                clusterId: 0x1f,
-                endpointId: 0,
+                clusterId: ClusterId(0x1f),
+                endpointId: EndpointNumber(0),
                 nodeId: undefined
             });
             expect(normalizedData[0].value).toEqual([
@@ -229,14 +230,14 @@ describe("AttributeDataDecoder", () => {
             const data: TypeFromSchema<typeof TlvAttributeReport>[] = [
                 {
                     attributeData: {
-                        path: { endpointId: 0, clusterId: 0x1f, attributeId: 0 },
+                        path: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x1f), attributeId: AttributeId(0) },
                         data: TlvArray(TlvAclTestSchema).encodeTlv([]),
                         dataVersion: 0,
                     }
                 },
                 {
                     attributeData: {
-                        path: { endpointId: 0, clusterId: 0x1f, attributeId: 0, listIndex: 0 },
+                        path: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x1f), attributeId: AttributeId(0), listIndex: 0 },
                         data: TlvAclTestSchema.encodeTlv({
                             privilege: 1,
                             authMode: 2,
@@ -248,7 +249,7 @@ describe("AttributeDataDecoder", () => {
                 },
                 {
                     attributeData: {
-                        path: { endpointId: 0, clusterId: 0x1f, attributeId: 0, listIndex: 1 },
+                        path: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x1f), attributeId: AttributeId(0), listIndex: 1 },
                         data: TlvAclTestSchema.encodeTlv({
                             privilege: 2,
                             authMode: 2,
@@ -260,7 +261,7 @@ describe("AttributeDataDecoder", () => {
                 },
                 {
                     attributeData: {
-                        path: { endpointId: 0, clusterId: 0x1f, attributeId: 0, listIndex: 2 },
+                        path: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x1f), attributeId: AttributeId(0), listIndex: 2 },
                         data: TlvAclTestSchema.encodeTlv({
                             privilege: 3,
                             authMode: 2,
@@ -272,7 +273,7 @@ describe("AttributeDataDecoder", () => {
                 },
                 {
                     attributeData: {
-                        path: { endpointId: 0, clusterId: 0x1f, attributeId: 0, listIndex: 1 },
+                        path: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x1f), attributeId: AttributeId(0), listIndex: 1 },
                         data: TlvAclTestSchema.encodeTlv({
                             privilege: 4,
                             authMode: 2,
@@ -287,10 +288,10 @@ describe("AttributeDataDecoder", () => {
 
             expect(normalizedData.length).toBe(1)
             expect(normalizedData[0].path).toEqual({
-                attributeId: 0,
+                attributeId: AttributeId(0),
                 attributeName: "acl",
-                clusterId: 0x1f,
-                endpointId: 0,
+                clusterId: ClusterId(0x1f),
+                endpointId: EndpointNumber(0),
                 nodeId: undefined
             });
             expect(normalizedData[0].value).toEqual([
@@ -331,18 +332,18 @@ describe("AttributeDataDecoder", () => {
 
             expect(normalizedData.length).toBe(1)
             expect(normalizedData[0].path).toEqual({
-                attributeId: 1,
+                attributeId: AttributeId(1),
                 attributeName: "serverList",
-                clusterId: 29,
-                endpointId: 0,
+                clusterId: ClusterId(29),
+                endpointId: EndpointNumber(0),
                 nodeId: undefined
             });
             expect(normalizedData[0].value).toEqual([
-                new ClusterId(4), new ClusterId(29), new ClusterId(31), new ClusterId(40), new ClusterId(42),
-                new ClusterId(43), new ClusterId(44), new ClusterId(48), new ClusterId(49), new ClusterId(50),
-                new ClusterId(51), new ClusterId(52), new ClusterId(53), new ClusterId(54), new ClusterId(55),
-                new ClusterId(59), new ClusterId(60), new ClusterId(62), new ClusterId(63), new ClusterId(64),
-                new ClusterId(65)
+                ClusterId(4), ClusterId(29), ClusterId(31), ClusterId(40), ClusterId(42),
+                ClusterId(43), ClusterId(44), ClusterId(48), ClusterId(49), ClusterId(50),
+                ClusterId(51), ClusterId(52), ClusterId(53), ClusterId(54), ClusterId(55),
+                ClusterId(59), ClusterId(60), ClusterId(62), ClusterId(63), ClusterId(64),
+                ClusterId(65)
             ]);
 
         });
@@ -360,10 +361,10 @@ describe("AttributeDataDecoder", () => {
 
             expect(normalizedData.length).toBe(1)
             expect(normalizedData[0].path).toEqual({
-                attributeId: 9,
+                attributeId: AttributeId(9),
                 attributeName: "softwareVersion",
-                clusterId: 40,
-                endpointId: 0,
+                clusterId: ClusterId(40),
+                endpointId: EndpointNumber(0),
                 nodeId: undefined
             });
             expect(normalizedData[0].value).toEqual(1)
@@ -413,7 +414,7 @@ describe("AttributeDataDecoder", () => {
                         "nodeId": undefined
                     },
                     "version": 2020087125,
-                    "value": new VendorId(65521)
+                    "value": VendorId(65521)
                 },
                 {
                     "path": {
@@ -658,7 +659,7 @@ describe("AttributeDataDecoder", () => {
                         "nodeId": undefined
                     },
                     "version": 2020087125,
-                    "value": [new EventId(0), new EventId(1), new EventId(2)]
+                    "value": [EventId(0), EventId(1), EventId(2)]
                 },
                 {
                     "path": {
@@ -669,7 +670,7 @@ describe("AttributeDataDecoder", () => {
                         "nodeId": undefined
                     },
                     "version": 2020087125,
-                    "value": [new AttributeId(0), new AttributeId(1), new AttributeId(2), new AttributeId(3), new AttributeId(4)]
+                    "value": [AttributeId(0), AttributeId(1), AttributeId(2), AttributeId(3), AttributeId(4)]
                 }
             ]);
         });
@@ -679,12 +680,12 @@ describe("AttributeDataDecoder", () => {
         it("normalize data with all paths given for one endpoint", () => {
             const data: TypeFromSchema<typeof TlvAttributeData>[] = [
                 {
-                    path: { endpointId: 0, clusterId: 0x1f, attributeId: 0 },
+                    path: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x1f), attributeId: AttributeId(0) },
                     data: TlvArray(TlvAclTestSchema).encodeTlv([]),
                     dataVersion: 0,
                 },
                 {
-                    path: { endpointId: 0, clusterId: 0x1f, attributeId: 0, listIndex: 0 },
+                    path: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x1f), attributeId: AttributeId(0), listIndex: 0 },
                     data: TlvAclTestSchema.encodeTlv({
                         privilege: 1,
                         authMode: 2,
@@ -694,7 +695,7 @@ describe("AttributeDataDecoder", () => {
                     dataVersion: 0,
                 },
                 {
-                    path: { endpointId: 0, clusterId: 0x1f, attributeId: 0, listIndex: 1 },
+                    path: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x1f), attributeId: AttributeId(0), listIndex: 1 },
                     data: TlvAclTestSchema.encodeTlv({
                         privilege: 2,
                         authMode: 2,
@@ -713,12 +714,12 @@ describe("AttributeDataDecoder", () => {
         it("normalize data with all paths given for two endpoints", () => {
             const data1: TypeFromSchema<typeof TlvAttributeData>[] = [
                 {
-                    path: { endpointId: 0, clusterId: 0x1f, attributeId: 0 },
+                    path: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x1f), attributeId: AttributeId(0) },
                     data: TlvArray(TlvAclTestSchema).encodeTlv([]),
                     dataVersion: 0,
                 },
                 {
-                    path: { endpointId: 0, clusterId: 0x1f, attributeId: 0, listIndex: 0 },
+                    path: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x1f), attributeId: AttributeId(0), listIndex: 0 },
                     data: TlvAclTestSchema.encodeTlv({
                         privilege: 1,
                         authMode: 2,
@@ -728,7 +729,7 @@ describe("AttributeDataDecoder", () => {
                     dataVersion: 0,
                 },
                 {
-                    path: { endpointId: 0, clusterId: 0x1f, attributeId: 0, listIndex: 1 },
+                    path: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x1f), attributeId: AttributeId(0), listIndex: 1 },
                     data: TlvAclTestSchema.encodeTlv({
                         privilege: 2,
                         authMode: 2,
@@ -740,7 +741,7 @@ describe("AttributeDataDecoder", () => {
             ];
             const data2: TypeFromSchema<typeof TlvAttributeData>[] = [
                 {
-                    path: { endpointId: 0, clusterId: 0x1f, attributeId: 1 },
+                    path: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x1f), attributeId: AttributeId(1) },
                     data: TlvArray(TlvAclTestSchema).encodeTlv([]),
                     dataVersion: 0,
                 }
@@ -754,7 +755,7 @@ describe("AttributeDataDecoder", () => {
         it("normalize data with all paths given for two endpoints with enabledtagCompression", () => {
             const data1: TypeFromSchema<typeof TlvAttributeData>[] = [
                 {
-                    path: { endpointId: 0, clusterId: 0x1f, attributeId: 0 },
+                    path: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x1f), attributeId: AttributeId(0) },
                     data: TlvArray(TlvAclTestSchema).encodeTlv([]),
                     dataVersion: 0,
                 },
@@ -781,17 +782,17 @@ describe("AttributeDataDecoder", () => {
             ];
             const data2: TypeFromSchema<typeof TlvAttributeData>[] = [
                 {
-                    path: { enableTagCompression: true, attributeId: 1 },
+                    path: { enableTagCompression: true, attributeId: AttributeId(1) },
                     data: TlvArray(TlvAclTestSchema).encodeTlv([]),
                     dataVersion: 0,
                 }
             ];
 
             const resultData1 = data1;
-            resultData1[1].path = { endpointId: 0, clusterId: 0x1f, attributeId: 0, listIndex: 0, enableTagCompression: true };
-            resultData1[2].path = { endpointId: 0, clusterId: 0x1f, attributeId: 0, listIndex: 1, enableTagCompression: true };
+            resultData1[1].path = { endpointId: EndpointNumber(0), clusterId: ClusterId(0x1f), attributeId: AttributeId(0), listIndex: 0, enableTagCompression: true };
+            resultData1[2].path = { endpointId: EndpointNumber(0), clusterId: ClusterId(0x1f), attributeId: AttributeId(0), listIndex: 1, enableTagCompression: true };
             const resultData2 = data2;
-            resultData2[0].path = { endpointId: 0, clusterId: 0x1f, attributeId: 1, enableTagCompression: true };
+            resultData2[0].path = { endpointId: EndpointNumber(0), clusterId: ClusterId(0x1f), attributeId: AttributeId(1), enableTagCompression: true };
 
             const normalized = normalizeAttributeData([...data1, ...data2]);
 

--- a/packages/matter.js/test/protocol/interaction/EventDataDecoderTest.ts
+++ b/packages/matter.js/test/protocol/interaction/EventDataDecoderTest.ts
@@ -8,6 +8,9 @@ import { TypeFromSchema } from "../../../src/tlv/TlvSchema.js";
 import { normalizeAndDecodeEventData, normalizeEventData } from "../../../src/protocol/interaction/EventDataDecoder.js";
 import { BasicInformation } from "../../../src/cluster/definitions/BasicInformationCluster.js";
 import { TlvVoid } from "../../../src/tlv/TlvVoid.js";
+import { ClusterId } from "../../../src/datatype/ClusterId.js";
+import { EventId } from "../../../src/datatype/EventId.js";
+import { EndpointNumber } from "../../../src/datatype/EndpointNumber.js";
 
 describe("EventDataDecoder", () => {
 
@@ -15,14 +18,14 @@ describe("EventDataDecoder", () => {
         it("normalize data with all paths given for single event entries", () => {
             const data: TypeFromSchema<typeof TlvEventData>[] = [
                 {
-                    path: { endpointId: 0, clusterId: 0x28, eventId: 0 },
+                    path: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x28), eventId: EventId(0) },
                     eventNumber: 1,
                     priority: 1,
                     epochTimestamp: 0,
                     data: BasicInformation.TlvStartUpEvent.encodeTlv({ softwareVersion: 1 }),
                 },
                 {
-                    path: { endpointId: 0, clusterId: 0x28, eventId: 1 },
+                    path: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x28), eventId: EventId(1) },
                     eventNumber: 2,
                     priority: 1,
                     epochTimestamp: 0,
@@ -34,14 +37,14 @@ describe("EventDataDecoder", () => {
 
             expect(normalized).toEqual([
                 [{
-                    path: { endpointId: 0, clusterId: 0x28, eventId: 0 },
+                    path: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x28), eventId: EventId(0) },
                     eventNumber: 1,
                     priority: 1,
                     epochTimestamp: 0,
                     data: BasicInformation.TlvStartUpEvent.encodeTlv({ softwareVersion: 1 }),
                 }],
                 [{
-                    path: { endpointId: 0, clusterId: 0x28, eventId: 1 },
+                    path: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x28), eventId: EventId(1) },
                     eventNumber: 2,
                     priority: 1,
                     epochTimestamp: 0,
@@ -53,21 +56,21 @@ describe("EventDataDecoder", () => {
         it("normalize data with all paths given for multiple events", () => {
             const data: TypeFromSchema<typeof TlvEventData>[] = [
                 {
-                    path: { endpointId: 0, clusterId: 0x28, eventId: 0 },
+                    path: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x28), eventId: EventId(0) },
                     eventNumber: 1,
                     priority: 1,
                     epochTimestamp: 0,
                     data: BasicInformation.TlvStartUpEvent.encodeTlv({ softwareVersion: 1 }),
                 },
                 {
-                    path: { endpointId: 0, clusterId: 0x28, eventId: 1 },
+                    path: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x28), eventId: EventId(1) },
                     eventNumber: 2,
                     priority: 1,
                     epochTimestamp: 0,
                     data: TlvVoid.encodeTlv(),
                 },
                 {
-                    path: { endpointId: 0, clusterId: 0x28, eventId: 0 },
+                    path: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x28), eventId: EventId(0) },
                     eventNumber: 3,
                     priority: 1,
                     epochTimestamp: 0,
@@ -111,7 +114,7 @@ describe("EventDataDecoder", () => {
         it("normalize and decode data with all paths given for single event entries", () => {
             const data: TypeFromSchema<typeof TlvEventData>[] = [
                 {
-                    path: { endpointId: 0, clusterId: 0x28, eventId: 0 },
+                    path: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x28), eventId: EventId(0) },
                     eventNumber: 1,
                     priority: 1,
                     epochTimestamp: 0,
@@ -121,7 +124,7 @@ describe("EventDataDecoder", () => {
                     data: BasicInformation.TlvStartUpEvent.encodeTlv({ softwareVersion: 1 }),
                 },
                 {
-                    path: { endpointId: 0, clusterId: 0x28, eventId: 1 },
+                    path: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x28), eventId: EventId(1) },
                     eventNumber: 2,
                     priority: 1,
                     epochTimestamp: 0,
@@ -136,7 +139,7 @@ describe("EventDataDecoder", () => {
 
             expect(normalized).toEqual([
                 {
-                    path: { endpointId: 0, clusterId: 0x28, eventId: 0, nodeId: undefined, eventName: "startUp" },
+                    path: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x28), eventId: EventId(0), nodeId: undefined, eventName: "startUp" },
                     events: [{
                         eventNumber: 1,
                         priority: 1,
@@ -149,7 +152,7 @@ describe("EventDataDecoder", () => {
                     }],
                 },
                 {
-                    path: { endpointId: 0, clusterId: 0x28, eventId: 1, nodeId: undefined, eventName: "shutDown" },
+                    path: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x28), eventId: EventId(1), nodeId: undefined, eventName: "shutDown" },
                     events: [{
                         eventNumber: 2,
                         priority: 1,
@@ -167,7 +170,7 @@ describe("EventDataDecoder", () => {
         it("normalize and decode data with all paths given for multiple events", () => {
             const data: TypeFromSchema<typeof TlvEventData>[] = [
                 {
-                    path: { endpointId: 0, clusterId: 0x28, eventId: 0 },
+                    path: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x28), eventId: EventId(0) },
                     eventNumber: 1,
                     priority: 1,
                     epochTimestamp: 0,
@@ -177,7 +180,7 @@ describe("EventDataDecoder", () => {
                     data: BasicInformation.TlvStartUpEvent.encodeTlv({ softwareVersion: 1 }),
                 },
                 {
-                    path: { endpointId: 0, clusterId: 0x28, eventId: 1 },
+                    path: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x28), eventId: EventId(1) },
                     eventNumber: 2,
                     priority: 1,
                     epochTimestamp: 0,
@@ -187,7 +190,7 @@ describe("EventDataDecoder", () => {
                     data: TlvVoid.encodeTlv(),
                 },
                 {
-                    path: { endpointId: 0, clusterId: 0x28, eventId: 0 },
+                    path: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x28), eventId: EventId(0) },
                     eventNumber: 3,
                     priority: 1,
                     epochTimestamp: 0,
@@ -202,7 +205,7 @@ describe("EventDataDecoder", () => {
 
             expect(normalized).toEqual([
                 {
-                    path: { endpointId: 0, clusterId: 0x28, eventId: 0, nodeId: undefined, eventName: "startUp" },
+                    path: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x28), eventId: EventId(0), nodeId: undefined, eventName: "startUp" },
                     events: [
                         {
                             eventNumber: 1,
@@ -227,7 +230,7 @@ describe("EventDataDecoder", () => {
                     ],
                 },
                 {
-                    path: { endpointId: 0, clusterId: 0x28, eventId: 1, nodeId: undefined, eventName: "shutDown" },
+                    path: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x28), eventId: EventId(1), nodeId: undefined, eventName: "shutDown" },
                     events: [{
                         eventNumber: 2,
                         priority: 1,

--- a/packages/matter.js/test/storage/StorageContextTest.ts
+++ b/packages/matter.js/test/storage/StorageContextTest.ts
@@ -10,6 +10,8 @@ import { SupportedStorageTypes } from "../../src/storage/StringifyTools.js";
 import { ByteArray } from "../../src/util/ByteArray.js";
 import { StorageManager } from "../../src/storage/StorageManager.js";
 import { StorageError } from "../../src/storage/Storage.js";
+import { NodeId } from "../../src/datatype/NodeId.js";
+import { AttributeId } from "../../src/datatype/AttributeId.js";
 
 type TestVector = { [testName: string]: { key: string, input: SupportedStorageTypes } };
 
@@ -17,6 +19,8 @@ const validateStorageTestVector: TestVector = {
     "store and retrieve string": { key: "stringKey", input: "value" },
     "store and retrieve number": { key: "numberKey", input: 1234 },
     "store and retrieve boolean": { key: "booleanKey", input: true },
+    "store and retrieve AttributeId": { key: "attributeIdKey", input: AttributeId(123) },
+    "store and retrieve NodeId": { key: "nodeIdKey", input: NodeId(123456789) },
     "store and retrieve bigint": { key: "bigintKey", input: BigInt(123456789) },
     "store and retrieve ByteArray": { key: "ByteArrayKey", input: ByteArray.fromHex("010203040506070809") },
     "store and retrieve array of string": { key: "stringArrayKey", input: ["1", "2", "3"] },

--- a/packages/matter.js/test/storage/StringifyToolsTest.ts
+++ b/packages/matter.js/test/storage/StringifyToolsTest.ts
@@ -125,21 +125,21 @@ describe("JsonConverter", () => {
 
         it("encode/decode object with matter.js datatypes", () => {
             const obj = {
-                attribute: new AttributeId(1),
-                cluster: new ClusterId(2),
-                command: new CommandId(3),
-                endpoint: new EndpointNumber(4),
-                event: new EventId(5),
-                fabric: new FabricId(BigInt(6)),
-                fabricIndex: new FabricIndex(7),
-                group: new GroupId(8),
-                node: new NodeId(BigInt(9)),
-                vendor: new VendorId(11)
+                attribute: AttributeId(1),
+                cluster: ClusterId(2),
+                command: CommandId(3),
+                endpoint: EndpointNumber(4),
+                event: EventId(5),
+                fabric: FabricId(BigInt(6)),
+                fabricIndex: FabricIndex(7),
+                group: GroupId(8),
+                node: NodeId(BigInt(9)),
+                vendor: VendorId(11)
             };
 
             const json = toJson(obj);
 
-            expect(json).toBe(`{"attribute":"{\\"__object__\\":\\"AttributeId\\",\\"__value__\\":1}","cluster":"{\\"__object__\\":\\"ClusterId\\",\\"__value__\\":2}","command":"{\\"__object__\\":\\"CommandId\\",\\"__value__\\":3}","endpoint":"{\\"__object__\\":\\"EndpointNumber\\",\\"__value__\\":4}","event":"{\\"__object__\\":\\"EventId\\",\\"__value__\\":5}","fabric":"{\\"__object__\\":\\"FabricId\\",\\"__value__\\":\\"6\\"}","fabricIndex":"{\\"__object__\\":\\"FabricIndex\\",\\"__value__\\":7}","group":"{\\"__object__\\":\\"GroupId\\",\\"__value__\\":8}","node":"{\\"__object__\\":\\"NodeId\\",\\"__value__\\":\\"9\\"}","vendor":"{\\"__object__\\":\\"VendorId\\",\\"__value__\\":11}"}`);
+            expect(json).toBe(`{"attribute":1,"cluster":2,"command":3,"endpoint":4,"event":5,"fabric":"{\\"__object__\\":\\"BigInt\\",\\"__value__\\":\\"6\\"}","fabricIndex":7,"group":8,"node":"{\\"__object__\\":\\"BigInt\\",\\"__value__\\":\\"9\\"}","vendor":11}`);
 
             const decodedObj = fromJson(json);
 

--- a/packages/matter.js/test/tlv/TlvComplexTest.ts
+++ b/packages/matter.js/test/tlv/TlvComplexTest.ts
@@ -55,8 +55,8 @@ const codecVector: CodecVector<TypeFromSchema<typeof schema>, string> = {
             ],
             optionalString: "test",
             nullableBoolean: true,
-            optionalWrapperBigInt: new FabricId(BigInt(1)),
-            optionalWrapperNumber: new FabricIndex(2),
+            optionalWrapperBigInt: FabricId(BigInt(1)),
+            optionalWrapperNumber: FabricIndex(2),
         },
         encoded: "15360115240101300203000000181524010230020399999918182c020474657374290324040124050218"
     },
@@ -135,7 +135,7 @@ const codecErrorVector: CodecErrorVector<TypeFromSchema<typeof schema>> = {
                 },
             ],
             nullableBoolean: null,
-            optionalWrapperNumber: new FabricIndex(0x12345678),
+            optionalWrapperNumber: FabricIndex(0x12345678),
         },
         expectedError: "Invalid value: 305419896 is above the maximum, 254."
     },

--- a/packages/matter.js/test/util/DeepEqualTest.ts
+++ b/packages/matter.js/test/util/DeepEqualTest.ts
@@ -52,8 +52,8 @@ describe("DeepEqual", () => {
     });
 
     it("Equality of special Matter objects", () => {
-        expect(isDeepEqual(new VendorId(0), new VendorId(0))).toBeTruthy();
-        expect(!isDeepEqual(new VendorId(0), new VendorId(1))).toBeTruthy();
+        expect(isDeepEqual(VendorId(0), VendorId(0))).toBeTruthy();
+        expect(!isDeepEqual(VendorId(0), VendorId(1))).toBeTruthy();
 
         expect(isDeepEqual(ByteArray.fromHex("00"), ByteArray.fromHex("00"))).toBeTruthy();
         expect(!isDeepEqual(ByteArray.fromHex("00"), ByteArray.fromHex("01"))).toBeTruthy();

--- a/tools/clusters/DefaultValueGenerator.ts
+++ b/tools/clusters/DefaultValueGenerator.ts
@@ -58,7 +58,7 @@ export class DefaultValueGenerator {
             }
             const constructor = importConf[1].replace("Tlv", "");
             this.tlv.importTlv(importConf[0], constructor);
-            return serialize.asIs(`new ${constructor}(${defaultValue})`);
+            return serialize.asIs(`${constructor}(${defaultValue})`);
         }
         return defaultValue;
     }

--- a/tools/clusters/NumberConstants.ts
+++ b/tools/clusters/NumberConstants.ts
@@ -27,7 +27,6 @@ import {
  * Map of matter datatype names to TlvGenerator.tlvImport arguments.
  */
 export const SpecializedNumbers: { [name: string]: [string, string] } = {
-    [Globals.actionId.name]: ["datatype", "TlvActionId"],
     [Globals.attributeId.name]: ["datatype", "TlvAttributeId"],
     [Globals.clusterId.name]: ["datatype", "TlvClusterId"],
     [Globals.commandId.name]: ["datatype", "TlvCommandId"],
@@ -52,23 +51,23 @@ export const SpecializedNumbers: { [name: string]: [string, string] } = {
 /**
  * Map of matter datatype names of wrapped TLV types to the wrapping field
  * name.
- * 
+ *
  * Turns out we don't actually need the key because we use the constructor but
  * leaving in place in case something changes.
  */
 export const WrappedConstantKeys = {
-    [Globals.actionId.name]: "id",
-    [Globals.clusterId.name]: "id",
-    [Globals.commandId.name]: "id",
-    [Globals.deviceTypeId.name]: "id",
-    [Globals.endpointNo.name]: "number",
-    [Globals.eventId.name]: "id",
-    [Globals.fabricId.name]: "id",
-    [Globals.fabricIdx.name]: "index",
-    [Globals.groupId.name]: "id",
-    [Globals.nodeId.name]: "id",
-    [Globals.SubjectId.name]: "id",
-    [Globals.vendorId.name]: "id"
+    [Globals.attributeId.name]: true,
+    [Globals.clusterId.name]: true,
+    [Globals.commandId.name]: true,
+    [Globals.deviceTypeId.name]: true,
+    [Globals.endpointNo.name]: true,
+    [Globals.eventId.name]: true,
+    [Globals.fabricId.name]: true,
+    [Globals.fabricIdx.name]: true,
+    [Globals.groupId.name]: true,
+    [Globals.nodeId.name]: true,
+    [Globals.SubjectId.name]: true,
+    [Globals.vendorId.name]: true,
 }
 
 /**
@@ -86,5 +85,5 @@ export const NumericRanges = {
     int64: { min: INT64_MIN, max: INT64_MAX },
     float32: { min: FLOAT32_MIN, max: FLOAT32_MAX },
     percent: { min: 0, max: 100 },
-    percent100ths: { min: 0, max: 10000 }
+    percent100ths: { min: 0, max: 10000 },
 }

--- a/tools/clusters/generate-cluster.ts
+++ b/tools/clusters/generate-cluster.ts
@@ -39,8 +39,7 @@ export function generateCluster(file: ClusterFile) {
         // Base cluster
         file.addImport("cluster/ClusterFactory", "ClusterComponent");
         base = file.ns.expressions(`export const Base = ClusterComponent({`, "})")
-            .document(`${cluster.name} is             // change to expect().rejects.toThrow() when no longer using jasmine expect
-            a derived cluster, not to be used directly.  These elements are present in all clusters derived from ${cluster.name}.`);
+            .document(`${cluster.name} is a derived cluster, not to be used directly.  These elements are present in all clusters derived from ${cluster.name}.`);
     } else if (!features.length) {
         // Non-extensible cluster
         file.addImport("cluster/Cluster", "Cluster as CreateCluster");


### PR DESCRIPTION
This PR moves away from the object style datatypes to branded types and simplifies the usage (no new anymore) and also increases the type safetieness.
(The old objects had the issue that all objects with an "id" or "index" propoerty looked the same for TypeScript and so could used and so the type safetieness was gone. now this can not happen anymore.