### PR TITLE
Allow to Subscribe-All for Controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ All Changes without a GitHub Username in brackets are from the core team: @Apoll
   * Breaking: Change from object style to Branded types for special Datatype objects (e.g. "new VendorId(0xFFF1)" -> "VendorId(0xFFF1)")
   * Breaking: ClusterClient and ClusterServer classes were moved from "interaction" export to "cluster" export
   * Breaking: Refactor the (low level) ClusterClient API to be more convenient to use with many optional fields for read/write/subscribe
+  * Breaking: Cluster*Obj and the internal representation for more correct typings
+  * Breaking: The InteractionClient is no longer exchangeable in ClusterClient cases (because makes no sense and was never working)
   * Feature: Enhance CommissioningServer options to also specify GeneralCommissioningServer details and settings
   * Feature: Adjust RegulatoryConfig Handling in Device and Controller to match with specifications
   * Feature: Endpoint Structures use custom-unique-id (from EndpointOptions)/uniqueStorageKey (from BasicInformationCluster)/serialNumber (from BasicInformationCluster)/ Index (in this order) to store and restore the endpoint ID in structures
@@ -67,6 +69,7 @@ All Changes without a GitHub Username in brackets are from the core team: @Apoll
   * Feature: Allow to also remove devices from Aggregators
   * Feature: Optionally allow to define discovery capabilities when generating Pairing code
   * Feature: Add methods to CommissioningServer/Controller class to get information on active sessions and commissioned fabrics
+  * Feature: Enhance CommissioningController to allow subscribing to all attributes and events directly on startup
 * Reference implementation/Examples:
   * Breaking: The storage key structure got changed to allow multi node operations within one process. This requires to change the storage key structure and to migrate or reset the storage.
     * Migration: prepend any storage key except Device.* and Controller.* with "0." in the filename

--- a/packages/matter-node.js-examples/src/examples/ControllerNode.ts
+++ b/packages/matter-node.js-examples/src/examples/ControllerNode.ts
@@ -183,6 +183,7 @@ class ControllerNode {
             passcode: setupPin,
             delayedPairing: true,
             commissioningOptions,
+            subscribeAllAttributes: true,
         });
         matterServer.addCommissioningController(commissioningController);
 
@@ -257,7 +258,12 @@ class ControllerNode {
                 const onOff = devices[0].getClusterClient(OnOffCluster);
                 if (onOff !== undefined) {
                     let onOffStatus = await onOff.getOnOffAttribute();
-                    console.log("onOffStatus", onOffStatus);
+                    console.log("initial onOffStatus", onOffStatus);
+
+                    onOff.addOnOffAttributeListener(value => {
+                        console.log("subscription onOffStatus", value);
+                        onOffStatus = value;
+                    });
                     // read data every minute to keep up the connection to show the subscription is working
                     setInterval(() => {
                         onOff
@@ -272,7 +278,7 @@ class ControllerNode {
             }
         } finally {
             //await matterServer.close(); // Comment out when subscribes are used, else the connection will be closed
-            setTimeout(() => process.exit(0), 100000);
+            setTimeout(() => process.exit(0), 1000000);
         }
     }
 }

--- a/packages/matter.js/src/CommissioningController.ts
+++ b/packages/matter.js/src/CommissioningController.ts
@@ -59,12 +59,15 @@ const logger = new Logger("CommissioningController");
  */
 export interface CommissioningControllerOptions {
     serverAddress?: ServerAddressIp;
-    localPort?: number;
-    disableIpv4?: boolean;
-    listeningAddressIpv4?: string;
-    listeningAddressIpv6?: string;
+    readonly localPort?: number;
+    readonly disableIpv4?: boolean;
+    readonly listeningAddressIpv4?: string;
+    readonly listeningAddressIpv6?: string;
 
-    delayedPairing?: boolean;
+    readonly delayedPairing?: boolean;
+    readonly subscribeAllAttributes?: boolean;
+    readonly subscribeMinIntervalFloorSeconds?: number;
+    readonly subscribeMaxIntervalCeilingSeconds?: number;
 
     passcode: number; // TODO: Move into commissioningOptions
     longDiscriminator?: number; // TODO: Move into commissioningOptions

--- a/packages/matter.js/src/cluster/client/ClusterClient.ts
+++ b/packages/matter.js/src/cluster/client/ClusterClient.ts
@@ -209,23 +209,33 @@ export function ClusterClient<F extends BitSchema, A extends Attributes, C exten
                 dataVersionFilters,
                 attributeListener: attributeData => {
                     const { path, value } = attributeData;
-                    const attributeName = attributeToId[path.attributeId];
-                    if (attributeName === undefined) {
-                        logger.warn("Unknown attribute id", path.attributeId);
-                        return;
-                    }
-                    (attributes as any)[attributeName].update(value);
+                    result._triggerAttributeUpdate(path.attributeId, value);
                 },
                 eventListener: eventData => {
                     const { path, events: newEvents } = eventData;
-                    const eventName = eventToId[path.eventId];
-                    if (eventName === undefined) {
-                        logger.warn("Unknown event id", path.eventId);
-                        return;
-                    }
-                    newEvents.forEach(event => (events as any)[eventName].update(event));
+                    result._triggerEventUpdate(path.eventId, newEvents);
                 },
             });
+        },
+
+        /** Trigger a value change for an Attributed, used by subscriptions. */
+        _triggerAttributeUpdate(attributeId: AttributeId, value: any) {
+            const attributeName = attributeToId[attributeId];
+            if (attributeName === undefined) {
+                logger.warn("Unknown attribute id", attributeId);
+                return;
+            }
+            (attributes as any)[attributeName].update(value);
+        },
+
+        /** Trigger a value change for an Event, used by subscriptions. */
+        _triggerEventUpdate(eventId: EventId, events: DecodedEventData<any>[]) {
+            const eventName = eventToId[eventId];
+            if (eventName === undefined) {
+                logger.warn("Unknown event id", eventId);
+                return;
+            }
+            events.forEach(event => (events as any)[eventName].update(event));
         },
     };
 


### PR DESCRIPTION
This PR adds the following:
* Adjust handling of data storage fpr clusters and dataversion and respect dataversion nbeing cluster wide
* Return subscription seed results when setting up a new Subscription via InteractionClient
* Allow a controller to automatically subscribe to all attributes and keep them updates
