### PR TITLE
Adjust maxInterval and SendInterval calculation for Subscriptions

### DIFF
--- a/packages/matter.js/src/CommissioningServer.ts
+++ b/packages/matter.js/src/CommissioningServer.ts
@@ -88,21 +88,66 @@ export interface DevicePairingInformation {
  * and allows to override the certificates used for the OperationalCredentials cluster
  */
 export interface CommissioningServerOptions {
+    /** Port of the server, normally automatically managed. */
     port: number;
+
+    /** If set to true no IPv4 socket listener is sed and only IPv6 is supported. */
     disableIpv4?: boolean;
+
+    /** IPv4 listener address, defaults to all interfaces.*/
     listeningAddressIpv4?: string;
+
+    /** IPv6 listener address, defaults to all interfaces.*/
     listeningAddressIpv6?: string;
+
+    /** The device name to be used for the BasicInformation cluster. */
     deviceName: string;
+
+    /** The device type to be used for the BasicInformation cluster. */
     deviceType: number;
+
+    /** The next endpoint ID to be assigned to a new endpoint. */
     nextEndpointId?: number;
 
+    /** The passcode/pin of the device to use for initial commissioning. */
     passcode: number;
+
+    /** The Discriminator to use for initial commissioning. */
     discriminator: number;
+
+    /** The Flow type of the Commissioning flow used in announcements. */
     flowType?: CommissionningFlowType;
+
+    /** Optional Vendor specific additional BLE Advertisement data. */
     additionalBleAdvertisementData?: ByteArray;
 
+    /** Should the device directly be announced automatically by the MatterServer of manually via announce(). */
     delayedAnnouncement?: boolean;
 
+    /**
+     * Optional maximum subscription interval to use for sending subscription reports. It will be used if not too low
+     * and inside the range requested by the connected controller.
+     */
+    subscriptionMaxIntervalSeconds?: number;
+
+    /**
+     * Optional minimum subscription interval to use for sending subscription reports. It will be used when other
+     * calculated values are smaller than it. Use this to make sure your device hardware can handle the load and to set
+     * limits.
+     */
+    subscriptionMinIntervalSeconds?: number;
+
+    /**
+     * Optional subscription randomization window to use for sending subscription reports. This specifies a window in
+     * seconds from which a random part is added to the calculated maximum interval to make sure that devices that get
+     * powered on in parallel not all send at the same timepoint.
+     */
+    subscriptionRandomizationWindowSeconds?: number;
+
+    /**
+     * Device details to be used for the BasicInformation cluster. Some of the values are initialized with defaults if
+     * not set here.
+     */
     basicInformation:
         | {
               vendorId: number;
@@ -112,11 +157,19 @@ export interface CommissioningServerOptions {
           }
         | AttributeInitialValues<typeof BasicInformationCluster.attributes>;
 
+    /**
+     * Vendor specific certificates to be used for the OperationalCredentials cluster. If not set Test certificates
+     * (official Chip tool test Root certificate is used) are generated automatically.
+     */
     certificates?: OperationalCredentialsServerConf;
 
+    /**
+     * Optional configuration for the GeneralCommissioning cluster. If not set the default values are used.
+     * Use these options to limit the allowed countries for regulatory configuration.
+     */
     generalCommissioning?: Partial<AttributeInitialValues<typeof GeneralCommissioningCluster.attributes>> & {
         allowCountryCodeChange?: boolean; // Default true if not set
-        countryCodeWhitelist?: string[];
+        countryCodeWhitelist?: string[]; // Default all countries are allowed
     };
 }
 
@@ -137,15 +190,9 @@ type CommissioningServerCommands = {
  */
 export class CommissioningServer extends MatterNode {
     private readonly port: number;
-    private readonly disableIpv4: boolean;
-    private readonly listeningAddressIpv4?: string;
-    private readonly listeningAddressIpv6?: string;
-    private readonly deviceName: string;
-    private readonly deviceType: DeviceTypeId;
     private readonly passcode: number;
     private readonly discriminator: number;
     private readonly flowType: CommissionningFlowType;
-    private readonly additionalBleAdvertisementData?: ByteArray;
 
     private storage?: StorageContext;
     private endpointStructureStorage?: StorageContext;
@@ -166,20 +213,13 @@ export class CommissioningServer extends MatterNode {
      *
      * @param options The options for the CommissioningServer node
      */
-    constructor(options: CommissioningServerOptions) {
+    constructor(private readonly options: CommissioningServerOptions) {
         super();
         this.port = options.port;
-        this.disableIpv4 = options.disableIpv4 ?? false;
-        this.listeningAddressIpv4 = options.listeningAddressIpv4;
-        this.listeningAddressIpv6 = options.listeningAddressIpv6;
-        this.deviceName = options.deviceName;
-        this.deviceType = DeviceTypeId(options.deviceType);
         this.passcode = options.passcode;
         this.discriminator = options.discriminator;
         this.flowType = options.flowType ?? CommissionningFlowType.Standard;
         this.nextEndpointId = EndpointNumber(options.nextEndpointId ?? 1);
-        this.delayedAnnouncement = options.delayedAnnouncement ?? false;
-        this.additionalBleAdvertisementData = options.additionalBleAdvertisementData;
 
         const vendorId = VendorId(options.basicInformation.vendorId);
         const productId = options.basicInformation.productId;
@@ -423,7 +463,11 @@ export class CommissioningServer extends MatterNode {
         const vendorId = basicInformation.attributes.vendorId.getLocal();
         const productId = basicInformation.attributes.productId.getLocal();
 
-        this.interactionServer = new InteractionServer(this.storage);
+        this.interactionServer = new InteractionServer(this.storage, {
+            subscriptionMaxIntervalSeconds: this.options.subscriptionMaxIntervalSeconds,
+            subscriptionMinIntervalSeconds: this.options.subscriptionMinIntervalSeconds,
+            subscriptionRandomizationWindowSeconds: this.options.subscriptionRandomizationWindowSeconds,
+        });
 
         this.nextEndpointId = this.endpointStructureStorage.get("nextEndpointId", this.nextEndpointId);
 
@@ -434,8 +478,8 @@ export class CommissioningServer extends MatterNode {
 
         // TODO adjust later and refactor MatterDevice
         this.deviceInstance = new MatterDevice(
-            this.deviceName,
-            this.deviceType,
+            this.options.deviceName,
+            DeviceTypeId(this.options.deviceType),
             vendorId,
             productId,
             this.discriminator,
@@ -450,13 +494,13 @@ export class CommissioningServer extends MatterNode {
                 }
             },
         )
-            .addTransportInterface(await UdpInterface.create("udp6", this.port, this.listeningAddressIpv6))
+            .addTransportInterface(await UdpInterface.create("udp6", this.port, this.options.listeningAddressIpv6))
             .addScanner(this.mdnsScanner)
             .addProtocolHandler(secureChannelProtocol)
             .addProtocolHandler(this.interactionServer);
-        if (!this.disableIpv4) {
+        if (this.options.disableIpv4 !== true) {
             this.deviceInstance.addTransportInterface(
-                await UdpInterface.create("udp4", this.port, this.listeningAddressIpv4),
+                await UdpInterface.create("udp4", this.port, this.options.listeningAddressIpv4),
             );
         }
 
@@ -468,7 +512,9 @@ export class CommissioningServer extends MatterNode {
                 const ble = Ble.get();
                 this.deviceInstance.addTransportInterface(ble.getBlePeripheralInterface());
                 if (limitTo === undefined || limitTo.ble) {
-                    this.deviceInstance.addBroadcaster(ble.getBleBroadcaster(this.additionalBleAdvertisementData));
+                    this.deviceInstance.addBroadcaster(
+                        ble.getBleBroadcaster(this.options.additionalBleAdvertisementData),
+                    );
                 }
             } catch (error) {
                 if (error instanceof NoProviderError) {
@@ -718,7 +764,7 @@ export class CommissioningServer extends MatterNode {
     }
 
     async start() {
-        if (!this.delayedAnnouncement) {
+        if (this.delayedAnnouncement !== true) {
             return this.advertise();
         }
     }

--- a/packages/matter.js/src/protocol/interaction/SubscriptionHandler.ts
+++ b/packages/matter.js/src/protocol/interaction/SubscriptionHandler.ts
@@ -48,7 +48,9 @@ const logger = Logger.get("SubscriptionHandler");
 // chip-tool is not respecting the 60 min at all and only respects the max sent by the controller
 // which can lead to spamming the network with unneeded packages. So I decided for 3 minutes for now
 // as a compromise until we have something better.
-const SUBSCRIPTION_MAX_INTERVAL_PUBLISHER_LIMIT_MS = 3 * 60 * 1000; /** 3 min */ // Officially: 1000 * 60 * 60; /** 1 hour */
+const SUBSCRIPTION_MAX_INTERVAL_PUBLISHER_LIMIT_S = 3 * 60; /** 3 min */ // Officially: 1000 * 60 * 60; /** 1 hour */
+const SUBSCRIPTION_MIN_INTERVAL_S = 2; // We do not send faster than 2 seconds
+const SUBSCRIPTION_DEFAULT_RANDOMIZATION_WINDOW_S = 10; // 10 seconds
 
 interface AttributePathWithValueVersion<T> {
     path: TypeFromSchema<typeof TlvAttributePath>;
@@ -84,8 +86,8 @@ export class SubscriptionHandler {
         }
     >();
     private sendUpdatesActivated = false;
-    private readonly maxInterval: number;
-    private readonly sendInterval: number;
+    readonly maxInterval: number;
+    readonly sendInterval: number;
     private readonly minIntervalFloorMs: number;
     private readonly maxIntervalCeilingMs: number;
     private readonly server: MatterDevice;
@@ -108,6 +110,9 @@ export class SubscriptionHandler {
         keepSubscriptions: boolean,
         minIntervalFloor: number,
         maxIntervalCeiling: number,
+        subscriptionMaxIntervalSeconds: number | undefined,
+        subscriptionMinIntervalSeconds: number | undefined,
+        subscriptionRandomizationWindowSeconds: number | undefined,
         private readonly cancelCallback: () => void,
     ) {
         this.server = this.session.getContext();
@@ -115,26 +120,55 @@ export class SubscriptionHandler {
         this.peerNodeId = this.session.getPeerNodeId();
         this.minIntervalFloorMs = minIntervalFloor * 1000;
         this.maxIntervalCeilingMs = maxIntervalCeiling * 1000;
-        // The final Max interval needs to be between min-floor and the MAX of max-ceiling and the defined publisher
-        // maximum of 60 minutes - this is to ensure that the publisher is not flooded with updates. But spec also
-        // says that it should be more frequent than the max interval.
-        // So let's calculate a maximum in the second half of the range between the two, but then already send at
-        // half of that time (so ideally we have 2 updates per max interval, so one could fail, and we still are good).
-        const halfMaxIntervalCeilingMs =
-            (Math.max(SUBSCRIPTION_MAX_INTERVAL_PUBLISHER_LIMIT_MS, this.maxIntervalCeilingMs) -
-                this.minIntervalFloorMs) /
-            2;
-        this.maxInterval = Math.floor(
-            this.minIntervalFloorMs + halfMaxIntervalCeilingMs + halfMaxIntervalCeilingMs * Math.random(),
+
+        const { maxInterval, sendInterval } = this.determineSendingIntervals(
+            (subscriptionMinIntervalSeconds ?? SUBSCRIPTION_MIN_INTERVAL_S) * 1000,
+            (subscriptionMaxIntervalSeconds ?? SUBSCRIPTION_MAX_INTERVAL_PUBLISHER_LIMIT_S) * 1000,
+            (subscriptionRandomizationWindowSeconds ?? SUBSCRIPTION_DEFAULT_RANDOMIZATION_WINDOW_S) * 1000,
         );
-        this.sendInterval = Math.floor(this.maxInterval / 2);
+        this.maxInterval = maxInterval;
+        this.sendInterval = sendInterval;
+
         this.updateTimer = Time.getTimer(this.sendInterval, () => this.prepareDataUpdate()); // will be started later
         this.sendDelayTimer = Time.getTimer(50, () => this.sendUpdate()); // will be started later
-
         if (!keepSubscriptions) {
             logger.debug(`Clear subscriptions for Session ${session.name}`);
             this.session.clearSubscriptions();
         }
+    }
+
+    private determineSendingIntervals(
+        subscriptionMinIntervalMs: number,
+        subscriptionMaxIntervalMs: number,
+        subscriptionRandomizationWindowMs: number,
+    ): { maxInterval: number; sendInterval: number } {
+        // Max Interval is the Max interval that the controller request, unless the configured one from the developer
+        // is lower. In that case we use the configured one. But we make sure to not be smaller than the requested
+        // controller minimum. But in general never faster than minimum interval configured or 2 seconds
+        // (SUBSCRIPTION_MIN_INTERVAL_S). Additionally, we add a randomization window to the max interval to avoid all
+        // devices sending at the same time.
+        const maxInterval =
+            Math.max(
+                Math.max(subscriptionMinIntervalMs, SUBSCRIPTION_MIN_INTERVAL_S * 1000),
+                Math.max(this.minIntervalFloorMs, Math.min(subscriptionMaxIntervalMs, this.maxIntervalCeilingMs)),
+            ) + Math.floor(subscriptionRandomizationWindowMs * Math.random());
+        console.log("maxInterval", maxInterval);
+        let sendInterval = Math.floor(maxInterval / 2); // Ideally we send at half the max interval
+        if (sendInterval < 60_000) {
+            // But if we have no chance of at least one full resubmission process we do like chip-tool.
+            // One full resubmission process takes 33-45 seconds. So 60s means we reach at least first 2 retries of a
+            // second subscription report after first failed.
+            sendInterval = Math.max(this.minIntervalFloorMs, Math.floor(maxInterval * 0.8));
+        }
+        if (sendInterval < subscriptionMinIntervalMs) {
+            // But not faster than once every 2s
+            logger.warn(
+                `Determined subscription send interval of ${sendInterval}ms is too low. Using maxInterval (${maxInterval}ms) instead.`,
+            );
+            sendInterval = Math.max(subscriptionMinIntervalMs, SUBSCRIPTION_MIN_INTERVAL_S * 1000);
+        }
+        console.log("sendInterval", sendInterval);
+        return { maxInterval, sendInterval };
     }
 
     private registerNewAttributes() {
@@ -306,6 +340,10 @@ export class SubscriptionHandler {
         return Math.ceil(this.maxInterval / 1000);
     }
 
+    getSendInterval(): number {
+        return Math.ceil(this.sendInterval / 1000);
+    }
+
     activateSendingUpdates() {
         this.session.addSubscription(this);
 
@@ -416,7 +454,6 @@ export class SubscriptionHandler {
         attributeErrors.forEach(attributeStatus => attributeReports.push({ attributeStatus }));
 
         const { newEvents, eventErrors } = this.registerNewEvents();
-        console.log(newEvents, eventErrors);
 
         const eventReports = newEvents
             .flatMap(({ path, event }): TypeFromSchema<typeof TlvEventReport>[] => {


### PR DESCRIPTION
As discussed in Core group I adjusted the maxInterval handling for Subscriptions and allo it to be configured via the CommissioningServer options.

In fact  we now have:
* subscriptionMaxIntervalSeconds: Optional maximum subscription interval to use for sending subscription reports. It will be used if not too low and inside the range requested by the connected controller.
* subscriptionMinIntervalSeconds: Optional minimum subscription interval to use for sending subscription reports. It will be used when other calculated values are smaller than it. Use this to make sure your device hardware can handle the load and to set limits.
* subscriptionRandomizationWindowSeconds: Optional subscription randomization window to use for sending subscription reports. This specifies a window in seconds from which a random part is added to the calculated maximum interval to make sure that devices that get powered on in parallel not all send at the same timepoint.

With the new logic and defaults Apple with it's "0-2" requirement ends up in 5-8s as interval. Google with requested 120s ends up in 120-130s.

The randomization Window can also be set to 0 to not have a random factor.

I added a bit refactoring in CommissioningController/Server to not duplicate data that are only needed in one place and better store the options object.

* finishs: https://github.com/orgs/project-chip/projects/11?pane=issue&itemId=35393216