### PR TITLE
Compliance: Correctly implement Cluster data version and DataVersionFilters for Subscriptions and Reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@ All Changes without a GitHub Username in brackets are from the core team: @Apoll
   * Breaking: All collection files meant to be used for exports only are renamed to export.ts and should not be used for internal imports
   * Breaking: Attribute listener methods renamed: addListener -> addValueSetListener, addMatterListener -> addValueChangeListener (also remove methods) to make it more clear what they do
   * Breaking: Change from object style to Branded types for special Datatype objects (e.g. "new VendorId(0xFFF1)" -> "VendorId(0xFFF1)")
-  * Breaking: ClusterClient and CLusterServer classes were moved from "interaction" export to "cluster" export
+  * Breaking: ClusterClient and ClusterServer classes were moved from "interaction" export to "cluster" export
+  * Breaking: Refactor the (low level) ClusterClient API to be more convenient to use with many optional fields for read/write/subscribe
   * Feature: Enhance CommissioningServer options to also specify GeneralCommissioningServer details and settings
   * Feature: Adjust RegulatoryConfig Handling in Device and Controller to match with specifications
   * Feature: Endpoint Structures use custom-unique-id (from EndpointOptions)/uniqueStorageKey (from BasicInformationCluster)/serialNumber (from BasicInformationCluster)/ Index (in this order) to store and restore the endpoint ID in structures
@@ -32,7 +33,8 @@ All Changes without a GitHub Username in brackets are from the core team: @Apoll
   * Feature: Correctly Handle FabricIndex fields for Read and Write requests
   * Feature: Handle subscription errors and destroy session if failing more than 3 times
   * Feature: Add full event support (Device and Controller) including triggering some default events automatically (startup, shutdown, reachabilityChanged, bootReason)
-  * Feature: Add more parameters to several InteractionClient methods to allow to configure more parameters of the requests
+  * Feature: Added support for dataVersionFiltering and eventFilters for read and subscribe requests for Device and Controllers
+  * Feature: Added more parameters to several InteractionClient methods to allow to configure more parameters of the requests
   * Feature: Allows subscripts to be updated dynamically when the endpoint structure for bridges changes by adding or removing a device
   * Enhance: Device port in MDNSBroadcaster is now dynamically set and add UDC (User directed Commissioning) Announcements
   * Enhance: Enhanced MessageCodec and check some more fields
@@ -51,6 +53,7 @@ All Changes without a GitHub Username in brackets are from the core team: @Apoll
   * Fix: Fixes a Subscription timer duplication issue and collect attribute changes within a 50ms window to reduce the number of subscription messages
   * Fix: Returns correct Error-Status for Read-/Write-/Subscribe- and Invoke-Requests
   * Fix: Fixes TLV Encoding for strings with UTF8 relevant characters
+  * Fix: Adjusted DataVersion handling to track version on ClusterInstance level as required by Specs. Stored values that might got invalid by this change are deleted and recreated on next change.
   * Refactor: Refactor Endpoint structuring and determination to allow dynamic and updating structures
 * matter.js API:
   * Breaking: 

--- a/packages/matter-node.js/src/storage/StorageBackendDisk.ts
+++ b/packages/matter-node.js/src/storage/StorageBackendDisk.ts
@@ -48,4 +48,9 @@ export class StorageBackendDisk implements Storage {
         if (!contexts.length || !key.length) throw new StorageError("Context and key must not be empty strings!");
         this.localStorage.setItem(this.buildStorageKey(contexts, key), toJson(value));
     }
+
+    delete(contexts: string[], key: string): void {
+        if (!contexts.length || !key.length) throw new StorageError("Context and key must not be empty strings!");
+        this.localStorage.removeItem(this.buildStorageKey(contexts, key));
+    }
 }

--- a/packages/matter-node.js/src/storage/StorageBackendJsonFile.ts
+++ b/packages/matter-node.js/src/storage/StorageBackendJsonFile.ts
@@ -48,6 +48,14 @@ export class StorageBackendJsonFile extends StorageBackendMemory {
         }
     }
 
