### PR TITLE
Feature: Transparency about commissionings, sessions and subscriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,7 @@ All Changes without a GitHub Username in brackets are from the core team: @Apoll
   * Feature: Enhance Storage system to allow to create subcontext stores to allow better separation of data
   * Feature: Allow to also remove devices from Aggregators
   * Feature: Optionally allow to define discovery capabilities when generating Pairing code
-  * Feature: Add methods to CommissioningServer class to get information on active subscriptions and commissioned fabrics
+  * Feature: Add methods to CommissioningServer/Controller class to get information on active sessions and commissioned fabrics
 * Reference implementation/Examples:
   * Breaking: The storage key structure got changed to allow multi node operations within one process. This requires to change the storage key structure and to migrate or reset the storage.
     * Migration: prepend any storage key except Device.* and Controller.* with "0." in the filename

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ All Changes without a GitHub Username in brackets are from the core team: @Apoll
   * Feature: Enhance Storage system to allow to create subcontext stores to allow better separation of data
   * Feature: Allow to also remove devices from Aggregators
   * Feature: Optionally allow to define discovery capabilities when generating Pairing code
+  * Feature: Add methods to CommissioningServer class to get information on active subscriptions and commissioned fabrics
 * Reference implementation/Examples:
   * Breaking: The storage key structure got changed to allow multi node operations within one process. This requires to change the storage key structure and to migrate or reset the storage.
     * Migration: prepend any storage key except Device.* and Controller.* with "0." in the filename

--- a/packages/matter.js/src/CommissioningController.ts
+++ b/packages/matter.js/src/CommissioningController.ts
@@ -495,4 +495,8 @@ export class CommissioningController extends MatterNode {
             return this.connect();
         }
     }
+
+    getActiveSessionInformation() {
+        return this.controllerInstance?.getActiveSessionInformation() ?? [];
+    }
 }

--- a/packages/matter.js/src/CommissioningServer.ts
+++ b/packages/matter.js/src/CommissioningServer.ts
@@ -722,4 +722,23 @@ export class CommissioningServer extends MatterNode {
             return this.advertise();
         }
     }
+
+    getCommissionedFabricInformation() {
+        if (!this.isCommissioned()) return [];
+        return this.deviceInstance?.getFabrics().map(fabric => fabric.getExternalInformation()) ?? [];
+    }
+
+    getSubscribedFabricInformation() {
+        if (!this.isCommissioned()) return [];
+        return this.interactionServer?.getSubscribedFabricInformation() ?? [];
+    }
+
+    getNumberOfActiveSubscriptions() {
+        if (!this.isCommissioned()) return 0;
+        return this.interactionServer?.getNumberOfActiveSubscriptions() ?? 0;
+    }
+
+    isSubscribed() {
+        return this.getNumberOfActiveSubscriptions() > 0;
+    }
 }

--- a/packages/matter.js/src/CommissioningServer.ts
+++ b/packages/matter.js/src/CommissioningServer.ts
@@ -729,20 +729,9 @@ export class CommissioningServer extends MatterNode {
         return this.deviceInstance?.getFabrics().map(fabric => fabric.getExternalInformation()) ?? [];
     }
 
-    /** get some basic details of all Fabrics where an active subscription exists. */
-    getSubscribedFabricInformation() {
+    /** Get some basic details of all currently active sessions. */
+    getActiveSessionInformation() {
         if (!this.isCommissioned()) return [];
-        return this.interactionServer?.getSubscribedFabricInformation() ?? [];
-    }
-
-    /** Get the number of active subscriptions. */
-    getNumberOfActiveSubscriptions() {
-        if (!this.isCommissioned()) return 0;
-        return this.interactionServer?.getNumberOfActiveSubscriptions() ?? 0;
-    }
-
-    /** Returns true if at least one active subscription exists. */
-    isSubscribed() {
-        return this.getNumberOfActiveSubscriptions() > 0;
+        return this.deviceInstance?.getActiveSessionInformation() ?? [];
     }
 }

--- a/packages/matter.js/src/CommissioningServer.ts
+++ b/packages/matter.js/src/CommissioningServer.ts
@@ -723,21 +723,25 @@ export class CommissioningServer extends MatterNode {
         }
     }
 
+    /** Get some basic details of all Fabrics the server is commissioned to. */
     getCommissionedFabricInformation() {
         if (!this.isCommissioned()) return [];
         return this.deviceInstance?.getFabrics().map(fabric => fabric.getExternalInformation()) ?? [];
     }
 
