### PR TITLE
Feature: Allow to query the onOff attribute via method

### DIFF
--- a/packages/matter.js/src/device/OnOffDevices.ts
+++ b/packages/matter.js/src/device/OnOffDevices.ts
@@ -102,6 +102,10 @@ abstract class OnOffBaseDevice extends extendPublicHandlerMethods<typeof Device,
         cluster?.setOnOffAttribute(!cluster?.getOnOffAttribute());
     }
 
+    async isOn() {
+        return this.getClusterServer(OnOffCluster)?.getOnOffAttribute();
+    }
+
     // Add Listeners convenient for chosen attributes
     /**
      * Adds a listener for the OnOff attribute


### PR DESCRIPTION
It might be still beneficial to have a method to query the state of the onOff device instead of only having the listeners