+    override delete(contexts: string[], key: string): void {
+        super.delete(contexts, key);
+        if (!this.waitForCommit) {
+            this.waitForCommit = true;
+            this.commitTimer.start();
+        }
+    }
+
     private async commit() {
         if (!this.initialized || this.closed) return;
         this.waitForCommit = false;

--- a/packages/matter-node.js/test/IntegrationTest.ts
+++ b/packages/matter-node.js/test/IntegrationTest.ts
@@ -685,27 +685,35 @@ describe("Integration Test", () => {
                 value: number;
                 time: number;
             }>();
-            const callback = (value: number) => firstResolver({ value, time: Time.nowMs() });
+            let callback = (value: number) => firstResolver({ value, time: Time.nowMs() });
 
             //onOffClient.attributes.onOff.addValueSetListener(value => callback(value));
             //await onOffClient.attributes.onOff.subscribe(0, 5);
             await scenesClient.subscribeSceneCountAttribute(value => callback(value), 0, 5);
 
-            await fakeTime.advanceTime(0);
+            await fakeTime.yield();
             const firstReport = await firstPromise;
             assert.deepEqual(firstReport, { value: 0, time: startTime });
 
-            /* Will be added later when we clean up getter subscriptions
             // Await update Report on value change
-            const { promise: updatePromise, resolver: updateResolver } = await getPromiseResolver<{ value: boolean, time: number }>();
-            callback = (value: boolean) => updateResolver({ value, time: Time.nowMs() });
+            const { promise: updatePromise, resolver: updateResolver } = await getPromiseResolver<{
+                value: number;
+                time: number;
+            }>();
+            callback = (value: number) => updateResolver({ value, time: Time.nowMs() });
 
             await fakeTime.advanceTime(2 * 1000);
-            await scenesClient.addScene({groupID: new GroupId(1), sceneId: 1, transitionTime: 0, sceneName: "Test", extensionFieldSets: []});
+            await scenesClient.addScene({
+                groupId: GroupId(1),
+                sceneId: 1,
+                transitionTime: 0,
+                sceneName: "Test",
+                extensionFieldSets: [],
+            });
+            await fakeTime.advanceTime(100);
             const updateReport = await updatePromise;
 
-            assert.deepEqual(updateReport, { value: true, time: startTime + 2 * 1000 });
-            */
+            assert.deepEqual(updateReport, { value: 1, time: startTime + 2 * 1000 + 100 });
         });
 
         it("subscription of one event sends updates when event got triggered via auto-wiring", async () => {

--- a/packages/matter-node.js/test/IntegrationTest.ts
+++ b/packages/matter-node.js/test/IntegrationTest.ts
@@ -304,16 +304,18 @@ describe("Integration Test", () => {
         });
 
         it("read multiple attributes", async () => {
-            const response = await defaultInteractionClient.getMultipleAttributes([
-                { clusterId: Descriptor.Cluster.id }, // * /DescriptorCluster/ *
-                { endpointId: EndpointNumber(0), clusterId: BasicInformation.Cluster.id }, // 0/BasicInformationCluster/ *
-                {
-                    endpointId: EndpointNumber(1),
-                    clusterId: OnOffCluster.id,
-                    attributeId: OnOffCluster.attributes.onOff.id,
-                }, // 1/OnOffCluster/onOff
-                { endpointId: EndpointNumber(2) }, // 2 / * /* - will be discarded in results!
-            ]);
+            const response = await defaultInteractionClient.getMultipleAttributes({
+                attributes: [
+                    { clusterId: Descriptor.Cluster.id }, // * /DescriptorCluster/ *
+                    { endpointId: EndpointNumber(0), clusterId: BasicInformation.Cluster.id }, // 0/BasicInformationCluster/ *
+                    {
+                        endpointId: EndpointNumber(1),
+                        clusterId: OnOffCluster.id,
+                        attributeId: OnOffCluster.attributes.onOff.id,
+                    }, // 1/OnOffCluster/onOff
+                    { endpointId: EndpointNumber(2) }, // 2 / * /* - will be discarded in results!
+                ],
+            });
 
             assert.equal(response.length, 43);
             assert.equal(
@@ -419,15 +421,17 @@ describe("Integration Test", () => {
         });
 
         it("read events", async () => {
-            const response = await defaultInteractionClient.getMultipleEvents([
-                { clusterId: BasicInformation.Cluster.id }, // * /BasicInformationCluster/ *
-                {
-                    endpointId: EndpointNumber(0),
-                    clusterId: GeneralDiagnostics.Cluster.id,
-                    eventId: GeneralDiagnostics.Cluster.events.bootReason.id,
-                }, // 0/GeneralDiagnosticsCluster/bootReason
-                { endpointId: EndpointNumber(2) }, // 2 / * /* - will be discarded in results!
-            ]);
+            const response = await defaultInteractionClient.getMultipleEvents({
+                events: [
+                    { clusterId: BasicInformation.Cluster.id }, // * /BasicInformationCluster/ *
+                    {
+                        endpointId: EndpointNumber(0),
+                        clusterId: GeneralDiagnostics.Cluster.id,
+                        eventId: GeneralDiagnostics.Cluster.events.bootReason.id,
+                    }, // 0/GeneralDiagnosticsCluster/bootReason
+                    { endpointId: EndpointNumber(2) }, // 2 / * /* - will be discarded in results!
+                ],
+            });
 
             assert.equal(response.length, 2);
             assert.equal(

--- a/packages/matter-node.js/test/IntegrationTest.ts
+++ b/packages/matter-node.js/test/IntegrationTest.ts
@@ -108,6 +108,15 @@ describe("Integration Test", () => {
         const serverStorageManager = new StorageManager(fakeServerStorage);
         await serverStorageManager.initialize();
 
+        // make cluster data version deterministic
+        const nodeContext = serverStorageManager.createContext("0");
+        const cluster16Context = nodeContext.createContext("Cluster-1-6");
+        cluster16Context.set("_clusterDataVersion", 0); // Make sure the onoff attribute has deterministic start version for tests
+        const cluster029Context = nodeContext.createContext("Cluster-0-29");
+        cluster029Context.set("_clusterDataVersion", 0); // Make sure the serverList attribute has deterministic start version for tests
+        const cluster040Context = nodeContext.createContext("Cluster-0-40");
+        cluster040Context.set("_clusterDataVersion", 0); // Make sure the serverList attribute has deterministic start version for tests
+
         matterServer = new MatterServer(serverStorageManager);
 
         commissioningServer = new CommissioningServer({
@@ -370,7 +379,7 @@ describe("Integration Test", () => {
                     attributeName: "softwareVersionString",
                 },
                 value: "v1",
-                version: 0,
+                version: 3,
             });
             const nodeLabelData = response.find(
                 ({ path: { endpointId, clusterId, attributeId } }) =>
@@ -387,7 +396,7 @@ describe("Integration Test", () => {
                     attributeName: "nodeLabel",
                 },
                 value: "345678",
-                version: 2,
+                version: 3,
             });
 
             const onOffData = response.find(
@@ -780,10 +789,8 @@ describe("Integration Test", () => {
 
             assert.equal(fakeServerStorage.get(["0", "FabricManager"], "nextFabricIndex"), 2);
 
-            const onOffValue = fakeServerStorage.get<{ value: any; version: number }>(["0", "Cluster-1-6"], "onOff");
-            assert.ok(typeof onOffValue === "object");
-            assert.equal(onOffValue.version, 2);
-            assert.equal(onOffValue.value, false);
+            const onOffValue = fakeServerStorage.get<any>(["0", "Cluster-1-6"], "onOff");
+            assert.equal(onOffValue, false);
 
             const storedServerResumptionRecords = fakeServerStorage.get(["0", "SessionManager"], "resumptionRecords");
             assert.ok(Array.isArray(storedServerResumptionRecords));

--- a/packages/matter-node.js/test/interaction/InteractionProtocolTest.ts
+++ b/packages/matter-node.js/test/interaction/InteractionProtocolTest.ts
@@ -92,6 +92,36 @@ const READ_REQUEST: ReadRequest = {
     ],
 };
 
+const READ_REQUEST_WITH_UNUSED_FILTER: ReadRequest = {
+    interactionModelRevision: 1,
+    isFabricFiltered: true,
+    attributeRequests: [
+        { endpointId: EndpointNumber(0), clusterId: ClusterId(0x28), attributeId: AttributeId(2) },
+        { endpointId: EndpointNumber(0), clusterId: ClusterId(0x28), attributeId: AttributeId(4) },
+        { endpointId: EndpointNumber(0), clusterId: ClusterId(0x28), attributeId: AttributeId(400) }, // unsupported attribute
+        { endpointId: EndpointNumber(0), clusterId: ClusterId(0x99), attributeId: AttributeId(4) }, // unsupported cluster
+        { endpointId: EndpointNumber(1), clusterId: ClusterId(0x28), attributeId: AttributeId(1) }, // unsupported endpoint
+        { endpointId: undefined, clusterId: ClusterId(0x28), attributeId: AttributeId(3) },
+        { endpointId: undefined, clusterId: ClusterId(0x99), attributeId: AttributeId(3) }, // ignore
+    ],
+    dataVersionFilters: [{ path: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x28) }, dataVersion: 1 }],
+};
+
+const READ_REQUEST_WITH_FILTER: ReadRequest = {
+    interactionModelRevision: 1,
+    isFabricFiltered: true,
+    attributeRequests: [
+        { endpointId: EndpointNumber(0), clusterId: ClusterId(0x28), attributeId: AttributeId(2) },
+        { endpointId: EndpointNumber(0), clusterId: ClusterId(0x28), attributeId: AttributeId(4) },
+        { endpointId: EndpointNumber(0), clusterId: ClusterId(0x28), attributeId: AttributeId(400) }, // unsupported attribute
+        { endpointId: EndpointNumber(0), clusterId: ClusterId(0x99), attributeId: AttributeId(4) }, // unsupported cluster
+        { endpointId: EndpointNumber(1), clusterId: ClusterId(0x28), attributeId: AttributeId(1) }, // unsupported endpoint
+        { endpointId: undefined, clusterId: ClusterId(0x28), attributeId: AttributeId(3) },
+        { endpointId: undefined, clusterId: ClusterId(0x99), attributeId: AttributeId(3) }, // ignore
+    ],
+    dataVersionFilters: [{ path: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x28) }, dataVersion: 0 }],
+};
+
 const READ_RESPONSE: DataReport = {
     interactionModelRevision: 1,
     suppressResponse: false,
@@ -134,6 +164,32 @@ const READ_RESPONSE: DataReport = {
                 path: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x28), attributeId: AttributeId(3) },
                 data: TlvString.encodeTlv("product"),
                 dataVersion: 0,
+            },
+        },
+    ],
+};
+
+const READ_RESPONSE_WITH_FILTER: DataReport = {
+    interactionModelRevision: 1,
+    suppressResponse: false,
+    eventReports: undefined,
+    attributeReports: [
+        {
+            attributeStatus: {
+                path: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x28), attributeId: AttributeId(400) },
+                status: { status: 134 },
+            },
+        },
+        {
+            attributeStatus: {
+                path: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x99), attributeId: AttributeId(4) },
+                status: { status: 195 },
+            },
+        },
+        {
+            attributeStatus: {
+                path: { endpointId: EndpointNumber(1), clusterId: ClusterId(0x28), attributeId: AttributeId(1) },
+                status: { status: 127 },
             },
         },
     ],
@@ -497,6 +553,92 @@ describe("InteractionProtocol", () => {
             );
 
             assert.deepEqual(result, READ_RESPONSE);
+        });
+
+        it("replies with attribute values using (unused) version filter", async () => {
+            const storageManager = new StorageManager(new StorageBackendMemory());
+            await storageManager.initialize();
+            const storageContext = storageManager.createContext("test");
+            const endpoint = new Endpoint([DummyTestDevice], { endpointId: EndpointNumber(0) });
+            endpoint.addClusterServer(
+                ClusterServer(
+                    BasicInformationCluster,
+                    {
+                        dataModelRevision: 1,
+                        vendorName: "vendor",
+                        vendorId: VendorId(1),
+                        productName: "product",
+                        productId: 2,
+                        nodeLabel: "",
+                        hardwareVersion: 0,
+                        hardwareVersionString: "0",
+                        location: "US",
+                        localConfigDisabled: false,
+                        softwareVersion: 1,
+                        softwareVersionString: "v1",
+                        capabilityMinima: {
+                            caseSessionsPerFabric: 100,
+                            subscriptionsPerFabric: 100,
+                        },
+                    },
+                    {},
+                    {
+                        startUp: true,
+                    },
+                ),
+            );
+            const interactionProtocol = new InteractionServer(storageContext);
+            interactionProtocol.setRootEndpoint(endpoint);
+
+            const result = interactionProtocol.handleReadRequest(
+                { channel: { name: "test" } } as MessageExchange<any>,
+                READ_REQUEST_WITH_UNUSED_FILTER,
+            );
+
+            assert.deepEqual(result, READ_RESPONSE);
+        });
+
+        it("replies with attribute values with active version filter", async () => {
+            const storageManager = new StorageManager(new StorageBackendMemory());
+            await storageManager.initialize();
+            const storageContext = storageManager.createContext("test");
+            const endpoint = new Endpoint([DummyTestDevice], { endpointId: EndpointNumber(0) });
+            endpoint.addClusterServer(
+                ClusterServer(
+                    BasicInformationCluster,
+                    {
+                        dataModelRevision: 1,
+                        vendorName: "vendor",
+                        vendorId: VendorId(1),
+                        productName: "product",
+                        productId: 2,
+                        nodeLabel: "",
+                        hardwareVersion: 0,
+                        hardwareVersionString: "0",
+                        location: "US",
+                        localConfigDisabled: false,
+                        softwareVersion: 1,
+                        softwareVersionString: "v1",
+                        capabilityMinima: {
+                            caseSessionsPerFabric: 100,
+                            subscriptionsPerFabric: 100,
+                        },
+                    },
+                    {},
+                    {
+                        startUp: true,
+                    },
+                ),
+            );
+            const interactionProtocol = new InteractionServer(storageContext);
+            interactionProtocol.setRootEndpoint(endpoint);
+
+            const result = interactionProtocol.handleReadRequest(
+                { channel: { name: "test" } } as MessageExchange<any>,
+                READ_REQUEST_WITH_FILTER,
+            );
+
+            assert.deepEqual(result, READ_RESPONSE_WITH_FILTER);
         });
     });
 