+    /** get some basic details of all Fabrics where an active subscription exists. */
     getSubscribedFabricInformation() {
         if (!this.isCommissioned()) return [];
         return this.interactionServer?.getSubscribedFabricInformation() ?? [];
     }
 
+    /** Get the number of active subscriptions. */
     getNumberOfActiveSubscriptions() {
         if (!this.isCommissioned()) return 0;
         return this.interactionServer?.getNumberOfActiveSubscriptions() ?? 0;
     }
 
+    /** Returns true if at least one active subscription exists. */
     isSubscribed() {
         return this.getNumberOfActiveSubscriptions() > 0;
     }

--- a/packages/matter.js/src/MatterController.ts
+++ b/packages/matter.js/src/MatterController.ts
@@ -647,4 +647,8 @@ export class MatterController {
         await this.netInterfaceIpv4?.close();
         await this.netInterfaceIpv6.close();
     }
+
+    getActiveSessionInformation() {
+        return this.sessionManager.getActiveSessionInformation();
+    }
 }

--- a/packages/matter.js/src/MatterDevice.ts
+++ b/packages/matter.js/src/MatterDevice.ts
@@ -291,4 +291,8 @@ export class MatterDevice {
         await this.exchangeManager.close();
         this.announceInterval.stop();
     }
+
+    getActiveSessionInformation() {
+        return this.sessionManager.getActiveSessionInformation();
+    }
 }

--- a/packages/matter.js/src/fabric/Fabric.ts
+++ b/packages/matter.js/src/fabric/Fabric.ts
@@ -204,6 +204,16 @@ export class Fabric {
         }
         return Array.from(this.scopedClusterData.get(cluster.id).keys());
     }
+
+    getExternalInformation() {
+        return {
+            fabricId: this.fabricId,
+            nodeId: this.nodeId,
+            rootNodeId: this.rootNodeId,
+            rootVendorId: this.rootVendorId,
+            label: this.label,
+        };
+    }
 }
 
 export class FabricBuilder {

--- a/packages/matter.js/src/protocol/interaction/InteractionServer.ts
+++ b/packages/matter.js/src/protocol/interaction/InteractionServer.ts
@@ -628,4 +628,14 @@ export class InteractionServer implements ProtocolHandler<MatterDevice> {
             subscription.cancel();
         }
     }
+
+    getSubscribedFabricInformation() {
+        return Array.from(this.subscriptionMap.values()).map(subscription =>
+            subscription.getFabric().getExternalInformation(),
+        );
+    }
+
+    getNumberOfActiveSubscriptions() {
+        return this.subscriptionMap.size;
+    }
 }

--- a/packages/matter.js/src/protocol/interaction/InteractionServer.ts
+++ b/packages/matter.js/src/protocol/interaction/InteractionServer.ts
@@ -485,7 +485,7 @@ export class InteractionServer implements ProtocolHandler<MatterDevice> {
 
         if (!keepSubscriptions) {
             logger.debug(`Clear subscriptions for Session ${session.name}`);
-            await session.clearSubscriptions();
+            session.clearSubscriptions(); // Before merge needs to be changed to await!!
         }
 
         const maxInterval = subscriptionHandler.getMaxInterval();

--- a/packages/matter.js/src/protocol/interaction/InteractionServer.ts
+++ b/packages/matter.js/src/protocol/interaction/InteractionServer.ts
@@ -542,7 +542,7 @@ export class InteractionServer implements ProtocolHandler<MatterDevice> {
 
         if (!keepSubscriptions) {
             logger.debug(`Clear subscriptions for Session ${session.name}`);
-            session.clearSubscriptions(); // Before merge needs to be changed to await!!
+            await session.clearSubscriptions();
         }
 
         const maxInterval = subscriptionHandler.getMaxInterval();

--- a/packages/matter.js/src/protocol/interaction/InteractionServer.ts
+++ b/packages/matter.js/src/protocol/interaction/InteractionServer.ts
@@ -628,14 +628,4 @@ export class InteractionServer implements ProtocolHandler<MatterDevice> {
             subscription.cancel();
         }
     }
-
-    getSubscribedFabricInformation() {
-        return Array.from(this.subscriptionMap.values()).map(subscription =>
-            subscription.getFabric().getExternalInformation(),
-        );
-    }
-
-    getNumberOfActiveSubscriptions() {
-        return this.subscriptionMap.size;
-    }
 }

