### PR TITLE
BasicInformation testing fixes

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -6,3 +6,4 @@ models/spec.ts
 models/chip.ts
 packages/matter.js/src/cluster/definitions/*.ts
 packages/matter.js/src/model/elements/Globals.ts
+packages/matter.js/src/model/standard/elements/*.ts

--- a/packages/matter-node.js/test/IntegrationTest.ts
+++ b/packages/matter-node.js/test/IntegrationTest.ts
@@ -336,14 +336,14 @@ describe("Integration Test", () => {
                 },
                 value: [
                     ClusterId(29),
+                    ClusterId(31),
                     ClusterId(40),
-                    ClusterId(62),
                     ClusterId(48),
                     ClusterId(49),
-                    ClusterId(31),
-                    ClusterId(63),
                     ClusterId(51),
                     ClusterId(60),
+                    ClusterId(62),
+                    ClusterId(63),
                 ],
                 version: 0,
             });

--- a/packages/matter.js/src/cluster/server/ClusterServer.ts
+++ b/packages/matter.js/src/cluster/server/ClusterServer.ts
@@ -95,8 +95,8 @@ export function ClusterServer<
 
             for (const attributeName in attributes) {
                 const attribute = (attributes as any)[attributeName];
-                if (!attributeStorageListeners.has(attribute.id)) return;
-                if (!storageContext.has(attribute.name)) return;
+                if (!attributeStorageListeners.has(attribute.id)) continue;
+                if (!storageContext.has(attribute.name)) continue;
                 try {
                     const data = storageContext.get<{ version: number; value: any }>(attribute.name);
                     logger.debug(

--- a/packages/matter.js/src/cluster/server/ClusterServer.ts
+++ b/packages/matter.js/src/cluster/server/ClusterServer.ts
@@ -321,7 +321,7 @@ export function ClusterServer<
             }
         }
     }
-    (attributes as any).attributeList.setLocal(attributeList);
+    (attributes as any).attributeList.setLocal(attributeList.sort((a, b) => a - b));
 
     // Create commands
     const acceptedCommandList = new Array<CommandId>();
@@ -394,8 +394,8 @@ export function ClusterServer<
             }
         }
     }
-    (attributes as any).acceptedCommandList.setLocal(acceptedCommandList.map(id => id));
-    (attributes as any).generatedCommandList.setLocal(generatedCommandList.map(id => id));
+    (attributes as any).acceptedCommandList.setLocal(acceptedCommandList.sort((a, b) => a - b));
+    (attributes as any).generatedCommandList.setLocal(generatedCommandList.sort((a, b) => a - b));
 
     const eventList = new Array<EventId>();
     for (const eventName in eventDef) {
@@ -449,7 +449,7 @@ export function ClusterServer<
                 (events as any)[eventName].triggerEvent(event);
         }
     }
-    (attributes as any).eventList.setLocal(eventList.map(id => id));
+    (attributes as any).eventList.setLocal(eventList.sort((a, b) => a - b));
 
     return result as ClusterServerObj<A, C, E>;
 }

--- a/packages/matter.js/src/device/Endpoint.ts
+++ b/packages/matter.js/src/device/Endpoint.ts
@@ -135,7 +135,7 @@ export class Endpoint {
             this.descriptorCluster = cluster as unknown as ClusterServerObjForCluster<typeof DescriptorCluster>;
         }
         this.clusterServers.set(cluster.id, cluster);
-        this.descriptorCluster.attributes.serverList.init(Array.from(this.clusterServers.keys()).map(id => id));
+        this.descriptorCluster.attributes.serverList.init(Array.from(this.clusterServers.keys()).sort((a, b) => a - b));
         this.structureChangedCallback(); // Inform parent about structure change
     }
 
@@ -143,7 +143,7 @@ export class Endpoint {
         cluster: ClusterClientObj<F, A, C, E>,
     ) {
         this.clusterClients.set(cluster.id, cluster);
-        this.descriptorCluster.attributes.clientList.init(Array.from(this.clusterClients.keys()).map(id => id));
+        this.descriptorCluster.attributes.clientList.init(Array.from(this.clusterClients.keys()).sort((a, b) => a - b));
         this.structureChangedCallback(); // Inform parent about structure change
     }
 

--- a/packages/matter.js/test/cluster/ClusterServerTest.ts
+++ b/packages/matter.js/test/cluster/ClusterServerTest.ts
@@ -457,12 +457,12 @@ describe("ClusterServer structure", () => {
                 AttributeId(0),
                 AttributeId(1),
                 AttributeId(2),
-                AttributeId(65533),
-                AttributeId(65532),
-                AttributeId(65531),
-                AttributeId(65530),
-                AttributeId(65529),
                 AttributeId(65528),
+                AttributeId(65529),
+                AttributeId(65530),
+                AttributeId(65531),
+                AttributeId(65532),
+                AttributeId(65533),
             ]);
             expect((server.attributes as any).acceptedCommandList.get()).toEqual([CommandId(0), CommandId(2)]);
             expect((server.attributes as any).generatedCommandList.get()).toEqual([]);
@@ -491,12 +491,12 @@ describe("ClusterServer structure", () => {
             expect((server.attributes as any).attributeList.get()).toEqual([
                 AttributeId(0),
                 AttributeId(1),
-                AttributeId(65533),
-                AttributeId(65532),
-                AttributeId(65531),
-                AttributeId(65530),
-                AttributeId(65529),
                 AttributeId(65528),
+                AttributeId(65529),
+                AttributeId(65530),
+                AttributeId(65531),
+                AttributeId(65532),
+                AttributeId(65533),
             ]);
             expect((server.attributes as any).acceptedCommandList.get()).toEqual([CommandId(0), CommandId(0x40)]);
             expect((server.attributes as any).generatedCommandList.get()).toEqual([]);
@@ -525,12 +525,12 @@ describe("ClusterServer structure", () => {
             expect((server.attributes as any).attributeList.get()).toEqual([
                 AttributeId(0),
                 AttributeId(1),
-                AttributeId(65533),
-                AttributeId(65532),
-                AttributeId(65531),
-                AttributeId(65530),
-                AttributeId(65529),
                 AttributeId(65528),
+                AttributeId(65529),
+                AttributeId(65530),
+                AttributeId(65531),
+                AttributeId(65532),
+                AttributeId(65533),
             ]);
             expect((server.attributes as any).acceptedCommandList.get()).toEqual([CommandId(0), CommandId(0x40)]);
             expect((server.attributes as any).generatedCommandList.get()).toEqual([]);
@@ -556,12 +556,12 @@ describe("ClusterServer structure", () => {
             expect((server.attributes as any).attributeList.get()).toEqual([
                 AttributeId(0),
                 AttributeId(1),
-                AttributeId(65533),
-                AttributeId(65532),
-                AttributeId(65531),
-                AttributeId(65530),
-                AttributeId(65529),
                 AttributeId(65528),
+                AttributeId(65529),
+                AttributeId(65530),
+                AttributeId(65531),
+                AttributeId(65532),
+                AttributeId(65533),
             ]);
             expect((server.attributes as any).acceptedCommandList.get()).toEqual([CommandId(0)]);
             expect((server.attributes as any).generatedCommandList.get()).toEqual([]);
@@ -599,12 +599,12 @@ describe("ClusterServer structure", () => {
             expect((server.attributes as any).featureMap.get()).toEqual({ groupNames: true });
             expect((server.attributes as any).attributeList.get()).toEqual([
                 AttributeId(0),
-                AttributeId(65533),
-                AttributeId(65532),
-                AttributeId(65531),
-                AttributeId(65530),
-                AttributeId(65529),
                 AttributeId(65528),
+                AttributeId(65529),
+                AttributeId(65530),
+                AttributeId(65531),
+                AttributeId(65532),
+                AttributeId(65533),
             ]);
             expect((server.attributes as any).acceptedCommandList.get()).toEqual([
                 CommandId(0),

--- a/packages/matter.js/test/cluster/definitions/WindowCoveringClusterTest.ts
+++ b/packages/matter.js/test/cluster/definitions/WindowCoveringClusterTest.ts
@@ -106,7 +106,7 @@ describe("WindowCoveringCluster", () => {
         expect(attrValues).toEqual({
             // TODO - make strict after updating web tester
             acceptedCommandList: [0, 1, 2],
-            attributeList: [0, 7, 10, 13, 23, 26, 65533, 65532, 65531, 65530, 65529, 65528, 11, 14],
+            attributeList: [0, 7, 10, 11, 13, 14, 23, 26, 65528, 65529, 65530, 65531, 65532, 65533],
             clusterRevision: 5,
             configStatus: {
                 operational: true,


### PR DESCRIPTION
I executed the "TestBasicInformation" chip-tool testsuite and discovered a bug and a needed change.

* Restoring storage was broken (this could also bee the cause of the "move to standardroom" or such issue!)
* tests expect lists to be sorted, so we sort them