--- a/packages/matter-node.js/test/interaction/InteractionProtocolTest.ts
+++ b/packages/matter-node.js/test/interaction/InteractionProtocolTest.ts
@@ -11,7 +11,14 @@ import { CryptoNode } from "../../src/crypto/CryptoNode";
 
 import { KEY } from "../cluster/ClusterServerTestingUtil.js";
 
-Crypto.get = () => new CryptoNode();
+Crypto.get = () => {
+    const crypto = new CryptoNode();
+    // Force random data to be deterministic
+    crypto.getRandomData = (length: number) => {
+        return new Uint8Array(length);
+    };
+    return crypto;
+};
 
 import { Time, TimeFake } from "@project-chip/matter.js/time";
 

--- a/packages/matter-node.js/test/storage/StorageBackendDiskTest.ts
+++ b/packages/matter-node.js/test/storage/StorageBackendDiskTest.ts
@@ -26,6 +26,16 @@ describe("Storage node-localstorage", () => {
         assert.equal(value, "value");
     });
 
+    it("write and delete success", async () => {
+        const storage = new StorageBackendDisk(TEST_STORAGE_LOCATION);
+
+        storage.set(["context"], "key", "value");
+        storage.delete(["context"], "key");
+
+        const value = storage.get(["context"], "key");
+        assert.equal(value, undefined);
+    });
+
     it("write and read success with multiple context levels", async () => {
         const storage = new StorageBackendDisk(TEST_STORAGE_LOCATION);
 

--- a/packages/matter.js/src/cluster/client/AttributeClient.ts
+++ b/packages/matter.js/src/cluster/client/AttributeClient.ts
@@ -66,7 +66,12 @@ export class AttributeClient<T> {
             );
         }
 
-        return await interactionClient.setAttribute<T>(this.endpointId, this.clusterId, this.attribute, value);
+        return await interactionClient.setAttribute<T>({
+            endpointId: this.endpointId,
+            clusterId: this.clusterId,
+            attribute: this.attribute,
+            value,
+        });
     }
 
     async get(alwaysRequestFromRemote = false) {
@@ -74,12 +79,12 @@ export class AttributeClient<T> {
         if (interactionClient === undefined) {
             throw new InternalError("No InteractionClient available");
         }
-        return await interactionClient.getAttribute(
-            this.endpointId,
-            this.clusterId,
-            this.attribute,
+        return await interactionClient.getAttribute({
+            endpointId: this.endpointId,
+            clusterId: this.clusterId,
+            attribute: this.attribute,
             alwaysRequestFromRemote,
-        );
+        });
     }
 
     async getWithVersion(alwaysRequestFromRemote = false) {
@@ -87,28 +92,34 @@ export class AttributeClient<T> {
         if (interactionClient === undefined) {
             throw new InternalError("No InteractionClient available");
         }
-        return await interactionClient.getAttributeWithVersion(
-            this.endpointId,
-            this.clusterId,
-            this.attribute,
+        return await interactionClient.getAttributeWithVersion({
+            endpointId: this.endpointId,
+            clusterId: this.clusterId,
+            attribute: this.attribute,
             alwaysRequestFromRemote,
-        );
+        });
     }
 
-    async subscribe(minIntervalS: number, maxIntervalS: number, isFabricFiltered?: boolean) {
+    async subscribe(
+        minIntervalFloorSeconds: number,
+        maxIntervalCeilingSeconds: number,
+        knownDataVersion?: number,
+        isFabricFiltered = true,
+    ) {
         const interactionClient = await this.getInteractionClientCallback();
         if (interactionClient === undefined) {
             throw new InternalError("No InteractionClient available");
         }
-        return await interactionClient.subscribeAttribute(
-            this.endpointId,
-            this.clusterId,
-            this.attribute,
-            minIntervalS,
-            maxIntervalS,
+        return await interactionClient.subscribeAttribute({
+            endpointId: this.endpointId,
+            clusterId: this.clusterId,
+            attribute: this.attribute,
+            minIntervalFloorSeconds,
+            maxIntervalCeilingSeconds,
             isFabricFiltered,
-            this.update.bind(this),
-        );
+            knownDataVersion,
+            listener: this.update.bind(this),
+        });
     }
 
     update(value: T) {

--- a/packages/matter.js/src/cluster/client/ClusterClient.ts
+++ b/packages/matter.js/src/cluster/client/ClusterClient.ts
@@ -7,14 +7,16 @@
 import { InternalError } from "../../common/MatterError.js";
 import { tryCatchAsync } from "../../common/TryCatchHandler.js";
 import { AttributeId } from "../../datatype/AttributeId.js";
+import { ClusterId } from "../../datatype/ClusterId.js";
 import { EndpointNumber } from "../../datatype/EndpointNumber.js";
 import { EventId } from "../../datatype/EventId.js";
 import { Logger } from "../../log/Logger.js";
 import { DecodedEventData } from "../../protocol/interaction/EventDataDecoder.js";
 import { InteractionClient } from "../../protocol/interaction/InteractionClient.js";
 import { StatusResponseError } from "../../protocol/interaction/InteractionMessenger.js";
-import { StatusCode } from "../../protocol/interaction/InteractionProtocol.js";
+import { StatusCode, TlvEventFilter } from "../../protocol/interaction/InteractionProtocol.js";
 import { BitSchema } from "../../schema/BitmapSchema.js";
+import { TypeFromSchema } from "../../tlv/TlvSchema.js";
 import { capitalize } from "../../util/String.js";
 import { Merge } from "../../util/Type.js";
 import { Attributes, Cluster, Command, Commands, Events, GlobalAttributes } from "../Cluster.js";
@@ -49,23 +51,37 @@ export function ClusterClient<F extends BitSchema, A extends Attributes, C exten
         attributes,
         events,
         commands,
-        subscribeAllAttributes: async (
-            minIntervalFloorSeconds: number,
-            maxIntervalCeilingSeconds: number,
-            keepSubscriptions?: boolean,
-            isFabricFiltered?: boolean,
-        ) => {
+        subscribeAllAttributes: async (options: {
+            minIntervalFloorSeconds: number;
+            maxIntervalCeilingSeconds: number;
+            keepSubscriptions?: boolean;
+            isFabricFiltered?: boolean;
+            eventFilters?: TypeFromSchema<typeof TlvEventFilter>[];
+            dataVersionFilters?: { endpointId: EndpointNumber; clusterId: ClusterId; dataVersion: number }[];
+        }) => {
             if (interactionClient === undefined) {
                 throw new InternalError("InteractionClient not set");
             }
-            return await interactionClient.subscribeMultipleAttributesAndEvents(
-                [{ endpointId: endpointId, clusterId: clusterId }],
-                [{ endpointId: endpointId, clusterId: clusterId }],
+
+            const {
                 minIntervalFloorSeconds,
                 maxIntervalCeilingSeconds,
                 keepSubscriptions,
                 isFabricFiltered,
-                attributeData => {
+                eventFilters,
+                dataVersionFilters,
+            } = options;
+
+            return await interactionClient.subscribeMultipleAttributesAndEvents({
+                attributes: [{ endpointId: endpointId, clusterId: clusterId }],
+                events: [{ endpointId: endpointId, clusterId: clusterId }],
+                minIntervalFloorSeconds,
+                maxIntervalCeilingSeconds,
+                keepSubscriptions,
+                isFabricFiltered,
+                eventFilters,
+                dataVersionFilters,
+                attributeListener: attributeData => {
                     const { path, value } = attributeData;
                     const attributeName = attributeToId[path.attributeId];
                     if (attributeName === undefined) {
@@ -74,7 +90,7 @@ export function ClusterClient<F extends BitSchema, A extends Attributes, C exten
                     }
                     (attributes as any)[attributeName].update(value);
                 },
-                eventData => {
+                eventListener: eventData => {
                     const { path, events } = eventData;
                     const eventName = eventToId[path.eventId];
                     if (eventName === undefined) {
@@ -83,7 +99,7 @@ export function ClusterClient<F extends BitSchema, A extends Attributes, C exten
                     }
                     events.forEach(event => (events as any)[eventName].update(event));
                 },
-            );
+            });
         },
 
         /**
@@ -142,9 +158,16 @@ export function ClusterClient<F extends BitSchema, A extends Attributes, C exten
             listener: (value: T) => void,
             minIntervalS: number,
             maxIntervalS: number,
+            knownDataVersion?: number,
+            isFabricFiltered?: boolean,
         ) => {
             (attributes as any)[attributeName].addListener(listener);
-            (attributes as any)[attributeName].subscribe(minIntervalS, maxIntervalS);
+            (attributes as any)[attributeName].subscribe(
+                minIntervalS,
+                maxIntervalS,
+                knownDataVersion,
+                isFabricFiltered,
+            );
         };
     }
 

--- a/packages/matter.js/src/cluster/client/ClusterClientTypes.ts
+++ b/packages/matter.js/src/cluster/client/ClusterClientTypes.ts
@@ -73,6 +73,8 @@ type ClientAttributeSubscribers<A extends Attributes> = {
         listener: (value: AttributeJsType<A[P]>) => void,
         minIntervalS: number,
         maxIntervalS: number,
+        knownDataVersion?: number,
+        isFabricFiltered?: boolean,
     ) => Promise<void>;
 };
 

--- a/packages/matter.js/src/cluster/client/EventClient.ts
+++ b/packages/matter.js/src/cluster/client/EventClient.ts
@@ -30,18 +30,18 @@ export class EventClient<T> {
         if (interactionClient === undefined) {
             throw new InternalError("No InteractionClient available");
         }
-        return await interactionClient.getEvent(
-            this.endpointId,
-            this.clusterId,
-            this.event,
+        return await interactionClient.getEvent({
+            endpointId: this.endpointId,
+            clusterId: this.clusterId,
+            event: this.event,
             minimumEventNumber,
             isFabricFiltered,
-        );
+        });
     }
 
     async subscribe(
-        minIntervalS: number,
-        maxIntervalS: number,
+        minIntervalFloorSeconds: number,
+        maxIntervalCeilingSeconds: number,
         isUrgent = true,
         minimumEventNumber?: number | bigint,
         isFabricFiltered?: boolean,
@@ -50,17 +50,17 @@ export class EventClient<T> {
         if (interactionClient === undefined) {
             throw new InternalError("No InteractionClient available");
         }
-        return await interactionClient.subscribeEvent(
-            this.endpointId,
-            this.clusterId,
-            this.event,
-            minIntervalS,
-            maxIntervalS,
+        return await interactionClient.subscribeEvent({
+            endpointId: this.endpointId,
+            clusterId: this.clusterId,
+            event: this.event,
+            minIntervalFloorSeconds,
+            maxIntervalCeilingSeconds,
             isUrgent,
             minimumEventNumber,
             isFabricFiltered,
-            this.update.bind(this),
-        );
+            listener: this.update.bind(this),
+        });
     }
 
     setInteractionClientRequestorCallback(callback: () => Promise<InteractionClient>) {

--- a/packages/matter.js/src/cluster/server/AttributeServer.ts
+++ b/packages/matter.js/src/cluster/server/AttributeServer.ts
@@ -40,6 +40,8 @@ export function createAttributeServer<
     attributeDef: Attribute<T, F>,
     attributeName: string,
     defaultValue: T,
+    getClusterDataVersion: () => number,
+    increaseClusterDataVersion: () => number,
     getter?: (session?: Session<MatterDevice>, endpoint?: Endpoint, isFabricFiltered?: boolean) => T,
     setter?: (value: T, session?: Session<MatterDevice>, endpoint?: Endpoint) => boolean,
     validator?: (value: T, session?: Session<MatterDevice>, endpoint?: Endpoint) => void,
@@ -47,7 +49,16 @@ export function createAttributeServer<
     const { id, schema, writable, fabricScoped, fixed, omitChanges } = attributeDef;
 
     if (fixed) {
-        return new FixedAttributeServer(id, attributeName, schema, writable, false, defaultValue, getter);
+        return new FixedAttributeServer(
+            id,
+            attributeName,
+            schema,
+            writable,
+            false,
+            defaultValue,
+            getClusterDataVersion,
+            getter,
+        );
     }
 
     if (fabricScoped) {
@@ -59,6 +70,8 @@ export function createAttributeServer<
             !omitChanges,
             defaultValue,
             clusterDef,
+            getClusterDataVersion,
+            increaseClusterDataVersion,
             getter,
             setter,
             validator,
@@ -72,6 +85,8 @@ export function createAttributeServer<
         writable,
         !omitChanges,
         defaultValue,
+        getClusterDataVersion,
+        increaseClusterDataVersion,
         getter,
         setter,
         validator,
@@ -86,7 +101,6 @@ export abstract class BaseAttributeServer<T> {
      * The value is undefined when getter/setter are used. But we still handle the version number here.
      */
     protected value: T | undefined = undefined;
-    protected version = 0;
     protected endpoint?: Endpoint;
 
     constructor(
@@ -120,7 +134,7 @@ export abstract class BaseAttributeServer<T> {
      * Initialize the value of the attribute, used when a persisted value is set initially or when values needs to be
      * adjusted before the Device gets announced. Do not use this method to change values when the device is in use!
      */
-    abstract init(value: T | undefined, version?: number): void;
+    abstract init(value: T | undefined): void;
 }
 
 /**
@@ -138,6 +152,7 @@ export class FixedAttributeServer<T> extends BaseAttributeServer<T> {
         isWritable: boolean,
         isSubscribable: boolean,
         defaultValue: T,
+        protected readonly getClusterDataVersion: () => number,
 
         /**
          * Optional getter function to handle special requirements or the data are stored in different places.
@@ -181,7 +196,7 @@ export class FixedAttributeServer<T> extends BaseAttributeServer<T> {
      * attributes.
      */
     getWithVersion(session: Session<MatterDevice>, isFabricFiltered: boolean) {
-        return { version: this.version, value: this.get(session, isFabricFiltered) };
+        return { version: this.getClusterDataVersion(), value: this.get(session, isFabricFiltered) };
     }
 
     /**
@@ -198,10 +213,7 @@ export class FixedAttributeServer<T> extends BaseAttributeServer<T> {
      * adjusted before the Device gets announced. Do not use this method to change values when the device is in use!
      * If a getter or setter is defined the value must be undefined The version number must also be undefined.
      */
-    init(value: T | undefined, version?: number) {
-        if (version !== undefined) {
-            throw new InternalError(`Version is not supported on fixed attribute "${this.name}".`);
-        }
+    init(value: T | undefined) {
         if (value === undefined) {
             throw new InternalError(`Can not initialize fixed attribute "${this.name}" with undefined value.`);
         }
@@ -265,6 +277,8 @@ export class AttributeServer<T> extends FixedAttributeServer<T> {
         isWritable: boolean,
         isSubscribable: boolean,
         defaultValue: T,
+        getClusterDataVersion: () => number,
+        protected readonly increaseClusterDataVersion: () => number,
         getter?: (session?: Session<MatterDevice>, endpoint?: Endpoint, isFabricFiltered?: boolean) => T,
 
         /**
@@ -301,7 +315,7 @@ export class AttributeServer<T> extends FixedAttributeServer<T> {
             );
         }
 
-        super(id, name, schema, isWritable, isSubscribable, defaultValue, getter);
+        super(id, name, schema, isWritable, isSubscribable, defaultValue, getClusterDataVersion, getter);
 
         if (setter === undefined) {
             this.setter = value => {
@@ -325,7 +339,7 @@ export class AttributeServer<T> extends FixedAttributeServer<T> {
      * Initialize the value of the attribute, used when a persisted value is set initially or when values needs to be
      * adjusted before the Device gets announced. Do not use this method to change values when the device is in use!
      */
-    override init(value: T | undefined, version: number) {
+    override init(value: T | undefined) {
         if (value === undefined) {
             value = this.getter(undefined, this.endpoint);
         }
@@ -334,7 +348,6 @@ export class AttributeServer<T> extends FixedAttributeServer<T> {
         }
         this.validator(value, undefined, this.endpoint);
         this.value = value;
-        this.version = version;
     }
 
     /**
@@ -388,8 +401,8 @@ export class AttributeServer<T> extends FixedAttributeServer<T> {
      */
     protected handleVersionAndTriggerListeners(value: T, oldValue: T | undefined, considerVersionChanged: boolean) {
         if (considerVersionChanged) {
-            this.version++;
-            this.valueChangeListeners.forEach(listener => listener(value, this.version));
+            const version = this.increaseClusterDataVersion();
+            this.valueChangeListeners.forEach(listener => listener(value, version));
         }
         if (oldValue !== undefined) {
             this.valueSetListeners.forEach(listener => listener(value, oldValue));
@@ -473,6 +486,8 @@ export class FabricScopedAttributeServer<T> extends AttributeServer<T> {
         isSubscribable: boolean,
         defaultValue: T,
         readonly cluster: Cluster<any, any, any, any, any>,
+        getClusterDataVersion: () => number,
+        increaseClusterDataVersion: () => number,
         getter?: (session?: Session<MatterDevice>, endpoint?: Endpoint, isFabricFiltered?: boolean) => T,
         setter?: (value: T, session?: Session<MatterDevice>, endpoint?: Endpoint) => boolean,
         validator?: (value: T, session?: Session<MatterDevice>, endpoint?: Endpoint) => void,
@@ -536,7 +551,19 @@ export class FabricScopedAttributeServer<T> extends AttributeServer<T> {
             isCustomSetter = true;
         }
 
-        super(id, name, schema, isWritable, isSubscribable, defaultValue, getter, setter, validator);
+        super(
+            id,
+            name,
+            schema,
+            isWritable,
+            isSubscribable,
+            defaultValue,
+            getClusterDataVersion,
+            increaseClusterDataVersion,
+            getter,
+            setter,
+            validator,
+        );
         this.isCustomGetter = isCustomGetter;
         this.isCustomSetter = isCustomSetter;
     }
@@ -545,11 +572,10 @@ export class FabricScopedAttributeServer<T> extends AttributeServer<T> {
      * Initialize the attribute with a value. Because the value is stored on fabric level this method only initializes
      * the version number.
      */
-    override init(value: T | undefined, version?: number) {
+    override init(value: T | undefined) {
         if (value !== undefined) {
             throw new InternalError(`Can not initialize fabric scoped attribute "${this.name}" with a value.`);
         }
-        this.version = version ?? 0;
     }
 
     /**

--- a/packages/matter.js/src/cluster/server/ClusterServer.ts
+++ b/packages/matter.js/src/cluster/server/ClusterServer.ts
@@ -102,6 +102,7 @@ export function ClusterServer<
                     storageContext.has("_clusterDataVersion") ? "Restore" : "Set"
                 } cluster data version ${clusterDataVersion} in cluster ${name} (${clusterId})`,
             );
+            storageContext.set("_clusterDataVersion", clusterDataVersion);
 
             for (const attributeName in attributes) {
                 const attribute = (attributes as any)[attributeName];

--- a/packages/matter.js/src/cluster/server/ClusterServer.ts
+++ b/packages/matter.js/src/cluster/server/ClusterServer.ts
@@ -5,6 +5,7 @@
  */
 
 import { ImplementationError } from "../../common/MatterError.js";
+import { Crypto } from "../../crypto/Crypto.js";
 import { AttributeId } from "../../datatype/AttributeId.js";
 import { CommandId } from "../../datatype/CommandId.js";
 import { EventId } from "../../datatype/EventId.js";
@@ -67,11 +68,13 @@ export function ClusterServer<
         supportedFeatures,
     } = clusterDef;
     let clusterStorage: StorageContext | null = null;
-    const attributeStorageListeners = new Map<AttributeId, (value: any, version: number) => void>();
+    const attributeStorageListeners = new Map<AttributeId, (value: any) => void>();
     const sceneAttributeList = new Array<string>();
     const attributes = <AttributeServers<A>>{};
     const commands = <CommandServers<C>>{};
     const events = <EventServers<E>>{};
+
+    let clusterDataVersion = Crypto.getRandomUInt32();
 
     const result: any = {
         id: clusterId,
@@ -93,16 +96,23 @@ export function ClusterServer<
         _setStorage: (storageContext: StorageContext) => {
             clusterStorage = storageContext;
 
+            clusterDataVersion = storageContext.get<number>("_clusterDataVersion", clusterDataVersion);
+            logger.debug(
+                `${
+                    storageContext.has("_clusterDataVersion") ? "Restore" : "Set"
+                } cluster data version ${clusterDataVersion} in cluster ${name} (${clusterId})`,
+            );
+
             for (const attributeName in attributes) {
                 const attribute = (attributes as any)[attributeName];
                 if (!attributeStorageListeners.has(attribute.id)) continue;
                 if (!storageContext.has(attribute.name)) continue;
                 try {
-                    const data = storageContext.get<{ version: number; value: any }>(attribute.name);
+                    const value = storageContext.get<any>(attribute.name);
                     logger.debug(
                         `Restoring attribute ${attributeName} (${attribute.id}) in cluster ${name} (${clusterId})`,
                     );
-                    attribute.init(data.value, data.version);
+                    attribute.init(value);
                 } catch (error) {
                     logger.warn(
                         `Failed to restore attribute ${attributeName} (${attribute.id}) in cluster ${name} (${clusterId})`,
@@ -167,10 +177,10 @@ export function ClusterServer<
         },
     };
 
-    const attributeStorageListener = (attributeName: string, version: number, value: any) => {
-        if (!clusterStorage) return;
+    const attributeStorageListener = (attributeName: string, value: any) => {
+        if (!clusterStorage || value === undefined) return;
         logger.debug(`Storing attribute ${attributeName} in cluster ${name} (${clusterId})`);
-        clusterStorage.set(attributeName, { version, value });
+        clusterStorage.set(attributeName, value);
     };
 
     // Create attributes
@@ -244,6 +254,15 @@ export function ClusterServer<
                 attributeDef[attributeName],
                 attributeName,
                 (attributesInitialValues as any)[attributeName],
+                () => clusterDataVersion,
+                () => {
+                    console.trace();
+                    if (clusterDataVersion === 0xffffffff) {
+                        clusterDataVersion = -1;
+                    }
+                    clusterStorage?.set("_clusterDataVersion", ++clusterDataVersion);
+                    return clusterDataVersion;
+                },
                 getter
                     ? (session, endpoint, isFabricFiltered) =>
                           getter({
@@ -294,12 +313,8 @@ export function ClusterServer<
                 ) => (attributes as any)[attributeName].addValueSetListener(listener);
             }
             if (persistent || getter || setter) {
-                const listener = (value: any, version: number) =>
-                    attributeStorageListener(
-                        attributeName,
-                        version,
-                        fabricScoped || getter || setter ? undefined : value,
-                    );
+                const listener = (value: any) =>
+                    attributeStorageListener(attributeName, fabricScoped || getter || setter ? undefined : value);
                 attributeStorageListeners.set(id, listener);
                 (attributes as any)[attributeName].addValueChangeListener(listener);
             }

--- a/packages/matter.js/src/cluster/server/ClusterServer.ts
+++ b/packages/matter.js/src/cluster/server/ClusterServer.ts
@@ -118,6 +118,7 @@ export function ClusterServer<
                         `Failed to restore attribute ${attributeName} (${attribute.id}) in cluster ${name} (${clusterId})`,
                         error,
                     );
+                    storageContext.delete(attribute.name); // Storage broken so we should delete it
                 }
             }
         },

--- a/packages/matter.js/src/cluster/server/ClusterServer.ts
+++ b/packages/matter.js/src/cluster/server/ClusterServer.ts
@@ -256,7 +256,6 @@ export function ClusterServer<
                 (attributesInitialValues as any)[attributeName],
                 () => clusterDataVersion,
                 () => {
-                    console.trace();
                     if (clusterDataVersion === 0xffffffff) {
                         clusterDataVersion = -1;
                     }

--- a/packages/matter.js/src/protocol/ControllerCommissioner.ts
+++ b/packages/matter.js/src/protocol/ControllerCommissioner.ts
@@ -358,16 +358,18 @@ export class ControllerCommissioner {
         this.collectedCommissioningData.rootPartsList = await descriptorClient.getPartsListAttribute();
         this.collectedCommissioningData.rootServerList = await descriptorClient.getServerListAttribute();
 
-        const networkData = await this.interactionClient.getMultipleAttributes([
-            {
-                clusterId: NetworkCommissioning.Cluster.id,
-                attributeId: NetworkCommissioning.Cluster.attributes.featureMap.id,
-            },
-            {
-                clusterId: NetworkCommissioning.Cluster.id,
-                attributeId: NetworkCommissioning.Cluster.attributes.networks.id,
-            },
-        ]);
+        const networkData = await this.interactionClient.getMultipleAttributes({
+            attributes: [
+                {
+                    clusterId: NetworkCommissioning.Cluster.id,
+                    attributeId: NetworkCommissioning.Cluster.attributes.featureMap.id,
+                },
+                {
+                    clusterId: NetworkCommissioning.Cluster.id,
+                    attributeId: NetworkCommissioning.Cluster.attributes.networks.id,
+                },
+            ],
+        });
         const networkFeatures = new Array<{
             endpointId: number;
             value: TypeFromPartialBitSchema<typeof NetworkCommissioning.Cluster.features>;

--- a/packages/matter.js/src/protocol/interaction/SubscriptionHandler.ts
+++ b/packages/matter.js/src/protocol/interaction/SubscriptionHandler.ts
@@ -27,6 +27,7 @@ import {
     TlvAttributePath,
     TlvAttributeReport,
     TlvAttributeStatus,
+    TlvDataVersionFilter,
     TlvEventFilter,
     TlvEventPath,
     TlvEventReport,
@@ -35,6 +36,7 @@ import {
 import {
     attributePathToId,
     AttributeWithPath,
+    clusterPathToId,
     eventPathToId,
     EventWithPath,
     INTERACTION_PROTOCOL_ID,
@@ -101,6 +103,7 @@ export class SubscriptionHandler {
         private readonly session: SecureSession<any>,
         private readonly endpointStructure: InteractionEndpointStructure,
         private readonly attributeRequests: TypeFromSchema<typeof TlvAttributePath>[] | undefined,
+        private readonly dataVersionFilters: TypeFromSchema<typeof TlvDataVersionFilter>[] | undefined,
         private readonly eventRequests: TypeFromSchema<typeof TlvEventPath>[] | undefined,
         private readonly eventFilters: TypeFromSchema<typeof TlvEventFilter>[] | undefined,
         private readonly eventHandler: EventHandler,
@@ -307,6 +310,10 @@ export class SubscriptionHandler {
     }
 
     activateSendingUpdates() {
+        // We do not need these data anymore, so we can free some memory
+        if (this.eventFilters !== undefined) this.eventFilters.length = 0;
+        if (this.dataVersionFilters !== undefined) this.dataVersionFilters.length = 0;
+
         this.session.addSubscription(this);
 
         this.sendUpdatesActivated = true;
@@ -397,13 +404,25 @@ export class SubscriptionHandler {
 
         const { newAttributes, attributeErrors } = this.registerNewAttributes();
 
-        const attributes = newAttributes
-            .map(({ path, attribute }) => {
-                // TODO: Maybe add try/catch when we add ACL handling and ignore the update if we can not get the value?
-                const { value, version } = attribute.getWithVersion(this.session, this.isFabricFiltered);
-                return { path, value, version, schema: attribute.schema };
-            })
-            .filter(({ value }) => value !== undefined) as AttributePathWithValueVersion<any>[];
+        const dataVersionFilterMap = new Map<string, number>(
+            this.dataVersionFilters?.map(({ path, dataVersion }) => [clusterPathToId(path), dataVersion]) ?? [],
+        );
+
+        const attributes = newAttributes.flatMap(({ path, attribute }) => {
+            // TODO: Maybe add try/catch when we add ACL handling and ignore the update if we can not get the value?
+            const { value, version } = attribute.getWithVersion(this.session, this.isFabricFiltered);
+            if (value === undefined) return [];
+
+            const { nodeId, endpointId, clusterId } = path;
+
+            const versionFilterValue =
+                endpointId !== undefined && clusterId !== undefined
+                    ? dataVersionFilterMap.get(clusterPathToId({ nodeId, endpointId, clusterId }))
+                    : undefined;
+            if (versionFilterValue !== undefined && versionFilterValue === version) return [];
+
+            return [{ path, value, version, schema: attribute.schema }];
+        });
         const attributeReports: TypeFromSchema<typeof TlvAttributeReport>[] = attributes.map(
             ({ path, schema, value, version }) => ({
                 attributeData: {
@@ -441,7 +460,7 @@ export class SubscriptionHandler {
                 }
             });
 
-        if (attributes.length === 0 && eventReports.length === 0) {
+        if (newAttributes.length === 0 && newEvents.length === 0) {
             throw new StatusResponseError(
                 "Subscription failed because no attributes or events are matching the query",
                 StatusCode.InvalidAction,

--- a/packages/matter.js/src/storage/Storage.ts
+++ b/packages/matter.js/src/storage/Storage.ts
@@ -13,4 +13,5 @@ export abstract class Storage {
     abstract close(): Promise<void>;
     abstract get<T extends SupportedStorageTypes>(contexts: string[], key: string): T | undefined;
     abstract set<T extends SupportedStorageTypes>(contexts: string[], key: string, value: T): void;
+    abstract delete(contexts: string[], key: string): void;
 }

--- a/packages/matter.js/src/storage/StorageBackendMemory.ts
+++ b/packages/matter.js/src/storage/StorageBackendMemory.ts
@@ -38,4 +38,9 @@ export class StorageBackendMemory implements Storage {
         }
         this.store[contextKey][key] = value;
     }
+
+    delete(contexts: string[], key: string): void {
+        if (!contexts.length || !key.length) throw new StorageError("Context and key must not be empty!");
+        delete this.store[this.createContextKey(contexts)]?.[key];
+    }
 }

--- a/packages/matter.js/src/storage/StorageContext.ts
+++ b/packages/matter.js/src/storage/StorageContext.ts
@@ -32,6 +32,10 @@ export class StorageContext {
         this.storage.set<T>(this.contexts, key, value);
     }
 
+    delete(key: string): void {
+        this.storage.delete(this.contexts, key);
+    }
+
     createContext(context: string) {
         if (context.length === 0) throw new StorageError("Context must not be an empty string");
         if (context.includes(".")) throw new StorageError("Context must not contain dots!");

--- a/packages/matter.js/test/cluster/AttributeServerTest.ts
+++ b/packages/matter.js/test/cluster/AttributeServerTest.ts
@@ -31,30 +31,43 @@ const KEY = PrivateKey(PRIVATE_KEY);
 describe("AttributeServerTest", () => {
     describe("FixedAttributeServer", () => {
         it("should return the value set in the constructor", () => {
-            const server = new FixedAttributeServer(AttributeId(1), "test", TlvUInt8, false, false, 3);
+            const server = new FixedAttributeServer(AttributeId(1), "test", TlvUInt8, false, false, 3, () => 1);
             assert.strictEqual(server.getLocal(), 3);
         });
 
         it("should return the value from getter", () => {
-            const server = new FixedAttributeServer(AttributeId(1), "test", TlvUInt8, false, false, 3, () => 4);
+            const server = new FixedAttributeServer(
+                AttributeId(1),
+                "test",
+                TlvUInt8,
+                false,
+                false,
+                3,
+                () => 1,
+                () => 4,
+            );
             assert.strictEqual(server.getLocal(), 4);
         });
 
         it("should successfully initialize with a value", () => {
-            const server = new FixedAttributeServer(AttributeId(1), "test", TlvUInt8, false, false, 3);
+            const server = new FixedAttributeServer(AttributeId(1), "test", TlvUInt8, false, false, 3, () => 1);
             server.init(5);
             assert.strictEqual(server.getLocal(), 5);
-        });
-
-        it("should throw an error if initialized with a version", () => {
-            const server = new FixedAttributeServer(AttributeId(1), "test", TlvUInt8, false, false, 3);
-            assert.throws(() => server.init(2, 1), { message: 'Version is not supported on fixed attribute "test".' });
         });
     });
 
     describe("AttributeServer", () => {
         it("should return the value set in the constructor", () => {
-            const server = new AttributeServer(AttributeId(1), "test", TlvUInt8, true, false, 3);
+            const server = new AttributeServer(
+                AttributeId(1),
+                "test",
+                TlvUInt8,
+                true,
+                false,
+                3,
+                () => 1,
+                () => 2,
+            );
             assert.strictEqual(server.getLocal(), 3);
         });
 
@@ -63,7 +76,16 @@ describe("AttributeServerTest", () => {
             let versionTriggered: number | undefined = undefined;
             let valueTriggered2: number | undefined = undefined;
             let oldValueTriggered2: number | undefined = undefined;
-            const server = new AttributeServer(AttributeId(1), "test", TlvUInt8, false, false, 3);
+            const server = new AttributeServer(
+                AttributeId(1),
+                "test",
+                TlvUInt8,
+                false,
+                false,
+                3,
+                () => 1,
+                () => 2,
+            );
             server.addValueChangeListener((value, version) => {
                 valueTriggered = value;
                 versionTriggered = version;
@@ -77,7 +99,7 @@ describe("AttributeServerTest", () => {
             server.setLocal(4);
             assert.strictEqual(server.getLocal(), 4);
             assert.strictEqual(valueTriggered, 4);
-            assert.strictEqual(versionTriggered, 1);
+            assert.strictEqual(versionTriggered, 2);
             assert.strictEqual(valueTriggered2, 4);
             assert.strictEqual(oldValueTriggered2, 3);
         });
@@ -85,7 +107,16 @@ describe("AttributeServerTest", () => {
         it("should set the value locally and trigger listeners on non change", () => {
             let valueTriggered2: number | undefined = undefined;
             let oldValueTriggered2: number | undefined = undefined;
-            const server = new AttributeServer(AttributeId(1), "test", TlvUInt8, false, false, 3);
+            const server = new AttributeServer(
+                AttributeId(1),
+                "test",
+                TlvUInt8,
+                false,
+                false,
+                3,
+                () => 1,
+                () => 2,
+            );
             server.addValueChangeListener(() => {
                 throw new Error("Should not be triggered.");
             });
@@ -102,20 +133,6 @@ describe("AttributeServerTest", () => {
         });
 
         it("should throw an error if the value is set non locally and not writable", () => {
-            const server = new AttributeServer(AttributeId(1), "test", TlvUInt8, false, false, 3);
-            assert.strictEqual(server.getLocal(), 3);
-            assert.throws(() => server.set(4, {} as SecureSession<MatterDevice>), {
-                message: '(136) Attribute "test" is not writable.',
-            });
-        });
-
-        it("should return the value from getter", () => {
-            const server = new AttributeServer(AttributeId(1), "test", TlvUInt8, false, false, 3, () => 4);
-            assert.strictEqual(server.getLocal(), 4);
-        });
-
-        it("should return the value from getter also with setter but increased version on change", () => {
-            let valueSet: number | undefined = undefined;
             const server = new AttributeServer(
                 AttributeId(1),
                 "test",
@@ -123,6 +140,42 @@ describe("AttributeServerTest", () => {
                 false,
                 false,
                 3,
+                () => 1,
+                () => 2,
+            );
+            assert.strictEqual(server.getLocal(), 3);
+            assert.throws(() => server.set(4, {} as SecureSession<MatterDevice>), {
+                message: '(136) Attribute "test" is not writable.',
+            });
+        });
+
+        it("should return the value from getter", () => {
+            const server = new AttributeServer(
+                AttributeId(1),
+                "test",
+                TlvUInt8,
+                false,
+                false,
+                3,
+                () => 1,
+                () => 2,
+                () => 4,
+            );
+            assert.strictEqual(server.getLocal(), 4);
+        });
+
+        it("should return the value from getter also with setter but increased version on change", () => {
+            let valueSet: number | undefined = undefined;
+            let version = 0;
+            const server = new AttributeServer(
+                AttributeId(1),
+                "test",
+                TlvUInt8,
+                false,
+                false,
+                3,
+                () => version,
+                () => version++,
                 () => 4,
                 value => {
                     valueSet = value;
@@ -133,10 +186,12 @@ describe("AttributeServerTest", () => {
             server.setLocal(5);
             assert.deepEqual(server.getWithVersion({} as SecureSession<MatterDevice>, false), { value: 4, version: 1 });
             assert.strictEqual(valueSet, 5);
+            assert.strictEqual(version, 1);
         });
 
         it("should return the value from getter also with setter but not increased version when no change", () => {
             let valueSet: number | undefined = undefined;
+            let version = 0;
             const server = new AttributeServer(
                 AttributeId(1),
                 "test",
@@ -144,6 +199,8 @@ describe("AttributeServerTest", () => {
                 false,
                 false,
                 3,
+                () => version,
+                () => version++,
                 () => 4,
                 value => {
                     valueSet = value;
@@ -154,10 +211,12 @@ describe("AttributeServerTest", () => {
             server.setLocal(5);
             assert.deepEqual(server.getWithVersion({} as SecureSession<MatterDevice>, false), { value: 4, version: 0 });
             assert.strictEqual(valueSet, 5);
+            assert.strictEqual(version, 0);
         });
 
         it("should return the value from getter and increased version after update", () => {
             let valueSet: number | undefined = undefined;
+            let version = 0;
             const server = new AttributeServer(
                 AttributeId(1),
                 "test",
@@ -165,6 +224,8 @@ describe("AttributeServerTest", () => {
                 false,
                 false,
                 3,
+                () => version,
+                () => version++,
                 () => 4,
                 value => {
                     valueSet = value;
@@ -175,6 +236,7 @@ describe("AttributeServerTest", () => {
             server.updated({} as SecureSession<MatterDevice>);
             assert.deepEqual(server.getWithVersion({} as SecureSession<MatterDevice>, false), { value: 4, version: 1 });
             assert.strictEqual(valueSet, undefined);
+            assert.strictEqual(version, 1);
         });
 
         it("should trigger listeners with getter also with setter but increased version on change", () => {
@@ -183,6 +245,7 @@ describe("AttributeServerTest", () => {
             let versionTriggered: number | undefined = undefined;
             let valueTriggered2: number | undefined = undefined;
             let oldValueTriggered2: number | undefined = undefined;
+            let version = 0;
             const server = new AttributeServer(
                 AttributeId(1),
                 "test",
@@ -190,6 +253,8 @@ describe("AttributeServerTest", () => {
                 false,
                 false,
                 3,
+                () => version,
+                () => version++,
                 () => 4,
                 value => {
                     valueSet = value;
@@ -209,15 +274,17 @@ describe("AttributeServerTest", () => {
             assert.deepEqual(server.getWithVersion({} as SecureSession<MatterDevice>, false), { value: 4, version: 1 });
             assert.strictEqual(valueSet, 5);
             assert.strictEqual(valueTriggered, 5);
-            assert.strictEqual(versionTriggered, 1);
+            assert.strictEqual(versionTriggered, 0);
             assert.strictEqual(valueTriggered2, 5);
             assert.strictEqual(oldValueTriggered2, 4);
+            assert.strictEqual(version, 1);
         });
 
         it("should return the value from getter also with setter but not increased version when no change", () => {
             let valueSet: number | undefined = undefined;
             let valueTriggered2: number | undefined = undefined;
             let oldValueTriggered2: number | undefined = undefined;
+            let version = 0;
             const server = new AttributeServer(
                 AttributeId(1),
                 "test",
@@ -225,6 +292,8 @@ describe("AttributeServerTest", () => {
                 false,
                 false,
                 3,
+                () => version,
+                () => version++,
                 () => 4,
                 value => {
                     valueSet = value;
@@ -244,10 +313,12 @@ describe("AttributeServerTest", () => {
             assert.strictEqual(valueSet, 5);
             assert.strictEqual(valueTriggered2, 5);
             assert.strictEqual(oldValueTriggered2, 4);
+            assert.strictEqual(version, 0);
         });
 
         it("should return the value from getter and increased version after update", () => {
             let valueSet: number | undefined = undefined;
+            let version = 0;
             const server = new AttributeServer(
                 AttributeId(1),
                 "test",
@@ -255,6 +326,8 @@ describe("AttributeServerTest", () => {
                 false,
                 false,
                 3,
+                () => version,
+                () => version++,
                 () => 4,
                 value => {
                     valueSet = value;
@@ -265,39 +338,89 @@ describe("AttributeServerTest", () => {
             server.updated({} as SecureSession<MatterDevice>);
             assert.deepEqual(server.getWithVersion({} as SecureSession<MatterDevice>, false), { value: 4, version: 1 });
             assert.strictEqual(valueSet, undefined);
+            assert.strictEqual(version, 1);
         });
 
         it("should successfully initialize with a value", () => {
-            const server = new AttributeServer(AttributeId(1), "test", TlvUInt8, false, false, 3);
-            server.init(5, 1);
+            const server = new AttributeServer(
+                AttributeId(1),
+                "test",
+                TlvUInt8,
+                false,
+                false,
+                3,
+                () => 1,
+                () => 2,
+            );
+            server.init(5);
             assert.strictEqual(server.getLocal(), 5);
         });
 
         it("if initialized with undefined value the default value uis used", () => {
-            const server = new AttributeServer(AttributeId(1), "test", TlvUInt8, false, false, 3);
-            server.init(undefined, 1);
+            const server = new AttributeServer(
+                AttributeId(1),
+                "test",
+                TlvUInt8,
+                false,
+                false,
+                3,
+                () => 1,
+                () => 2,
+            );
+            server.init(undefined);
             assert.strictEqual(server.getLocal(), 3);
         });
 
         it("use getter value if initialized with undefined", () => {
-            const server = new AttributeServer(AttributeId(1), "test", TlvUInt8, false, false, 3, () => 4);
-            server.init(1, 1);
+            const server = new AttributeServer(
+                AttributeId(1),
+                "test",
+                TlvUInt8,
+                false,
+                false,
+                3,
+                () => 1,
+                () => 2,
+                () => 4,
+            );
+            server.init(1);
             assert.strictEqual(server.getLocal(), 4);
         });
 
         it("setter is not called when initialized", () => {
             let setterCalled = false;
-            const server = new AttributeServer(AttributeId(1), "test", TlvUInt8, false, false, 3, undefined, () => {
-                setterCalled = true;
-                return true;
-            });
-            server.init(1, 1);
+            const server = new AttributeServer(
+                AttributeId(1),
+                "test",
+                TlvUInt8,
+                false,
+                false,
+                3,
+                () => 1,
+                () => 2,
+                undefined,
+                () => {
+                    setterCalled = true;
+                    return true;
+                },
+            );
+            server.init(1);
             assert.strictEqual(setterCalled, false);
         });
 
         it("should throw an error if default value is invalid", () => {
             assert.throws(
-                () => new AttributeServer(AttributeId(1), "test", TlvUInt8.bound({ min: 0, max: 2 }), false, false, 3),
+                () =>
+                    new AttributeServer(
+                        AttributeId(1),
+                        "test",
+                        TlvUInt8.bound({ min: 0, max: 2 }),
+                        false,
+                        false,
+                        3,
+                        () => 1,
+                        () => 2,
+                    ),
                 { message: 'Validation error for attribute "test": Invalid value: 3 is above the maximum, 2.' },
             );
         });
@@ -310,6 +433,8 @@ describe("AttributeServerTest", () => {
                 false,
                 false,
                 3,
+                () => 1,
+                () => 2,
                 undefined,
                 () => true,
             );
@@ -326,6 +451,8 @@ describe("AttributeServerTest", () => {
                 false,
                 false,
                 3,
+                () => 1,
+                () => 2,
                 undefined,
                 undefined,
                 () => {
@@ -363,6 +490,8 @@ describe("AttributeServerTest", () => {
                 false,
                 3,
                 BasicInformationCluster,
+                () => 1,
+                () => 2,
             );
             assert.strictEqual(server.getLocalForFabric(testFabric), 3);
         });
@@ -394,6 +523,8 @@ describe("AttributeServerTest", () => {
                 false,
                 3,
                 BasicInformationCluster,
+                () => 1,
+                () => 2,
             );
             assert.strictEqual(server.getLocalForFabric(testFabric), 5);
         });
@@ -424,6 +555,8 @@ describe("AttributeServerTest", () => {
                 false,
                 3,
                 BasicInformationCluster,
+                () => 1,
+                () => 2,
             );
             testFabric.setScopedClusterDataValue(BasicInformationCluster, "test", { value: 5 });
             assert.strictEqual(server.getLocalForFabric(testFabric), 5);
@@ -434,6 +567,7 @@ describe("AttributeServerTest", () => {
             let versionTriggered: number | undefined = undefined;
             let valueTriggered2: number | undefined = undefined;
             let oldValueTriggered2: number | undefined = undefined;
+            let counter = 0;
             const testFabric = new Fabric(
                 FabricIndex(1),
                 FabricId(BigInt(1)),
@@ -460,6 +594,8 @@ describe("AttributeServerTest", () => {
                 false,
                 3,
                 BasicInformationCluster,
+                () => counter,
+                () => counter++,
             );
             server.addValueChangeListener((value, version) => {
                 valueTriggered = value;
@@ -474,9 +610,10 @@ describe("AttributeServerTest", () => {
             assert.strictEqual(server.getLocalForFabric(testFabric), 7);
             assert.deepEqual(testFabric.getScopedClusterDataValue(BasicInformationCluster, "test"), { value: 7 });
             assert.strictEqual(valueTriggered, 7);
-            assert.strictEqual(versionTriggered, 1);
+            assert.strictEqual(versionTriggered, 0);
             assert.strictEqual(valueTriggered2, 7);
             assert.strictEqual(oldValueTriggered2, 5);
+            assert.strictEqual(counter, 1);
         });
 
         it("should handle the value from fabric scoped storage when set and trigger ony external listeners", () => {
@@ -508,6 +645,8 @@ describe("AttributeServerTest", () => {
                 false,
                 3,
                 BasicInformationCluster,
+                () => 1,
+                () => 2,
             );
             server.addValueChangeListener(() => {
                 throw new Error("Should not be triggered");
@@ -535,6 +674,8 @@ describe("AttributeServerTest", () => {
                         false,
                         3,
                         BasicInformationCluster,
+                        () => 1,
+                        () => 2,
                         () => 7,
                     ),
                 { message: 'Getter and setter must be implemented together writeable fabric scoped attribute "test".' },
@@ -568,6 +709,8 @@ describe("AttributeServerTest", () => {
                 false,
                 3,
                 BasicInformationCluster,
+                () => 1,
+                () => 2,
                 () => 7,
             );
             assert.throws(() => server.getLocalForFabric(testFabric), {
@@ -603,6 +746,8 @@ describe("AttributeServerTest", () => {
                 false,
                 3,
                 BasicInformationCluster,
+                () => 1,
+                () => 2,
                 () => 7,
             );
             assert.strictEqual(server.get(testSession, true), 7);
@@ -631,6 +776,7 @@ describe("AttributeServerTest", () => {
             );
             const testSession = { getAssociatedFabric: () => testFabric } as SecureSession<MatterDevice>;
 
+            let counter = 3;
             const server = new FabricScopedAttributeServer(
                 AttributeId(1),
                 "test",
@@ -639,10 +785,12 @@ describe("AttributeServerTest", () => {
                 false,
                 3,
                 BasicInformationCluster,
+                () => counter,
+                () => counter++,
                 () => 7,
                 () => true,
             );
-            server.init(undefined, 2);
+            server.init(undefined);
             server.addValueChangeListener((value, version) => {
                 valueTriggered = value;
                 versionTriggered = version;
@@ -658,6 +806,7 @@ describe("AttributeServerTest", () => {
             assert.strictEqual(versionTriggered, 3);
             assert.strictEqual(valueTriggered2, 9);
             assert.strictEqual(oldValueTriggered2, 7);
+            assert.strictEqual(counter, 4);
         });
     });
 });

--- a/packages/matter.js/test/cluster/ClusterFactoryTest.ts
+++ b/packages/matter.js/test/cluster/ClusterFactoryTest.ts
@@ -4,6 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { Crypto } from "../../src/crypto/Crypto.js";
+Crypto.get = () =>
+    ({
+        // make Random data deterministic
+        getRandomData: (length: number) => {
+            return new Uint8Array(length);
+        },
+    }) as Crypto;
+
 import {
     Attribute,
     Cluster,

--- a/packages/matter.js/test/cluster/ClusterServerTest.ts
+++ b/packages/matter.js/test/cluster/ClusterServerTest.ts
@@ -4,6 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { Crypto } from "../../src/crypto/Crypto.js";
+Crypto.get = () =>
+    ({
+        // make Random data deterministic
+        getRandomData: (length: number) => {
+            return new Uint8Array(length);
+        },
+    }) as Crypto;
+
 import { Cluster, ClusterExtend } from "../../src/cluster/Cluster.js";
 import { AdministratorCommissioningCluster } from "../../src/cluster/definitions/AdministratorCommissioningCluster.js";
 import { BasicInformationCluster } from "../../src/cluster/definitions/BasicInformationCluster.js";

--- a/packages/matter.js/test/cluster/definitions/WindowCoveringClusterTest.ts
+++ b/packages/matter.js/test/cluster/definitions/WindowCoveringClusterTest.ts
@@ -4,6 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { Crypto } from "../../../src/crypto/Crypto.js";
+Crypto.get = () =>
+    ({
+        // make Random data deterministic
+        getRandomData: (length: number) => {
+            return new Uint8Array(length);
+        },
+    }) as Crypto;
+
 import { WindowCovering, WindowCoveringCluster } from "../../../src/cluster/definitions/WindowCoveringCluster.js";
 import { ClusterServer } from "../../../src/cluster/server/ClusterServer.js";
 import { BitFlags } from "../../../src/schema/BitmapSchema.js";

--- a/packages/matter.js/test/storage/StorageBackendMemoryTest.ts
+++ b/packages/matter.js/test/storage/StorageBackendMemoryTest.ts
@@ -17,6 +17,16 @@ describe("StorageInMemory", () => {
         expect(value).toBe("value");
     });
 
+    it("write and delete success", () => {
+        const storage = new StorageBackendMemory();
+
+        storage.set(["context"], "key", "value");
+        storage.delete(["context"], "key");
+
+        const value = storage.get(["context"], "key");
+        expect(value).toBe(undefined);
+    });
+
     it("write and read success with multiple context levels", () => {
         const storage = new StorageBackendMemory();
 


### PR DESCRIPTION
This PR adjusts/adds the following:
* The data version needs to be tracked on a cluster instance basis ans not (as implemented) on Attrribute level. This PR corrects this.
* The above change adjusts how data are stored - so I also added options to delete storage keys from the storage and added cleanup if a storage is broken.
* Now with correct Dataversion I added "dataVersionFilters" support to Read and Subscribe interactions. With this we should be feature complete there!
* The API of the InteractionClient  (low level api!)was refactored because it got messy mwith all the optional fields and is now mainly a object based approach. The High level API via AttributeClients got adjusted and was only enhanced and not breaking
* Also tests were added for all this and also some more tests activated that were commented out and now allowed.

Review can be done commit based.

* finishs https://github.com/orgs/project-chip/projects/11?pane=issue&itemId=35232364
* finishs https://github.com/orgs/project-chip/projects/11/views/1?pane=issue&itemId=35400162