### PR TITLE
Crypto tweaks

### DIFF
--- a/packages/matter-node.js/src/crypto/CryptoNode.ts
+++ b/packages/matter-node.js/src/crypto/CryptoNode.ts
@@ -10,6 +10,7 @@ import {
     CryptoError,
     CRYPTO_AUTH_TAG_LENGTH,
     CRYPTO_EC_CURVE,
+    CRYPTO_EC_KEY_BYTES,
     CRYPTO_ENCRYPT_ALGORITHM,
     CRYPTO_HASH_ALGORITHM,
     CRYPTO_SYMMETRIC_KEY_LENGTH,
@@ -151,6 +152,14 @@ export class CryptoNode extends Crypto {
     createKeyPair() {
         const ecdh = crypto.createECDH(CRYPTO_EC_CURVE);
         ecdh.generateKeys();
-        return PrivateKey(ecdh.getPrivateKey(), { publicKey: ecdh.getPublicKey() });
+
+        // The key exported from Node doesn't include most-significant bytes
+        // that are 0.  This doesn't affect how we currently use keys but it's
+        // a little weird so 0 pad to avoid future confusion
+        const privateKey = new ByteArray(CRYPTO_EC_KEY_BYTES);
+        const nodePrivateKey = ecdh.getPrivateKey();
+        privateKey.set(nodePrivateKey, CRYPTO_EC_KEY_BYTES - nodePrivateKey.length);
+
+        return PrivateKey(privateKey, { publicKey: ecdh.getPublicKey() });
     }
 }

--- a/packages/matter-node.js/test/crypto/CryptoTest.ts
+++ b/packages/matter-node.js/test/crypto/CryptoTest.ts
@@ -61,13 +61,7 @@ describe("Crypto", () => {
             cryptoNode.verify(PublicKey(PUBLIC_KEY), ENCRYPTED_DATA, result);
         });
 
-        it("signs data with generated private key", () => {
-            const ecdh = crypto.createECDH("prime256v1");
-            ecdh.generateKeys();
-            const result = cryptoNode.sign(PrivateKey(ecdh.getPrivateKey()), ENCRYPTED_DATA);
-
-            cryptoNode.verify(PublicKey(ecdh.getPublicKey()), ENCRYPTED_DATA, result);
-        });
+        // See createKeyPair test for further tests with private key
     });
 
     describe("sign & verify with SEC1 private and SPKI public keys", () => {
@@ -91,5 +85,18 @@ describe("Crypto", () => {
 
             cryptoNode.verify(key, ENCRYPTED_DATA, cryptoNode.sign(key, ENCRYPTED_DATA));
         });
+
+        // Too slow to leave enabled by default but useful for confirming key variance doesn't cause failure
+        // it("creates a large volume of private keys", () => {
+        //     for (let i = 0; i < 100000; i++) {
+        //         if (!(i % 100)) {
+        //             console.log(`Key iteration ${i}`);
+        //         }
+        //         const key = cryptoNode.createKeyPair();
+
+        //         const signature = cryptoNode.sign(key, ENCRYPTED_DATA);
+        //         cryptoNode.verify(key, ENCRYPTED_DATA, signature);
+        //     }
+        // });
     });
 });

--- a/packages/matter.js/src/crypto/Crypto.ts
+++ b/packages/matter.js/src/crypto/Crypto.ts
@@ -14,6 +14,7 @@ export const CRYPTO_RANDOM_LENGTH = 32;
 export const CRYPTO_ENCRYPT_ALGORITHM = "aes-128-ccm";
 export const CRYPTO_HASH_ALGORITHM = "sha256";
 export const CRYPTO_EC_CURVE = "prime256v1";
+export const CRYPTO_EC_KEY_BYTES = 32;
 export const CRYPTO_AUTH_TAG_LENGTH = 16;
 export const CRYPTO_SYMMETRIC_KEY_LENGTH = 16;
 export type CryptoDsaEncoding = "ieee-p1363" | "der";


### PR DESCRIPTION
Removed test that generates EC key pair using node's crypto API directly. Due to test implementation it used a code path that attempted to infer the elliptic curve from the private key size but Node doesn't include significant bytes that are 0.  This would cause key size inference to fail.

We test with a dynamic key using our "createKeyPair" method so above test was redundant.

Also added code to pad the Node key when we generate our own key internally. This isn't absolutely necessary because we always provide the public key point rather than computing from the private key.  The public key is encoded in a format with fixed length coordinates so curve inference works correctly.

But the truncated private key is a bit weird and could lead to future confusion.  We now pad to full key length just to be safe.

Fixes #276