### PR TITLE
Compliance: Add Leave event and flush events before ending sessions, fix eventlist

### DIFF
--- a/packages/matter.js/src/CommissioningServer.ts
+++ b/packages/matter.js/src/CommissioningServer.ts
@@ -215,6 +215,7 @@ export class CommissioningServer extends MatterNode {
                 startUp: true,
                 shutDown: true,
                 reachableChanged: reachabilitySupported,
+                leave: true,
             },
         );
         this.rootEndpoint.addClusterServer(basicInformationCluster);

--- a/packages/matter.js/src/cluster/server/AttributeServer.ts
+++ b/packages/matter.js/src/cluster/server/AttributeServer.ts
@@ -26,8 +26,9 @@ import { Attribute, Attributes, Cluster, Commands, Events } from "../Cluster.js"
  */
 export class FabricScopeError extends MatterError {}
 
-// TODO create Factory method to create AttributeServer instances
-
+/**
+ * Factory function to create an attribute server.
+ */
 export function createAttributeServer<
     T,
     F extends BitSchema,

--- a/packages/matter.js/src/cluster/server/ClusterServer.ts
+++ b/packages/matter.js/src/cluster/server/ClusterServer.ts
@@ -447,6 +447,7 @@ export function ClusterServer<
             const capitalizedEventName = capitalize(eventName);
             result[`trigger${capitalizedEventName}Event`] = <T>(event: T) =>
                 (events as any)[eventName].triggerEvent(event);
+            eventList.push(id);
         }
     }
     (attributes as any).eventList.setLocal(eventList.sort((a, b) => a - b));

--- a/packages/matter.js/src/fabric/Fabric.ts
+++ b/packages/matter.js/src/fabric/Fabric.ts
@@ -156,8 +156,10 @@ export class Fabric {
         this.persistCallback = callback;
     }
 
-    remove() {
-        this.sessions.forEach(session => session.destroy());
+    async remove() {
+        for (const session of this.sessions) {
+            await session.end();
+        }
         this.removeCallback?.();
     }
 

--- a/packages/matter.js/src/protocol/interaction/InteractionServer.ts
+++ b/packages/matter.js/src/protocol/interaction/InteractionServer.ts
@@ -622,21 +622,4 @@ export class InteractionServer implements ProtocolHandler<MatterDevice> {
             await subscription.cancel(true);
         }
     }
-
-    getSubscribedFabricInformation() {
-        return Array.from(this.subscriptionMap.values()).map(subscription => {
-            const fabric = subscription.getFabric();
-            return {
-                fabricId: fabric.fabricId,
-                nodeId: fabric.nodeId,
-                rootNodeId: fabric.rootNodeId,
-                rootVendorId: fabric.rootVendorId,
-                label: fabric.label,
-            };
-        });
-    }
-
-    getNumberOfActiveSubscriptions() {
-        return this.subscriptionMap.size;
-    }
 }

--- a/packages/matter.js/src/protocol/interaction/SubscriptionHandler.ts
+++ b/packages/matter.js/src/protocol/interaction/SubscriptionHandler.ts
@@ -377,9 +377,9 @@ export class SubscriptionHandler {
                 this.sendNextUpdateImmediately = false;
                 if (error instanceof RetransmissionLimitReachedError) {
                     // We could not send at all, consider session as dead
-                    this.session.destroy();
+                    await this.session.destroy();
                 } else {
-                    this.cancel();
+                    await this.cancel();
                 }
             }
         }
