### PR TITLE
Allow to configure loglevel and logformat for examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ All Changes without a GitHub Username in brackets are from the core team: @Apoll
   * Feature: The Controller example script got a new parameter -ble to also initialize the Bluetooth transport layer
   * Feature: The Controller example script got a new parameters -ble-* to provide Wi-Fi/Thread network credentials to use for device commissioning
   * Feature: Add stopping of the example scripts to allow clean shutdown and sending shutdown Event
+  * Feature: Add CLI parameter to define the loglevel and log format; default log format changed to ANSI when executed in a shell/tty
 * Misc:
   * Added Specification links for Matter Specifications 1.1
   * Optimize typing exports for node10 TS settings

--- a/packages/matter-node.js-examples/README.md
+++ b/packages/matter-node.js-examples/README.md
@@ -28,6 +28,13 @@ Then after `cd packages/matter-node.js-examples` you can use `npm run matter-dev
 
 ## CLI usage
 
+### Common CLI parameter for all examples
+The following CLI parameters are the same for all examples:
+
+* -clearstorage: the storage location will be reset on start of the process. The sorage location is set via parameter "-store" (see concrete examples below)
+* -loglevel: the log level to use (default: debug, possible values: fatal, error, warn, info, debug)
+* -logformat: the log format to use (default: ansi (if executed in a shell/tty), else plain, possible values: ansi, plain, html)
+
 ### Start a simple Matter Device Node
 
 > The code for this example is in [src/examples/DeviceNode.ts](./src/examples/DeviceNode.ts).
@@ -72,7 +79,6 @@ The following parameters are available:
 * -ble: enable BLE support (default: false) If this is enabled the device will announce itself _only_ via BLE if not commissioned and also presents a "Wifi only" device for commissioning to show this feature!
 * -port: the port to listen on for the device (default: 5540)
 * -store: the storage location (directory) to use for storing the pairing information (default: .device-node). Ideally use names starting with a ".". Delete the directory or provide an alternative name to reset the device
-* -clearstorage: the storage location will be reset on start of the process
 * -on: the command to run when the device is turned on (see example above)
 * -off: the command to run when the device is turned off (see example above)
 

--- a/packages/matter-node.js-examples/src/examples/BridgedDevicesNode.ts
+++ b/packages/matter-node.js-examples/src/examples/BridgedDevicesNode.ts
@@ -17,7 +17,7 @@
 import { CommissioningServer, MatterServer } from "@project-chip/matter-node.js";
 
 import { Aggregator, DeviceTypes, OnOffLightDevice, OnOffPluginUnitDevice } from "@project-chip/matter-node.js/device";
-import { Logger } from "@project-chip/matter-node.js/log";
+import { Format, Level, Logger } from "@project-chip/matter-node.js/log";
 import { StorageBackendDisk, StorageManager } from "@project-chip/matter-node.js/storage";
 import { Time } from "@project-chip/matter-node.js/time";
 import {
@@ -32,6 +32,33 @@ import { VendorId } from "@project-chip/matter.js/datatype";
 const logger = Logger.get("Device");
 
 requireMinNodeVersion(16);
+
+/** Configure logging */
+switch (getParameter("loglevel")) {
+    case "fatal":
+        Logger.defaultLogLevel = Level.FATAL;
+        break;
+    case "error":
+        Logger.defaultLogLevel = Level.ERROR;
+        break;
+    case "warn":
+        Logger.defaultLogLevel = Level.WARN;
+        break;
+    case "info":
+        Logger.defaultLogLevel = Level.INFO;
+        break;
+}
+
+switch (getParameter("logformat")) {
+    case "plain":
+        Logger.format = Format.PLAIN;
+        break;
+    case "html":
+        Logger.format = Format.HTML;
+        break;
+    default:
+        if (process.stdin?.isTTY) Logger.format = Format.ANSI;
+}
 
 const storageLocation = getParameter("store") ?? ".device-node";
 const storage = new StorageBackendDisk(storageLocation, hasParameter("clearstorage"));

--- a/packages/matter-node.js-examples/src/examples/ComposedDeviceNode.ts
+++ b/packages/matter-node.js-examples/src/examples/ComposedDeviceNode.ts
@@ -20,7 +20,7 @@ import { CommissioningServer, MatterServer } from "@project-chip/matter-node.js"
 
 import { VendorId } from "@project-chip/matter-node.js/datatype";
 import { DeviceTypes, OnOffLightDevice, OnOffPluginUnitDevice } from "@project-chip/matter-node.js/device";
-import { Logger } from "@project-chip/matter-node.js/log";
+import { Format, Level, Logger } from "@project-chip/matter-node.js/log";
 import { StorageBackendDisk, StorageManager } from "@project-chip/matter-node.js/storage";
 import { Time } from "@project-chip/matter-node.js/time";
 import {
@@ -34,6 +34,33 @@ import {
 const logger = Logger.get("Device");
 
 requireMinNodeVersion(16);
+
+/** Configure logging */
+switch (getParameter("loglevel")) {
+    case "fatal":
+        Logger.defaultLogLevel = Level.FATAL;
+        break;
+    case "error":
+        Logger.defaultLogLevel = Level.ERROR;
+        break;
+    case "warn":
+        Logger.defaultLogLevel = Level.WARN;
+        break;
+    case "info":
+        Logger.defaultLogLevel = Level.INFO;
+        break;
+}
+
+switch (getParameter("logformat")) {
+    case "plain":
+        Logger.format = Format.PLAIN;
+        break;
+    case "html":
+        Logger.format = Format.HTML;
+        break;
+    default:
+        if (process.stdin?.isTTY) Logger.format = Format.ANSI;
+}
 
 const storageLocation = getParameter("store") ?? ".device-node";
 const storage = new StorageBackendDisk(storageLocation, hasParameter("clearstorage"));

--- a/packages/matter-node.js-examples/src/examples/ControllerNode.ts
+++ b/packages/matter-node.js-examples/src/examples/ControllerNode.ts
@@ -16,8 +16,9 @@
  * Import needed modules from @project-chip/matter-node.js
  */
 // Include this first to auto-register Crypto, Network and Time Node.js implementations
-import { BleNode } from "@project-chip/matter-node-ble.js/ble";
 import { CommissioningController, MatterServer } from "@project-chip/matter-node.js";
+
+import { BleNode } from "@project-chip/matter-node-ble.js/ble";
 import { Ble } from "@project-chip/matter-node.js/ble";
 import {
     BasicInformationCluster,
@@ -25,7 +26,7 @@ import {
     GeneralCommissioning,
     OnOffCluster,
 } from "@project-chip/matter-node.js/cluster";
-import { Logger } from "@project-chip/matter-node.js/log";
+import { Format, Level, Logger } from "@project-chip/matter-node.js/log";
 import { CommissioningOptions } from "@project-chip/matter-node.js/protocol";
 import { ManualPairingCodeCodec } from "@project-chip/matter-node.js/schema";
 import { StorageBackendDisk, StorageManager } from "@project-chip/matter-node.js/storage";
@@ -37,14 +38,41 @@ import {
     singleton,
 } from "@project-chip/matter-node.js/util";
 
+const logger = Logger.get("Controller");
+
+requireMinNodeVersion(16);
+
+/** Configure logging */
+switch (getParameter("loglevel")) {
+    case "fatal":
+        Logger.defaultLogLevel = Level.FATAL;
+        break;
+    case "error":
+        Logger.defaultLogLevel = Level.ERROR;
+        break;
+    case "warn":
+        Logger.defaultLogLevel = Level.WARN;
+        break;
+    case "info":
+        Logger.defaultLogLevel = Level.INFO;
+        break;
+}
+
+switch (getParameter("logformat")) {
+    case "plain":
+        Logger.format = Format.PLAIN;
+        break;
+    case "html":
+        Logger.format = Format.HTML;
+        break;
+    default:
+        if (process.stdin?.isTTY) Logger.format = Format.ANSI;
+}
+
 if (hasParameter("ble")) {
     // Initialize Ble
     Ble.get = singleton(() => new BleNode());
 }
-
-const logger = Logger.get("Controller");
-
-requireMinNodeVersion(16);
 
 const storageLocation = getParameter("store") ?? ".controller-node";
 const storage = new StorageBackendDisk(storageLocation, hasParameter("clearstorage"));

--- a/packages/matter-node.js-examples/src/examples/DeviceNode.ts
+++ b/packages/matter-node.js-examples/src/examples/DeviceNode.ts
@@ -14,12 +14,13 @@
  * Import needed modules from @project-chip/matter-node.js
  */
 // Include this first to auto-register Crypto, Network and Time Node.js implementations
-import { BleNode } from "@project-chip/matter-node-ble.js/ble";
 import { CommissioningServer, MatterServer } from "@project-chip/matter-node.js";
+
+import { BleNode } from "@project-chip/matter-node-ble.js/ble";
 import { Ble } from "@project-chip/matter-node.js/ble";
 import { ClusterServer, GeneralCommissioningCluster, NetworkCommissioning } from "@project-chip/matter-node.js/cluster";
 import { OnOffLightDevice, OnOffPluginUnitDevice } from "@project-chip/matter-node.js/device";
-import { Logger } from "@project-chip/matter-node.js/log";
+import { Format, Level, Logger } from "@project-chip/matter-node.js/log";
 import { StorageBackendDisk, StorageManager } from "@project-chip/matter-node.js/storage";
 import { Time } from "@project-chip/matter-node.js/time";
 import {
@@ -33,14 +34,41 @@ import {
 } from "@project-chip/matter-node.js/util";
 import { DeviceTypeId, VendorId } from "@project-chip/matter.js/datatype";
 
+const logger = Logger.get("Device");
+
+requireMinNodeVersion(16);
+
+/** Configure logging */
+switch (getParameter("loglevel")) {
+    case "fatal":
+        Logger.defaultLogLevel = Level.FATAL;
+        break;
+    case "error":
+        Logger.defaultLogLevel = Level.ERROR;
+        break;
+    case "warn":
+        Logger.defaultLogLevel = Level.WARN;
+        break;
+    case "info":
+        Logger.defaultLogLevel = Level.INFO;
+        break;
+}
+
+switch (getParameter("logformat")) {
+    case "plain":
+        Logger.format = Format.PLAIN;
+        break;
+    case "html":
+        Logger.format = Format.HTML;
+        break;
+    default:
+        if (process.stdin?.isTTY) Logger.format = Format.ANSI;
+}
+
 if (hasParameter("ble")) {
     // Initialize Ble
     Ble.get = singleton(() => new BleNode());
 }
-
-const logger = Logger.get("Device");
-
-requireMinNodeVersion(16);
 
 const storageLocation = getParameter("store") ?? ".device-node";
 const storage = new StorageBackendDisk(storageLocation, hasParameter("clearstorage"));

--- a/packages/matter-node.js-examples/src/examples/MultiDeviceNode.ts
+++ b/packages/matter-node.js-examples/src/examples/MultiDeviceNode.ts
@@ -19,7 +19,7 @@
 import { CommissioningServer, MatterServer } from "@project-chip/matter-node.js";
 
 import { DeviceTypes, OnOffLightDevice, OnOffPluginUnitDevice } from "@project-chip/matter-node.js/device";
-import { Logger } from "@project-chip/matter-node.js/log";
+import { Format, Level, Logger } from "@project-chip/matter-node.js/log";
 import { StorageBackendDisk, StorageManager } from "@project-chip/matter-node.js/storage";
 import { Time } from "@project-chip/matter-node.js/time";
 import {
@@ -34,6 +34,33 @@ import { VendorId } from "@project-chip/matter.js/datatype";
 const logger = Logger.get("MultiDevice");
 
 requireMinNodeVersion(16);
+
+/** Configure logging */
+switch (getParameter("loglevel")) {
+    case "fatal":
+        Logger.defaultLogLevel = Level.FATAL;
+        break;
+    case "error":
+        Logger.defaultLogLevel = Level.ERROR;
+        break;
+    case "warn":
+        Logger.defaultLogLevel = Level.WARN;
+        break;
+    case "info":
+        Logger.defaultLogLevel = Level.INFO;
+        break;
+}
+
+switch (getParameter("logformat")) {
+    case "plain":
+        Logger.format = Format.PLAIN;
+        break;
+    case "html":
+        Logger.format = Format.HTML;
+        break;
+    default:
+        if (process.stdin?.isTTY) Logger.format = Format.ANSI;
+}
 
 const storageLocation = getParameter("store") ?? ".device-node";
 const storage = new StorageBackendDisk(storageLocation, hasParameter("clearstorage"));

--- a/packages/matter.js/src/log/Logger.ts
+++ b/packages/matter.js/src/log/Logger.ts
@@ -86,15 +86,15 @@ function plainLogFormatter(now: Date, level: Level, facility: string, values: an
 }
 
 const ANSI_CODES = {
-    PREFIX: "\x1b[90m\x1b[2m",
-    FACILITY: "\x1b[90m\x1b[1m",
-    LEVEL_DEBUG: "\x1b[90m",
-    LEVEL_INFO: "\x1b[32m",
-    LEVEL_WARN: "\x1b[33m",
-    LEVEL_ERROR: "\x1b[31m",
-    LEVEL_FATAL: "\x1b[31m\x1b[1m",
-    KEY: "\x1b[34m",
-    NONE: "\x1b[0m",
+    PREFIX: "\x1b[90m\x1b[2m", // dark gray, dim
+    FACILITY: "\x1b[90m\x1b[1m", // dark grey, bold
+    LEVEL_DEBUG: "\x1b[90m", // dark gray
+    LEVEL_INFO: "\x1b[32m", // green
+    LEVEL_WARN: "\x1b[33m", // yellow
+    LEVEL_ERROR: "\x1b[31m", // red
+    LEVEL_FATAL: "\x1b[31m\x1b[1m", // red, bold
+    KEY: "\x1b[34m", // blue
+    NONE: "\x1b[0m", // reset
 };
 
 function ansiLogFormatter(now: Date, level: Level, facility: string, values: any[]) {

--- a/packages/matter.js/src/log/Logger.ts
+++ b/packages/matter.js/src/log/Logger.ts
@@ -86,9 +86,9 @@ function plainLogFormatter(now: Date, level: Level, facility: string, values: an
 }
 
 const ANSI_CODES = {
-    PREFIX: "\x1b[37m\x1b[2m",
-    FACILITY: "\x1b[37m\x1b[1m",
-    LEVEL_DEBUG: "\x1b[37m",
+    PREFIX: "\x1b[90m\x1b[2m",
+    FACILITY: "\x1b[90m\x1b[1m",
+    LEVEL_DEBUG: "\x1b[90m",
     LEVEL_INFO: "\x1b[32m",
     LEVEL_WARN: "\x1b[33m",
     LEVEL_ERROR: "\x1b[31m",

--- a/packages/matter.js/test/log/LoggerTest.ts
+++ b/packages/matter.js/test/log/LoggerTest.ts
@@ -222,7 +222,7 @@ describe("Logger", () => {
             const result = logTestLine({ format: Format.ANSI });
 
             expect(result?.message).toBe(
-                "\u001b[37m\u001b[2mxxxx-xx-xx xx:xx:xx.xxx DEBUG\u001b[0m \u001b[37m\u001b[1mUnitTest            \u001b[0m \u001b[37mtest\u001b[0m",
+                "\u001b[90m\u001b[2mxxxx-xx-xx xx:xx:xx.xxx DEBUG\u001b[0m \u001b[90m\u001b[1mUnitTest            \u001b[0m \u001b[90mtest\u001b[0m",
             );
         });
 
@@ -230,7 +230,7 @@ describe("Logger", () => {
             const result = logTestDict({ format: Format.ANSI });
 
             expect(result?.message).toBe(
-                "\u001b[37m\u001b[2mxxxx-xx-xx xx:xx:xx.xxx DEBUG\u001b[0m \u001b[37m\u001b[1mUnitTest            \u001b[0m \u001b[37mdict test \u001b[34mfoo:\u001b[37m bar \u001b[34mbiz:\u001b[37m 1\u001b[0m",
+                "\u001b[90m\u001b[2mxxxx-xx-xx xx:xx:xx.xxx DEBUG\u001b[0m \u001b[90m\u001b[1mUnitTest            \u001b[0m \u001b[90mdict test \u001b[34mfoo:\u001b[90m bar \u001b[34mbiz:\u001b[90m 1\u001b[0m",
             );
         });
 
@@ -241,7 +241,7 @@ describe("Logger", () => {
                 logger.debug("test");
             });
             expect(result?.message).toBe(
-                "\u001b[37m\u001b[2mxxxx-xx-xx xx:xx:xx.xxx DEBUG\u001b[0m \u001b[37m\u001b[1mThisIsAFac~yLongName\u001b[0m \u001b[37mtest\u001b[0m",
+                "\u001b[90m\u001b[2mxxxx-xx-xx xx:xx:xx.xxx DEBUG\u001b[0m \u001b[90m\u001b[1mThisIsAFac~yLongName\u001b[0m \u001b[90mtest\u001b[0m",
             );
         });
     });


### PR DESCRIPTION
The PR changes the default log format for shell usage to ANSI and adds parameters to all examples to allow configuration of loglevel and format.
Additionally I adjusted ANSI colors a bit to be darkgrey and so better readable in white shells.

* finishs https://github.com/orgs/project-chip/projects/11/views/1?pane=issue&itemId=34444331