### PR TITLE
Add Dataversion support for Write

### DIFF
--- a/packages/matter-node.js/test/interaction/InteractionProtocolTest.ts
+++ b/packages/matter-node.js/test/interaction/InteractionProtocolTest.ts
@@ -219,12 +219,10 @@ const WRITE_REQUEST: WriteRequest = {
         {
             path: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x28), attributeId: AttributeId(100) },
             data: TlvUInt8.encodeTlv(3),
-            dataVersion: 0,
         },
         {
             path: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x99), attributeId: AttributeId(4) },
             data: TlvUInt8.encodeTlv(3),
-            dataVersion: 0,
         },
         {
             path: { endpointId: EndpointNumber(1), clusterId: ClusterId(0x28), attributeId: AttributeId(4) },

--- a/packages/matter-node.js/test/interaction/InteractionProtocolTest.ts
+++ b/packages/matter-node.js/test/interaction/InteractionProtocolTest.ts
@@ -236,6 +236,16 @@ const WRITE_REQUEST: WriteRequest = {
             data: TlvString.encodeTlv("test"),
             dataVersion: 0,
         },
+        {
+            path: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x28), attributeId: AttributeId(6) },
+            data: TlvString.encodeTlv("AB"),
+            dataVersion: 10,
+        },
+        {
+            path: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x28), attributeId: AttributeId(3) },
+            data: TlvString.encodeTlv("test"),
+            dataVersion: 0,
+        },
     ],
     moreChunkedMessages: false,
 };
@@ -258,6 +268,14 @@ const WRITE_RESPONSE: WriteResponse = {
         {
             path: { attributeId: AttributeId(5), clusterId: ClusterId(40), endpointId: EndpointNumber(0) },
             status: { status: 0 },
+        },
+        {
+            path: { attributeId: AttributeId(6), clusterId: ClusterId(40), endpointId: EndpointNumber(0) },
+            status: { status: 146 },
+        },
+        {
+            path: { attributeId: AttributeId(3), clusterId: ClusterId(40), endpointId: EndpointNumber(0) },
+            status: { status: 136 },
         },
     ],
 };

--- a/packages/matter.js/src/protocol/interaction/InteractionServer.ts
+++ b/packages/matter.js/src/protocol/interaction/InteractionServer.ts
@@ -354,7 +354,7 @@ export class InteractionServer implements ProtocolHandler<MatterDevice> {
                         logger.debug(
                             `Write from ${exchange.channel.name}: ${this.endpointStructure.resolveAttributeName(
                                 path,
-                            )}: unsupported path: Status=${statusCode}`,
+                            )} not allowed: Status=${statusCode}`,
                         );
                         return [{ path, statusCode }];
                     }

--- a/packages/matter.js/src/protocol/interaction/InteractionServer.ts
+++ b/packages/matter.js/src/protocol/interaction/InteractionServer.ts
@@ -323,9 +323,10 @@ export class InteractionServer implements ProtocolHandler<MatterDevice> {
             (values): { path: TypeFromSchema<typeof TlvAttributePath>; statusCode: StatusCode }[] => {
                 const { path, dataVersion } = values[0];
                 const attributes = this.endpointStructure.getAttributes([path], true);
+                const { endpointId, clusterId, attributeId } = path;
                 if (attributes.length === 0) {
+                    // No attribute found
                     // TODO: Also check nodeId
-                    const { endpointId, clusterId, attributeId } = path;
                     if (endpointId === undefined || clusterId === undefined || attributeId === undefined) {
                         // Wildcard path: Just ignore
                         logger.debug(
@@ -343,6 +344,12 @@ export class InteractionServer implements ProtocolHandler<MatterDevice> {
                             statusCode = StatusCode.UnsupportedEndpoint;
                         } else if (!this.endpointStructure.hasClusterServer(endpointId, clusterId)) {
                             statusCode = StatusCode.UnsupportedCluster;
+                        } else {
+                            // check if concrete path and just "not writable"
+                            const allAttributes = this.endpointStructure.getAttributes([path]);
+                            if (allAttributes.length > 0) {
+                                statusCode = StatusCode.UnsupportedWrite;
+                            }
                         }
                         logger.debug(
                             `Write from ${exchange.channel.name}: ${this.endpointStructure.resolveAttributeName(
@@ -351,10 +358,23 @@ export class InteractionServer implements ProtocolHandler<MatterDevice> {
                         );
                         return [{ path, statusCode }];
                     }
+                } else if (
+                    attributes.length === 1 &&
+                    endpointId !== undefined &&
+                    clusterId !== undefined &&
+                    attributeId !== undefined
+                ) {
+                    // Concrete path
+                    if (dataVersion !== undefined) {
+                        const cluster = this.endpointStructure.getClusterServer(endpointId, clusterId);
+                        if (cluster !== undefined && dataVersion !== cluster.clusterDataVersion) {
+                            return [{ path, statusCode: StatusCode.DataVersionMismatch }];
+                        }
+                    }
                 }
 
                 return attributes.map(({ path, attribute }) => {
-                    // TODO add checks or dataVersion
+                    // TODO add checks for timed writes, fabric scoped writes
                     // TODO add ACL checks
                     const { schema, defaultValue } = attribute;
 


### PR DESCRIPTION
This PR adds the data version support as required by specs for Write interactions. It additionally splits out "non writable" requests to it's own error code as required