### PR TITLE
Handle session closes by re-announcing

### DIFF
--- a/packages/matter.js/src/CommissioningController.ts
+++ b/packages/matter.js/src/CommissioningController.ts
@@ -119,7 +119,12 @@ export class CommissioningController extends MatterNode {
             await UdpInterface.create("udp6", this.localPort, this.listeningAddressIpv6),
             this.storage,
             this.serverAddress,
-            this.commissioningOptions
+            this.commissioningOptions,
+            (peerNodeId) => {
+                logger.info(`Peer node ${peerNodeId} disconnected ...`);
+                // TODO Add handling
+                // this.initializeAfterConnect().then().catch(); ....
+            }
         );
 
         if (this.controllerInstance.isCommissioned()) {
@@ -170,6 +175,10 @@ export class CommissioningController extends MatterNode {
 
         logger.debug(`Successfully Paired with Node ID ${this.nodeId} ... requesting endpoint structure`);
 
+        await this.initializeAfterConnect();
+    }
+
+    async initializeAfterConnect() {
         await this.initializeEndpointStructure();
     }
 

--- a/packages/matter.js/src/session/SessionManager.ts
+++ b/packages/matter.js/src/session/SessionManager.ts
@@ -52,8 +52,36 @@ export class SessionManager<ContextT> {
         this.sessions.set(UNICAST_UNSECURE_SESSION_ID, this.unsecureSession);
     }
 
-    async createSecureSession(sessionId: number, fabric: Fabric | undefined, peerNodeId: NodeId, peerSessionId: number, sharedSecret: ByteArray, salt: ByteArray, isInitiator: boolean, isResumption: boolean, idleRetransTimeoutMs?: number, activeRetransTimeoutMs?: number) {
-        const session = await SecureSession.create(this.context, sessionId, fabric, peerNodeId, peerSessionId, sharedSecret, salt, isInitiator, isResumption, () => this.removeSession(sessionId, peerNodeId), idleRetransTimeoutMs, activeRetransTimeoutMs);
+    async createSecureSession(
+        sessionId: number,
+        fabric: Fabric | undefined,
+        peerNodeId: NodeId,
+        peerSessionId: number,
+        sharedSecret: ByteArray,
+        salt: ByteArray,
+        isInitiator: boolean,
+        isResumption: boolean,
+        idleRetransTimeoutMs?: number,
+        activeRetransTimeoutMs?: number,
+        closeCallback?: () => void
+    ) {
+        const session = await SecureSession.create(
+            this.context,
+            sessionId,
+            fabric,
+            peerNodeId,
+            peerSessionId,
+            sharedSecret,
+            salt,
+            isInitiator,
+            isResumption,
+            () => {
+                this.removeSession(sessionId, peerNodeId);
+                closeCallback?.();
+            },
+            idleRetransTimeoutMs,
+            activeRetransTimeoutMs
+        );
         this.sessions.set(sessionId, session);
 
         // TODO: close previous secure channel for


### PR DESCRIPTION
When we close a session, currently mainly in case of subscriptions erros or other sending errors then we should reannounce the device to allow controller to discover it again.
What we do in Controller we need to decice, added Todo there.