@@ -416,7 +416,6 @@ export class SubscriptionHandler {
         attributeErrors.forEach(attributeStatus => attributeReports.push({ attributeStatus }));
 
         const { newEvents, eventErrors } = this.registerNewEvents();
-        console.log(newEvents, eventErrors);
 
         const eventReports = newEvents
             .flatMap(({ path, event }): TypeFromSchema<typeof TlvEventReport>[] => {
@@ -500,12 +499,15 @@ export class SubscriptionHandler {
         }
     }
 
-    cancel() {
+    async cancel(flush = false) {
         this.sendUpdatesActivated = false;
         this.updateTimer.stop();
         this.sendDelayTimer.stop();
         this.unregisterAttributeListeners(Array.from(this.attributeListeners.keys()));
         this.unregisterEventListeners(Array.from(this.eventListeners.keys()));
+        if (flush) {
+            await this.flush();
+        }
         this.session.removeSubscription(this.subscriptionId);
         this.cancelCallback();
     }
@@ -566,7 +568,7 @@ export class SubscriptionHandler {
                 async error => {
                     if (error.code === StatusCode.InvalidSubscription || error.code === StatusCode.Failure) {
                         logger.info(`Subscription ${this.subscriptionId} cancelled by peer.`);
-                        this.cancel();
+                        await this.cancel();
                     } else {
                         throw error;
                     }

--- a/packages/matter.js/src/protocol/interaction/SubscriptionHandler.ts
+++ b/packages/matter.js/src/protocol/interaction/SubscriptionHandler.ts
@@ -133,7 +133,7 @@ export class SubscriptionHandler {
 
         if (!keepSubscriptions) {
             logger.debug(`Clear subscriptions for Session ${session.name}`);
-            this.session.clearSubscriptions();
+            void this.session.clearSubscriptions(); // Temporary void: Will be cleaned up in PR #814
         }
     }
 

--- a/packages/matter.js/src/session/SecureSession.ts
+++ b/packages/matter.js/src/session/SecureSession.ts
@@ -182,13 +182,22 @@ export class SecureSession<T> implements Session<T> {
         }
     }
 
-    clearSubscriptions() {
-        this.subscriptions.forEach(subscription => subscription.cancel());
+    async clearSubscriptions(flushSubscriptions = false) {
+        for (const subscription of this.subscriptions) {
+            await subscription.cancel(flushSubscriptions);
+        }
         this.subscriptions.length = 0;
     }
 
-    destroy() {
-        this.clearSubscriptions();
+    /** Ends a session. Outstanding subscription data will be flushed before the session is destroyed. */
+    async end() {
+        await this.clearSubscriptions(true);
+        await this.destroy();
+    }
+
+    /** Destroys a session. Outstanding subscription data will be discarded. */
+    async destroy() {
+        await this.clearSubscriptions(false);
         this.fabric?.removeSession(this);
         this.closeCallback();
     }

--- a/packages/matter.js/src/session/case/CaseServer.ts
+++ b/packages/matter.js/src/session/case/CaseServer.ts
@@ -105,7 +105,7 @@ export class CaseServer implements ProtocolHandler<MatterDevice> {
                 await messenger.sendSigma2Resume({ resumptionId, resumeMic, sessionId });
             } catch (error) {
                 // If we fail to send the resume, we destroy the session
-                secureSession.destroy();
+                await secureSession.destroy();
                 throw error;
             }
 

--- a/packages/matter.js/test/device/MatterNodeStructureTest.ts
+++ b/packages/matter.js/test/device/MatterNodeStructureTest.ts
@@ -334,7 +334,21 @@ describe("Endpoint Structures", () => {
 
             expect(attributePaths.length).toBe(110);
             expect(commandPaths.length).toBe(18);
-            expect(eventPaths.length).toBe(5);
+            expect(eventPaths.length).toBe(6);
+
+            const basicInformationCluster = rootEndpoint.getClusterServer(BasicInformationCluster);
+            expect(basicInformationCluster).toBeDefined();
+            expect((basicInformationCluster?.attributes as any).attributeList.get().length).toBe(20);
+            expect((basicInformationCluster?.attributes as any).eventList.get().length).toBe(3);
+            expect((basicInformationCluster?.attributes as any).generatedCommandList.get().length).toBe(0);
+            expect((basicInformationCluster?.attributes as any).acceptedCommandList.get().length).toBe(0);
+
+            const generalCommissioningCluster = rootEndpoint.getClusterServer(GeneralCommissioning.Cluster);
+            expect(generalCommissioningCluster).toBeDefined();
+            expect((generalCommissioningCluster?.attributes as any).attributeList.get().length).toBe(11);
+            expect((generalCommissioningCluster?.attributes as any).eventList.get().length).toBe(0);
+            expect((generalCommissioningCluster?.attributes as any).generatedCommandList.get().length).toBe(3);
+            expect((generalCommissioningCluster?.attributes as any).acceptedCommandList.get().length).toBe(3);
         });
 
         it("One device with one Light endpoints - no unique id, use index", async () => {
@@ -425,7 +439,7 @@ describe("Endpoint Structures", () => {
 
             expect(attributePaths.length).toBe(161);
             expect(commandPaths.length).toBe(38);
-            expect(eventPaths.length).toBe(5);
+            expect(eventPaths.length).toBe(6);
         });
 
         it("One device with one Light endpoints - with uniqueid", async () => {
@@ -516,7 +530,7 @@ describe("Endpoint Structures", () => {
 
             expect(attributePaths.length).toBe(161);
             expect(commandPaths.length).toBe(38);
-            expect(eventPaths.length).toBe(5);
+            expect(eventPaths.length).toBe(6);
         });
 
         it("One device with one Light endpoints - no uniqueid, use index, from storage", async () => {
@@ -608,7 +622,7 @@ describe("Endpoint Structures", () => {
 
             expect(attributePaths.length).toBe(161);
             expect(commandPaths.length).toBe(38);
-            expect(eventPaths.length).toBe(5);
+            expect(eventPaths.length).toBe(6);
         });
 
         it("One device with one Light endpoints - with uniqueid, from storage", async () => {
@@ -700,7 +714,7 @@ describe("Endpoint Structures", () => {
 
             expect(attributePaths.length).toBe(161);
             expect(commandPaths.length).toBe(38);
-            expect(eventPaths.length).toBe(5);
+            expect(eventPaths.length).toBe(6);
         });
     });
 
@@ -1314,7 +1328,7 @@ describe("Endpoint Structures", () => {
 
             expect(attributePaths.length).toBe(380);
             expect(commandPaths.length).toBe(98);
-            expect(eventPaths.length).toBe(9);
+            expect(eventPaths.length).toBe(10);
         });
 
         it("Device Structure with two aggregators and three Light/Composed endpoints and all partly auto-assigned endpoint IDs", async () => {
@@ -1574,7 +1588,7 @@ describe("Endpoint Structures", () => {
 
             expect(attributePaths.length).toBe(502);
             expect(commandPaths.length).toBe(138);
-            expect(eventPaths.length).toBe(10);
+            expect(eventPaths.length).toBe(11);
         });
 
         it("Device Structure with two aggregators and three Light/Composed endpoints and all partly auto-assigned endpoint IDs and removing adding devices", async () => {
@@ -1835,7 +1849,7 @@ describe("Endpoint Structures", () => {
 
             expect(attributePaths.length).toBe(502);
             expect(commandPaths.length).toBe(138);
-            expect(eventPaths.length).toBe(10);
+            expect(eventPaths.length).toBe(11);
 
             let structureChangeCounter = 0;
             rootEndpoint.setStructureChangedCallback(() => {


### PR DESCRIPTION
This PR does the following:
* Enhance options to end a session by introducing "end" which is endling the session including flushing open events
* Adding leave event triggered when a fabric gets removed via removeFabric
* Fixing eventList attribute population and tests