### PR TITLE
Upgrade Basic Info to revision 2

### DIFF
--- a/models/local/BasicInformationOverrides.ts
+++ b/models/local/BasicInformationOverrides.ts
@@ -1,0 +1,17 @@
+/**
+ * @license
+ * Copyright 2022-2023 Project CHIP Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { LocalMatter } from "../local.js";
+
+LocalMatter.children.push({
+    tag: "cluster",
+    name: "BasicInformation",
+
+    children: [
+        // The used chip xmls with revision 2 fields, so we should also use it really
+        { tag: "attribute", name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 2 },
+    ],
+});

--- a/models/local/index.ts
+++ b/models/local/index.ts
@@ -13,6 +13,7 @@
 // matching.
 
 import "./AdministratorCommissioningOverrides.js";
+import "./BasicInformationOverrides.js";
 import "./ColorControlOverrides.js";
 import "./DoorLockOverrides.js";
 import "./GroupKeyManagementOverrides.js";

--- a/models/spec.ts
+++ b/models/spec.ts
@@ -12270,7 +12270,7 @@ export const SpecMatter: MatterElement = {
             xref: { document: "core", section: "11.1" },
 
             children: [
-                { tag: "attribute", name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 2 },
+                { tag: "attribute", name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 1 },
 
                 {
                     tag: "attribute", name: "DataModelRevision", id: 0x0, type: "uint16", access: "R V",

--- a/models/spec.ts
+++ b/models/spec.ts
@@ -12270,7 +12270,7 @@ export const SpecMatter: MatterElement = {
             xref: { document: "core", section: "11.1" },
 
             children: [
-                { tag: "attribute", name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 1 },
+                { tag: "attribute", name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 2 },
 
                 {
                     tag: "attribute", name: "DataModelRevision", id: 0x0, type: "uint16", access: "R V",

--- a/packages/matter.js/src/cluster/definitions/BasicInformationCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/BasicInformationCluster.ts
@@ -151,7 +151,7 @@ export namespace BasicInformation {
     export const Cluster = CreateCluster({
         id: 0x28,
         name: "BasicInformation",
-        revision: 1,
+        revision: 2,
 
         attributes: {
             /**


### PR DESCRIPTION
I we use some fields from chip XMLs already because of reasons we should also upgrade the cluster revision accordingly.