### PR TITLE
optimize Cluster typing and remove InteractionClient being changeable

### DIFF
--- a/packages/matter-node.js/src/time/TimeNode.ts
+++ b/packages/matter-node.js/src/time/TimeNode.ts
@@ -7,7 +7,7 @@
 import { Time, Timer, TimerCallback } from "@project-chip/matter.js/time";
 
 class TimerNode implements Timer {
-    private timerId: NodeJS.Timer | undefined;
+    private timerId: NodeJS.Timeout | undefined;
     isRunning = false;
 
     constructor(

--- a/packages/matter-node.js/test/IntegrationTest.ts
+++ b/packages/matter-node.js/test/IntegrationTest.ts
@@ -563,10 +563,7 @@ describe("Integration Test", () => {
         it("subscription of one attribute sends updates when the value changes", async () => {
             const onoffEndpoint = commissioningController.getDevices().find(endpoint => endpoint.id === 1);
             assert.ok(onoffEndpoint);
-            const onOffClient = onoffEndpoint.getClusterClient(
-                OnOffCluster,
-                await commissioningController.createInteractionClient(),
-            );
+            const onOffClient = onoffEndpoint.getClusterClient(OnOffCluster);
             assert.ok(onOffClient);
 
             assert.ok(onOffLightDeviceServer);

--- a/packages/matter-node.js/test/cluster/ClusterServerTestingUtil.ts
+++ b/packages/matter-node.js/test/cluster/ClusterServerTestingUtil.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Attributes, ClusterServerObj, Commands, Events } from "@project-chip/matter.js/cluster";
+import { asClusterServerInternal, Attributes, ClusterServerObj, Events } from "@project-chip/matter.js/cluster";
 import { Message } from "@project-chip/matter.js/codec";
 import { PrivateKey } from "@project-chip/matter.js/crypto";
 import { FabricId, FabricIndex, NodeId, VendorId } from "@project-chip/matter.js/datatype";
@@ -20,15 +20,15 @@ PRIVATE_KEY[31] = 1; // EC doesn't like all-zero private key
 export const KEY = PrivateKey(PRIVATE_KEY);
 
 // TODO make that nicer
-export async function callCommandOnClusterServer<A extends Attributes, C extends Commands, E extends Events>(
-    clusterServer: ClusterServerObj<A, C, E>,
+export async function callCommandOnClusterServer<A extends Attributes, E extends Events>(
+    clusterServer: ClusterServerObj<A, E>,
     commandName: string,
     args: any,
     endpoint: Endpoint,
     session?: SecureSession<any>,
     message?: Message,
 ): Promise<{ code: StatusCode; responseId: number; response: any }> {
-    const command = (clusterServer._commands as any)[commandName];
+    const command = (asClusterServerInternal(clusterServer)._commands as any)[commandName];
     if (command === undefined) throw new Error(`Command ${commandName} not found`);
     const { code, responseId, response } = await command.invoke(
         session ?? ({} as SecureSession<any>),

--- a/packages/matter.js/src/CommissioningController.ts
+++ b/packages/matter.js/src/CommissioningController.ts
@@ -5,7 +5,7 @@
  */
 import { Ble } from "./ble/Ble.js";
 import { ClusterClient } from "./cluster/client/ClusterClient.js";
-import { asClusterClientInternal, ClusterClientObj, isClusterClient } from "./cluster/client/ClusterClientTypes.js";
+import { ClusterClientObj, isClusterClient } from "./cluster/client/ClusterClientTypes.js";
 import { Attributes, Commands, Events } from "./cluster/Cluster.js";
 import { getClusterById } from "./cluster/ClusterHelper.js";
 import { DescriptorCluster } from "./cluster/definitions/DescriptorCluster.js";
@@ -238,9 +238,9 @@ export class CommissioningController extends MatterNode {
      * @private
      */
     private async initializeEndpointStructure() {
-        const interactionClient = await this.createInteractionClient();
+        this.defaultInteractionClient = await this.createInteractionClient();
 
-        const allClusterAttributes = await interactionClient.getAllAttributes();
+        const allClusterAttributes = await this.defaultInteractionClient.getAllAttributes();
         const allData = structureReadAttributeDataToClusterObject(allClusterAttributes);
 
         const partLists = new Map<EndpointNumber, EndpointNumber[]>();

--- a/packages/matter.js/src/CommissioningController.ts
+++ b/packages/matter.js/src/CommissioningController.ts
@@ -5,8 +5,8 @@
  */
 import { Ble } from "./ble/Ble.js";
 import { ClusterClient } from "./cluster/client/ClusterClient.js";
-import { ClusterClientObj, isClusterClient } from "./cluster/client/ClusterClientTypes.js";
-import { Attributes, Cluster, Commands, Events } from "./cluster/Cluster.js";
+import { asClusterClientInternal, ClusterClientObj, isClusterClient } from "./cluster/client/ClusterClientTypes.js";
+import { Attributes, Commands, Events } from "./cluster/Cluster.js";
 import { getClusterById } from "./cluster/ClusterHelper.js";
 import { DescriptorCluster } from "./cluster/definitions/DescriptorCluster.js";
 import { ClusterServer } from "./cluster/server/ClusterServer.js";
@@ -40,7 +40,6 @@ import { UdpInterface } from "./net/UdpInterface.js";
 import { CommissioningOptions } from "./protocol/ControllerCommissioner.js";
 import { structureReadAttributeDataToClusterObject } from "./protocol/interaction/AttributeDataDecoder.js";
 import { InteractionClient } from "./protocol/interaction/InteractionClient.js";
-import { BitSchema, TypeFromPartialBitSchema } from "./schema/BitmapSchema.js";
 import { StorageContext } from "./storage/StorageContext.js";
 import { AtLeastOne } from "./util/Array.js";
 
@@ -351,7 +350,7 @@ export class CommissioningController extends MatterNode {
         }
 
         const endpointClusters = Array<
-            ClusterServerObj<Attributes, Commands, Events> | ClusterClientObj<any, Attributes, Commands, Events>
+            ClusterServerObj<Attributes, Events> | ClusterClientObj<any, Attributes, Commands, Events>
         >();
 
         // Add ClusterClients for all server clusters of the device
@@ -370,7 +369,6 @@ export class CommissioningController extends MatterNode {
             endpointClusters.push(
                 ClusterServer(cluster, /*clusterData.featureMap,*/ clusterData, {}) as ClusterServerObj<
                     Attributes,
-                    Commands,
                     Events
                 >,
             ); // TODO Add Default handler!

--- a/packages/matter.js/src/CommissioningServer.ts
+++ b/packages/matter.js/src/CommissioningServer.ts
@@ -7,7 +7,7 @@
 import { Ble } from "./ble/Ble.js";
 import { AttestationCertificateManager } from "./certificate/AttestationCertificateManager.js";
 import { CertificationDeclarationManager } from "./certificate/CertificationDeclarationManager.js";
-import { Attributes, Commands, Events } from "./cluster/Cluster.js";
+import { Attributes, Events } from "./cluster/Cluster.js";
 import { AccessControlCluster } from "./cluster/definitions/AccessControlCluster.js";
 import {
     AdministratorCommissioning,
@@ -405,9 +405,7 @@ export class CommissioningServer extends MatterNode {
      *
      * @param cluster
      */
-    override addRootClusterServer<A extends Attributes, C extends Commands, E extends Events>(
-        cluster: ClusterServerObj<A, C, E>,
-    ) {
+    override addRootClusterServer<A extends Attributes, E extends Events>(cluster: ClusterServerObj<A, E>) {
         if (cluster.id === BasicInformationCluster.id) {
             throw new ImplementationError(
                 "BasicInformationCluster can not be modified, provide all details in constructor options!",

--- a/packages/matter.js/src/MatterNode.ts
+++ b/packages/matter.js/src/MatterNode.ts
@@ -12,7 +12,6 @@ import { RootEndpoint } from "./device/Device.js";
 import { Endpoint } from "./device/Endpoint.js";
 import { MdnsBroadcaster } from "./mdns/MdnsBroadcaster.js";
 import { MdnsScanner } from "./mdns/MdnsScanner.js";
-import { InteractionClient } from "./protocol/interaction/InteractionClient.js";
 import { BitSchema, TypeFromPartialBitSchema } from "./schema/BitmapSchema.js";
 
 /**
@@ -62,8 +61,6 @@ export abstract class MatterNode {
      * Get a cluster client from the root endpoint. This is mainly used internally and not needed to be called by the user.
      *
      * @param cluster ClusterClient to get or undefined if not existing
-     * @param interactionClient Optional InteractionClient to use for the cluster client. If not provided, the default
-     *                          InteractionClient of the root endpoint is used.
      */
     getRootClusterClient<
         F extends BitSchema,
@@ -71,11 +68,8 @@ export abstract class MatterNode {
         A extends Attributes,
         C extends Commands,
         E extends Events,
-    >(
-        cluster: Cluster<F, SF, A, C, E>,
-        interactionClient?: InteractionClient,
-    ): ClusterClientObj<F, A, C, E> | undefined {
-        return this.rootEndpoint.getClusterClient(cluster, interactionClient);
+    >(cluster: Cluster<F, SF, A, C, E>): ClusterClientObj<F, A, C, E> | undefined {
+        return this.rootEndpoint.getClusterClient(cluster);
     }
 
     /**

--- a/packages/matter.js/src/MatterNode.ts
+++ b/packages/matter.js/src/MatterNode.ts
@@ -25,9 +25,7 @@ export abstract class MatterNode {
      *
      * @param cluster ClusterServer object to add
      */
-    addRootClusterServer<A extends Attributes, C extends Commands, E extends Events>(
-        cluster: ClusterServerObj<A, C, E>,
-    ) {
+    addRootClusterServer<A extends Attributes, E extends Events>(cluster: ClusterServerObj<A, E>) {
         this.rootEndpoint.addClusterServer(cluster);
     }
 
@@ -42,7 +40,7 @@ export abstract class MatterNode {
         A extends Attributes,
         C extends Commands,
         E extends Events,
-    >(cluster: Cluster<F, SF, A, C, E>): ClusterServerObj<A, C, E> | undefined {
+    >(cluster: Cluster<F, SF, A, C, E>): ClusterServerObj<A, E> | undefined {
         return this.rootEndpoint.getClusterServer(cluster);
     }
 

--- a/packages/matter.js/src/cluster/client/AttributeClient.ts
+++ b/packages/matter.js/src/cluster/client/AttributeClient.ts
@@ -142,10 +142,7 @@ export class AttributeClient<T> {
         this.listeners.forEach(listener => listener(value));
     }
 
-    setInteractionClientRequestorCallback(callback: () => Promise<InteractionClient>) {
-        this.getInteractionClientCallback = callback;
-    }
-
+    /** Add a listener to the attribute. */
     addListener(listener: (newValue: T) => void) {
         this.listeners.push(listener);
     }

--- a/packages/matter.js/src/cluster/client/ClusterClient.ts
+++ b/packages/matter.js/src/cluster/client/ClusterClient.ts
@@ -227,25 +227,6 @@ export function ClusterClient<F extends BitSchema, A extends Attributes, C exten
                 },
             });
         },
-
-        /**
-         * Clones the cluster client, optionally with a new interaction client.
-         * When the clusterClient is the same then also AttributeClients will be reused.
-         *
-         * @param newInteractionClient Optionally a new interactionClient to bind to
-         */
-        _clone(newInteractionClient?: InteractionClient) {
-            const clonedClusterClient = ClusterClient(
-                clusterDef,
-                endpointId,
-                newInteractionClient ?? interactionClient,
-            );
-            if (newInteractionClient === undefined) {
-                // When we keep the InteractionClient we also reuse the AttributeServers bound to it
-                clonedClusterClient.attributes = attributes;
-            }
-            return clonedClusterClient;
-        },
     };
 
     const attributeToId = <{ [key: AttributeId]: string }>{};

--- a/packages/matter.js/src/cluster/client/ClusterClient.ts
+++ b/packages/matter.js/src/cluster/client/ClusterClient.ts
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { InternalError } from "../../common/MatterError.js";
 import { tryCatchAsync } from "../../common/TryCatchHandler.js";
 import { AttributeId } from "../../datatype/AttributeId.js";
 import { ClusterId } from "../../datatype/ClusterId.js";
@@ -52,7 +51,7 @@ export function ClusterClient<F extends BitSchema, A extends Attributes, C exten
             attributeName,
             endpointId,
             clusterId,
-            async () => interactionClient,
+            interactionClient,
             globalAttributeValues?.attributeList ? globalAttributeValues?.attributeList.includes(attribute.id) : false,
         );
         attributeToId[attribute.id] = attributeName;
@@ -97,7 +96,7 @@ export function ClusterClient<F extends BitSchema, A extends Attributes, C exten
             eventName,
             endpointId,
             clusterId,
-            async () => interactionClient,
+            interactionClient,
             globalAttributeValues?.eventList ? globalAttributeValues?.eventList.includes(event.id) : false,
         );
         eventToId[event.id] = eventName;
@@ -181,10 +180,6 @@ export function ClusterClient<F extends BitSchema, A extends Attributes, C exten
             eventFilters?: TypeFromSchema<typeof TlvEventFilter>[];
             dataVersionFilters?: { endpointId: EndpointNumber; clusterId: ClusterId; dataVersion: number }[];
         }) => {
-            if (interactionClient === undefined) {
-                throw new InternalError("InteractionClient not set.");
-            }
-
             const {
                 minIntervalFloorSeconds,
                 maxIntervalCeilingSeconds,
@@ -288,9 +283,6 @@ export function ClusterClient<F extends BitSchema, A extends Attributes, C exten
 
         commandToId[requestId] = commandName;
         commands[commandName] = async <RequestT, ResponseT>(request: RequestT) => {
-            if (interactionClient === undefined) {
-                throw new InternalError("InteractionClient not set.");
-            }
             return interactionClient.invoke<Command<RequestT, ResponseT, any>>(
                 endpointId,
                 clusterId,

--- a/packages/matter.js/src/cluster/client/ClusterClient.ts
+++ b/packages/matter.js/src/cluster/client/ClusterClient.ts
@@ -56,10 +56,13 @@ export function ClusterClient<F extends BitSchema, A extends Attributes, C exten
         );
         attributeToId[attribute.id] = attributeName;
         const capitalizedAttributeName = capitalize(attributeName);
-        result[`get${capitalizedAttributeName}Attribute`] = async (alwaysRequestFromRemote = false) => {
+        result[`get${capitalizedAttributeName}Attribute`] = async (
+            alwaysRequestFromRemote?: boolean,
+            isFabricFiltered = true,
+        ) => {
             return await tryCatchAsync(
                 async () => {
-                    return await (attributes as any)[attributeName].get(alwaysRequestFromRemote);
+                    return await (attributes as any)[attributeName].get(isFabricFiltered, alwaysRequestFromRemote);
                 },
                 StatusResponseError,
                 e => {
@@ -71,8 +74,8 @@ export function ClusterClient<F extends BitSchema, A extends Attributes, C exten
                 },
             );
         };
-        result[`set${capitalizedAttributeName}Attribute`] = async <T>(value: T) =>
-            (attributes as any)[attributeName].set(value);
+        result[`set${capitalizedAttributeName}Attribute`] = async <T>(value: T, dataVersion?: number) =>
+            (attributes as any)[attributeName].set(value, dataVersion);
         result[`subscribe${capitalizedAttributeName}Attribute`] = async <T>(
             listener: (value: T) => void,
             minIntervalS: number,
@@ -87,6 +90,9 @@ export function ClusterClient<F extends BitSchema, A extends Attributes, C exten
                 knownDataVersion,
                 isFabricFiltered,
             );
+        };
+        result[`add${capitalizedAttributeName}AttributeListener`] = <T>(listener: (value: T) => void) => {
+            (attributes as any)[attributeName].addListener(listener);
         };
     }
 
@@ -135,6 +141,9 @@ export function ClusterClient<F extends BitSchema, A extends Attributes, C exten
                 minimumEventNumber,
                 isFabricFiltered,
             );
+        };
+        result[`add${capitalizedEventName}EventListener`] = <T>(listener: (value: DecodedEventData<T>) => void) => {
+            (events as any)[eventName].addListener(listener);
         };
     }
 

--- a/packages/matter.js/src/cluster/client/ClusterClient.ts
+++ b/packages/matter.js/src/cluster/client/ClusterClient.ts
@@ -40,7 +40,7 @@ import { createEventClient } from "./EventClient.js";
 const logger = Logger.get("ClusterClient");
 
 export function ClusterClient<F extends BitSchema, A extends Attributes, C extends Commands, E extends Events>(
-    clusterDef: Cluster<F, any, A, C, E>,
+    clusterDef: Cluster<F, TypeFromPartialBitSchema<F>, A, C, E>,
     endpointId: EndpointNumber,
     interactionClient: InteractionClient,
     globalAttributeValues: Partial<AttributeServerValues<GlobalAttributes<F>>> = {},

--- a/packages/matter.js/src/cluster/server/ClusterServer.ts
+++ b/packages/matter.js/src/cluster/server/ClusterServer.ts
@@ -58,7 +58,7 @@ export function ClusterServer<
     attributesInitialValues: AttributeInitialValues<A>,
     handlers: H,
     supportedEvents: SupportedEventsList<E> = <SupportedEventsList<E>>{},
-): ClusterServerObj<A, C, E> {
+): ClusterServerObj<A, E> {
     const {
         id: clusterId,
         name,
@@ -468,5 +468,5 @@ export function ClusterServer<
     }
     (attributes as any).eventList.setLocal(eventList.sort((a, b) => a - b));
 
-    return result as ClusterServerObj<A, C, E>;
+    return result as ClusterServerObj<A, E>;
 }

--- a/packages/matter.js/src/cluster/server/ScenesServer.ts
+++ b/packages/matter.js/src/cluster/server/ScenesServer.ts
@@ -14,7 +14,7 @@ import { assertSecureSession } from "../../session/SecureSession.js";
 import { TypeFromSchema } from "../../tlv/TlvSchema.js";
 import { Scenes, ScenesCluster } from "../definitions/ScenesCluster.js";
 import { ClusterServer } from "./ClusterServer.js";
-import { ClusterServerHandlers } from "./ClusterServerTypes.js";
+import { asClusterServerInternal, ClusterServerHandlers } from "./ClusterServerTypes.js";
 import { GroupsManager } from "./GroupsServer.js";
 
 interface scenesTableEntry {
@@ -314,7 +314,7 @@ export const ScenesClusterHandler: () => ClusterServerHandlers<typeof ScenesClus
 
             const extensionFieldSets = new Array<TypeFromSchema<typeof Scenes.TlvExtensionFieldSet>>();
             endpoint.getAllClusterServers().forEach(cluster => {
-                const attributeValueList = cluster._getSceneExtensionFieldSets();
+                const attributeValueList = asClusterServerInternal(cluster)._getSceneExtensionFieldSets();
                 if (attributeValueList.length) {
                     extensionFieldSets.push({ clusterId: cluster.id, attributeValueList });
                 }
@@ -375,7 +375,10 @@ export const ScenesClusterHandler: () => ClusterServerHandlers<typeof ScenesClus
                 const { clusterId, attributeValueList } = clusterData;
                 const cluster = endpoint.getClusterServerById(clusterId);
                 if (cluster !== undefined) {
-                    cluster._setSceneExtensionFieldSets(attributeValueList, usedTransitionTime);
+                    asClusterServerInternal(cluster)._setSceneExtensionFieldSets(
+                        attributeValueList,
+                        usedTransitionTime,
+                    );
                 }
             });
             currentScene.setLocal(sceneId);
@@ -563,7 +566,7 @@ export const ScenesClusterHandler: () => ClusterServerHandlers<typeof ScenesClus
                 const { clusterId, attributeValueList } = clusterData;
                 const cluster = endpoint.getClusterServerById(clusterId);
                 if (cluster !== undefined) {
-                    if (!cluster._verifySceneExtensionFieldSets(attributeValueList)) {
+                    if (!asClusterServerInternal(cluster)._verifySceneExtensionFieldSets(attributeValueList)) {
                         return false;
                     }
                 }

--- a/packages/matter.js/src/device/Device.ts
+++ b/packages/matter.js/src/device/Device.ts
@@ -59,10 +59,7 @@ export class PairedDevice extends Endpoint {
      */
     constructor(
         definition: AtLeastOne<DeviceTypeDefinition>,
-        clusters: (
-            | ClusterServerObj<Attributes, Commands, Events>
-            | ClusterClientObj<any, Attributes, Commands, Events>
-        )[] = [],
+        clusters: (ClusterServerObj<Attributes, Events> | ClusterClientObj<any, Attributes, Commands, Events>)[] = [],
         endpointId: EndpointNumber,
     ) {
         super(definition, { endpointId });
@@ -81,9 +78,7 @@ export class PairedDevice extends Endpoint {
      * Add cluster servers (used internally only!)
      * @deprecated PairedDevice does not support adding additional clusters
      */
-    override addClusterServer<A extends Attributes, C extends Commands, E extends Events>(
-        cluster: ClusterServerObj<A, C, E>,
-    ) {
+    override addClusterServer<A extends Attributes, E extends Events>(cluster: ClusterServerObj<A, E>) {
         if (this.declineAddingMoreClusters) {
             throw new ImplementationError("PairedDevice does not support adding additional clusters");
         }
@@ -195,7 +190,7 @@ export class Device extends Endpoint {
         A extends Attributes,
         C extends Commands,
         E extends Events,
-    >(_cluster: Cluster<F, SF, A, C, E>): ClusterServerObj<A, C, E> {
+    >(_cluster: Cluster<F, SF, A, C, E>): ClusterServerObj<A, E> {
         // TODO: Implement this in upper classes to add optional clusters on the fly
         throw new ImplementationError("createOptionalClusterServer needs to be implemented by derived classes");
     }
@@ -217,7 +212,7 @@ export class Device extends Endpoint {
         A extends Attributes,
         C extends Commands,
         E extends Events,
-    >(cluster: Cluster<F, SF, A, C, E>): ClusterServerObj<A, C, E> | undefined {
+    >(cluster: Cluster<F, SF, A, C, E>): ClusterServerObj<A, E> | undefined {
         const clusterServer = super.getClusterServer(cluster);
         if (clusterServer !== undefined) {
             return clusterServer;

--- a/packages/matter.js/src/device/Endpoint.ts
+++ b/packages/matter.js/src/device/Endpoint.ts
@@ -109,9 +109,9 @@ export class Endpoint {
             );
         }
         const fixedLabelCluster = this.getClusterServer(FixedLabelCluster);
-        const labelList = fixedLabelCluster?.attributes.labelList.getLocal() ?? [];
+        const labelList = fixedLabelCluster?.getLabelListAttribute() ?? [];
         labelList.push({ label, value });
-        fixedLabelCluster?.attributes.labelList.setLocal(labelList);
+        fixedLabelCluster?.setLabelListAttribute(labelList);
     }
 
     addUserLabel(label: string, value: string) {
@@ -127,13 +127,13 @@ export class Endpoint {
             );
         }
         const fixedLabelCluster = this.getClusterServer(UserLabelCluster);
-        const labelList = fixedLabelCluster?.attributes.labelList.getLocal() ?? [];
+        const labelList = fixedLabelCluster?.getLabelListAttribute() ?? [];
         labelList.push({ label, value });
-        fixedLabelCluster?.attributes.labelList.setLocal(labelList);
+        fixedLabelCluster?.setLabelListAttribute(labelList);
     }
 
-    addClusterServer<A extends Attributes, C extends Commands, E extends Events>(cluster: ClusterServerObj<A, C, E>) {
-        cluster._assignToEndpoint(this);
+    addClusterServer<A extends Attributes, E extends Events>(cluster: ClusterServerObj<A, E>) {
+        asClusterServerInternal(cluster)._assignToEndpoint(this);
         if (cluster.id === DescriptorCluster.id) {
             this.descriptorCluster = cluster as unknown as ClusterServerObjForCluster<typeof DescriptorCluster>;
         }

--- a/packages/matter.js/src/protocol/ControllerCommissioner.ts
+++ b/packages/matter.js/src/protocol/ControllerCommissioner.ts
@@ -128,7 +128,7 @@ const DEFAULT_ADMIN_VENDOR_ID = VendorId(0xfff1);
 export class ControllerCommissioner {
     private readonly commissioningSteps = new Array<CommissioningStep>();
     private readonly commissioningStepResults = new Map<string, CommissioningStepResult>();
-    private readonly clusterClients = new Map<number, ClusterClientObj<any, Attributes, Commands, Events>>();
+    private readonly clusterClients = new Map<ClusterId, ClusterClientObj<any, Attributes, Commands, Events>>();
     private commissioningStartedTime: number | undefined;
     private commissioningExpiryTime: number | undefined;
     private lastFailSafeTime: number | undefined;

--- a/packages/matter.js/src/protocol/interaction/InteractionEndpointStructure.ts
+++ b/packages/matter.js/src/protocol/interaction/InteractionEndpointStructure.ts
@@ -9,7 +9,7 @@ import {
     FabricScopedAttributeServer,
     FixedAttributeServer,
 } from "../../cluster/server/AttributeServer.js";
-import { ClusterServerObj } from "../../cluster/server/ClusterServerTypes.js";
+import { asClusterServerInternal, ClusterServerObj } from "../../cluster/server/ClusterServerTypes.js";
 import { CommandServer } from "../../cluster/server/CommandServer.js";
 import { EventServer } from "../../cluster/server/EventServer.js";
 import { ImplementationError, InternalError } from "../../common/MatterError.js";
@@ -82,7 +82,7 @@ export class InteractionEndpointStructure {
                 attributes: clusterAttributes,
                 _events: clusterEvents,
                 _commands: clusterCommands,
-            } = cluster;
+            } = asClusterServerInternal(cluster);
             // Add attributes
             for (const name in clusterAttributes) {
                 const attribute = clusterAttributes[name];

--- a/packages/matter.js/src/protocol/interaction/InteractionEndpointStructure.ts
+++ b/packages/matter.js/src/protocol/interaction/InteractionEndpointStructure.ts
@@ -179,7 +179,7 @@ export class InteractionEndpointStructure {
         return this.endpoints.has(endpointId);
     }
 
-    getClusterServer(endpointId: EndpointNumber, clusterId: ClusterId): ClusterServerObj<any, any, any> | undefined {
+    getClusterServer(endpointId: EndpointNumber, clusterId: ClusterId): ClusterServerObj<any, any> | undefined {
         return this.endpoints.get(endpointId)?.getClusterServerById(clusterId);
     }
 

--- a/packages/matter.js/src/protocol/interaction/InteractionServer.ts
+++ b/packages/matter.js/src/protocol/interaction/InteractionServer.ts
@@ -10,6 +10,7 @@ import {
     FabricScopedAttributeServer,
     FixedAttributeServer,
 } from "../../cluster/server/AttributeServer.js";
+import { asClusterServerInternal } from "../../cluster/server/ClusterServerTypes.js";
 import { CommandServer } from "../../cluster/server/CommandServer.js";
 import { EventServer } from "../../cluster/server/EventServer.js";
 import { Message } from "../../codec/MessageCodec.js";
@@ -147,8 +148,9 @@ export class InteractionServer implements ProtocolHandler<MatterDevice> {
 
         for (const endpoint of this.endpointStructure.endpoints.values()) {
             for (const cluster of endpoint.getAllClusterServers()) {
-                cluster._setStorage(this.storage.createContext(`Cluster-${endpoint.id}-${cluster.id}`));
-                cluster._registerEventHandler(this.eventHandler);
+                const clusterServer = asClusterServerInternal(cluster);
+                clusterServer._setStorage(this.storage.createContext(`Cluster-${endpoint.id}-${cluster.id}`));
+                clusterServer._registerEventHandler(this.eventHandler);
             }
         }
 

--- a/packages/matter.js/src/util/EndpointStructureLogger.ts
+++ b/packages/matter.js/src/util/EndpointStructureLogger.ts
@@ -14,7 +14,7 @@ import {
     FabricScopeError,
     FixedAttributeServer,
 } from "../cluster/server/AttributeServer.js";
-import { ClusterServerObj } from "../cluster/server/ClusterServerTypes.js";
+import { asClusterServerInternal, ClusterServerObj } from "../cluster/server/ClusterServerTypes.js";
 import { Endpoint } from "../device/Endpoint.js";
 import { Logger } from "../log/Logger.js";
 import { toHexString } from "./Number.js";
@@ -131,8 +131,9 @@ function logClusterServer(
         Logger.nest(() => {
             logger.info("Commands:");
             Logger.nest(() => {
-                for (const commandName in clusterServer._commands) {
-                    const command = clusterServer._commands[commandName];
+                const commands = asClusterServerInternal(clusterServer)._commands;
+                for (const commandName in commands) {
+                    const command = commands[commandName];
                     if (command === undefined) continue;
                     logger.info(`"${command.name}" (${toHexString(command.invokeId)}/${command.responseId})`);
                 }
@@ -143,8 +144,9 @@ function logClusterServer(
         Logger.nest(() => {
             logger.info("Events:");
             Logger.nest(() => {
-                for (const eventName in clusterServer._events) {
-                    const event = clusterServer._events[eventName];
+                const events = asClusterServerInternal(clusterServer)._events;
+                for (const eventName in events) {
+                    const event = events[eventName];
                     if (event === undefined) continue;
                     logger.info(`"${event.name}" (${toHexString(event.id)})`);
                 }
@@ -164,7 +166,7 @@ function logClusterClient(
     const globalAttributes = GlobalAttributes<any>(features);
     const supportedFeatures = new Array<string>();
     for (const featureName in features) {
-        if ((features as any)[featureName] === true) supportedFeatures.push(featureName);
+        if (features[featureName] === true) supportedFeatures.push(featureName);
     }
 
     logger.info(

--- a/packages/matter.js/src/util/EndpointStructureLogger.ts
+++ b/packages/matter.js/src/util/EndpointStructureLogger.ts
@@ -38,7 +38,7 @@ type EndpointLoggingOptions = {
     logAttributePrimitiveValues?: boolean;
     logAttributeObjectValues?: boolean;
 
-    clusterServerFilter?: (endpoint: Endpoint, cluster: ClusterServerObj<any, any, any>) => boolean;
+    clusterServerFilter?: (endpoint: Endpoint, cluster: ClusterServerObj<any, any>) => boolean;
     clusterClientFilter?: (endpoint: Endpoint, cluster: ClusterClientObj<any, any, any, any>) => boolean;
     endpointFilter?: (endpoint: Endpoint) => boolean;
 };
@@ -78,7 +78,7 @@ function getAttributeServerValue(
 
 function logClusterServer(
     endpoint: Endpoint,
-    clusterServer: ClusterServerObj<any, any, any>,
+    clusterServer: ClusterServerObj<any, any>,
     options: EndpointLoggingOptions = {},
 ) {
     if (options.clusterServerFilter !== undefined && !options.clusterServerFilter(endpoint, clusterServer)) return;


### PR DESCRIPTION
This PR is implementing the following:
* The ClusterClientObj and ClusterServerObj objects and types had some "internal private" method that needed to be exposed in types but should neverbe used by normal developers. This PR is splitting the typings into a Cluster*Obj with only the external facing methods and a Cluster*ObjectInternal type with also the internal methods. The objects given out by all methods tyoing-wise are "only" the external ones, but because all methdos are in the dynamically created object it can y typecasted into the Internal Representation.
* The Attribute/EventClients allowed to echange the InteractionClient object they are bound to on creation. This was never working and also blocks other upcoming features. IntercationCLients alreayd have a reconnection mechanism build in and our implementation also only handles one channel per node, so it makes in fact no sense to have InteractionCLient exchangeable. This PR also removes this and cleans the API
* The PR also adds some more documentation on the Cluster methods

@lauckhart it seems I run into another case of "too deep infer" ...