--- a/packages/matter.js/src/protocol/interaction/SubscriptionHandler.ts
+++ b/packages/matter.js/src/protocol/interaction/SubscriptionHandler.ts
@@ -105,7 +105,6 @@ export class SubscriptionHandler {
         private readonly eventFilters: TypeFromSchema<typeof TlvEventFilter>[] | undefined,
         private readonly eventHandler: EventHandler,
         private readonly isFabricFiltered: boolean,
-        keepSubscriptions: boolean,
         minIntervalFloor: number,
         maxIntervalCeiling: number,
         private readonly cancelCallback: () => void,
@@ -130,11 +129,6 @@ export class SubscriptionHandler {
         this.sendInterval = Math.floor(this.maxInterval / 2);
         this.updateTimer = Time.getTimer(this.sendInterval, () => this.prepareDataUpdate()); // will be started later
         this.sendDelayTimer = Time.getTimer(50, () => this.sendUpdate()); // will be started later
-
-        if (!keepSubscriptions) {
-            logger.debug(`Clear subscriptions for Session ${session.name}`);
-            this.session.clearSubscriptions();
-        }
     }
 
     private registerNewAttributes() {
@@ -307,8 +301,6 @@ export class SubscriptionHandler {
     }
 
     activateSendingUpdates() {
-        this.session.addSubscription(this);
-
         this.sendUpdatesActivated = true;
         if (this.outstandingAttributeUpdates.size > 0 || this.outstandingEventUpdates.size > 0) {
             void this.sendUpdate();

--- a/packages/matter.js/src/protocol/interaction/SubscriptionHandler.ts
+++ b/packages/matter.js/src/protocol/interaction/SubscriptionHandler.ts
@@ -568,8 +568,4 @@ export class SubscriptionHandler {
             messenger.close();
         }
     }
-
-    getFabric(): Fabric {
-        return this.fabric;
-    }
 }

--- a/packages/matter.js/src/protocol/interaction/SubscriptionHandler.ts
+++ b/packages/matter.js/src/protocol/interaction/SubscriptionHandler.ts
@@ -568,4 +568,8 @@ export class SubscriptionHandler {
             messenger.close();
         }
     }
+
+    getFabric(): Fabric {
+        return this.fabric;
+    }
 }

--- a/packages/matter.js/src/session/SecureSession.ts
+++ b/packages/matter.js/src/session/SecureSession.ts
@@ -32,8 +32,8 @@ export class NoAssociatedFabricError extends Error {}
 
 export class SecureSession<T> implements Session<T> {
     private readonly subscriptions = new Array<SubscriptionHandler>();
-    private timestamp = Time.nowMs();
-    private activeTimestamp = this.timestamp;
+    timestamp = Time.nowMs();
+    activeTimestamp = this.timestamp;
 
     static async create<T>(
         context: T,
@@ -172,6 +172,10 @@ export class SecureSession<T> implements Session<T> {
     addSubscription(subscription: SubscriptionHandler) {
         this.subscriptions.push(subscription);
         logger.debug(`Added subscription ${subscription.subscriptionId} to ${this.name}/${this.id}`);
+    }
+
+    get numberOfActiveSubscriptions() {
+        return this.subscriptions.length;
     }
 
     removeSubscription(subscriptionId: number) {

--- a/packages/matter.js/src/session/SessionManager.ts
+++ b/packages/matter.js/src/session/SessionManager.ts
@@ -167,4 +167,18 @@ export class SessionManager<ContextT> {
             });
         });
     }
+
+    getActiveSessionInformation() {
+        return [...this.sessions.values()].map(session => ({
+            name: session.name,
+            nodeId: session.getNodeId(),
+            peerNodeId: session.getPeerNodeId(),
+            fabric: session instanceof SecureSession ? session.getFabric()?.getExternalInformation() : undefined,
+            isPeerActive: session.isPeerActive(),
+            secure: session.isSecure(),
+            lastInteractionTimestamp: session instanceof SecureSession ? session.timestamp : undefined,
+            lastActiveTimestamp: session instanceof SecureSession ? session.activeTimestamp : undefined,
+            numberOfActiveSubscriptions: session instanceof SecureSession ? session.numberOfActiveSubscriptions : 0,
+        }));
+    }
 }


### PR DESCRIPTION
In order to better guide users on issue when using a device based on matter.js displaying information about the commissioning status, commissioned fabrics and active sessions including information if subscriptions are active.

This PR adds some methods for this.

* finishs https://github.com/project-chip/matter.js/issues/271
* closes https://github.com/project-chip/matter.js/discussions/221