### PR TITLE
New method for defining clusters

### DIFF
--- a/codegen/src/clusters/ClusterComponentGenerator.ts
+++ b/codegen/src/clusters/ClusterComponentGenerator.ts
@@ -43,10 +43,9 @@ export class ClusterComponentGenerator {
     }
 
     defineComponent(component: NamedComponent) {
-        this.file.addImport("cluster/ClusterFactory", "ClusterComponent");
         const name = `${component.name}Component`;
         const block = this.target
-            .expressions(`export const ${name} = ClusterComponent({`, `})`)
+            .expressions(`export const ${name} = ClusterFactory.Component({`, `})`)
             .document(component.documentation);
         return this.populateComponent(component, block);
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -126,6 +126,7 @@
             "resolved": "https://registry.npmjs.org/@abandonware/bleno/-/bleno-0.6.1.tgz",
             "integrity": "sha512-UYJhfOlRpg+o6H9VCL3xvBBchEV3mfGS+/ESmFd4cTy/HmoBTofFTecBMvV79/AZP5CSmQ9Qifx03kPBA4PgsQ==",
             "hasInstallScript": true,
+            "optional": true,
             "os": [
                 "darwin",
                 "linux",
@@ -173,6 +174,7 @@
             "resolved": "https://registry.npmjs.org/@abandonware/noble/-/noble-1.9.2-23.tgz",
             "integrity": "sha512-BPb/a2s+t6SIZRU4oNfY61cPM91/+dH0t8Ulb4QpQ1zBfKtR+n4r/r6j+vPcnAOiQ5hWC2lDj+Mc/iiZPAYLRw==",
             "hasInstallScript": true,
+            "optional": true,
             "os": [
                 "darwin",
                 "linux",
@@ -195,7 +197,8 @@
         "node_modules/@abandonware/noble/node_modules/node-addon-api": {
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
-            "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ=="
+            "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==",
+            "optional": true
         },
         "node_modules/@bcoe/v8-coverage": {
             "version": "0.2.3",
@@ -4848,7 +4851,8 @@
         "node_modules/napi-thread-safe-callback": {
             "version": "0.0.6",
             "resolved": "https://registry.npmjs.org/napi-thread-safe-callback/-/napi-thread-safe-callback-0.0.6.tgz",
-            "integrity": "sha512-X7uHCOCdY4u0yamDxDrv3jF2NtYc8A1nvPzBQgvpoSX+WB3jAe2cVNsY448V1ucq7Whf9Wdy02HEUoLW5rJKWg=="
+            "integrity": "sha512-X7uHCOCdY4u0yamDxDrv3jF2NtYc8A1nvPzBQgvpoSX+WB3jAe2cVNsY448V1ucq7Whf9Wdy02HEUoLW5rJKWg==",
+            "optional": true
         },
         "node_modules/natural-compare": {
             "version": "1.4.0",
@@ -4873,7 +4877,8 @@
         "node_modules/node-addon-api": {
             "version": "6.1.0",
             "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.1.0.tgz",
-            "integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA=="
+            "integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==",
+            "optional": true
         },
         "node_modules/node-fetch": {
             "version": "2.7.0",
@@ -4940,6 +4945,7 @@
             "version": "4.6.1",
             "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.1.tgz",
             "integrity": "sha512-24vnklJmyRS8ViBNI8KbtK/r/DmXQMRiOMXTNz2nrTnAYUwjmEEbnnpB/+kt+yWRv73bPsSPRFddrcIbAxSiMQ==",
+            "optional": true,
             "bin": {
                 "node-gyp-build": "bin.js",
                 "node-gyp-build-optional": "optional.js",
@@ -7156,8 +7162,6 @@
             "version": "0.5.0",
             "license": "Apache-2.0",
             "dependencies": {
-                "@abandonware/bleno": "^0.6.1",
-                "@abandonware/noble": "^1.9.2-23",
                 "@project-chip/matter.js": "^0.5.0"
             },
             "devDependencies": {
@@ -7167,6 +7171,10 @@
             },
             "engines": {
                 "node": ">=16.0.0"
+            },
+            "optionalDependencies": {
+                "@abandonware/bleno": "^0.6.1",
+                "@abandonware/noble": "^1.9.2-23"
             }
         },
         "packages/matter-node-shell.js": {

--- a/packages/matter-node.js-examples/src/examples/ControllerNode.ts
+++ b/packages/matter-node.js-examples/src/examples/ControllerNode.ts
@@ -26,6 +26,7 @@ import {
     GeneralCommissioning,
     OnOffCluster,
 } from "@project-chip/matter-node.js/cluster";
+import { logEndpoint } from "@project-chip/matter-node.js/device";
 import { Format, Level, Logger } from "@project-chip/matter-node.js/log";
 import { CommissioningOptions } from "@project-chip/matter-node.js/protocol";
 import { ManualPairingCodeCodec } from "@project-chip/matter-node.js/schema";
@@ -34,7 +35,6 @@ import {
     getIntParameter,
     getParameter,
     hasParameter,
-    logEndpoint,
     requireMinNodeVersion,
     singleton,
 } from "@project-chip/matter-node.js/util";

--- a/packages/matter-node.js-examples/src/examples/DeviceNode.ts
+++ b/packages/matter-node.js-examples/src/examples/DeviceNode.ts
@@ -19,7 +19,7 @@ import { CommissioningServer, MatterServer } from "@project-chip/matter-node.js"
 import { BleNode } from "@project-chip/matter-node-ble.js/ble";
 import { Ble } from "@project-chip/matter-node.js/ble";
 import { ClusterServer, GeneralCommissioningCluster, NetworkCommissioning } from "@project-chip/matter-node.js/cluster";
-import { OnOffLightDevice, OnOffPluginUnitDevice } from "@project-chip/matter-node.js/device";
+import { OnOffLightDevice, OnOffPluginUnitDevice, logEndpoint } from "@project-chip/matter-node.js/device";
 import { Format, Level, Logger } from "@project-chip/matter-node.js/log";
 import { StorageBackendDisk, StorageManager } from "@project-chip/matter-node.js/storage";
 import { Time } from "@project-chip/matter-node.js/time";
@@ -29,7 +29,6 @@ import {
     getIntParameter,
     getParameter,
     hasParameter,
-    logEndpoint,
     requireMinNodeVersion,
     singleton,
 } from "@project-chip/matter-node.js/util";
@@ -249,11 +248,11 @@ class Device {
                                 wiFiScanResults: [
                                     {
                                         security: {
-                                            Unencrypted: false,
-                                            Wep: false,
-                                            "WPA-PERSONAL": false,
-                                            "WPA2-PERSONAL": true,
-                                            "WPA3-PERSONAL": true,
+                                            unencrypted: false,
+                                            wep: false,
+                                            wpaPersonal: false,
+                                            wpa2Personal: true,
+                                            wpa3Personal: true,
                                         },
                                         ssid:
                                             ssid ||

--- a/packages/matter-node.js/test/IntegrationTest.ts
+++ b/packages/matter-node.js/test/IntegrationTest.ts
@@ -162,6 +162,8 @@ describe("Integration Test", () => {
                             connected: true,
                         },
                     ],
+                    scanMaxTimeSeconds: 30,
+                    connectMaxTimeSeconds: 60,
                 },
                 {
                     scanNetworks: async function () {

--- a/packages/matter-node.js/test/interaction/InteractionProtocolTest.ts
+++ b/packages/matter-node.js/test/interaction/InteractionProtocolTest.ts
@@ -590,6 +590,19 @@ const INVOKE_COMMAND_RESPONSE_MULTI: InvokeResponse = {
     ],
 };
 
+const BasicInformationClusterWithTimedInteraction = {
+    ...BasicInformationCluster,
+    attributes: {
+        ...BasicInformationCluster.attributes,
+        nodeLabel: WritableAttribute(0x5, TlvString.bound({ maxLength: 32 }), {
+            persistent: true,
+            default: "",
+            writeAcl: AccessLevel.Manage,
+            timed: true,
+        }),
+    },
+};
+
 const testFabric = new Fabric(
     FabricIndex(1),
     FabricId(1),
@@ -952,12 +965,6 @@ describe("InteractionProtocol", () => {
 
         it("write values and return errors on invalid values timed interaction required by attribute", async () => {
             let timedInteractionCleared = false;
-            const BasicInformationClusterWithTimedInteraction = BasicInformationCluster;
-            BasicInformationClusterWithTimedInteraction.attributes.nodeLabel = WritableAttribute(
-                0x5,
-                TlvString.bound({ maxLength: 32 }),
-                { persistent: true, default: "", writeAcl: AccessLevel.Manage, timed: true },
-            );
             const basicCluster = ClusterServer(
                 BasicInformationClusterWithTimedInteraction,
                 {
@@ -1000,12 +1007,6 @@ describe("InteractionProtocol", () => {
 
         it("write values and return errors on invalid values timed interaction required by attribute success", async () => {
             let timedInteractionCleared = false;
-            const BasicInformationClusterWithTimedInteraction = BasicInformationCluster;
-            BasicInformationClusterWithTimedInteraction.attributes.nodeLabel = WritableAttribute(
-                0x5,
-                TlvString.bound({ maxLength: 32 }),
-                { persistent: true, default: "", writeAcl: AccessLevel.Manage, timed: true },
-            );
             const basicCluster = ClusterServer(
                 BasicInformationClusterWithTimedInteraction,
                 {

--- a/packages/matter.js/src/cluster/ClusterFactory.ts
+++ b/packages/matter.js/src/cluster/ClusterFactory.ts
@@ -5,269 +5,329 @@
  */
 
 import { MatterError } from "../common/MatterError.js";
+import { ClusterId } from "../datatype/ClusterId.js";
 import { BitSchema, TypeFromPartialBitSchema } from "../schema/BitmapSchema.js";
 import { serialize } from "../util/String.js";
-import { Merge } from "../util/Type.js";
+import { Branded, Merge } from "../util/Type.js";
 import {
-    Attribute,
-    Attributes,
-    Cluster,
-    Command,
-    Commands,
+    Attribute as ClusterAttribute,
+    Command as ClusterCommand,
+    Event as ClusterEvent,
     ConditionalFeatureList,
-    Event,
-    Events,
     GlobalAttributes,
 } from "./Cluster.js";
 
 export class IllegalClusterError extends MatterError {}
 
 /**
- * A "cluster component" is a set of elements that can be added to a cluster.
+ * The formal definitions of clusters in matter.js are generated
+ * programmatically.  There is no single formal "cluster factory" but rather a
+ * set of types and methods for each cluster.
+ *
+ * Individual modules associated with each cluster use the utility types and
+ * methods as building blocks.
+ *
+ * Note:  There is overlap between the types here and those in Cluster.ts.
+ * They may converge over time but are fully compatible.
  */
-export type ClusterComponent<A extends Attributes, C extends Commands, E extends Events> = {
-    readonly attributes: A;
-    readonly commands: C;
-    readonly events: E;
-};
+export namespace ClusterFactory {
+    /**
+     * An "element set" defines the set of elements (commands, attributes or
+     * events) of a cluster.
+     */
+    export type ElementSet<T> = Record<string, T | undefined>;
 
-export function ClusterComponent<A extends Attributes, C extends Commands, E extends Events>({
-    attributes = {} as A,
-    commands = {} as C,
-    events = {} as E,
-}: Partial<ClusterComponent<A, C, E>>): ClusterComponent<A, C, E> {
-    return {
-        attributes,
-        commands,
-        events,
+    /**
+     * Definition of a cluster attribute.
+     */
+    export type Attribute = ClusterAttribute<any, any>;
+
+    /**
+     * Definition of a cluster command.
+     */
+    export type Command = ClusterCommand<any, any, any>;
+
+    /**
+     * Definition of a cluster event.
+     */
+    export type Event = ClusterEvent<any, any>;
+
+    /**
+     * These fields uniquely identify a cluster.
+     */
+    export interface Identity {
+        readonly id: ClusterId;
+        readonly name: string;
+        readonly revision: number;
+    }
+
+    /**
+     * Cluster "elements" are attributes, commands and events that may comprise
+     * a cluster.
+     */
+    export interface ClusterElements {
+        readonly attributes: ElementSet<Attribute>;
+        readonly commands: ElementSet<Command>;
+        readonly events: ElementSet<Event>;
+    }
+
+    /**
+     * A cluster "component" is a set of elements intended to be added to a
+     * cluster definition.
+     */
+    export interface Component extends ClusterElements {}
+
+    /**
+     * A "typed component" is a component with detailed type information.
+     */
+    export interface TypedComponent<T extends Partial<Component>> {
+        attributes: T["attributes"] extends ElementSet<Attribute> ? T["attributes"] : {};
+        commands: T["commands"] extends ElementSet<Command> ? T["commands"] : {};
+        events: T["events"] extends ElementSet<Event> ? T["events"] : {};
+    }
+
+    /**
+     * Cluster "features" describe the features supported by a cluster.
+     */
+    export interface Features<F extends BitSchema = {}> {
+        readonly features: F;
+        readonly supportedFeatures: TypeFromPartialBitSchema<F>;
+        readonly unknown?: boolean;
+    }
+
+    /**
+     * A Cluster represents a fully formed cluster with features selected.
+     */
+    export interface Cluster extends Identity, Features<BitSchema>, ClusterElements {}
+
+    /**
+     * A "partial definition" is a cluster definition that does not require
+     * empty elements to be present.
+     */
+    export type PartialDefinition = { id: number } & Omit<Identity, "id"> &
+        Partial<Features> & {
+            attributes?: ElementSet<Attribute>;
+            commands?: ElementSet<Command>;
+            events?: ElementSet<Event>;
+        };
+
+    /**
+     * A "definition" is the fully typed Cluster for a PartialDefinition.
+     */
+    export type Definition<T extends PartialDefinition> = {
+        id: Branded<T["id"], "ClusterId">;
+        name: T["name"];
+        revision: T["revision"];
+        features: T["features"] extends {} ? T["features"] : {};
+        supportedFeatures: T["supportedFeatures"] extends {} ? T["supportedFeatures"] : {};
+        attributes: T["attributes"] extends infer A extends {}
+            ? Merge<A, GlobalAttributes<T["features"] extends {} ? T["features"] : {}>>
+            : {};
+        commands: T["commands"] extends {} ? T["commands"] : {};
+        events: T["events"] extends {} ? T["events"] : {};
+        unknown: T["unknown"] extends boolean ? T["unknown"] : false;
+    } & Omit<T, "attributes">;
+
+    /**
+     * A "MutableDefinition" is a Cluster with fields that may be modified.
+     */
+    export type MutableDefinition = {
+        -readonly [Key in keyof Cluster]: Cluster[Key];
     };
-}
 
-/**
- * A "base cluster component" contains properties and elements that apply to a
- * cluster regardless of which features are enabled.
- */
-export type BaseClusterComponent<F extends BitSchema, A extends Attributes, C extends Commands, E extends Events> = {
-    id: number;
-    name: string;
-    revision: number;
-    readonly features: F;
-} & ClusterComponent<A, C, E>;
+    /**
+     * An "extender" is a function that creates a cluster with specific
+     * features enabled.
+     */
+    export type Extender = (...features: any) => Cluster;
 
-export function BaseClusterComponent<F extends BitSchema, A extends Attributes, C extends Commands, E extends Events>({
-    id,
-    name,
-    revision,
-    features = {} as F,
-    attributes = {} as A,
-    commands = {} as C,
-    events = {} as E,
-}: {
-    id: number;
-    name: string;
-    revision: number;
-    features?: F;
-} & Partial<ClusterComponent<A, C, E>>): BaseClusterComponent<F, A, C, E> {
-    return {
-        id,
-        name,
-        revision,
-        features,
-        attributes,
-        commands,
-        events,
-    };
-}
+    /**
+     * An "extensible" cluster is a base cluster with support for enabling
+     * features.
+     */
+    export interface Extensible extends Cluster {
+        with: Extender;
+    }
 
-/**
- * Obtain a cluster type for a BaseClusterComponent.
- */
-export type ClusterForBaseCluster<T, SF> = T extends BaseClusterComponent<infer F, infer A, infer C, infer E>
-    ? SF extends TypeFromPartialBitSchema<F>
-        ? Cluster<F, SF, A, C, E>
-        : never
-    : never;
+    /**
+     * An "element" is a single attribute, command or event of a cluster.
+     */
+    export type Element = Attribute | Command | Event;
 
-/**
- * Injects a set of functionality into a cluster if the cluster supports the
- * specified features.
- */
-export function extendCluster<F extends BitSchema>(
-    cluster: Cluster<F, any, any, any, any>,
-    component: ClusterComponent<any, any, any>,
-    ...applicableFeatures: TypeFromPartialBitSchema<F>[]
-) {
-    let applicable = false;
-    pool: for (const features of applicableFeatures) {
-        for (const k in features) {
-            if (!!cluster.supportedFeatures[k] !== !!features[k]) {
-                continue pool;
+    /**
+     * Define a cluster component.
+     */
+    export function Component<const T extends Partial<Component>>(component: T): TypedComponent<T> {
+        return {
+            attributes: {},
+            commands: {},
+            events: {},
+            ...component,
+        };
+    }
+
+    /**
+     * Define a cluster.
+     */
+    export function Definition<const T extends PartialDefinition>(definition: T) {
+        return {
+            id: ClusterId(definition.id),
+            name: definition.name,
+            revision: definition.revision,
+            features: definition.features ?? {},
+            supportedFeatures: definition.supportedFeatures ?? {},
+            attributes: {
+                ...GlobalAttributes(definition.features ?? {}),
+                ...definition.attributes,
+            },
+            commands: definition.commands ?? {},
+            events: definition.events ?? {},
+            unknown: definition.unknown,
+        } as Definition<T>;
+    }
+
+    /**
+     * Define an extensible cluster.
+     */
+    export function Extensible<
+        const DefinitionT extends Identity & Partial<ClusterElements> & Partial<Features>,
+        const ExtenderT extends Extender,
+    >(definition: DefinitionT, extender: ExtenderT) {
+        return {
+            ...Definition(definition),
+            with: extender,
+        } as const;
+    }
+
+    /**
+     * Define a cluster that can only be extended.
+     */
+    export function ExtensibleOnly<const ExtenderT extends Extender>(extender: ExtenderT) {
+        return {
+            with: extender,
+        } as const;
+    }
+
+    /**
+     * Injects a set of functionality into a cluster if the cluster supports
+     * the specified features.
+     *
+     * This is used by extenders and does not convey type information.
+     */
+    export function extend(
+        definition: MutableDefinition,
+        elements: ClusterElements,
+        ...applicableFeatures: TypeFromPartialBitSchema<any>[]
+    ) {
+        let applicable = false;
+        pool: for (const features of applicableFeatures) {
+            for (const k in features) {
+                if (!!definition.supportedFeatures[k] !== !!features[k]) {
+                    continue pool;
+                }
+            }
+            applicable = true;
+            break;
+        }
+
+        if (!applicable) {
+            return;
+        }
+
+        if (elements.attributes) {
+            if (definition.attributes) {
+                definition.attributes = { ...definition.attributes, ...elements.attributes };
+            } else {
+                definition.attributes = elements.attributes;
             }
         }
-        applicable = true;
-        break;
-    }
 
-    if (!applicable) {
-        return;
-    }
-
-    if (component.attributes) {
-        if (cluster.attributes) {
-            cluster.attributes = { ...cluster.attributes, ...component.attributes };
-        } else {
-            cluster.attributes = component.attributes;
-        }
-    }
-
-    if (component.commands) {
-        if (cluster.commands) {
-            cluster.commands = { ...cluster.commands, ...component.commands };
-        } else {
-            cluster.commands = component.commands;
-        }
-    }
-
-    if (component.events) {
-        if (cluster.events) {
-            cluster.events = { ...cluster.events, ...component.events };
-        } else {
-            cluster.events = component.events;
-        }
-    }
-}
-
-/**
- * Validates a set of feature flags against the features supported by a
- * cluster.
- */
-export function validateFeatureSelection(features: string[], validFeatures: { [name: string]: string }) {
-    for (const f of features) {
-        if (!validFeatures[f]) {
-            throw new IllegalClusterError(`"${f}" is not a valid feature identifier`);
-        }
-    }
-}
-
-/**
- * Throws an error if a feature combination is illegal per the Matter
- * specification.
- */
-export function preventCluster<F extends BitSchema>(
-    cluster: Cluster<F, any, any, any, any>,
-    ...illegalFeatureCombinations: TypeFromPartialBitSchema<F>[]
-) {
-    pool: for (const bitmap of illegalFeatureCombinations) {
-        for (const k in bitmap) {
-            if (!!cluster.supportedFeatures[k] !== !!bitmap[k]) {
-                continue pool;
+        if (elements.commands) {
+            if (definition.commands) {
+                definition.commands = { ...definition.commands, ...elements.commands };
+            } else {
+                definition.commands = elements.commands;
             }
         }
-        throw new IllegalClusterError(
-            `Feature combination ${serialize(bitmap)} is disallowed by the Matter specification`,
-        );
+
+        if (elements.events) {
+            if (definition.events) {
+                definition.events = { ...definition.events, ...elements.events };
+            } else {
+                definition.events = elements.events;
+            }
+        }
     }
-}
 
-export type ClusterFactory = (...features: any) => Cluster<any, any, any, any, any>;
+    /**
+     * Validates a set of feature flags against the features supported by a
+     * cluster.
+     *
+     * Used by extenders.
+     */
+    export function validateFeatureSelection(features: string[], validFeatures: Record<string, string>) {
+        for (const f of features) {
+            if (!validFeatures[f]) {
+                throw new IllegalClusterError(`"${f}" is not a valid feature identifier`);
+            }
+        }
+    }
 
-/**
- * This is a cluster that can be extended with optional features.
- */
-export type ExtensibleCluster<
-    F extends BitSchema,
-    SF extends TypeFromPartialBitSchema<F>,
-    A extends Attributes,
-    C extends Commands,
-    E extends Events,
-    W extends ClusterFactory,
-> = Cluster<F, SF, A, C, E> & {
-    with: W;
-};
+    /**
+     * Throws an error if a feature combination is illegal per the Matter
+     * specification.
+     *
+     * Used by extenders.
+     */
+    export function prevent(definition: Cluster, ...illegalFeatureCombinations: Record<string, boolean>[]) {
+        pool: for (const bitmap of illegalFeatureCombinations) {
+            for (const k in bitmap) {
+                if (!!definition.supportedFeatures[k] !== !!bitmap[k]) {
+                    continue pool;
+                }
+            }
+            throw new IllegalClusterError(
+                `Feature combination ${serialize(bitmap)} is disallowed by the Matter specification`,
+            );
+        }
+    }
 
-export function ExtensibleCluster<
-    F extends BitSchema,
-    SF extends TypeFromPartialBitSchema<F>,
-    W extends ClusterFactory,
-    A extends Attributes = {},
-    C extends Commands = {},
-    E extends Events = {},
->({
-    id,
-    name,
-    revision,
-    features = <F>{},
-    supportedFeatures = <SF>{},
-    attributes = <A>{},
-    commands = <C>{},
-    events = <E>{},
-    factory,
-}: {
-    id: number;
-    name: string;
-    revision: number;
-    features?: F;
-    supportedFeatures?: SF;
-    attributes?: A;
-    commands?: C;
-    events?: E;
-    factory: W;
-}): ExtensibleCluster<F, SF, Merge<A, GlobalAttributes<F>>, C, E, W> {
-    return {
-        ...Cluster({
-            id,
-            name,
-            revision,
-            features,
-            supportedFeatures,
-            commands,
-            attributes,
-            events,
-        }),
-        with: factory,
-    };
-}
+    /**
+     * Create a conditional version of an unconditional element definition.
+     */
+    export function AsConditional<
+        const ClusterT extends Cluster,
+        const E extends Element,
+        const OI extends ConditionalFeatureList<ClusterT["features"]>,
+        const MI extends ConditionalFeatureList<ClusterT["features"]>,
+    >(element: E, { optionalIf, mandatoryIf }: { optionalIf?: OI; mandatoryIf?: MI }) {
+        return {
+            ...element,
+            optional: true,
+            isConditional: true,
+            optionalIf: optionalIf ?? [],
+            mandatoryIf: mandatoryIf ?? [],
+        } as const;
+    }
 
-/**
- * This is a factory for clusters that cannot be used without supporting one
- * or more optional features.  These features are "optional" in the sense that
- * they need not all be present but one or more is required.
- */
-export type ExtensionRequiredCluster<W extends ClusterFactory> = {
-    with: W;
-};
+    /**
+     * Extract the type of a cluster's attributes.
+     */
+    export type AttributesOf<C extends Cluster> = C extends { attributes: infer E extends { [K in string]: Attribute } }
+        ? { [K in Extract<keyof E, string> as E[K] extends Attribute ? K : never]: E[K] }
+        : never;
 
-export function ExtensionRequiredCluster<W extends ClusterFactory>({
-    factory,
-}: {
-    factory: W;
-}): ExtensionRequiredCluster<W> {
-    return { with: factory };
-}
+    /**
+     * Extract the type of a cluster's commands.
+     */
+    export type CommandsOf<C extends Cluster> = C extends { commands: infer E extends { [K in string]: Command } }
+        ? { [K in Extract<keyof E, string> as E[K] extends Command ? K : never]: E[K] }
+        : never;
 
-export type ClusterElement<F extends BitSchema> = Attribute<any, F> | Command<any, any, F> | Event<any, F>;
-
-export type AsConditional<F extends BitSchema, E extends ClusterElement<F>> = Omit<E, "optional"> & {
-    optional: true;
-    isConditional: true;
-};
-
-export type ClusterElementConditions<F extends BitSchema> = {
-    optionalIf: ConditionalFeatureList<F>;
-    mandatoryIf: ConditionalFeatureList<F>;
-};
-
-export function AsConditional<F extends BitSchema, E extends ClusterElement<F>>(
-    element: E,
-    { optionalIf = [], mandatoryIf = [] }: Partial<ClusterElementConditions<F>>,
-) {
-    const result = {
-        ...element,
-        optional: true,
-        isConditional: true,
-        optionalIf: optionalIf,
-        mandatoryIf: mandatoryIf,
-    };
-    result.optional = true;
-    return result as AsConditional<F, E>;
+    /**
+     * Extract the type of a cluster's events.
+     */
+    export type EventsOf<C extends Cluster> = C extends { events: infer E extends { [K in string]: Event } }
+        ? { [K in Extract<keyof E, string> as E[K] extends Event ? K : never]: E[K] }
+        : never;
 }

--- a/packages/matter.js/src/cluster/definitions/AccessControlCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/AccessControlCluster.ts
@@ -6,8 +6,9 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
+import { ClusterFactory } from "../../cluster/ClusterFactory.js";
+import { MatterCoreSpecificationV1_1 } from "../../spec/Specifications.js";
 import {
-    Cluster as CreateCluster,
     WritableFabricScopedAttribute,
     AccessLevel,
     OptionalWritableFabricScopedAttribute,
@@ -15,7 +16,6 @@ import {
     Event,
     EventPriority
 } from "../../cluster/Cluster.js";
-import { MatterCoreSpecificationV1_1 } from "../../spec/Specifications.js";
 import { TlvArray } from "../../tlv/TlvArray.js";
 import { TlvObject, TlvField } from "../../tlv/TlvObject.js";
 import { TlvEnum, TlvUInt16 } from "../../tlv/TlvNumber.js";
@@ -321,7 +321,7 @@ export namespace AccessControl {
      *
      * @see {@link MatterCoreSpecificationV1_1} § 9.10
      */
-    export const Cluster = CreateCluster({
+    export const Cluster = ClusterFactory.Definition({
         id: 0x1f,
         name: "AccessControl",
         revision: 1,

--- a/packages/matter.js/src/cluster/definitions/AccountLoginCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/AccountLoginCluster.ts
@@ -6,8 +6,9 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import { Cluster as CreateCluster, Command, AccessLevel, TlvNoResponse } from "../../cluster/Cluster.js";
+import { ClusterFactory } from "../../cluster/ClusterFactory.js";
 import { MatterApplicationClusterSpecificationV1_1 } from "../../spec/Specifications.js";
+import { Command, AccessLevel, TlvNoResponse } from "../../cluster/Cluster.js";
 import { TlvObject, TlvField } from "../../tlv/TlvObject.js";
 import { TlvString } from "../../tlv/TlvString.js";
 import { TlvNullable } from "../../tlv/TlvNullable.js";
@@ -76,7 +77,7 @@ export namespace AccountLogin {
      *
      * @see {@link MatterApplicationClusterSpecificationV1_1} § 6.2
      */
-    export const Cluster = CreateCluster({
+    export const Cluster = ClusterFactory.Definition({
         id: 0x50e,
         name: "AccountLogin",
         revision: 1,

--- a/packages/matter.js/src/cluster/definitions/ActionsCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/ActionsCluster.ts
@@ -6,8 +6,9 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
+import { ClusterFactory } from "../../cluster/ClusterFactory.js";
+import { MatterCoreSpecificationV1_1 } from "../../spec/Specifications.js";
 import {
-    Cluster as CreateCluster,
     Attribute,
     OptionalAttribute,
     OptionalCommand,
@@ -15,7 +16,6 @@ import {
     Event,
     EventPriority
 } from "../../cluster/Cluster.js";
-import { MatterCoreSpecificationV1_1 } from "../../spec/Specifications.js";
 import { TlvArray } from "../../tlv/TlvArray.js";
 import { TlvObject, TlvField, TlvOptionalField } from "../../tlv/TlvObject.js";
 import { TlvUInt16, TlvEnum, TlvBitmap, TlvUInt32 } from "../../tlv/TlvNumber.js";
@@ -563,7 +563,7 @@ export namespace Actions {
      *
      * @see {@link MatterCoreSpecificationV1_1} § 9.14
      */
-    export const Cluster = CreateCluster({
+    export const Cluster = ClusterFactory.Definition({
         id: 0x25,
         name: "Actions",
         revision: 1,

--- a/packages/matter.js/src/cluster/definitions/AdministratorCommissioningCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/AdministratorCommissioningCluster.ts
@@ -6,18 +6,10 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
+import { ClusterFactory } from "../../cluster/ClusterFactory.js";
 import { MatterCoreSpecificationV1_1 } from "../../spec/Specifications.js";
-import {
-    BaseClusterComponent,
-    ClusterComponent,
-    ExtensibleCluster,
-    validateFeatureSelection,
-    extendCluster,
-    ClusterForBaseCluster,
-    AsConditional
-} from "../../cluster/ClusterFactory.js";
 import { BitFlag, BitFlags, TypeFromPartialBitSchema } from "../../schema/BitmapSchema.js";
-import { Attribute, Command, TlvNoResponse, AccessLevel, Cluster as CreateCluster } from "../../cluster/Cluster.js";
+import { Attribute, Command, TlvNoResponse, AccessLevel } from "../../cluster/Cluster.js";
 import { TlvEnum, TlvUInt16, TlvUInt32 } from "../../tlv/TlvNumber.js";
 import { TlvFabricIndex } from "../../datatype/FabricIndex.js";
 import { TlvNullable } from "../../tlv/TlvNullable.js";
@@ -139,7 +131,7 @@ export namespace AdministratorCommissioning {
     /**
      * These elements and properties are present in all AdministratorCommissioning clusters.
      */
-    export const Base = BaseClusterComponent({
+    export const Base = ClusterFactory.Definition({
         id: 0x3c,
         name: "AdministratorCommissioning",
         revision: 1,
@@ -261,7 +253,7 @@ export namespace AdministratorCommissioning {
     /**
      * A AdministratorCommissioningCluster supports these elements if it supports feature Basic.
      */
-    export const BasicComponent = ClusterComponent({
+    export const BasicComponent = ClusterFactory.Component({
         commands: {
             /**
              * This command may be used by a current Administrator to instruct a Node to go into commissioning mode, if
@@ -319,8 +311,8 @@ export namespace AdministratorCommissioning {
      *
      * @see {@link MatterCoreSpecificationV1_1} § 11.18
      */
-    export const Cluster = ExtensibleCluster({
-        ...Base,
+    export const Cluster = ClusterFactory.Extensible(
+        Base,
 
         /**
          * Use this factory method to create an AdministratorCommissioning cluster with support for optional features.
@@ -330,16 +322,19 @@ export namespace AdministratorCommissioning {
          * @returns an AdministratorCommissioning cluster with specified features enabled
          * @throws {IllegalClusterError} if the feature combination is disallowed by the Matter specification
          */
-        factory: <T extends `${Feature}`[]>(...features: [...T]) => {
-            validateFeatureSelection(features, Feature);
-            const cluster = CreateCluster({ ...Base, supportedFeatures: BitFlags(Base.features, ...features) });
-            extendCluster(cluster, BasicComponent, { basic: true });
+        <T extends `${Feature}`[]>(...features: [...T]) => {
+            ClusterFactory.validateFeatureSelection(features, Feature);
+            const cluster = ClusterFactory.Definition({
+                ...Base,
+                supportedFeatures: BitFlags(Base.features, ...features)
+            });
+            ClusterFactory.extend(cluster, BasicComponent, { basic: true });
             return cluster as unknown as Extension<BitFlags<typeof Base.features, T>>;
         }
-    });
+    );
 
     export type Extension<SF extends TypeFromPartialBitSchema<typeof Base.features>> =
-        ClusterForBaseCluster<typeof Base, SF>
+        Omit<typeof Base, "supportedFeatures">
         & { supportedFeatures: SF }
         & (SF extends { basic: true } ? typeof BasicComponent : {});
     const BC = { basic: true };
@@ -350,7 +345,7 @@ export namespace AdministratorCommissioning {
      * If you use this cluster you must manually specify which features are active and ensure the set of active
      * features is legal per the Matter specification.
      */
-    export const Complete = CreateCluster({
+    export const Complete = ClusterFactory.Definition({
         id: Cluster.id,
         name: Cluster.name,
         revision: Cluster.revision,
@@ -359,7 +354,7 @@ export namespace AdministratorCommissioning {
 
         commands: {
             ...Cluster.commands,
-            openBasicCommissioningWindow: AsConditional(
+            openBasicCommissioningWindow: ClusterFactory.AsConditional(
                 BasicComponent.commands.openBasicCommissioningWindow,
                 { mandatoryIf: [BC] }
             )

--- a/packages/matter.js/src/cluster/definitions/ApplicationBasicCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/ApplicationBasicCluster.ts
@@ -6,14 +6,9 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import {
-    Cluster as CreateCluster,
-    OptionalFixedAttribute,
-    FixedAttribute,
-    Attribute,
-    AccessLevel
-} from "../../cluster/Cluster.js";
+import { ClusterFactory } from "../../cluster/ClusterFactory.js";
 import { MatterApplicationClusterSpecificationV1_1 } from "../../spec/Specifications.js";
+import { OptionalFixedAttribute, FixedAttribute, Attribute, AccessLevel } from "../../cluster/Cluster.js";
 import { TlvString } from "../../tlv/TlvString.js";
 import { TlvVendorId, VendorId } from "../../datatype/VendorId.js";
 import { TlvUInt16, TlvEnum } from "../../tlv/TlvNumber.js";
@@ -83,7 +78,7 @@ export namespace ApplicationBasic {
      *
      * @see {@link MatterApplicationClusterSpecificationV1_1} § 6.3
      */
-    export const Cluster = CreateCluster({
+    export const Cluster = ClusterFactory.Definition({
         id: 0x50d,
         name: "ApplicationBasic",
         revision: 1,

--- a/packages/matter.js/src/cluster/definitions/BallastConfigurationCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/BallastConfigurationCluster.ts
@@ -6,15 +6,15 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
+import { ClusterFactory } from "../../cluster/ClusterFactory.js";
+import { MatterApplicationClusterSpecificationV1_1 } from "../../spec/Specifications.js";
 import {
-    Cluster as CreateCluster,
     Attribute,
     OptionalAttribute,
     WritableAttribute,
     AccessLevel,
     OptionalWritableAttribute
 } from "../../cluster/Cluster.js";
-import { MatterApplicationClusterSpecificationV1_1 } from "../../spec/Specifications.js";
 import { TlvUInt8, TlvBitmap, TlvUInt24 } from "../../tlv/TlvNumber.js";
 import { BitFlag } from "../../schema/BitmapSchema.js";
 import { TlvNullable } from "../../tlv/TlvNullable.js";
@@ -42,7 +42,7 @@ export namespace BallastConfiguration {
      *
      * @see {@link MatterApplicationClusterSpecificationV1_1} § 3.3
      */
-    export const Cluster = CreateCluster({
+    export const Cluster = ClusterFactory.Definition({
         id: 0x301,
         name: "BallastConfiguration",
         revision: 4,

--- a/packages/matter.js/src/cluster/definitions/BarrierControlCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/BarrierControlCluster.ts
@@ -6,13 +6,8 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import {
-    Cluster as CreateCluster,
-    Attribute,
-    OptionalWritableAttribute,
-    Command,
-    TlvNoResponse
-} from "../../cluster/Cluster.js";
+import { ClusterFactory } from "../../cluster/ClusterFactory.js";
+import { Attribute, OptionalWritableAttribute, Command, TlvNoResponse } from "../../cluster/Cluster.js";
 import { TlvUInt8, TlvUInt16 } from "../../tlv/TlvNumber.js";
 import { TlvObject, TlvField } from "../../tlv/TlvObject.js";
 import { TlvNoArguments } from "../../tlv/TlvNoArguments.js";
@@ -28,7 +23,7 @@ export namespace BarrierControl {
      *
      * This cluster provides control of a barrier (garage door).
      */
-    export const Cluster = CreateCluster({
+    export const Cluster = ClusterFactory.Definition({
         id: 0x103,
         name: "BarrierControl",
         revision: 1,

--- a/packages/matter.js/src/cluster/definitions/BasicInformationCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/BasicInformationCluster.ts
@@ -6,8 +6,9 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
+import { ClusterFactory } from "../../cluster/ClusterFactory.js";
+import { MatterCoreSpecificationV1_1 } from "../../spec/Specifications.js";
 import {
-    Cluster as CreateCluster,
     FixedAttribute,
     WritableAttribute,
     AccessLevel,
@@ -18,7 +19,6 @@ import {
     EventPriority,
     OptionalEvent
 } from "../../cluster/Cluster.js";
-import { MatterCoreSpecificationV1_1 } from "../../spec/Specifications.js";
 import { TlvUInt16, TlvUInt32, TlvEnum } from "../../tlv/TlvNumber.js";
 import { TlvString } from "../../tlv/TlvString.js";
 import { TlvVendorId } from "../../datatype/VendorId.js";
@@ -148,7 +148,7 @@ export namespace BasicInformation {
      *
      * @see {@link MatterCoreSpecificationV1_1} § 11.1
      */
-    export const Cluster = CreateCluster({
+    export const Cluster = ClusterFactory.Definition({
         id: 0x28,
         name: "BasicInformation",
         revision: 2,

--- a/packages/matter.js/src/cluster/definitions/BinaryInputBasicCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/BinaryInputBasicCluster.ts
@@ -6,13 +6,8 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import {
-    Cluster as CreateCluster,
-    OptionalWritableAttribute,
-    WritableAttribute,
-    OptionalAttribute,
-    Attribute
-} from "../../cluster/Cluster.js";
+import { ClusterFactory } from "../../cluster/ClusterFactory.js";
+import { OptionalWritableAttribute, WritableAttribute, OptionalAttribute, Attribute } from "../../cluster/Cluster.js";
 import { TlvString } from "../../tlv/TlvString.js";
 import { TlvBoolean } from "../../tlv/TlvBoolean.js";
 import { TlvUInt8, TlvUInt32 } from "../../tlv/TlvNumber.js";
@@ -24,7 +19,7 @@ export namespace BinaryInputBasic {
      * An interface for reading the value of a binary measurement and accessing various characteristics of that
      * measurement.
      */
-    export const Cluster = CreateCluster({
+    export const Cluster = ClusterFactory.Definition({
         id: 0xf,
         name: "BinaryInputBasic",
         revision: 1,

--- a/packages/matter.js/src/cluster/definitions/BindingCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/BindingCluster.ts
@@ -6,8 +6,9 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import { Cluster as CreateCluster, WritableFabricScopedAttribute, AccessLevel } from "../../cluster/Cluster.js";
+import { ClusterFactory } from "../../cluster/ClusterFactory.js";
 import { MatterCoreSpecificationV1_1 } from "../../spec/Specifications.js";
+import { WritableFabricScopedAttribute, AccessLevel } from "../../cluster/Cluster.js";
 import { TlvArray } from "../../tlv/TlvArray.js";
 import { TlvObject, TlvOptionalField, TlvField } from "../../tlv/TlvObject.js";
 import { TlvNodeId } from "../../datatype/NodeId.js";
@@ -90,7 +91,7 @@ export namespace Binding {
      *
      * @see {@link MatterCoreSpecificationV1_1} § 9.6
      */
-    export const Cluster = CreateCluster({
+    export const Cluster = ClusterFactory.Definition({
         id: 0x1e,
         name: "Binding",
         revision: 1,

--- a/packages/matter.js/src/cluster/definitions/BooleanStateCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/BooleanStateCluster.ts
@@ -6,8 +6,9 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import { Cluster as CreateCluster, Attribute, OptionalEvent, EventPriority } from "../../cluster/Cluster.js";
+import { ClusterFactory } from "../../cluster/ClusterFactory.js";
 import { MatterApplicationClusterSpecificationV1_1 } from "../../spec/Specifications.js";
+import { Attribute, OptionalEvent, EventPriority } from "../../cluster/Cluster.js";
 import { TlvBoolean } from "../../tlv/TlvBoolean.js";
 import { TlvObject, TlvField } from "../../tlv/TlvObject.js";
 
@@ -26,7 +27,7 @@ export namespace BooleanState {
      *
      * @see {@link MatterApplicationClusterSpecificationV1_1} § 1.7
      */
-    export const Cluster = CreateCluster({
+    export const Cluster = ClusterFactory.Definition({
         id: 0x45,
         name: "BooleanState",
         revision: 1,

--- a/packages/matter.js/src/cluster/definitions/BridgedDeviceBasicInformationCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/BridgedDeviceBasicInformationCluster.ts
@@ -6,8 +6,9 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
+import { ClusterFactory } from "../../cluster/ClusterFactory.js";
+import { MatterCoreSpecificationV1_1 } from "../../spec/Specifications.js";
 import {
-    Cluster as CreateCluster,
     OptionalFixedAttribute,
     OptionalWritableAttribute,
     AccessLevel,
@@ -17,7 +18,6 @@ import {
     EventPriority,
     Event
 } from "../../cluster/Cluster.js";
-import { MatterCoreSpecificationV1_1 } from "../../spec/Specifications.js";
 import { TlvString } from "../../tlv/TlvString.js";
 import { TlvVendorId } from "../../datatype/VendorId.js";
 import { TlvUInt16, TlvUInt32, TlvEnum } from "../../tlv/TlvNumber.js";
@@ -107,7 +107,7 @@ export namespace BridgedDeviceBasicInformation {
      *
      * @see {@link MatterCoreSpecificationV1_1} § 9.13
      */
-    export const Cluster = CreateCluster({
+    export const Cluster = ClusterFactory.Definition({
         id: 0x39,
         name: "BridgedDeviceBasicInformation",
         revision: 2,

--- a/packages/matter.js/src/cluster/definitions/ClientMonitoringCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/ClientMonitoringCluster.ts
@@ -6,14 +6,8 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import {
-    Cluster as CreateCluster,
-    Attribute,
-    Command,
-    TlvNoResponse,
-    AccessLevel,
-    OptionalCommand
-} from "../../cluster/Cluster.js";
+import { ClusterFactory } from "../../cluster/ClusterFactory.js";
+import { Attribute, Command, TlvNoResponse, AccessLevel, OptionalCommand } from "../../cluster/Cluster.js";
 import { TlvUInt32, TlvUInt16, TlvUInt64 } from "../../tlv/TlvNumber.js";
 import { TlvArray } from "../../tlv/TlvArray.js";
 import { TlvObject, TlvField } from "../../tlv/TlvObject.js";
@@ -47,7 +41,7 @@ export namespace ClientMonitoring {
      *
      * Client Monitoring allows for ensuring that listed clients meet the required monitoring conditions on the server.
      */
-    export const Cluster = CreateCluster({
+    export const Cluster = ClusterFactory.Definition({
         id: 0x1046,
         name: "ClientMonitoring",
         revision: 1,

--- a/packages/matter.js/src/cluster/definitions/ColorControlCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/ColorControlCluster.ts
@@ -6,16 +6,8 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
+import { ClusterFactory } from "../../cluster/ClusterFactory.js";
 import { MatterApplicationClusterSpecificationV1_1 } from "../../spec/Specifications.js";
-import {
-    BaseClusterComponent,
-    ClusterComponent,
-    ExtensibleCluster,
-    validateFeatureSelection,
-    extendCluster,
-    ClusterForBaseCluster,
-    AsConditional
-} from "../../cluster/ClusterFactory.js";
 import { BitFlag, BitField, BitFlags, TypeFromPartialBitSchema } from "../../schema/BitmapSchema.js";
 import {
     OptionalAttribute,
@@ -26,8 +18,7 @@ import {
     OptionalWritableAttribute,
     AccessLevel,
     Command,
-    TlvNoResponse,
-    Cluster as CreateCluster
+    TlvNoResponse
 } from "../../cluster/Cluster.js";
 import { TlvUInt16, TlvEnum, TlvUInt8, TlvBitmap, TlvUInt32, TlvInt16 } from "../../tlv/TlvNumber.js";
 import { TlvString } from "../../tlv/TlvString.js";
@@ -814,7 +805,7 @@ export namespace ColorControl {
     /**
      * These elements and properties are present in all ColorControl clusters.
      */
-    export const Base = BaseClusterComponent({
+    export const Base = ClusterFactory.Definition({
         id: 0x300,
         name: "ColorControl",
         revision: 5,
@@ -1205,7 +1196,7 @@ export namespace ColorControl {
     /**
      * A ColorControlCluster supports these elements if it supports feature HueSaturation.
      */
-    export const HueSaturationComponent = ClusterComponent({
+    export const HueSaturationComponent = ClusterFactory.Component({
         attributes: {
             /**
              * The CurrentHue attribute contains the current hue value of the light. It is updated as fast as practical
@@ -1280,7 +1271,7 @@ export namespace ColorControl {
     /**
      * A ColorControlCluster supports these elements if it supports feature Xy.
      */
-    export const XyComponent = ClusterComponent({
+    export const XyComponent = ClusterFactory.Component({
         attributes: {
             /**
              * The CurrentX attribute contains the current value of the normalized chromaticity value x, as defined in
@@ -1334,7 +1325,7 @@ export namespace ColorControl {
     /**
      * A ColorControlCluster supports these elements if it supports feature ColorTemperature.
      */
-    export const ColorTemperatureComponent = ClusterComponent({
+    export const ColorTemperatureComponent = ClusterFactory.Component({
         attributes: {
             /**
              * The ColorTemperatureMireds attribute contains a scaled inverse of the current value of the color
@@ -1439,7 +1430,7 @@ export namespace ColorControl {
     /**
      * A ColorControlCluster supports these elements if it supports feature EnhancedHue.
      */
-    export const EnhancedHueComponent = ClusterComponent({
+    export const EnhancedHueComponent = ClusterFactory.Component({
         attributes: {
             /**
              * The EnhancedCurrentHue attribute represents non-equidistant steps along the CIE 1931 color triangle, and
@@ -1500,7 +1491,7 @@ export namespace ColorControl {
     /**
      * A ColorControlCluster supports these elements if it supports feature ColorLoop.
      */
-    export const ColorLoopComponent = ClusterComponent({
+    export const ColorLoopComponent = ClusterFactory.Component({
         attributes: {
             /**
              * The ColorLoopActive attribute specifies the current active status of the color loop. If this attribute
@@ -1561,7 +1552,7 @@ export namespace ColorControl {
     /**
      * A ColorControlCluster supports these elements if it supports features HueSaturation, Xy or ColorTemperature.
      */
-    export const HueSaturationOrXyOrColorTemperatureComponent = ClusterComponent({
+    export const HueSaturationOrXyOrColorTemperatureComponent = ClusterFactory.Component({
         commands: {
             /**
              * The StopMoveStep command is provided to allow MoveTo and Step commands to be stopped. (Note this
@@ -1585,8 +1576,8 @@ export namespace ColorControl {
      *
      * @see {@link MatterApplicationClusterSpecificationV1_1} § 3.2
      */
-    export const Cluster = ExtensibleCluster({
-        ...Base,
+    export const Cluster = ClusterFactory.Extensible(
+        Base,
 
         /**
          * Use this factory method to create a ColorControl cluster with support for optional features. Include each
@@ -1596,16 +1587,19 @@ export namespace ColorControl {
          * @returns a ColorControl cluster with specified features enabled
          * @throws {IllegalClusterError} if the feature combination is disallowed by the Matter specification
          */
-        factory: <T extends `${Feature}`[]>(...features: [...T]) => {
-            validateFeatureSelection(features, Feature);
-            const cluster = CreateCluster({ ...Base, supportedFeatures: BitFlags(Base.features, ...features) });
-            extendCluster(cluster, HueSaturationComponent, { hueSaturation: true });
-            extendCluster(cluster, XyComponent, { xy: true });
-            extendCluster(cluster, ColorTemperatureComponent, { colorTemperature: true });
-            extendCluster(cluster, EnhancedHueComponent, { enhancedHue: true });
-            extendCluster(cluster, ColorLoopComponent, { colorLoop: true });
+        <T extends `${Feature}`[]>(...features: [...T]) => {
+            ClusterFactory.validateFeatureSelection(features, Feature);
+            const cluster = ClusterFactory.Definition({
+                ...Base,
+                supportedFeatures: BitFlags(Base.features, ...features)
+            });
+            ClusterFactory.extend(cluster, HueSaturationComponent, { hueSaturation: true });
+            ClusterFactory.extend(cluster, XyComponent, { xy: true });
+            ClusterFactory.extend(cluster, ColorTemperatureComponent, { colorTemperature: true });
+            ClusterFactory.extend(cluster, EnhancedHueComponent, { enhancedHue: true });
+            ClusterFactory.extend(cluster, ColorLoopComponent, { colorLoop: true });
 
-            extendCluster(
+            ClusterFactory.extend(
                 cluster,
                 HueSaturationOrXyOrColorTemperatureComponent,
                 { hueSaturation: true },
@@ -1615,10 +1609,10 @@ export namespace ColorControl {
 
             return cluster as unknown as Extension<BitFlags<typeof Base.features, T>>;
         }
-    });
+    );
 
     export type Extension<SF extends TypeFromPartialBitSchema<typeof Base.features>> =
-        ClusterForBaseCluster<typeof Base, SF>
+        Omit<typeof Base, "supportedFeatures">
         & { supportedFeatures: SF }
         & (SF extends { hueSaturation: true } ? typeof HueSaturationComponent : {})
         & (SF extends { xy: true } ? typeof XyComponent : {})
@@ -1639,7 +1633,7 @@ export namespace ColorControl {
      * If you use this cluster you must manually specify which features are active and ensure the set of active
      * features is legal per the Matter specification.
      */
-    export const Complete = CreateCluster({
+    export const Complete = ClusterFactory.Definition({
         id: Cluster.id,
         name: Cluster.name,
         revision: Cluster.revision,
@@ -1647,85 +1641,115 @@ export namespace ColorControl {
 
         attributes: {
             ...Cluster.attributes,
-            currentHue: AsConditional(HueSaturationComponent.attributes.currentHue, { mandatoryIf: [HS] }),
-            currentSaturation: AsConditional(
+            currentHue: ClusterFactory.AsConditional(
+                HueSaturationComponent.attributes.currentHue,
+                { mandatoryIf: [HS] }
+            ),
+            currentSaturation: ClusterFactory.AsConditional(
                 HueSaturationComponent.attributes.currentSaturation,
                 { mandatoryIf: [HS] }
             ),
-            currentX: AsConditional(XyComponent.attributes.currentX, { mandatoryIf: [XY] }),
-            currentY: AsConditional(XyComponent.attributes.currentY, { mandatoryIf: [XY] }),
-            colorTemperatureMireds: AsConditional(
+            currentX: ClusterFactory.AsConditional(XyComponent.attributes.currentX, { mandatoryIf: [XY] }),
+            currentY: ClusterFactory.AsConditional(XyComponent.attributes.currentY, { mandatoryIf: [XY] }),
+            colorTemperatureMireds: ClusterFactory.AsConditional(
                 ColorTemperatureComponent.attributes.colorTemperatureMireds,
                 { mandatoryIf: [CT] }
             ),
-            enhancedCurrentHue: AsConditional(
+            enhancedCurrentHue: ClusterFactory.AsConditional(
                 EnhancedHueComponent.attributes.enhancedCurrentHue,
                 { mandatoryIf: [EHUE] }
             ),
-            colorLoopActive: AsConditional(ColorLoopComponent.attributes.colorLoopActive, { mandatoryIf: [CL] }),
-            colorLoopDirection: AsConditional(ColorLoopComponent.attributes.colorLoopDirection, { mandatoryIf: [CL] }),
-            colorLoopTime: AsConditional(ColorLoopComponent.attributes.colorLoopTime, { mandatoryIf: [CL] }),
-            colorLoopStartEnhancedHue: AsConditional(
+            colorLoopActive: ClusterFactory.AsConditional(
+                ColorLoopComponent.attributes.colorLoopActive,
+                { mandatoryIf: [CL] }
+            ),
+            colorLoopDirection: ClusterFactory.AsConditional(
+                ColorLoopComponent.attributes.colorLoopDirection,
+                { mandatoryIf: [CL] }
+            ),
+            colorLoopTime: ClusterFactory.AsConditional(
+                ColorLoopComponent.attributes.colorLoopTime,
+                { mandatoryIf: [CL] }
+            ),
+            colorLoopStartEnhancedHue: ClusterFactory.AsConditional(
                 ColorLoopComponent.attributes.colorLoopStartEnhancedHue,
                 { mandatoryIf: [CL] }
             ),
-            colorLoopStoredEnhancedHue: AsConditional(
+            colorLoopStoredEnhancedHue: ClusterFactory.AsConditional(
                 ColorLoopComponent.attributes.colorLoopStoredEnhancedHue,
                 { mandatoryIf: [CL] }
             ),
-            colorTempPhysicalMinMireds: AsConditional(
+            colorTempPhysicalMinMireds: ClusterFactory.AsConditional(
                 ColorTemperatureComponent.attributes.colorTempPhysicalMinMireds,
                 { mandatoryIf: [CT] }
             ),
-            colorTempPhysicalMaxMireds: AsConditional(
+            colorTempPhysicalMaxMireds: ClusterFactory.AsConditional(
                 ColorTemperatureComponent.attributes.colorTempPhysicalMaxMireds,
                 { mandatoryIf: [CT] }
             ),
-            coupleColorTempToLevelMinMireds: AsConditional(
+            coupleColorTempToLevelMinMireds: ClusterFactory.AsConditional(
                 ColorTemperatureComponent.attributes.coupleColorTempToLevelMinMireds,
                 { optionalIf: [CT] }
             ),
-            startUpColorTemperatureMireds: AsConditional(
+            startUpColorTemperatureMireds: ClusterFactory.AsConditional(
                 ColorTemperatureComponent.attributes.startUpColorTemperatureMireds,
                 { optionalIf: [CT] }
             )
         },
 
         commands: {
-            moveToHue: AsConditional(HueSaturationComponent.commands.moveToHue, { mandatoryIf: [HS] }),
-            moveHue: AsConditional(HueSaturationComponent.commands.moveHue, { mandatoryIf: [HS] }),
-            stepHue: AsConditional(HueSaturationComponent.commands.stepHue, { mandatoryIf: [HS] }),
-            moveToSaturation: AsConditional(HueSaturationComponent.commands.moveToSaturation, { mandatoryIf: [HS] }),
-            moveSaturation: AsConditional(HueSaturationComponent.commands.moveSaturation, { mandatoryIf: [HS] }),
-            stepSaturation: AsConditional(HueSaturationComponent.commands.stepSaturation, { mandatoryIf: [HS] }),
-            moveToHueAndSaturation: AsConditional(
+            moveToHue: ClusterFactory.AsConditional(HueSaturationComponent.commands.moveToHue, { mandatoryIf: [HS] }),
+            moveHue: ClusterFactory.AsConditional(HueSaturationComponent.commands.moveHue, { mandatoryIf: [HS] }),
+            stepHue: ClusterFactory.AsConditional(HueSaturationComponent.commands.stepHue, { mandatoryIf: [HS] }),
+            moveToSaturation: ClusterFactory.AsConditional(
+                HueSaturationComponent.commands.moveToSaturation,
+                { mandatoryIf: [HS] }
+            ),
+            moveSaturation: ClusterFactory.AsConditional(
+                HueSaturationComponent.commands.moveSaturation,
+                { mandatoryIf: [HS] }
+            ),
+            stepSaturation: ClusterFactory.AsConditional(
+                HueSaturationComponent.commands.stepSaturation,
+                { mandatoryIf: [HS] }
+            ),
+            moveToHueAndSaturation: ClusterFactory.AsConditional(
                 HueSaturationComponent.commands.moveToHueAndSaturation,
                 { mandatoryIf: [HS] }
             ),
-            moveToColor: AsConditional(XyComponent.commands.moveToColor, { mandatoryIf: [XY] }),
-            moveColor: AsConditional(XyComponent.commands.moveColor, { mandatoryIf: [XY] }),
-            stepColor: AsConditional(XyComponent.commands.stepColor, { mandatoryIf: [XY] }),
-            moveToColorTemperature: AsConditional(
+            moveToColor: ClusterFactory.AsConditional(XyComponent.commands.moveToColor, { mandatoryIf: [XY] }),
+            moveColor: ClusterFactory.AsConditional(XyComponent.commands.moveColor, { mandatoryIf: [XY] }),
+            stepColor: ClusterFactory.AsConditional(XyComponent.commands.stepColor, { mandatoryIf: [XY] }),
+            moveToColorTemperature: ClusterFactory.AsConditional(
                 ColorTemperatureComponent.commands.moveToColorTemperature,
                 { mandatoryIf: [CT] }
             ),
-            enhancedMoveToHue: AsConditional(EnhancedHueComponent.commands.enhancedMoveToHue, { mandatoryIf: [EHUE] }),
-            enhancedMoveHue: AsConditional(EnhancedHueComponent.commands.enhancedMoveHue, { mandatoryIf: [EHUE] }),
-            enhancedStepHue: AsConditional(EnhancedHueComponent.commands.enhancedStepHue, { mandatoryIf: [EHUE] }),
-            enhancedMoveToHueAndSaturation: AsConditional(
+            enhancedMoveToHue: ClusterFactory.AsConditional(
+                EnhancedHueComponent.commands.enhancedMoveToHue,
+                { mandatoryIf: [EHUE] }
+            ),
+            enhancedMoveHue: ClusterFactory.AsConditional(
+                EnhancedHueComponent.commands.enhancedMoveHue,
+                { mandatoryIf: [EHUE] }
+            ),
+            enhancedStepHue: ClusterFactory.AsConditional(
+                EnhancedHueComponent.commands.enhancedStepHue,
+                { mandatoryIf: [EHUE] }
+            ),
+            enhancedMoveToHueAndSaturation: ClusterFactory.AsConditional(
                 EnhancedHueComponent.commands.enhancedMoveToHueAndSaturation,
                 { mandatoryIf: [EHUE] }
             ),
-            colorLoopSet: AsConditional(ColorLoopComponent.commands.colorLoopSet, { mandatoryIf: [CL] }),
-            stopMoveStep: AsConditional(
+            colorLoopSet: ClusterFactory.AsConditional(ColorLoopComponent.commands.colorLoopSet, { mandatoryIf: [CL] }),
+            stopMoveStep: ClusterFactory.AsConditional(
                 HueSaturationOrXyOrColorTemperatureComponent.commands.stopMoveStep,
                 { mandatoryIf: [HS, XY, CT] }
             ),
-            moveColorTemperature: AsConditional(
+            moveColorTemperature: ClusterFactory.AsConditional(
                 ColorTemperatureComponent.commands.moveColorTemperature,
                 { mandatoryIf: [CT] }
             ),
-            stepColorTemperature: AsConditional(
+            stepColorTemperature: ClusterFactory.AsConditional(
                 ColorTemperatureComponent.commands.stepColorTemperature,
                 { mandatoryIf: [CT] }
             )

--- a/packages/matter.js/src/cluster/definitions/ContentLauncherCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/ContentLauncherCluster.ts
@@ -6,18 +6,10 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
+import { ClusterFactory } from "../../cluster/ClusterFactory.js";
 import { MatterApplicationClusterSpecificationV1_1 } from "../../spec/Specifications.js";
-import {
-    BaseClusterComponent,
-    ClusterComponent,
-    ExtensibleCluster,
-    validateFeatureSelection,
-    extendCluster,
-    ClusterForBaseCluster,
-    AsConditional
-} from "../../cluster/ClusterFactory.js";
 import { BitFlag, BitFlags, TypeFromPartialBitSchema } from "../../schema/BitmapSchema.js";
-import { Attribute, Command, Cluster as CreateCluster } from "../../cluster/Cluster.js";
+import { Attribute, Command } from "../../cluster/Cluster.js";
 import { TlvArray } from "../../tlv/TlvArray.js";
 import { TlvString, TlvByteString } from "../../tlv/TlvString.js";
 import { TlvUInt32, TlvBitmap, TlvDouble, TlvEnum } from "../../tlv/TlvNumber.js";
@@ -461,7 +453,7 @@ export namespace ContentLauncher {
     /**
      * These elements and properties are present in all ContentLauncher clusters.
      */
-    export const Base = BaseClusterComponent({
+    export const Base = ClusterFactory.Definition({
         id: 0x50a,
         name: "ContentLauncher",
         revision: 1,
@@ -486,7 +478,7 @@ export namespace ContentLauncher {
     /**
      * A ContentLauncherCluster supports these elements if it supports feature UrlPlayback.
      */
-    export const UrlPlaybackComponent = ClusterComponent({
+    export const UrlPlaybackComponent = ClusterFactory.Component({
         attributes: {
             /**
              * This list provides list of content types supported by the Video Player or Content App in the form of
@@ -524,7 +516,7 @@ export namespace ContentLauncher {
     /**
      * A ContentLauncherCluster supports these elements if it supports feature ContentSearch.
      */
-    export const ContentSearchComponent = ClusterComponent({
+    export const ContentSearchComponent = ClusterFactory.Component({
         commands: {
             /**
              * Upon receipt, this shall launch the specified content with optional search criteria. This command
@@ -539,7 +531,7 @@ export namespace ContentLauncher {
     /**
      * A ContentLauncherCluster supports these elements if it supports features ContentSearch or UrlPlayback.
      */
-    export const ContentSearchOrUrlPlaybackComponent = ClusterComponent({});
+    export const ContentSearchOrUrlPlaybackComponent = ClusterFactory.Component({});
 
     /**
      * Content Launcher
@@ -552,8 +544,8 @@ export namespace ContentLauncher {
      *
      * @see {@link MatterApplicationClusterSpecificationV1_1} § 6.7
      */
-    export const Cluster = ExtensibleCluster({
-        ...Base,
+    export const Cluster = ClusterFactory.Extensible(
+        Base,
 
         /**
          * Use this factory method to create a ContentLauncher cluster with support for optional features. Include each
@@ -563,18 +555,28 @@ export namespace ContentLauncher {
          * @returns a ContentLauncher cluster with specified features enabled
          * @throws {IllegalClusterError} if the feature combination is disallowed by the Matter specification
          */
-        factory: <T extends `${Feature}`[]>(...features: [...T]) => {
-            validateFeatureSelection(features, Feature);
-            const cluster = CreateCluster({ ...Base, supportedFeatures: BitFlags(Base.features, ...features) });
-            extendCluster(cluster, UrlPlaybackComponent, { urlPlayback: true });
-            extendCluster(cluster, ContentSearchComponent, { contentSearch: true });
-            extendCluster(cluster, ContentSearchOrUrlPlaybackComponent, { contentSearch: true }, { urlPlayback: true });
+        <T extends `${Feature}`[]>(...features: [...T]) => {
+            ClusterFactory.validateFeatureSelection(features, Feature);
+            const cluster = ClusterFactory.Definition({
+                ...Base,
+                supportedFeatures: BitFlags(Base.features, ...features)
+            });
+            ClusterFactory.extend(cluster, UrlPlaybackComponent, { urlPlayback: true });
+            ClusterFactory.extend(cluster, ContentSearchComponent, { contentSearch: true });
+
+            ClusterFactory.extend(
+                cluster,
+                ContentSearchOrUrlPlaybackComponent,
+                { contentSearch: true },
+                { urlPlayback: true }
+            );
+
             return cluster as unknown as Extension<BitFlags<typeof Base.features, T>>;
         }
-    });
+    );
 
     export type Extension<SF extends TypeFromPartialBitSchema<typeof Base.features>> =
-        ClusterForBaseCluster<typeof Base, SF>
+        Omit<typeof Base, "supportedFeatures">
         & { supportedFeatures: SF }
         & (SF extends { urlPlayback: true } ? typeof UrlPlaybackComponent : {})
         & (SF extends { contentSearch: true } ? typeof ContentSearchComponent : {})
@@ -589,23 +591,29 @@ export namespace ContentLauncher {
      * If you use this cluster you must manually specify which features are active and ensure the set of active
      * features is legal per the Matter specification.
      */
-    export const Complete = CreateCluster({
+    export const Complete = ClusterFactory.Definition({
         id: Cluster.id,
         name: Cluster.name,
         revision: Cluster.revision,
         features: Cluster.features,
 
         attributes: {
-            acceptHeader: AsConditional(UrlPlaybackComponent.attributes.acceptHeader, { mandatoryIf: [UP] }),
-            supportedStreamingProtocols: AsConditional(
+            acceptHeader: ClusterFactory.AsConditional(
+                UrlPlaybackComponent.attributes.acceptHeader,
+                { mandatoryIf: [UP] }
+            ),
+            supportedStreamingProtocols: ClusterFactory.AsConditional(
                 UrlPlaybackComponent.attributes.supportedStreamingProtocols,
                 { mandatoryIf: [UP] }
             )
         },
 
         commands: {
-            launchContent: AsConditional(ContentSearchComponent.commands.launchContent, { mandatoryIf: [CS] }),
-            launchUrl: AsConditional(UrlPlaybackComponent.commands.launchUrl, { mandatoryIf: [UP] })
+            launchContent: ClusterFactory.AsConditional(
+                ContentSearchComponent.commands.launchContent,
+                { mandatoryIf: [CS] }
+            ),
+            launchUrl: ClusterFactory.AsConditional(UrlPlaybackComponent.commands.launchUrl, { mandatoryIf: [UP] })
         }
     });
 }

--- a/packages/matter.js/src/cluster/definitions/DescriptorCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/DescriptorCluster.ts
@@ -6,8 +6,9 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import { Cluster as CreateCluster, FixedAttribute, Attribute } from "../../cluster/Cluster.js";
+import { ClusterFactory } from "../../cluster/ClusterFactory.js";
 import { MatterCoreSpecificationV1_1 } from "../../spec/Specifications.js";
+import { FixedAttribute, Attribute } from "../../cluster/Cluster.js";
 import { TlvArray } from "../../tlv/TlvArray.js";
 import { TlvObject, TlvField } from "../../tlv/TlvObject.js";
 import { TlvDeviceTypeId } from "../../datatype/DeviceTypeId.js";
@@ -57,7 +58,7 @@ export namespace Descriptor {
      *
      * @see {@link MatterCoreSpecificationV1_1} § 9.5
      */
-    export const Cluster = CreateCluster({
+    export const Cluster = ClusterFactory.Definition({
         id: 0x1d,
         name: "Descriptor",
         revision: 1,

--- a/packages/matter.js/src/cluster/definitions/DiagnosticLogsCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/DiagnosticLogsCluster.ts
@@ -6,8 +6,9 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import { Cluster as CreateCluster, Command } from "../../cluster/Cluster.js";
+import { ClusterFactory } from "../../cluster/ClusterFactory.js";
 import { MatterCoreSpecificationV1_1 } from "../../spec/Specifications.js";
+import { Command } from "../../cluster/Cluster.js";
 import { TlvObject, TlvField, TlvOptionalField } from "../../tlv/TlvObject.js";
 import { TlvEnum, TlvEpochUs, TlvSysTimeUs } from "../../tlv/TlvNumber.js";
 import { TlvString, TlvByteString } from "../../tlv/TlvString.js";
@@ -243,7 +244,7 @@ export namespace DiagnosticLogs {
      *
      * @see {@link MatterCoreSpecificationV1_1} § 11.10
      */
-    export const Cluster = CreateCluster({
+    export const Cluster = ClusterFactory.Definition({
         id: 0x32,
         name: "DiagnosticLogs",
         revision: 1,

--- a/packages/matter.js/src/cluster/definitions/DoorLockCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/DoorLockCluster.ts
@@ -6,17 +6,8 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
+import { ClusterFactory } from "../../cluster/ClusterFactory.js";
 import { MatterApplicationClusterSpecificationV1_1 } from "../../spec/Specifications.js";
-import {
-    BaseClusterComponent,
-    ClusterComponent,
-    ExtensibleCluster,
-    validateFeatureSelection,
-    extendCluster,
-    preventCluster,
-    ClusterForBaseCluster,
-    AsConditional
-} from "../../cluster/ClusterFactory.js";
 import { BitFlag, BitsFromPartial, BitFlags, TypeFromPartialBitSchema } from "../../schema/BitmapSchema.js";
 import {
     Attribute,
@@ -29,8 +20,7 @@ import {
     TlvNoResponse,
     OptionalCommand,
     Event,
-    EventPriority,
-    Cluster as CreateCluster
+    EventPriority
 } from "../../cluster/Cluster.js";
 import { TlvEnum, TlvUInt8, TlvUInt32, TlvUInt16, TlvBitmap, TlvEpochS } from "../../tlv/TlvNumber.js";
 import { TlvNullable } from "../../tlv/TlvNullable.js";
@@ -1286,7 +1276,7 @@ export namespace DoorLock {
     /**
      * These elements and properties are present in all DoorLock clusters.
      */
-    export const Base = BaseClusterComponent({
+    export const Base = ClusterFactory.Definition({
         id: 0x101,
         name: "DoorLock",
         revision: 6,
@@ -1639,7 +1629,7 @@ export namespace DoorLock {
     /**
      * A DoorLockCluster supports these elements if it supports feature DoorPositionSensor.
      */
-    export const DoorPositionSensorComponent = ClusterComponent({
+    export const DoorPositionSensorComponent = ClusterFactory.Component({
         attributes: {
             /**
              * The current door state as defined in DoorStateEnum.
@@ -1686,7 +1676,7 @@ export namespace DoorLock {
     /**
      * A DoorLockCluster supports these elements if it supports feature Logging.
      */
-    export const LoggingComponent = ClusterComponent({
+    export const LoggingComponent = ClusterFactory.Component({
         attributes: {
             /**
              * The number of available log records.
@@ -1717,7 +1707,7 @@ export namespace DoorLock {
     /**
      * A DoorLockCluster supports these elements if it supports feature User.
      */
-    export const UserComponent = ClusterComponent({
+    export const UserComponent = ClusterFactory.Component({
         attributes: {
             /**
              * Number of total users supported by the lock.
@@ -1842,7 +1832,7 @@ export namespace DoorLock {
     /**
      * A DoorLockCluster supports these elements if it supports feature PinCredential.
      */
-    export const PinCredentialComponent = ClusterComponent({
+    export const PinCredentialComponent = ClusterFactory.Component({
         attributes: {
             /**
              * The number of PIN users supported.
@@ -1890,7 +1880,7 @@ export namespace DoorLock {
     /**
      * A DoorLockCluster supports these elements if it supports feature RfidCredential.
      */
-    export const RfidCredentialComponent = ClusterComponent({
+    export const RfidCredentialComponent = ClusterFactory.Component({
         attributes: {
             /**
              * The number of RFID users supported.
@@ -1922,7 +1912,7 @@ export namespace DoorLock {
     /**
      * A DoorLockCluster supports these elements if it supports feature WeekDayAccessSchedules.
      */
-    export const WeekDayAccessSchedulesComponent = ClusterComponent({
+    export const WeekDayAccessSchedulesComponent = ClusterFactory.Component({
         attributes: {
             /**
              * The number of configurable week day schedule supported per user.
@@ -1971,7 +1961,7 @@ export namespace DoorLock {
     /**
      * A DoorLockCluster supports these elements if it supports feature YearDayAccessSchedules.
      */
-    export const YearDayAccessSchedulesComponent = ClusterComponent({
+    export const YearDayAccessSchedulesComponent = ClusterFactory.Component({
         attributes: {
             /**
              * The number of configurable year day schedule supported per user.
@@ -2020,7 +2010,7 @@ export namespace DoorLock {
     /**
      * A DoorLockCluster supports these elements if it supports feature HolidaySchedules.
      */
-    export const HolidaySchedulesComponent = ClusterComponent({
+    export const HolidaySchedulesComponent = ClusterFactory.Component({
         attributes: {
             /**
              * The number of holiday schedules supported for the entire door lock device.
@@ -2069,7 +2059,7 @@ export namespace DoorLock {
     /**
      * A DoorLockCluster supports these elements if it supports features PinCredential or RfidCredential.
      */
-    export const PinCredentialOrRfidCredentialComponent = ClusterComponent({
+    export const PinCredentialOrRfidCredentialComponent = ClusterFactory.Component({
         attributes: {
             /**
              * The number of incorrect Pin codes or RFID presentment attempts a user is allowed to enter before the
@@ -2110,7 +2100,7 @@ export namespace DoorLock {
     /**
      * A DoorLockCluster supports these elements if it supports features CredentialOverTheAirAccess and PinCredential.
      */
-    export const CredentialOverTheAirAccessAndPinCredentialComponent = ClusterComponent({
+    export const CredentialOverTheAirAccessAndPinCredentialComponent = ClusterFactory.Component({
         attributes: {
             /**
              * Boolean set to True if the door lock server requires that an optional PINs be included in the payload of
@@ -2129,7 +2119,7 @@ export namespace DoorLock {
     /**
      * A DoorLockCluster supports these elements if it supports features Notification and PinCredential.
      */
-    export const NotificationAndPinCredentialComponent = ClusterComponent({
+    export const NotificationAndPinCredentialComponent = ClusterFactory.Component({
         attributes: {
             /**
              * Event mask used to turn on and off the transmission of keypad operation events. This mask DOES NOT apply
@@ -2171,7 +2161,7 @@ export namespace DoorLock {
     /**
      * A DoorLockCluster supports these elements if it supports feature Notification.
      */
-    export const NotificationComponent = ClusterComponent({
+    export const NotificationComponent = ClusterFactory.Component({
         attributes: {
             /**
              * Event mask used to turn on and off the transmission of remote operation events. This mask DOES NOT apply
@@ -2231,7 +2221,7 @@ export namespace DoorLock {
     /**
      * A DoorLockCluster supports these elements if it supports features Notification and RfidCredential.
      */
-    export const NotificationAndRfidCredentialComponent = ClusterComponent({
+    export const NotificationAndRfidCredentialComponent = ClusterFactory.Component({
         attributes: {
             /**
              * Event mask used to turn on and off RFID operation events. This mask DOES NOT apply to the storing of
@@ -2273,7 +2263,7 @@ export namespace DoorLock {
      * A DoorLockCluster supports these elements if it supports feature PinCredential and it doesn't support feature
      * USR.
      */
-    export const PinCredentialNotUserComponent = ClusterComponent({
+    export const PinCredentialNotUserComponent = ClusterFactory.Component({
         commands: {
             /**
              * @see {@link MatterApplicationClusterSpecificationV1_1} § 5.2.4
@@ -2319,7 +2309,7 @@ export namespace DoorLock {
      * A DoorLockCluster supports these elements if it supports features PinCredential, RfidCredential and
      * FingerCredentials and it doesn't support feature USR.
      */
-    export const PinCredentialAndRfidCredentialAndFingerCredentialsNotUserComponent = ClusterComponent({
+    export const PinCredentialAndRfidCredentialAndFingerCredentialsNotUserComponent = ClusterFactory.Component({
         commands: {
             /**
              * @see {@link MatterApplicationClusterSpecificationV1_1} § 5.2.4
@@ -2370,13 +2360,13 @@ export namespace DoorLock {
     /**
      * A DoorLockCluster supports these elements if doesn't support feature USR.
      */
-    export const NotUserComponent = ClusterComponent({});
+    export const NotUserComponent = ClusterFactory.Component({});
 
     /**
      * A DoorLockCluster supports these elements if it supports feature RfidCredential and it doesn't support feature
      * USR.
      */
-    export const RfidCredentialNotUserComponent = ClusterComponent({
+    export const RfidCredentialNotUserComponent = ClusterFactory.Component({
         commands: {
             /**
              * @see {@link MatterApplicationClusterSpecificationV1_1} § 5.2.4
@@ -2427,8 +2417,8 @@ export namespace DoorLock {
      *
      * @see {@link MatterApplicationClusterSpecificationV1_1} § 5.2
      */
-    export const Cluster = ExtensibleCluster({
-        ...Base,
+    export const Cluster = ClusterFactory.Extensible(
+        Base,
 
         /**
          * Use this factory method to create a DoorLock cluster with support for optional features. Include each
@@ -2438,47 +2428,54 @@ export namespace DoorLock {
          * @returns a DoorLock cluster with specified features enabled
          * @throws {IllegalClusterError} if the feature combination is disallowed by the Matter specification
          */
-        factory: <T extends `${Feature}`[]>(...features: [...T]) => {
-            validateFeatureSelection(features, Feature);
-            const cluster = CreateCluster({ ...Base, supportedFeatures: BitFlags(Base.features, ...features) });
-            extendCluster(cluster, DoorPositionSensorComponent, { doorPositionSensor: true });
-            extendCluster(cluster, LoggingComponent, { logging: true });
-            extendCluster(cluster, UserComponent, { user: true });
-            extendCluster(cluster, PinCredentialComponent, { pinCredential: true });
-            extendCluster(cluster, RfidCredentialComponent, { rfidCredential: true });
-            extendCluster(cluster, WeekDayAccessSchedulesComponent, { weekDayAccessSchedules: true });
-            extendCluster(cluster, YearDayAccessSchedulesComponent, { yearDayAccessSchedules: true });
-            extendCluster(cluster, HolidaySchedulesComponent, { holidaySchedules: true });
+        <T extends `${Feature}`[]>(...features: [...T]) => {
+            ClusterFactory.validateFeatureSelection(features, Feature);
+            const cluster = ClusterFactory.Definition({
+                ...Base,
+                supportedFeatures: BitFlags(Base.features, ...features)
+            });
+            ClusterFactory.extend(cluster, DoorPositionSensorComponent, { doorPositionSensor: true });
+            ClusterFactory.extend(cluster, LoggingComponent, { logging: true });
+            ClusterFactory.extend(cluster, UserComponent, { user: true });
+            ClusterFactory.extend(cluster, PinCredentialComponent, { pinCredential: true });
+            ClusterFactory.extend(cluster, RfidCredentialComponent, { rfidCredential: true });
+            ClusterFactory.extend(cluster, WeekDayAccessSchedulesComponent, { weekDayAccessSchedules: true });
+            ClusterFactory.extend(cluster, YearDayAccessSchedulesComponent, { yearDayAccessSchedules: true });
+            ClusterFactory.extend(cluster, HolidaySchedulesComponent, { holidaySchedules: true });
 
-            extendCluster(
+            ClusterFactory.extend(
                 cluster,
                 PinCredentialOrRfidCredentialComponent,
                 { pinCredential: true },
                 { rfidCredential: true }
             );
 
-            extendCluster(
+            ClusterFactory.extend(
                 cluster,
                 CredentialOverTheAirAccessAndPinCredentialComponent,
                 { credentialOverTheAirAccess: true, pinCredential: true }
             );
-            extendCluster(cluster, NotificationAndPinCredentialComponent, { notification: true, pinCredential: true });
-            extendCluster(cluster, NotificationComponent, { notification: true });
-            extendCluster(
+            ClusterFactory.extend(
+                cluster,
+                NotificationAndPinCredentialComponent,
+                { notification: true, pinCredential: true }
+            );
+            ClusterFactory.extend(cluster, NotificationComponent, { notification: true });
+            ClusterFactory.extend(
                 cluster,
                 NotificationAndRfidCredentialComponent,
                 { notification: true, rfidCredential: true }
             );
-            extendCluster(cluster, PinCredentialNotUserComponent, { pinCredential: true, user: false });
-            extendCluster(
+            ClusterFactory.extend(cluster, PinCredentialNotUserComponent, { pinCredential: true, user: false });
+            ClusterFactory.extend(
                 cluster,
                 PinCredentialAndRfidCredentialAndFingerCredentialsNotUserComponent,
                 { pinCredential: true, rfidCredential: true, fingerCredentials: true, user: false }
             );
-            extendCluster(cluster, NotUserComponent, { user: false });
-            extendCluster(cluster, RfidCredentialNotUserComponent, { rfidCredential: true, user: false });
+            ClusterFactory.extend(cluster, NotUserComponent, { user: false });
+            ClusterFactory.extend(cluster, RfidCredentialNotUserComponent, { rfidCredential: true, user: false });
 
-            preventCluster(
+            ClusterFactory.prevent(
                 cluster,
 
                 {
@@ -2492,10 +2489,10 @@ export namespace DoorLock {
 
             return cluster as unknown as Extension<BitFlags<typeof Base.features, T>>;
         }
-    });
+    );
 
     export type Extension<SF extends TypeFromPartialBitSchema<typeof Base.features>> =
-        ClusterForBaseCluster<typeof Base, SF>
+        Omit<typeof Base, "supportedFeatures">
         & { supportedFeatures: SF }
         & (SF extends { doorPositionSensor: true } ? typeof DoorPositionSensorComponent : {})
         & (SF extends { logging: true } ? typeof LoggingComponent : {})
@@ -2538,7 +2535,7 @@ export namespace DoorLock {
      * If you use this cluster you must manually specify which features are active and ensure the set of active
      * features is legal per the Matter specification.
      */
-    export const Complete = CreateCluster({
+    export const Complete = ClusterFactory.Definition({
         id: Cluster.id,
         name: Cluster.name,
         revision: Cluster.revision,
@@ -2546,102 +2543,123 @@ export namespace DoorLock {
 
         attributes: {
             ...Cluster.attributes,
-            doorState: AsConditional(DoorPositionSensorComponent.attributes.doorState, { mandatoryIf: [DPS] }),
-            doorOpenEvents: AsConditional(DoorPositionSensorComponent.attributes.doorOpenEvents, { optionalIf: [DPS] }),
-            doorClosedEvents: AsConditional(
+            doorState: ClusterFactory.AsConditional(
+                DoorPositionSensorComponent.attributes.doorState,
+                { mandatoryIf: [DPS] }
+            ),
+            doorOpenEvents: ClusterFactory.AsConditional(
+                DoorPositionSensorComponent.attributes.doorOpenEvents,
+                { optionalIf: [DPS] }
+            ),
+            doorClosedEvents: ClusterFactory.AsConditional(
                 DoorPositionSensorComponent.attributes.doorClosedEvents,
                 { optionalIf: [DPS] }
             ),
-            openPeriod: AsConditional(DoorPositionSensorComponent.attributes.openPeriod, { optionalIf: [DPS] }),
-            numberOfLogRecordsSupported: AsConditional(
+            openPeriod: ClusterFactory.AsConditional(
+                DoorPositionSensorComponent.attributes.openPeriod,
+                { optionalIf: [DPS] }
+            ),
+            numberOfLogRecordsSupported: ClusterFactory.AsConditional(
                 LoggingComponent.attributes.numberOfLogRecordsSupported,
                 { mandatoryIf: [LOG] }
             ),
-            numberOfTotalUsersSupported: AsConditional(
+            numberOfTotalUsersSupported: ClusterFactory.AsConditional(
                 UserComponent.attributes.numberOfTotalUsersSupported,
                 { mandatoryIf: [USR] }
             ),
-            numberOfPinUsersSupported: AsConditional(
+            numberOfPinUsersSupported: ClusterFactory.AsConditional(
                 PinCredentialComponent.attributes.numberOfPinUsersSupported,
                 { mandatoryIf: [PIN] }
             ),
-            numberOfRfidUsersSupported: AsConditional(
+            numberOfRfidUsersSupported: ClusterFactory.AsConditional(
                 RfidCredentialComponent.attributes.numberOfRfidUsersSupported,
                 { mandatoryIf: [RID] }
             ),
-            numberOfWeekDaySchedulesSupportedPerUser: AsConditional(
+            numberOfWeekDaySchedulesSupportedPerUser: ClusterFactory.AsConditional(
                 WeekDayAccessSchedulesComponent.attributes.numberOfWeekDaySchedulesSupportedPerUser,
                 { mandatoryIf: [WDSCH] }
             ),
-            numberOfYearDaySchedulesSupportedPerUser: AsConditional(
+            numberOfYearDaySchedulesSupportedPerUser: ClusterFactory.AsConditional(
                 YearDayAccessSchedulesComponent.attributes.numberOfYearDaySchedulesSupportedPerUser,
                 { mandatoryIf: [YDSCH] }
             ),
-            numberOfHolidaySchedulesSupported: AsConditional(
+            numberOfHolidaySchedulesSupported: ClusterFactory.AsConditional(
                 HolidaySchedulesComponent.attributes.numberOfHolidaySchedulesSupported,
                 { mandatoryIf: [HDSCH] }
             ),
-            maxPinCodeLength: AsConditional(PinCredentialComponent.attributes.maxPinCodeLength, { mandatoryIf: [PIN] }),
-            minPinCodeLength: AsConditional(PinCredentialComponent.attributes.minPinCodeLength, { mandatoryIf: [PIN] }),
-            maxRfidCodeLength: AsConditional(
+            maxPinCodeLength: ClusterFactory.AsConditional(
+                PinCredentialComponent.attributes.maxPinCodeLength,
+                { mandatoryIf: [PIN] }
+            ),
+            minPinCodeLength: ClusterFactory.AsConditional(
+                PinCredentialComponent.attributes.minPinCodeLength,
+                { mandatoryIf: [PIN] }
+            ),
+            maxRfidCodeLength: ClusterFactory.AsConditional(
                 RfidCredentialComponent.attributes.maxRfidCodeLength,
                 { mandatoryIf: [RID] }
             ),
-            minRfidCodeLength: AsConditional(
+            minRfidCodeLength: ClusterFactory.AsConditional(
                 RfidCredentialComponent.attributes.minRfidCodeLength,
                 { mandatoryIf: [RID] }
             ),
-            credentialRulesSupport: AsConditional(
+            credentialRulesSupport: ClusterFactory.AsConditional(
                 UserComponent.attributes.credentialRulesSupport,
                 { mandatoryIf: [USR] }
             ),
-            numberOfCredentialsSupportedPerUser: AsConditional(
+            numberOfCredentialsSupportedPerUser: ClusterFactory.AsConditional(
                 UserComponent.attributes.numberOfCredentialsSupportedPerUser,
                 { mandatoryIf: [USR] }
             ),
-            enableLogging: AsConditional(LoggingComponent.attributes.enableLogging, { mandatoryIf: [LOG] }),
-            wrongCodeEntryLimit: AsConditional(
+            enableLogging: ClusterFactory.AsConditional(
+                LoggingComponent.attributes.enableLogging,
+                { mandatoryIf: [LOG] }
+            ),
+            wrongCodeEntryLimit: ClusterFactory.AsConditional(
                 PinCredentialOrRfidCredentialComponent.attributes.wrongCodeEntryLimit,
                 { mandatoryIf: [PIN, RID] }
             ),
-            userCodeTemporaryDisableTime: AsConditional(
+            userCodeTemporaryDisableTime: ClusterFactory.AsConditional(
                 PinCredentialOrRfidCredentialComponent.attributes.userCodeTemporaryDisableTime,
                 { mandatoryIf: [PIN, RID] }
             ),
-            sendPinOverTheAir: AsConditional(
+            sendPinOverTheAir: ClusterFactory.AsConditional(
                 PinCredentialComponent.attributes.sendPinOverTheAir,
                 { optionalIf: [PIN] }
             ),
-            requirePinForRemoteOperation: AsConditional(
+            requirePinForRemoteOperation: ClusterFactory.AsConditional(
                 CredentialOverTheAirAccessAndPinCredentialComponent.attributes.requirePinForRemoteOperation,
                 { mandatoryIf: [COTA_PIN] }
             ),
-            expiringUserTimeout: AsConditional(UserComponent.attributes.expiringUserTimeout, { optionalIf: [USR] }),
-            keypadOperationEventMask: AsConditional(
+            expiringUserTimeout: ClusterFactory.AsConditional(
+                UserComponent.attributes.expiringUserTimeout,
+                { optionalIf: [USR] }
+            ),
+            keypadOperationEventMask: ClusterFactory.AsConditional(
                 NotificationAndPinCredentialComponent.attributes.keypadOperationEventMask,
                 { optionalIf: [NOT_PIN] }
             ),
-            remoteOperationEventMask: AsConditional(
+            remoteOperationEventMask: ClusterFactory.AsConditional(
                 NotificationComponent.attributes.remoteOperationEventMask,
                 { optionalIf: [NOT] }
             ),
-            manualOperationEventMask: AsConditional(
+            manualOperationEventMask: ClusterFactory.AsConditional(
                 NotificationComponent.attributes.manualOperationEventMask,
                 { optionalIf: [NOT] }
             ),
-            rfidOperationEventMask: AsConditional(
+            rfidOperationEventMask: ClusterFactory.AsConditional(
                 NotificationAndRfidCredentialComponent.attributes.rfidOperationEventMask,
                 { optionalIf: [NOT_RID] }
             ),
-            keypadProgrammingEventMask: AsConditional(
+            keypadProgrammingEventMask: ClusterFactory.AsConditional(
                 NotificationAndPinCredentialComponent.attributes.keypadProgrammingEventMask,
                 { optionalIf: [NOT_PIN] }
             ),
-            remoteProgrammingEventMask: AsConditional(
+            remoteProgrammingEventMask: ClusterFactory.AsConditional(
                 NotificationComponent.attributes.remoteProgrammingEventMask,
                 { optionalIf: [NOT] }
             ),
-            rfidProgrammingEventMask: AsConditional(
+            rfidProgrammingEventMask: ClusterFactory.AsConditional(
                 NotificationAndRfidCredentialComponent.attributes.rfidProgrammingEventMask,
                 { optionalIf: [NOT_RID] }
             )
@@ -2649,103 +2667,112 @@ export namespace DoorLock {
 
         commands: {
             ...Cluster.commands,
-            getLogRecord: AsConditional(LoggingComponent.commands.getLogRecord, { mandatoryIf: [LOG] }),
-            setPinCode: AsConditional(
+            getLogRecord: ClusterFactory.AsConditional(LoggingComponent.commands.getLogRecord, { mandatoryIf: [LOG] }),
+            setPinCode: ClusterFactory.AsConditional(
                 PinCredentialNotUserComponent.commands.setPinCode,
                 { mandatoryIf: [PIN_NOT_USR] }
             ),
-            getPinCode: AsConditional(
+            getPinCode: ClusterFactory.AsConditional(
                 PinCredentialNotUserComponent.commands.getPinCode,
                 { mandatoryIf: [PIN_NOT_USR] }
             ),
-            clearPinCode: AsConditional(
+            clearPinCode: ClusterFactory.AsConditional(
                 PinCredentialNotUserComponent.commands.clearPinCode,
                 { mandatoryIf: [PIN_NOT_USR] }
             ),
-            clearAllPinCodes: AsConditional(
+            clearAllPinCodes: ClusterFactory.AsConditional(
                 PinCredentialNotUserComponent.commands.clearAllPinCodes,
                 { mandatoryIf: [PIN_NOT_USR] }
             ),
-            setUserStatus: AsConditional(
+            setUserStatus: ClusterFactory.AsConditional(
                 PinCredentialAndRfidCredentialAndFingerCredentialsNotUserComponent.commands.setUserStatus,
                 { optionalIf: [PIN_RID_FGP_NOT_USR] }
             ),
-            getUserStatus: AsConditional(
+            getUserStatus: ClusterFactory.AsConditional(
                 PinCredentialAndRfidCredentialAndFingerCredentialsNotUserComponent.commands.getUserStatus,
                 { optionalIf: [PIN_RID_FGP_NOT_USR] }
             ),
-            setWeekDaySchedule: AsConditional(
+            setWeekDaySchedule: ClusterFactory.AsConditional(
                 WeekDayAccessSchedulesComponent.commands.setWeekDaySchedule,
                 { mandatoryIf: [WDSCH] }
             ),
-            getWeekDaySchedule: AsConditional(
+            getWeekDaySchedule: ClusterFactory.AsConditional(
                 WeekDayAccessSchedulesComponent.commands.getWeekDaySchedule,
                 { mandatoryIf: [WDSCH] }
             ),
-            clearWeekDaySchedule: AsConditional(
+            clearWeekDaySchedule: ClusterFactory.AsConditional(
                 WeekDayAccessSchedulesComponent.commands.clearWeekDaySchedule,
                 { mandatoryIf: [WDSCH] }
             ),
-            setYearDaySchedule: AsConditional(
+            setYearDaySchedule: ClusterFactory.AsConditional(
                 YearDayAccessSchedulesComponent.commands.setYearDaySchedule,
                 { mandatoryIf: [YDSCH] }
             ),
-            getYearDaySchedule: AsConditional(
+            getYearDaySchedule: ClusterFactory.AsConditional(
                 YearDayAccessSchedulesComponent.commands.getYearDaySchedule,
                 { mandatoryIf: [YDSCH] }
             ),
-            clearYearDaySchedule: AsConditional(
+            clearYearDaySchedule: ClusterFactory.AsConditional(
                 YearDayAccessSchedulesComponent.commands.clearYearDaySchedule,
                 { mandatoryIf: [YDSCH] }
             ),
-            setHolidaySchedule: AsConditional(
+            setHolidaySchedule: ClusterFactory.AsConditional(
                 HolidaySchedulesComponent.commands.setHolidaySchedule,
                 { mandatoryIf: [HDSCH] }
             ),
-            getHolidaySchedule: AsConditional(
+            getHolidaySchedule: ClusterFactory.AsConditional(
                 HolidaySchedulesComponent.commands.getHolidaySchedule,
                 { mandatoryIf: [HDSCH] }
             ),
-            clearHolidaySchedule: AsConditional(
+            clearHolidaySchedule: ClusterFactory.AsConditional(
                 HolidaySchedulesComponent.commands.clearHolidaySchedule,
                 { mandatoryIf: [HDSCH] }
             ),
-            setUserType: AsConditional(
+            setUserType: ClusterFactory.AsConditional(
                 PinCredentialAndRfidCredentialAndFingerCredentialsNotUserComponent.commands.setUserType,
                 { optionalIf: [PIN_RID_FGP_NOT_USR] }
             ),
-            getUserType: AsConditional(
+            getUserType: ClusterFactory.AsConditional(
                 PinCredentialAndRfidCredentialAndFingerCredentialsNotUserComponent.commands.getUserType,
                 { optionalIf: [PIN_RID_FGP_NOT_USR] }
             ),
-            setRfidCode: AsConditional(
+            setRfidCode: ClusterFactory.AsConditional(
                 RfidCredentialNotUserComponent.commands.setRfidCode,
                 { mandatoryIf: [RID_NOT_USR] }
             ),
-            getRfidCode: AsConditional(
+            getRfidCode: ClusterFactory.AsConditional(
                 RfidCredentialNotUserComponent.commands.getRfidCode,
                 { mandatoryIf: [RID_NOT_USR] }
             ),
-            clearRfidCode: AsConditional(
+            clearRfidCode: ClusterFactory.AsConditional(
                 RfidCredentialNotUserComponent.commands.clearRfidCode,
                 { mandatoryIf: [RID_NOT_USR] }
             ),
-            clearAllRfidCodes: AsConditional(
+            clearAllRfidCodes: ClusterFactory.AsConditional(
                 RfidCredentialNotUserComponent.commands.clearAllRfidCodes,
                 { mandatoryIf: [RID_NOT_USR] }
             ),
-            setUser: AsConditional(UserComponent.commands.setUser, { mandatoryIf: [USR] }),
-            getUser: AsConditional(UserComponent.commands.getUser, { mandatoryIf: [USR] }),
-            clearUser: AsConditional(UserComponent.commands.clearUser, { mandatoryIf: [USR] }),
-            setCredential: AsConditional(UserComponent.commands.setCredential, { mandatoryIf: [USR] }),
-            getCredentialStatus: AsConditional(UserComponent.commands.getCredentialStatus, { mandatoryIf: [USR] }),
-            clearCredential: AsConditional(UserComponent.commands.clearCredential, { mandatoryIf: [USR] })
+            setUser: ClusterFactory.AsConditional(UserComponent.commands.setUser, { mandatoryIf: [USR] }),
+            getUser: ClusterFactory.AsConditional(UserComponent.commands.getUser, { mandatoryIf: [USR] }),
+            clearUser: ClusterFactory.AsConditional(UserComponent.commands.clearUser, { mandatoryIf: [USR] }),
+            setCredential: ClusterFactory.AsConditional(UserComponent.commands.setCredential, { mandatoryIf: [USR] }),
+            getCredentialStatus: ClusterFactory.AsConditional(
+                UserComponent.commands.getCredentialStatus,
+                { mandatoryIf: [USR] }
+            ),
+            clearCredential: ClusterFactory.AsConditional(
+                UserComponent.commands.clearCredential,
+                { mandatoryIf: [USR] }
+            )
         },
 
         events: {
             ...Cluster.events,
-            doorStateChange: AsConditional(DoorPositionSensorComponent.events.doorStateChange, { mandatoryIf: [DPS] }),
-            lockUserChange: AsConditional(UserComponent.events.lockUserChange, { mandatoryIf: [USR] })
+            doorStateChange: ClusterFactory.AsConditional(
+                DoorPositionSensorComponent.events.doorStateChange,
+                { mandatoryIf: [DPS] }
+            ),
+            lockUserChange: ClusterFactory.AsConditional(UserComponent.events.lockUserChange, { mandatoryIf: [USR] })
         }
     });
 }

--- a/packages/matter.js/src/cluster/definitions/ElectricalMeasurementCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/ElectricalMeasurementCluster.ts
@@ -6,13 +6,8 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import {
-    Cluster as CreateCluster,
-    OptionalAttribute,
-    OptionalWritableAttribute,
-    OptionalCommand,
-    TlvNoResponse
-} from "../../cluster/Cluster.js";
+import { ClusterFactory } from "../../cluster/ClusterFactory.js";
+import { OptionalAttribute, OptionalWritableAttribute, OptionalCommand, TlvNoResponse } from "../../cluster/Cluster.js";
 import { TlvUInt32, TlvInt16, TlvUInt16, TlvInt32, TlvInt8, TlvUInt8 } from "../../tlv/TlvNumber.js";
 import { TlvNoArguments } from "../../tlv/TlvNoArguments.js";
 import { TlvObject, TlvField } from "../../tlv/TlvObject.js";
@@ -34,7 +29,7 @@ export namespace ElectricalMeasurement {
      * devices that need to provide instantaneous data as opposed to metrology data which should be retrieved from the
      * metering cluster..
      */
-    export const Cluster = CreateCluster({
+    export const Cluster = ClusterFactory.Definition({
         id: 0xb04,
         name: "ElectricalMeasurement",
         revision: 1,

--- a/packages/matter.js/src/cluster/definitions/EthernetNetworkDiagnosticsCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/EthernetNetworkDiagnosticsCluster.ts
@@ -6,25 +6,10 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
+import { ClusterFactory } from "../../cluster/ClusterFactory.js";
 import { MatterCoreSpecificationV1_1 } from "../../spec/Specifications.js";
-import {
-    BaseClusterComponent,
-    ClusterComponent,
-    ExtensibleCluster,
-    validateFeatureSelection,
-    extendCluster,
-    ClusterForBaseCluster,
-    AsConditional
-} from "../../cluster/ClusterFactory.js";
 import { BitFlag, BitFlags, TypeFromPartialBitSchema } from "../../schema/BitmapSchema.js";
-import {
-    OptionalAttribute,
-    Attribute,
-    Command,
-    TlvNoResponse,
-    AccessLevel,
-    Cluster as CreateCluster
-} from "../../cluster/Cluster.js";
+import { OptionalAttribute, Attribute, Command, TlvNoResponse, AccessLevel } from "../../cluster/Cluster.js";
 import { TlvEnum, TlvUInt64 } from "../../tlv/TlvNumber.js";
 import { TlvNullable } from "../../tlv/TlvNullable.js";
 import { TlvBoolean } from "../../tlv/TlvBoolean.js";
@@ -111,7 +96,7 @@ export namespace EthernetNetworkDiagnostics {
     /**
      * These elements and properties are present in all EthernetNetworkDiagnostics clusters.
      */
-    export const Base = BaseClusterComponent({
+    export const Base = ClusterFactory.Definition({
         id: 0x37,
         name: "EthernetNetworkDiagnostics",
         revision: 1,
@@ -171,7 +156,7 @@ export namespace EthernetNetworkDiagnostics {
     /**
      * A EthernetNetworkDiagnosticsCluster supports these elements if it supports feature PacketCounts.
      */
-    export const PacketCountsComponent = ClusterComponent({
+    export const PacketCountsComponent = ClusterFactory.Component({
         attributes: {
             /**
              * The PacketRxCount attribute shall indicate the number of packets that have been received on the ethernet
@@ -195,7 +180,7 @@ export namespace EthernetNetworkDiagnostics {
     /**
      * A EthernetNetworkDiagnosticsCluster supports these elements if it supports feature ErrorCounts.
      */
-    export const ErrorCountsComponent = ClusterComponent({
+    export const ErrorCountsComponent = ClusterFactory.Component({
         attributes: {
             /**
              * The TxErrCount attribute shall indicate the number of failed packet transmissions that have occurred on
@@ -228,7 +213,7 @@ export namespace EthernetNetworkDiagnostics {
     /**
      * A EthernetNetworkDiagnosticsCluster supports these elements if it supports features PacketCounts or ErrorCounts.
      */
-    export const PacketCountsOrErrorCountsComponent = ClusterComponent({
+    export const PacketCountsOrErrorCountsComponent = ClusterFactory.Component({
         commands: {
             /**
              * Reception of this command shall reset the following attributes to 0:
@@ -264,8 +249,8 @@ export namespace EthernetNetworkDiagnostics {
      *
      * @see {@link MatterCoreSpecificationV1_1} § 11.15
      */
-    export const Cluster = ExtensibleCluster({
-        ...Base,
+    export const Cluster = ClusterFactory.Extensible(
+        Base,
 
         /**
          * Use this factory method to create an EthernetNetworkDiagnostics cluster with support for optional features.
@@ -275,18 +260,28 @@ export namespace EthernetNetworkDiagnostics {
          * @returns an EthernetNetworkDiagnostics cluster with specified features enabled
          * @throws {IllegalClusterError} if the feature combination is disallowed by the Matter specification
          */
-        factory: <T extends `${Feature}`[]>(...features: [...T]) => {
-            validateFeatureSelection(features, Feature);
-            const cluster = CreateCluster({ ...Base, supportedFeatures: BitFlags(Base.features, ...features) });
-            extendCluster(cluster, PacketCountsComponent, { packetCounts: true });
-            extendCluster(cluster, ErrorCountsComponent, { errorCounts: true });
-            extendCluster(cluster, PacketCountsOrErrorCountsComponent, { packetCounts: true }, { errorCounts: true });
+        <T extends `${Feature}`[]>(...features: [...T]) => {
+            ClusterFactory.validateFeatureSelection(features, Feature);
+            const cluster = ClusterFactory.Definition({
+                ...Base,
+                supportedFeatures: BitFlags(Base.features, ...features)
+            });
+            ClusterFactory.extend(cluster, PacketCountsComponent, { packetCounts: true });
+            ClusterFactory.extend(cluster, ErrorCountsComponent, { errorCounts: true });
+
+            ClusterFactory.extend(
+                cluster,
+                PacketCountsOrErrorCountsComponent,
+                { packetCounts: true },
+                { errorCounts: true }
+            );
+
             return cluster as unknown as Extension<BitFlags<typeof Base.features, T>>;
         }
-    });
+    );
 
     export type Extension<SF extends TypeFromPartialBitSchema<typeof Base.features>> =
-        ClusterForBaseCluster<typeof Base, SF>
+        Omit<typeof Base, "supportedFeatures">
         & { supportedFeatures: SF }
         & (SF extends { packetCounts: true } ? typeof PacketCountsComponent : {})
         & (SF extends { errorCounts: true } ? typeof ErrorCountsComponent : {})
@@ -301,7 +296,7 @@ export namespace EthernetNetworkDiagnostics {
      * If you use this cluster you must manually specify which features are active and ensure the set of active
      * features is legal per the Matter specification.
      */
-    export const Complete = CreateCluster({
+    export const Complete = ClusterFactory.Definition({
         id: Cluster.id,
         name: Cluster.name,
         revision: Cluster.revision,
@@ -309,15 +304,30 @@ export namespace EthernetNetworkDiagnostics {
 
         attributes: {
             ...Cluster.attributes,
-            packetRxCount: AsConditional(PacketCountsComponent.attributes.packetRxCount, { mandatoryIf: [PKTCNT] }),
-            packetTxCount: AsConditional(PacketCountsComponent.attributes.packetTxCount, { mandatoryIf: [PKTCNT] }),
-            txErrCount: AsConditional(ErrorCountsComponent.attributes.txErrCount, { mandatoryIf: [ERRCNT] }),
-            collisionCount: AsConditional(ErrorCountsComponent.attributes.collisionCount, { mandatoryIf: [ERRCNT] }),
-            overrunCount: AsConditional(ErrorCountsComponent.attributes.overrunCount, { mandatoryIf: [ERRCNT] })
+            packetRxCount: ClusterFactory.AsConditional(
+                PacketCountsComponent.attributes.packetRxCount,
+                { mandatoryIf: [PKTCNT] }
+            ),
+            packetTxCount: ClusterFactory.AsConditional(
+                PacketCountsComponent.attributes.packetTxCount,
+                { mandatoryIf: [PKTCNT] }
+            ),
+            txErrCount: ClusterFactory.AsConditional(
+                ErrorCountsComponent.attributes.txErrCount,
+                { mandatoryIf: [ERRCNT] }
+            ),
+            collisionCount: ClusterFactory.AsConditional(
+                ErrorCountsComponent.attributes.collisionCount,
+                { mandatoryIf: [ERRCNT] }
+            ),
+            overrunCount: ClusterFactory.AsConditional(
+                ErrorCountsComponent.attributes.overrunCount,
+                { mandatoryIf: [ERRCNT] }
+            )
         },
 
         commands: {
-            resetCounts: AsConditional(
+            resetCounts: ClusterFactory.AsConditional(
                 PacketCountsOrErrorCountsComponent.commands.resetCounts,
                 { mandatoryIf: [PKTCNT, ERRCNT] }
             )

--- a/packages/matter.js/src/cluster/definitions/FanControlCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/FanControlCluster.ts
@@ -6,18 +6,10 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
+import { ClusterFactory } from "../../cluster/ClusterFactory.js";
 import { MatterApplicationClusterSpecificationV1_1 } from "../../spec/Specifications.js";
-import {
-    BaseClusterComponent,
-    ClusterComponent,
-    ExtensibleCluster,
-    validateFeatureSelection,
-    extendCluster,
-    ClusterForBaseCluster,
-    AsConditional
-} from "../../cluster/ClusterFactory.js";
 import { BitFlag, BitFlags, TypeFromPartialBitSchema } from "../../schema/BitmapSchema.js";
-import { WritableAttribute, Attribute, FixedAttribute, Cluster as CreateCluster } from "../../cluster/Cluster.js";
+import { WritableAttribute, Attribute, FixedAttribute } from "../../cluster/Cluster.js";
 import { TlvEnum, TlvUInt8, TlvBitmap } from "../../tlv/TlvNumber.js";
 import { TlvNullable } from "../../tlv/TlvNullable.js";
 
@@ -174,7 +166,7 @@ export namespace FanControl {
     /**
      * These elements and properties are present in all FanControl clusters.
      */
-    export const Base = BaseClusterComponent({
+    export const Base = ClusterFactory.Definition({
         id: 0x202,
         name: "FanControl",
         revision: 2,
@@ -252,7 +244,7 @@ export namespace FanControl {
     /**
      * A FanControlCluster supports these elements if it supports feature MultiSpeed.
      */
-    export const MultiSpeedComponent = ClusterComponent({
+    export const MultiSpeedComponent = ClusterFactory.Component({
         attributes: {
             /**
              * This attribute shall indicate that the fan has one speed (value of 1) or the maximum speed, if the fan
@@ -285,7 +277,7 @@ export namespace FanControl {
     /**
      * A FanControlCluster supports these elements if it supports feature Rocking.
      */
-    export const RockingComponent = ClusterComponent({
+    export const RockingComponent = ClusterFactory.Component({
         attributes: {
             /**
              * This attribute is a bitmap that indicates what rocking motions the server supports. The bitmap is shown
@@ -318,7 +310,7 @@ export namespace FanControl {
     /**
      * A FanControlCluster supports these elements if it supports feature Wind.
      */
-    export const WindComponent = ClusterComponent({
+    export const WindComponent = ClusterFactory.Component({
         attributes: {
             /**
              * This attribute is a bitmap that indicates what wind modes the server supports. At least one wind mode
@@ -358,8 +350,8 @@ export namespace FanControl {
      *
      * @see {@link MatterApplicationClusterSpecificationV1_1} § 4.4
      */
-    export const Cluster = ExtensibleCluster({
-        ...Base,
+    export const Cluster = ClusterFactory.Extensible(
+        Base,
 
         /**
          * Use this factory method to create a FanControl cluster with support for optional features. Include each
@@ -369,18 +361,21 @@ export namespace FanControl {
          * @returns a FanControl cluster with specified features enabled
          * @throws {IllegalClusterError} if the feature combination is disallowed by the Matter specification
          */
-        factory: <T extends `${Feature}`[]>(...features: [...T]) => {
-            validateFeatureSelection(features, Feature);
-            const cluster = CreateCluster({ ...Base, supportedFeatures: BitFlags(Base.features, ...features) });
-            extendCluster(cluster, MultiSpeedComponent, { multiSpeed: true });
-            extendCluster(cluster, RockingComponent, { rocking: true });
-            extendCluster(cluster, WindComponent, { wind: true });
+        <T extends `${Feature}`[]>(...features: [...T]) => {
+            ClusterFactory.validateFeatureSelection(features, Feature);
+            const cluster = ClusterFactory.Definition({
+                ...Base,
+                supportedFeatures: BitFlags(Base.features, ...features)
+            });
+            ClusterFactory.extend(cluster, MultiSpeedComponent, { multiSpeed: true });
+            ClusterFactory.extend(cluster, RockingComponent, { rocking: true });
+            ClusterFactory.extend(cluster, WindComponent, { wind: true });
             return cluster as unknown as Extension<BitFlags<typeof Base.features, T>>;
         }
-    });
+    );
 
     export type Extension<SF extends TypeFromPartialBitSchema<typeof Base.features>> =
-        ClusterForBaseCluster<typeof Base, SF>
+        Omit<typeof Base, "supportedFeatures">
         & { supportedFeatures: SF }
         & (SF extends { multiSpeed: true } ? typeof MultiSpeedComponent : {})
         & (SF extends { rocking: true } ? typeof RockingComponent : {})
@@ -396,7 +391,7 @@ export namespace FanControl {
      * If you use this cluster you must manually specify which features are active and ensure the set of active
      * features is legal per the Matter specification.
      */
-    export const Complete = CreateCluster({
+    export const Complete = ClusterFactory.Definition({
         id: Cluster.id,
         name: Cluster.name,
         revision: Cluster.revision,
@@ -404,13 +399,19 @@ export namespace FanControl {
 
         attributes: {
             ...Cluster.attributes,
-            speedMax: AsConditional(MultiSpeedComponent.attributes.speedMax, { mandatoryIf: [SPD] }),
-            speedSetting: AsConditional(MultiSpeedComponent.attributes.speedSetting, { mandatoryIf: [SPD] }),
-            speedCurrent: AsConditional(MultiSpeedComponent.attributes.speedCurrent, { mandatoryIf: [SPD] }),
-            rockSupport: AsConditional(RockingComponent.attributes.rockSupport, { mandatoryIf: [RCK] }),
-            rockSetting: AsConditional(RockingComponent.attributes.rockSetting, { mandatoryIf: [RCK] }),
-            windSupport: AsConditional(WindComponent.attributes.windSupport, { mandatoryIf: [WND] }),
-            windSetting: AsConditional(WindComponent.attributes.windSetting, { mandatoryIf: [WND] })
+            speedMax: ClusterFactory.AsConditional(MultiSpeedComponent.attributes.speedMax, { mandatoryIf: [SPD] }),
+            speedSetting: ClusterFactory.AsConditional(
+                MultiSpeedComponent.attributes.speedSetting,
+                { mandatoryIf: [SPD] }
+            ),
+            speedCurrent: ClusterFactory.AsConditional(
+                MultiSpeedComponent.attributes.speedCurrent,
+                { mandatoryIf: [SPD] }
+            ),
+            rockSupport: ClusterFactory.AsConditional(RockingComponent.attributes.rockSupport, { mandatoryIf: [RCK] }),
+            rockSetting: ClusterFactory.AsConditional(RockingComponent.attributes.rockSetting, { mandatoryIf: [RCK] }),
+            windSupport: ClusterFactory.AsConditional(WindComponent.attributes.windSupport, { mandatoryIf: [WND] }),
+            windSetting: ClusterFactory.AsConditional(WindComponent.attributes.windSetting, { mandatoryIf: [WND] })
         }
     });
 }

--- a/packages/matter.js/src/cluster/definitions/FaultInjectionCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/FaultInjectionCluster.ts
@@ -6,7 +6,8 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import { Cluster as CreateCluster, Command, TlvNoResponse, AccessLevel } from "../../cluster/Cluster.js";
+import { ClusterFactory } from "../../cluster/ClusterFactory.js";
+import { Command, TlvNoResponse, AccessLevel } from "../../cluster/Cluster.js";
 import { TlvObject, TlvField } from "../../tlv/TlvObject.js";
 import { TlvEnum, TlvUInt32, TlvUInt8 } from "../../tlv/TlvNumber.js";
 import { TlvBoolean } from "../../tlv/TlvBoolean.js";
@@ -46,7 +47,7 @@ export namespace FaultInjection {
      * The Fault Injection Cluster provide a means for a test harness to configure faults(for example triggering a
      * fault in the system).
      */
-    export const Cluster = CreateCluster({
+    export const Cluster = ClusterFactory.Definition({
         id: 0xfff1fc06,
         name: "FaultInjection",
         revision: 1,

--- a/packages/matter.js/src/cluster/definitions/FixedLabelCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/FixedLabelCluster.ts
@@ -6,8 +6,9 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import { Cluster as CreateCluster, Attribute } from "../../cluster/Cluster.js";
+import { ClusterFactory } from "../../cluster/ClusterFactory.js";
 import { MatterCoreSpecificationV1_1 } from "../../spec/Specifications.js";
+import { Attribute } from "../../cluster/Cluster.js";
 import { TlvArray } from "../../tlv/TlvArray.js";
 import { Label } from "../../cluster/definitions/LabelCluster.js";
 
@@ -27,7 +28,7 @@ export namespace FixedLabel {
      *
      * @see {@link MatterCoreSpecificationV1_1} § 9.8
      */
-    export const Cluster = CreateCluster({
+    export const Cluster = ClusterFactory.Definition({
         id: 0x40,
         name: "FixedLabel",
         revision: 1,

--- a/packages/matter.js/src/cluster/definitions/FlowMeasurementCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/FlowMeasurementCluster.ts
@@ -6,8 +6,9 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import { Cluster as CreateCluster, Attribute, OptionalAttribute } from "../../cluster/Cluster.js";
+import { ClusterFactory } from "../../cluster/ClusterFactory.js";
 import { MatterApplicationClusterSpecificationV1_1 } from "../../spec/Specifications.js";
+import { Attribute, OptionalAttribute } from "../../cluster/Cluster.js";
 import { TlvUInt16 } from "../../tlv/TlvNumber.js";
 import { TlvNullable } from "../../tlv/TlvNullable.js";
 
@@ -20,7 +21,7 @@ export namespace FlowMeasurement {
      *
      * @see {@link MatterApplicationClusterSpecificationV1_1} § 2.5
      */
-    export const Cluster = CreateCluster({
+    export const Cluster = ClusterFactory.Definition({
         id: 0x404,
         name: "FlowMeasurement",
         revision: 3,

--- a/packages/matter.js/src/cluster/definitions/GeneralCommissioningCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/GeneralCommissioningCluster.ts
@@ -6,15 +6,9 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import {
-    Cluster as CreateCluster,
-    WritableAttribute,
-    AccessLevel,
-    FixedAttribute,
-    Attribute,
-    Command
-} from "../../cluster/Cluster.js";
+import { ClusterFactory } from "../../cluster/ClusterFactory.js";
 import { MatterCoreSpecificationV1_1 } from "../../spec/Specifications.js";
+import { WritableAttribute, AccessLevel, FixedAttribute, Attribute, Command } from "../../cluster/Cluster.js";
 import { TlvUInt64, TlvUInt16, TlvEnum } from "../../tlv/TlvNumber.js";
 import { TlvObject, TlvField } from "../../tlv/TlvObject.js";
 import { TlvBoolean } from "../../tlv/TlvBoolean.js";
@@ -187,7 +181,7 @@ export namespace GeneralCommissioning {
      *
      * @see {@link MatterCoreSpecificationV1_1} § 11.9
      */
-    export const Cluster = CreateCluster({
+    export const Cluster = ClusterFactory.Definition({
         id: 0x30,
         name: "GeneralCommissioning",
         revision: 1,

--- a/packages/matter.js/src/cluster/definitions/GeneralDiagnosticsCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/GeneralDiagnosticsCluster.ts
@@ -6,8 +6,9 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
+import { ClusterFactory } from "../../cluster/ClusterFactory.js";
+import { MatterCoreSpecificationV1_1 } from "../../spec/Specifications.js";
 import {
-    Cluster as CreateCluster,
     Attribute,
     OptionalAttribute,
     Command,
@@ -17,7 +18,6 @@ import {
     EventPriority,
     Event
 } from "../../cluster/Cluster.js";
-import { MatterCoreSpecificationV1_1 } from "../../spec/Specifications.js";
 import { TlvArray } from "../../tlv/TlvArray.js";
 import { TlvObject, TlvField } from "../../tlv/TlvObject.js";
 import { TlvString, TlvByteString } from "../../tlv/TlvString.js";
@@ -416,7 +416,7 @@ export namespace GeneralDiagnostics {
      *
      * @see {@link MatterCoreSpecificationV1_1} § 11.11
      */
-    export const Cluster = CreateCluster({
+    export const Cluster = ClusterFactory.Definition({
         id: 0x33,
         name: "GeneralDiagnostics",
         revision: 1,

--- a/packages/matter.js/src/cluster/definitions/GroupKeyManagementCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/GroupKeyManagementCluster.ts
@@ -6,13 +6,8 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
+import { ClusterFactory } from "../../cluster/ClusterFactory.js";
 import { MatterCoreSpecificationV1_1 } from "../../spec/Specifications.js";
-import {
-    BaseClusterComponent,
-    ExtensibleCluster,
-    validateFeatureSelection,
-    ClusterForBaseCluster
-} from "../../cluster/ClusterFactory.js";
 import { BitFlag, BitFlags, TypeFromPartialBitSchema } from "../../schema/BitmapSchema.js";
 import {
     WritableFabricScopedAttribute,
@@ -20,8 +15,7 @@ import {
     FabricScopedAttribute,
     FixedAttribute,
     Command,
-    TlvNoResponse,
-    Cluster as CreateCluster
+    TlvNoResponse
 } from "../../cluster/Cluster.js";
 import { TlvArray } from "../../tlv/TlvArray.js";
 import { TlvObject, TlvField, TlvOptionalField } from "../../tlv/TlvObject.js";
@@ -269,7 +263,7 @@ export namespace GroupKeyManagement {
     /**
      * These elements and properties are present in all GroupKeyManagement clusters.
      */
-    export const Base = BaseClusterComponent({
+    export const Base = ClusterFactory.Definition({
         id: 0x3f,
         name: "GroupKeyManagement",
         revision: 1,
@@ -461,8 +455,8 @@ export namespace GroupKeyManagement {
      *
      * @see {@link MatterCoreSpecificationV1_1} § 11.2
      */
-    export const Cluster = ExtensibleCluster({
-        ...Base,
+    export const Cluster = ClusterFactory.Extensible(
+        Base,
 
         /**
          * Use this factory method to create a GroupKeyManagement cluster with support for optional features. Include
@@ -472,15 +466,18 @@ export namespace GroupKeyManagement {
          * @returns a GroupKeyManagement cluster with specified features enabled
          * @throws {IllegalClusterError} if the feature combination is disallowed by the Matter specification
          */
-        factory: <T extends `${Feature}`[]>(...features: [...T]) => {
-            validateFeatureSelection(features, Feature);
-            const cluster = CreateCluster({ ...Base, supportedFeatures: BitFlags(Base.features, ...features) });
+        <T extends `${Feature}`[]>(...features: [...T]) => {
+            ClusterFactory.validateFeatureSelection(features, Feature);
+            const cluster = ClusterFactory.Definition({
+                ...Base,
+                supportedFeatures: BitFlags(Base.features, ...features)
+            });
             return cluster as unknown as Extension<BitFlags<typeof Base.features, T>>;
         }
-    });
+    );
 
     export type Extension<SF extends TypeFromPartialBitSchema<typeof Base.features>> =
-        ClusterForBaseCluster<typeof Base, SF>
+        Omit<typeof Base, "supportedFeatures">
         & { supportedFeatures: SF };
 }
 

--- a/packages/matter.js/src/cluster/definitions/GroupsCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/GroupsCluster.ts
@@ -6,21 +6,10 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
+import { ClusterFactory } from "../../cluster/ClusterFactory.js";
 import { MatterApplicationClusterSpecificationV1_1 } from "../../spec/Specifications.js";
-import {
-    BaseClusterComponent,
-    ExtensibleCluster,
-    validateFeatureSelection,
-    ClusterForBaseCluster
-} from "../../cluster/ClusterFactory.js";
 import { BitFlag, BitFlags, TypeFromPartialBitSchema } from "../../schema/BitmapSchema.js";
-import {
-    FixedAttribute,
-    Command,
-    AccessLevel,
-    TlvNoResponse,
-    Cluster as CreateCluster
-} from "../../cluster/Cluster.js";
+import { FixedAttribute, Command, AccessLevel, TlvNoResponse } from "../../cluster/Cluster.js";
 import { TlvUInt8, TlvBitmap, TlvEnum } from "../../tlv/TlvNumber.js";
 import { TlvObject, TlvField } from "../../tlv/TlvObject.js";
 import { TlvGroupId } from "../../datatype/GroupId.js";
@@ -166,7 +155,7 @@ export namespace Groups {
     /**
      * These elements and properties are present in all Groups clusters.
      */
-    export const Base = BaseClusterComponent({
+    export const Base = ClusterFactory.Definition({
         id: 0x4,
         name: "Groups",
         revision: 4,
@@ -283,9 +272,8 @@ export namespace Groups {
      *
      * @see {@link MatterApplicationClusterSpecificationV1_1} § 1.3
      */
-    export const Cluster = ExtensibleCluster({
-        ...Base,
-        supportedFeatures: { groupNames: true },
+    export const Cluster = ClusterFactory.Extensible(
+        { ...Base, supportedFeatures: { groupNames: true } },
 
         /**
          * Use this factory method to create a Groups cluster with support for optional features. Include each
@@ -295,15 +283,18 @@ export namespace Groups {
          * @returns a Groups cluster with specified features enabled
          * @throws {IllegalClusterError} if the feature combination is disallowed by the Matter specification
          */
-        factory: <T extends `${Feature}`[]>(...features: [...T]) => {
-            validateFeatureSelection(features, Feature);
-            const cluster = CreateCluster({ ...Base, supportedFeatures: BitFlags(Base.features, ...features) });
+        <T extends `${Feature}`[]>(...features: [...T]) => {
+            ClusterFactory.validateFeatureSelection(features, Feature);
+            const cluster = ClusterFactory.Definition({
+                ...Base,
+                supportedFeatures: BitFlags(Base.features, ...features)
+            });
             return cluster as unknown as Extension<BitFlags<typeof Base.features, T>>;
         }
-    });
+    );
 
     export type Extension<SF extends TypeFromPartialBitSchema<typeof Base.features>> =
-        ClusterForBaseCluster<typeof Base, SF>
+        Omit<typeof Base, "supportedFeatures">
         & { supportedFeatures: SF };
 }
 

--- a/packages/matter.js/src/cluster/definitions/IlluminanceMeasurementCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/IlluminanceMeasurementCluster.ts
@@ -6,8 +6,9 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import { Cluster as CreateCluster, Attribute, OptionalAttribute } from "../../cluster/Cluster.js";
+import { ClusterFactory } from "../../cluster/ClusterFactory.js";
 import { MatterApplicationClusterSpecificationV1_1 } from "../../spec/Specifications.js";
+import { Attribute, OptionalAttribute } from "../../cluster/Cluster.js";
 import { TlvUInt16, TlvUInt8 } from "../../tlv/TlvNumber.js";
 import { TlvNullable } from "../../tlv/TlvNullable.js";
 
@@ -19,7 +20,7 @@ export namespace IlluminanceMeasurement {
      *
      * @see {@link MatterApplicationClusterSpecificationV1_1} § 2.2
      */
-    export const Cluster = CreateCluster({
+    export const Cluster = ClusterFactory.Definition({
         id: 0x400,
         name: "IlluminanceMeasurement",
         revision: 3,

--- a/packages/matter.js/src/cluster/definitions/KeypadInputCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/KeypadInputCluster.ts
@@ -6,15 +6,10 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
+import { ClusterFactory } from "../../cluster/ClusterFactory.js";
 import { MatterApplicationClusterSpecificationV1_1 } from "../../spec/Specifications.js";
-import {
-    BaseClusterComponent,
-    ExtensibleCluster,
-    validateFeatureSelection,
-    ClusterForBaseCluster
-} from "../../cluster/ClusterFactory.js";
 import { BitFlag, BitFlags, TypeFromPartialBitSchema } from "../../schema/BitmapSchema.js";
-import { Command, Cluster as CreateCluster } from "../../cluster/Cluster.js";
+import { Command } from "../../cluster/Cluster.js";
 import { TlvObject, TlvField } from "../../tlv/TlvObject.js";
 import { TlvEnum } from "../../tlv/TlvNumber.js";
 
@@ -187,7 +182,7 @@ export namespace KeypadInput {
     /**
      * These elements and properties are present in all KeypadInput clusters.
      */
-    export const Base = BaseClusterComponent({
+    export const Base = ClusterFactory.Definition({
         id: 0x509,
         name: "KeypadInput",
         revision: 1,
@@ -240,8 +235,8 @@ export namespace KeypadInput {
      *
      * @see {@link MatterApplicationClusterSpecificationV1_1} § 6.8
      */
-    export const Cluster = ExtensibleCluster({
-        ...Base,
+    export const Cluster = ClusterFactory.Extensible(
+        Base,
 
         /**
          * Use this factory method to create a KeypadInput cluster with support for optional features. Include each
@@ -251,15 +246,18 @@ export namespace KeypadInput {
          * @returns a KeypadInput cluster with specified features enabled
          * @throws {IllegalClusterError} if the feature combination is disallowed by the Matter specification
          */
-        factory: <T extends `${Feature}`[]>(...features: [...T]) => {
-            validateFeatureSelection(features, Feature);
-            const cluster = CreateCluster({ ...Base, supportedFeatures: BitFlags(Base.features, ...features) });
+        <T extends `${Feature}`[]>(...features: [...T]) => {
+            ClusterFactory.validateFeatureSelection(features, Feature);
+            const cluster = ClusterFactory.Definition({
+                ...Base,
+                supportedFeatures: BitFlags(Base.features, ...features)
+            });
             return cluster as unknown as Extension<BitFlags<typeof Base.features, T>>;
         }
-    });
+    );
 
     export type Extension<SF extends TypeFromPartialBitSchema<typeof Base.features>> =
-        ClusterForBaseCluster<typeof Base, SF>
+        Omit<typeof Base, "supportedFeatures">
         & { supportedFeatures: SF };
 }
 

--- a/packages/matter.js/src/cluster/definitions/LabelCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/LabelCluster.ts
@@ -6,7 +6,7 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import { ClusterComponent } from "../../cluster/ClusterFactory.js";
+import { ClusterFactory } from "../../cluster/ClusterFactory.js";
 import { Attribute } from "../../cluster/Cluster.js";
 import { TlvArray } from "../../tlv/TlvArray.js";
 import { TlvObject, TlvField } from "../../tlv/TlvObject.js";
@@ -41,7 +41,7 @@ export namespace Label {
      * Label is a derived cluster, not to be used directly. These elements are present in all clusters derived from
      * Label.
      */
-    export const Base = ClusterComponent({
+    export const Base = ClusterFactory.Component({
         attributes: {
             /**
              * This is a list of string tuples. Each entry is a LabelStruct.

--- a/packages/matter.js/src/cluster/definitions/LeafWetnessMeasurementCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/LeafWetnessMeasurementCluster.ts
@@ -6,8 +6,9 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import { Cluster as CreateCluster, Attribute, OptionalAttribute } from "../../cluster/Cluster.js";
+import { ClusterFactory } from "../../cluster/ClusterFactory.js";
 import { MatterApplicationClusterSpecificationV1_1 } from "../../spec/Specifications.js";
+import { Attribute, OptionalAttribute } from "../../cluster/Cluster.js";
 import { TlvUInt16 } from "../../tlv/TlvNumber.js";
 import { TlvNullable } from "../../tlv/TlvNullable.js";
 
@@ -19,7 +20,7 @@ export namespace LeafWetnessMeasurement {
      *
      * @see {@link MatterApplicationClusterSpecificationV1_1} § 2.6
      */
-    export const Cluster = CreateCluster({
+    export const Cluster = ClusterFactory.Definition({
         id: 0x407,
         name: "LeafWetnessMeasurement",
         revision: 3,

--- a/packages/matter.js/src/cluster/definitions/LevelControlCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/LevelControlCluster.ts
@@ -6,16 +6,8 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
+import { ClusterFactory } from "../../cluster/ClusterFactory.js";
 import { MatterApplicationClusterSpecificationV1_1 } from "../../spec/Specifications.js";
-import {
-    BaseClusterComponent,
-    ClusterComponent,
-    ExtensibleCluster,
-    validateFeatureSelection,
-    extendCluster,
-    ClusterForBaseCluster,
-    AsConditional
-} from "../../cluster/ClusterFactory.js";
 import { BitFlag, BitFlags, TypeFromPartialBitSchema } from "../../schema/BitmapSchema.js";
 import {
     Attribute,
@@ -24,8 +16,7 @@ import {
     OptionalWritableAttribute,
     Command,
     TlvNoResponse,
-    AccessLevel,
-    Cluster as CreateCluster
+    AccessLevel
 } from "../../cluster/Cluster.js";
 import { TlvUInt8, TlvBitmap, TlvUInt16, TlvEnum } from "../../tlv/TlvNumber.js";
 import { TlvNullable } from "../../tlv/TlvNullable.js";
@@ -199,7 +190,7 @@ export namespace LevelControl {
     /**
      * These elements and properties are present in all LevelControl clusters.
      */
-    export const Base = BaseClusterComponent({
+    export const Base = ClusterFactory.Definition({
         id: 0x8,
         name: "LevelControl",
         revision: 5,
@@ -378,7 +369,7 @@ export namespace LevelControl {
     /**
      * A LevelControlCluster supports these elements if it supports feature Lighting.
      */
-    export const LightingComponent = ClusterComponent({
+    export const LightingComponent = ClusterFactory.Component({
         attributes: {
             /**
              * The RemainingTime attribute represents the time remaining until the current command is complete - it is
@@ -411,7 +402,7 @@ export namespace LevelControl {
     /**
      * A LevelControlCluster supports these elements if it supports feature Frequency.
      */
-    export const FrequencyComponent = ClusterComponent({
+    export const FrequencyComponent = ClusterFactory.Component({
         attributes: {
             /**
              * The CurrentFrequency attribute represents the frequency at which the device is at CurrentLevel. A
@@ -457,9 +448,8 @@ export namespace LevelControl {
      *
      * @see {@link MatterApplicationClusterSpecificationV1_1} § 1.6
      */
-    export const Cluster = ExtensibleCluster({
-        ...Base,
-        supportedFeatures: { onOff: true },
+    export const Cluster = ClusterFactory.Extensible(
+        { ...Base, supportedFeatures: { onOff: true } },
 
         /**
          * Use this factory method to create a LevelControl cluster with support for optional features. Include each
@@ -469,17 +459,20 @@ export namespace LevelControl {
          * @returns a LevelControl cluster with specified features enabled
          * @throws {IllegalClusterError} if the feature combination is disallowed by the Matter specification
          */
-        factory: <T extends `${Feature}`[]>(...features: [...T]) => {
-            validateFeatureSelection(features, Feature);
-            const cluster = CreateCluster({ ...Base, supportedFeatures: BitFlags(Base.features, ...features) });
-            extendCluster(cluster, LightingComponent, { lighting: true });
-            extendCluster(cluster, FrequencyComponent, { frequency: true });
+        <T extends `${Feature}`[]>(...features: [...T]) => {
+            ClusterFactory.validateFeatureSelection(features, Feature);
+            const cluster = ClusterFactory.Definition({
+                ...Base,
+                supportedFeatures: BitFlags(Base.features, ...features)
+            });
+            ClusterFactory.extend(cluster, LightingComponent, { lighting: true });
+            ClusterFactory.extend(cluster, FrequencyComponent, { frequency: true });
             return cluster as unknown as Extension<BitFlags<typeof Base.features, T>>;
         }
-    });
+    );
 
     export type Extension<SF extends TypeFromPartialBitSchema<typeof Base.features>> =
-        ClusterForBaseCluster<typeof Base, SF>
+        Omit<typeof Base, "supportedFeatures">
         & { supportedFeatures: SF }
         & (SF extends { lighting: true } ? typeof LightingComponent : {})
         & (SF extends { frequency: true } ? typeof FrequencyComponent : {});
@@ -492,7 +485,7 @@ export namespace LevelControl {
      * If you use this cluster you must manually specify which features are active and ensure the set of active
      * features is legal per the Matter specification.
      */
-    export const Complete = CreateCluster({
+    export const Complete = ClusterFactory.Definition({
         id: Cluster.id,
         name: Cluster.name,
         revision: Cluster.revision,
@@ -500,16 +493,31 @@ export namespace LevelControl {
 
         attributes: {
             ...Cluster.attributes,
-            remainingTime: AsConditional(LightingComponent.attributes.remainingTime, { mandatoryIf: [LT] }),
-            currentFrequency: AsConditional(FrequencyComponent.attributes.currentFrequency, { mandatoryIf: [FQ] }),
-            minFrequency: AsConditional(FrequencyComponent.attributes.minFrequency, { mandatoryIf: [FQ] }),
-            maxFrequency: AsConditional(FrequencyComponent.attributes.maxFrequency, { mandatoryIf: [FQ] }),
-            startUpCurrentLevel: AsConditional(LightingComponent.attributes.startUpCurrentLevel, { mandatoryIf: [LT] })
+            remainingTime: ClusterFactory.AsConditional(
+                LightingComponent.attributes.remainingTime,
+                { mandatoryIf: [LT] }
+            ),
+            currentFrequency: ClusterFactory.AsConditional(
+                FrequencyComponent.attributes.currentFrequency,
+                { mandatoryIf: [FQ] }
+            ),
+            minFrequency: ClusterFactory.AsConditional(
+                FrequencyComponent.attributes.minFrequency,
+                { mandatoryIf: [FQ] }
+            ),
+            maxFrequency: ClusterFactory.AsConditional(
+                FrequencyComponent.attributes.maxFrequency,
+                { mandatoryIf: [FQ] }
+            ),
+            startUpCurrentLevel: ClusterFactory.AsConditional(
+                LightingComponent.attributes.startUpCurrentLevel,
+                { mandatoryIf: [LT] }
+            )
         },
 
         commands: {
             ...Cluster.commands,
-            moveToClosestFrequency: AsConditional(
+            moveToClosestFrequency: ClusterFactory.AsConditional(
                 FrequencyComponent.commands.moveToClosestFrequency,
                 { mandatoryIf: [FQ] }
             )

--- a/packages/matter.js/src/cluster/definitions/LocalizationConfigurationCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/LocalizationConfigurationCluster.ts
@@ -6,8 +6,9 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import { Cluster as CreateCluster, WritableAttribute, AccessLevel, FixedAttribute } from "../../cluster/Cluster.js";
+import { ClusterFactory } from "../../cluster/ClusterFactory.js";
 import { MatterCoreSpecificationV1_1 } from "../../spec/Specifications.js";
+import { WritableAttribute, AccessLevel, FixedAttribute } from "../../cluster/Cluster.js";
 import { TlvString } from "../../tlv/TlvString.js";
 import { TlvArray } from "../../tlv/TlvArray.js";
 
@@ -25,7 +26,7 @@ export namespace LocalizationConfiguration {
      *
      * @see {@link MatterCoreSpecificationV1_1} § 11.3
      */
-    export const Cluster = CreateCluster({
+    export const Cluster = ClusterFactory.Definition({
         id: 0x2b,
         name: "LocalizationConfiguration",
         revision: 1,

--- a/packages/matter.js/src/cluster/definitions/LowPowerCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/LowPowerCluster.ts
@@ -6,8 +6,9 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import { Cluster as CreateCluster, Command, TlvNoResponse } from "../../cluster/Cluster.js";
+import { ClusterFactory } from "../../cluster/ClusterFactory.js";
 import { MatterApplicationClusterSpecificationV1_1 } from "../../spec/Specifications.js";
+import { Command, TlvNoResponse } from "../../cluster/Cluster.js";
 import { TlvNoArguments } from "../../tlv/TlvNoArguments.js";
 
 export namespace LowPower {
@@ -18,7 +19,7 @@ export namespace LowPower {
      *
      * @see {@link MatterApplicationClusterSpecificationV1_1} § 1.9
      */
-    export const Cluster = CreateCluster({
+    export const Cluster = ClusterFactory.Definition({
         id: 0x508,
         name: "LowPower",
         revision: 1,

--- a/packages/matter.js/src/cluster/definitions/MediaInputCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/MediaInputCluster.ts
@@ -6,18 +6,10 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
+import { ClusterFactory } from "../../cluster/ClusterFactory.js";
 import { MatterApplicationClusterSpecificationV1_1 } from "../../spec/Specifications.js";
-import {
-    BaseClusterComponent,
-    ClusterComponent,
-    ExtensibleCluster,
-    validateFeatureSelection,
-    extendCluster,
-    ClusterForBaseCluster,
-    AsConditional
-} from "../../cluster/ClusterFactory.js";
 import { BitFlag, BitFlags, TypeFromPartialBitSchema } from "../../schema/BitmapSchema.js";
-import { Attribute, Command, TlvNoResponse, AccessLevel, Cluster as CreateCluster } from "../../cluster/Cluster.js";
+import { Attribute, Command, TlvNoResponse, AccessLevel } from "../../cluster/Cluster.js";
 import { TlvArray } from "../../tlv/TlvArray.js";
 import { TlvObject, TlvField } from "../../tlv/TlvObject.js";
 import { TlvUInt8, TlvEnum } from "../../tlv/TlvNumber.js";
@@ -125,7 +117,7 @@ export namespace MediaInput {
     /**
      * These elements and properties are present in all MediaInput clusters.
      */
-    export const Base = BaseClusterComponent({
+    export const Base = ClusterFactory.Definition({
         id: 0x507,
         name: "MediaInput",
         revision: 1,
@@ -183,7 +175,7 @@ export namespace MediaInput {
     /**
      * A MediaInputCluster supports these elements if it supports feature NameUpdates.
      */
-    export const NameUpdatesComponent = ClusterComponent({
+    export const NameUpdatesComponent = ClusterFactory.Component({
         commands: {
             /**
              * Upon receipt, this shall rename the input at a specific index in the Input List. Updates to the input
@@ -205,8 +197,8 @@ export namespace MediaInput {
      *
      * @see {@link MatterApplicationClusterSpecificationV1_1} § 6.9
      */
-    export const Cluster = ExtensibleCluster({
-        ...Base,
+    export const Cluster = ClusterFactory.Extensible(
+        Base,
 
         /**
          * Use this factory method to create a MediaInput cluster with support for optional features. Include each
@@ -216,16 +208,19 @@ export namespace MediaInput {
          * @returns a MediaInput cluster with specified features enabled
          * @throws {IllegalClusterError} if the feature combination is disallowed by the Matter specification
          */
-        factory: <T extends `${Feature}`[]>(...features: [...T]) => {
-            validateFeatureSelection(features, Feature);
-            const cluster = CreateCluster({ ...Base, supportedFeatures: BitFlags(Base.features, ...features) });
-            extendCluster(cluster, NameUpdatesComponent, { nameUpdates: true });
+        <T extends `${Feature}`[]>(...features: [...T]) => {
+            ClusterFactory.validateFeatureSelection(features, Feature);
+            const cluster = ClusterFactory.Definition({
+                ...Base,
+                supportedFeatures: BitFlags(Base.features, ...features)
+            });
+            ClusterFactory.extend(cluster, NameUpdatesComponent, { nameUpdates: true });
             return cluster as unknown as Extension<BitFlags<typeof Base.features, T>>;
         }
-    });
+    );
 
     export type Extension<SF extends TypeFromPartialBitSchema<typeof Base.features>> =
-        ClusterForBaseCluster<typeof Base, SF>
+        Omit<typeof Base, "supportedFeatures">
         & { supportedFeatures: SF }
         & (SF extends { nameUpdates: true } ? typeof NameUpdatesComponent : {});
     const NU = { nameUpdates: true };
@@ -236,7 +231,7 @@ export namespace MediaInput {
      * If you use this cluster you must manually specify which features are active and ensure the set of active
      * features is legal per the Matter specification.
      */
-    export const Complete = CreateCluster({
+    export const Complete = ClusterFactory.Definition({
         id: Cluster.id,
         name: Cluster.name,
         revision: Cluster.revision,
@@ -244,7 +239,7 @@ export namespace MediaInput {
         attributes: Cluster.attributes,
         commands: {
             ...Cluster.commands,
-            renameInput: AsConditional(NameUpdatesComponent.commands.renameInput, { mandatoryIf: [NU] })
+            renameInput: ClusterFactory.AsConditional(NameUpdatesComponent.commands.renameInput, { mandatoryIf: [NU] })
         }
     });
 }

--- a/packages/matter.js/src/cluster/definitions/MediaPlaybackCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/MediaPlaybackCluster.ts
@@ -6,18 +6,10 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
+import { ClusterFactory } from "../../cluster/ClusterFactory.js";
 import { MatterApplicationClusterSpecificationV1_1 } from "../../spec/Specifications.js";
-import {
-    BaseClusterComponent,
-    ClusterComponent,
-    ExtensibleCluster,
-    validateFeatureSelection,
-    extendCluster,
-    ClusterForBaseCluster,
-    AsConditional
-} from "../../cluster/ClusterFactory.js";
 import { BitFlag, BitFlags, TypeFromPartialBitSchema } from "../../schema/BitmapSchema.js";
-import { Attribute, Command, OptionalCommand, Cluster as CreateCluster } from "../../cluster/Cluster.js";
+import { Attribute, Command, OptionalCommand } from "../../cluster/Cluster.js";
 import { TlvEnum, TlvUInt64, TlvEpochUs, TlvFloat } from "../../tlv/TlvNumber.js";
 import { TlvNoArguments } from "../../tlv/TlvNoArguments.js";
 import { TlvObject, TlvField, TlvOptionalField } from "../../tlv/TlvObject.js";
@@ -218,7 +210,7 @@ export namespace MediaPlayback {
     /**
      * These elements and properties are present in all MediaPlayback clusters.
      */
-    export const Base = BaseClusterComponent({
+    export const Base = ClusterFactory.Definition({
         id: 0x506,
         name: "MediaPlayback",
         revision: 1,
@@ -317,7 +309,7 @@ export namespace MediaPlayback {
     /**
      * A MediaPlaybackCluster supports these elements if it supports feature AdvancedSeek.
      */
-    export const AdvancedSeekComponent = ClusterComponent({
+    export const AdvancedSeekComponent = ClusterFactory.Component({
         attributes: {
             /**
              * This shall indicate the start time of the media, in case the media has a fixed start time (for example,
@@ -432,7 +424,7 @@ export namespace MediaPlayback {
     /**
      * A MediaPlaybackCluster supports these elements if it supports feature VariableSpeed.
      */
-    export const VariableSpeedComponent = ClusterComponent({
+    export const VariableSpeedComponent = ClusterFactory.Component({
         commands: {
             /**
              * Upon receipt, this shall start playback of the media backward in case the media is currently playing in
@@ -483,8 +475,8 @@ export namespace MediaPlayback {
      *
      * @see {@link MatterApplicationClusterSpecificationV1_1} § 6.10
      */
-    export const Cluster = ExtensibleCluster({
-        ...Base,
+    export const Cluster = ClusterFactory.Extensible(
+        Base,
 
         /**
          * Use this factory method to create a MediaPlayback cluster with support for optional features. Include each
@@ -494,17 +486,20 @@ export namespace MediaPlayback {
          * @returns a MediaPlayback cluster with specified features enabled
          * @throws {IllegalClusterError} if the feature combination is disallowed by the Matter specification
          */
-        factory: <T extends `${Feature}`[]>(...features: [...T]) => {
-            validateFeatureSelection(features, Feature);
-            const cluster = CreateCluster({ ...Base, supportedFeatures: BitFlags(Base.features, ...features) });
-            extendCluster(cluster, AdvancedSeekComponent, { advancedSeek: true });
-            extendCluster(cluster, VariableSpeedComponent, { variableSpeed: true });
+        <T extends `${Feature}`[]>(...features: [...T]) => {
+            ClusterFactory.validateFeatureSelection(features, Feature);
+            const cluster = ClusterFactory.Definition({
+                ...Base,
+                supportedFeatures: BitFlags(Base.features, ...features)
+            });
+            ClusterFactory.extend(cluster, AdvancedSeekComponent, { advancedSeek: true });
+            ClusterFactory.extend(cluster, VariableSpeedComponent, { variableSpeed: true });
             return cluster as unknown as Extension<BitFlags<typeof Base.features, T>>;
         }
-    });
+    );
 
     export type Extension<SF extends TypeFromPartialBitSchema<typeof Base.features>> =
-        ClusterForBaseCluster<typeof Base, SF>
+        Omit<typeof Base, "supportedFeatures">
         & { supportedFeatures: SF }
         & (SF extends { advancedSeek: true } ? typeof AdvancedSeekComponent : {})
         & (SF extends { variableSpeed: true } ? typeof VariableSpeedComponent : {});
@@ -517,7 +512,7 @@ export namespace MediaPlayback {
      * If you use this cluster you must manually specify which features are active and ensure the set of active
      * features is legal per the Matter specification.
      */
-    export const Complete = CreateCluster({
+    export const Complete = ClusterFactory.Definition({
         id: Cluster.id,
         name: Cluster.name,
         revision: Cluster.revision,
@@ -525,19 +520,34 @@ export namespace MediaPlayback {
 
         attributes: {
             ...Cluster.attributes,
-            startTime: AsConditional(AdvancedSeekComponent.attributes.startTime, { mandatoryIf: [AS] }),
-            duration: AsConditional(AdvancedSeekComponent.attributes.duration, { mandatoryIf: [AS] }),
-            sampledPosition: AsConditional(AdvancedSeekComponent.attributes.sampledPosition, { mandatoryIf: [AS] }),
-            playbackSpeed: AsConditional(AdvancedSeekComponent.attributes.playbackSpeed, { mandatoryIf: [AS] }),
-            seekRangeEnd: AsConditional(AdvancedSeekComponent.attributes.seekRangeEnd, { mandatoryIf: [AS] }),
-            seekRangeStart: AsConditional(AdvancedSeekComponent.attributes.seekRangeStart, { mandatoryIf: [AS] })
+            startTime: ClusterFactory.AsConditional(AdvancedSeekComponent.attributes.startTime, { mandatoryIf: [AS] }),
+            duration: ClusterFactory.AsConditional(AdvancedSeekComponent.attributes.duration, { mandatoryIf: [AS] }),
+            sampledPosition: ClusterFactory.AsConditional(
+                AdvancedSeekComponent.attributes.sampledPosition,
+                { mandatoryIf: [AS] }
+            ),
+            playbackSpeed: ClusterFactory.AsConditional(
+                AdvancedSeekComponent.attributes.playbackSpeed,
+                { mandatoryIf: [AS] }
+            ),
+            seekRangeEnd: ClusterFactory.AsConditional(
+                AdvancedSeekComponent.attributes.seekRangeEnd,
+                { mandatoryIf: [AS] }
+            ),
+            seekRangeStart: ClusterFactory.AsConditional(
+                AdvancedSeekComponent.attributes.seekRangeStart,
+                { mandatoryIf: [AS] }
+            )
         },
 
         commands: {
             ...Cluster.commands,
-            rewind: AsConditional(VariableSpeedComponent.commands.rewind, { mandatoryIf: [VS] }),
-            fastForward: AsConditional(VariableSpeedComponent.commands.fastForward, { mandatoryIf: [VS] }),
-            seek: AsConditional(AdvancedSeekComponent.commands.seek, { mandatoryIf: [AS] })
+            rewind: ClusterFactory.AsConditional(VariableSpeedComponent.commands.rewind, { mandatoryIf: [VS] }),
+            fastForward: ClusterFactory.AsConditional(
+                VariableSpeedComponent.commands.fastForward,
+                { mandatoryIf: [VS] }
+            ),
+            seek: ClusterFactory.AsConditional(AdvancedSeekComponent.commands.seek, { mandatoryIf: [AS] })
         }
     });
 }

--- a/packages/matter.js/src/cluster/definitions/NetworkCommissioningCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/NetworkCommissioningCluster.ts
@@ -6,26 +6,10 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
+import { ClusterFactory } from "../../cluster/ClusterFactory.js";
 import { MatterCoreSpecificationV1_1 } from "../../spec/Specifications.js";
-import {
-    BaseClusterComponent,
-    ClusterComponent,
-    ExtensibleCluster,
-    validateFeatureSelection,
-    extendCluster,
-    preventCluster,
-    ClusterForBaseCluster,
-    AsConditional
-} from "../../cluster/ClusterFactory.js";
 import { BitFlag, BitFlags, TypeFromPartialBitSchema } from "../../schema/BitmapSchema.js";
-import {
-    FixedAttribute,
-    AccessLevel,
-    Attribute,
-    WritableAttribute,
-    Command,
-    Cluster as CreateCluster
-} from "../../cluster/Cluster.js";
+import { FixedAttribute, AccessLevel, Attribute, WritableAttribute, Command } from "../../cluster/Cluster.js";
 import { TlvUInt8, TlvEnum, TlvInt32, TlvUInt64, TlvBitmap, TlvUInt16, TlvInt8 } from "../../tlv/TlvNumber.js";
 import { TlvArray } from "../../tlv/TlvArray.js";
 import { TlvObject, TlvField, TlvOptionalField } from "../../tlv/TlvObject.js";
@@ -606,7 +590,7 @@ export namespace NetworkCommissioning {
     /**
      * These elements and properties are present in all NetworkCommissioning clusters.
      */
-    export const Base = BaseClusterComponent({
+    export const Base = ClusterFactory.Definition({
         id: 0x31,
         name: "NetworkCommissioning",
         revision: 1,
@@ -763,7 +747,7 @@ export namespace NetworkCommissioning {
      * A NetworkCommissioningCluster supports these elements if it supports features WiFiNetworkInterface or
      * ThreadNetworkInterface.
      */
-    export const WiFiNetworkInterfaceOrThreadNetworkInterfaceComponent = ClusterComponent({
+    export const WiFiNetworkInterfaceOrThreadNetworkInterfaceComponent = ClusterFactory.Component({
         attributes: {
             /**
              * This attribute shall indicate the maximum duration taken, in seconds, by the network interface on this
@@ -1010,7 +994,7 @@ export namespace NetworkCommissioning {
     /**
      * A NetworkCommissioningCluster supports these elements if it supports feature WiFiNetworkInterface.
      */
-    export const WiFiNetworkInterfaceComponent = ClusterComponent({
+    export const WiFiNetworkInterfaceComponent = ClusterFactory.Component({
         commands: {
             /**
              * This command shall be used to add or modify Wi-Fi network configurations.
@@ -1042,7 +1026,7 @@ export namespace NetworkCommissioning {
     /**
      * A NetworkCommissioningCluster supports these elements if it supports feature ThreadNetworkInterface.
      */
-    export const ThreadNetworkInterfaceComponent = ClusterComponent({
+    export const ThreadNetworkInterfaceComponent = ClusterFactory.Component({
         commands: {
             /**
              * This command shall be used to add or modify Thread network configurations.
@@ -1094,8 +1078,8 @@ export namespace NetworkCommissioning {
      *
      * @see {@link MatterCoreSpecificationV1_1} § 11.8
      */
-    export const Cluster = ExtensibleCluster({
-        ...Base,
+    export const Cluster = ClusterFactory.Extensible(
+        Base,
 
         /**
          * Use this factory method to create a NetworkCommissioning cluster with support for optional features. Include
@@ -1105,21 +1089,24 @@ export namespace NetworkCommissioning {
          * @returns a NetworkCommissioning cluster with specified features enabled
          * @throws {IllegalClusterError} if the feature combination is disallowed by the Matter specification
          */
-        factory: <T extends `${Feature}`[]>(...features: [...T]) => {
-            validateFeatureSelection(features, Feature);
-            const cluster = CreateCluster({ ...Base, supportedFeatures: BitFlags(Base.features, ...features) });
+        <T extends `${Feature}`[]>(...features: [...T]) => {
+            ClusterFactory.validateFeatureSelection(features, Feature);
+            const cluster = ClusterFactory.Definition({
+                ...Base,
+                supportedFeatures: BitFlags(Base.features, ...features)
+            });
 
-            extendCluster(
+            ClusterFactory.extend(
                 cluster,
                 WiFiNetworkInterfaceOrThreadNetworkInterfaceComponent,
                 { wiFiNetworkInterface: true },
                 { threadNetworkInterface: true }
             );
 
-            extendCluster(cluster, WiFiNetworkInterfaceComponent, { wiFiNetworkInterface: true });
-            extendCluster(cluster, ThreadNetworkInterfaceComponent, { threadNetworkInterface: true });
+            ClusterFactory.extend(cluster, WiFiNetworkInterfaceComponent, { wiFiNetworkInterface: true });
+            ClusterFactory.extend(cluster, ThreadNetworkInterfaceComponent, { threadNetworkInterface: true });
 
-            preventCluster(
+            ClusterFactory.prevent(
                 cluster,
                 { wiFiNetworkInterface: true, threadNetworkInterface: true },
                 { wiFiNetworkInterface: true, ethernetNetworkInterface: true },
@@ -1129,10 +1116,10 @@ export namespace NetworkCommissioning {
 
             return cluster as unknown as Extension<BitFlags<typeof Base.features, T>>;
         }
-    });
+    );
 
     export type Extension<SF extends TypeFromPartialBitSchema<typeof Base.features>> =
-        ClusterForBaseCluster<typeof Base, SF>
+        Omit<typeof Base, "supportedFeatures">
         & { supportedFeatures: SF }
         & (SF extends { wiFiNetworkInterface: true } | { threadNetworkInterface: true } ? typeof WiFiNetworkInterfaceOrThreadNetworkInterfaceComponent : {})
         & (SF extends { wiFiNetworkInterface: true } ? typeof WiFiNetworkInterfaceComponent : {})
@@ -1151,7 +1138,7 @@ export namespace NetworkCommissioning {
      * If you use this cluster you must manually specify which features are active and ensure the set of active
      * features is legal per the Matter specification.
      */
-    export const Complete = CreateCluster({
+    export const Complete = ClusterFactory.Definition({
         id: Cluster.id,
         name: Cluster.name,
         revision: Cluster.revision,
@@ -1159,38 +1146,38 @@ export namespace NetworkCommissioning {
 
         attributes: {
             ...Cluster.attributes,
-            scanMaxTimeSeconds: AsConditional(
+            scanMaxTimeSeconds: ClusterFactory.AsConditional(
                 WiFiNetworkInterfaceOrThreadNetworkInterfaceComponent.attributes.scanMaxTimeSeconds,
                 { mandatoryIf: [WI, TH] }
             ),
-            connectMaxTimeSeconds: AsConditional(
+            connectMaxTimeSeconds: ClusterFactory.AsConditional(
                 WiFiNetworkInterfaceOrThreadNetworkInterfaceComponent.attributes.connectMaxTimeSeconds,
                 { mandatoryIf: [WI, TH] }
             )
         },
 
         commands: {
-            scanNetworks: AsConditional(
+            scanNetworks: ClusterFactory.AsConditional(
                 WiFiNetworkInterfaceOrThreadNetworkInterfaceComponent.commands.scanNetworks,
                 { mandatoryIf: [WI, TH] }
             ),
-            addOrUpdateWiFiNetwork: AsConditional(
+            addOrUpdateWiFiNetwork: ClusterFactory.AsConditional(
                 WiFiNetworkInterfaceComponent.commands.addOrUpdateWiFiNetwork,
                 { mandatoryIf: [WI] }
             ),
-            addOrUpdateThreadNetwork: AsConditional(
+            addOrUpdateThreadNetwork: ClusterFactory.AsConditional(
                 ThreadNetworkInterfaceComponent.commands.addOrUpdateThreadNetwork,
                 { mandatoryIf: [TH] }
             ),
-            removeNetwork: AsConditional(
+            removeNetwork: ClusterFactory.AsConditional(
                 WiFiNetworkInterfaceOrThreadNetworkInterfaceComponent.commands.removeNetwork,
                 { mandatoryIf: [WI, TH] }
             ),
-            connectNetwork: AsConditional(
+            connectNetwork: ClusterFactory.AsConditional(
                 WiFiNetworkInterfaceOrThreadNetworkInterfaceComponent.commands.connectNetwork,
                 { mandatoryIf: [WI, TH] }
             ),
-            reorderNetwork: AsConditional(
+            reorderNetwork: ClusterFactory.AsConditional(
                 WiFiNetworkInterfaceOrThreadNetworkInterfaceComponent.commands.reorderNetwork,
                 { mandatoryIf: [WI, TH] }
             )

--- a/packages/matter.js/src/cluster/definitions/OccupancySensingCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/OccupancySensingCluster.ts
@@ -6,8 +6,9 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import { Cluster as CreateCluster, Attribute, OptionalWritableAttribute, AccessLevel } from "../../cluster/Cluster.js";
+import { ClusterFactory } from "../../cluster/ClusterFactory.js";
 import { MatterApplicationClusterSpecificationV1_1 } from "../../spec/Specifications.js";
+import { Attribute, OptionalWritableAttribute, AccessLevel } from "../../cluster/Cluster.js";
 import { BitFlag } from "../../schema/BitmapSchema.js";
 import { TlvUInt8, TlvBitmap, TlvEnum, TlvUInt16 } from "../../tlv/TlvNumber.js";
 import { TlvNullable } from "../../tlv/TlvNullable.js";
@@ -77,7 +78,7 @@ export namespace OccupancySensing {
      *
      * @see {@link MatterApplicationClusterSpecificationV1_1} § 2.7
      */
-    export const Cluster = CreateCluster({
+    export const Cluster = ClusterFactory.Definition({
         id: 0x406,
         name: "OccupancySensing",
         revision: 3,

--- a/packages/matter.js/src/cluster/definitions/OnOffCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/OnOffCluster.ts
@@ -6,25 +6,10 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
+import { ClusterFactory } from "../../cluster/ClusterFactory.js";
 import { MatterApplicationClusterSpecificationV1_1 } from "../../spec/Specifications.js";
-import {
-    BaseClusterComponent,
-    ClusterComponent,
-    ExtensibleCluster,
-    validateFeatureSelection,
-    extendCluster,
-    ClusterForBaseCluster,
-    AsConditional
-} from "../../cluster/ClusterFactory.js";
 import { BitFlag, BitField, BitFlags, TypeFromPartialBitSchema } from "../../schema/BitmapSchema.js";
-import {
-    Attribute,
-    Command,
-    TlvNoResponse,
-    WritableAttribute,
-    AccessLevel,
-    Cluster as CreateCluster
-} from "../../cluster/Cluster.js";
+import { Attribute, Command, TlvNoResponse, WritableAttribute, AccessLevel } from "../../cluster/Cluster.js";
 import { TlvBoolean } from "../../tlv/TlvBoolean.js";
 import { TlvNoArguments } from "../../tlv/TlvNoArguments.js";
 import { TlvUInt16, TlvEnum, TlvUInt8, TlvBitmap } from "../../tlv/TlvNumber.js";
@@ -142,7 +127,7 @@ export namespace OnOff {
     /**
      * These elements and properties are present in all OnOff clusters.
      */
-    export const Base = BaseClusterComponent({
+    export const Base = ClusterFactory.Definition({
         id: 0x6,
         name: "OnOff",
         revision: 4,
@@ -193,7 +178,7 @@ export namespace OnOff {
     /**
      * A OnOffCluster supports these elements if it supports feature LevelControlForLighting.
      */
-    export const LevelControlForLightingComponent = ClusterComponent({
+    export const LevelControlForLightingComponent = ClusterFactory.Component({
         attributes: {
             /**
              * In order to support the use case where the user gets back the last setting of a set of devices (e.g.
@@ -295,8 +280,8 @@ export namespace OnOff {
      *
      * @see {@link MatterApplicationClusterSpecificationV1_1} § 1.5
      */
-    export const Cluster = ExtensibleCluster({
-        ...Base,
+    export const Cluster = ClusterFactory.Extensible(
+        Base,
 
         /**
          * Use this factory method to create an OnOff cluster with support for optional features. Include each
@@ -306,16 +291,19 @@ export namespace OnOff {
          * @returns an OnOff cluster with specified features enabled
          * @throws {IllegalClusterError} if the feature combination is disallowed by the Matter specification
          */
-        factory: <T extends `${Feature}`[]>(...features: [...T]) => {
-            validateFeatureSelection(features, Feature);
-            const cluster = CreateCluster({ ...Base, supportedFeatures: BitFlags(Base.features, ...features) });
-            extendCluster(cluster, LevelControlForLightingComponent, { levelControlForLighting: true });
+        <T extends `${Feature}`[]>(...features: [...T]) => {
+            ClusterFactory.validateFeatureSelection(features, Feature);
+            const cluster = ClusterFactory.Definition({
+                ...Base,
+                supportedFeatures: BitFlags(Base.features, ...features)
+            });
+            ClusterFactory.extend(cluster, LevelControlForLightingComponent, { levelControlForLighting: true });
             return cluster as unknown as Extension<BitFlags<typeof Base.features, T>>;
         }
-    });
+    );
 
     export type Extension<SF extends TypeFromPartialBitSchema<typeof Base.features>> =
-        ClusterForBaseCluster<typeof Base, SF>
+        Omit<typeof Base, "supportedFeatures">
         & { supportedFeatures: SF }
         & (SF extends { levelControlForLighting: true } ? typeof LevelControlForLightingComponent : {});
     const LT = { levelControlForLighting: true };
@@ -326,7 +314,7 @@ export namespace OnOff {
      * If you use this cluster you must manually specify which features are active and ensure the set of active
      * features is legal per the Matter specification.
      */
-    export const Complete = CreateCluster({
+    export const Complete = ClusterFactory.Definition({
         id: Cluster.id,
         name: Cluster.name,
         revision: Cluster.revision,
@@ -334,13 +322,19 @@ export namespace OnOff {
 
         attributes: {
             ...Cluster.attributes,
-            globalSceneControl: AsConditional(
+            globalSceneControl: ClusterFactory.AsConditional(
                 LevelControlForLightingComponent.attributes.globalSceneControl,
                 { mandatoryIf: [LT] }
             ),
-            onTime: AsConditional(LevelControlForLightingComponent.attributes.onTime, { mandatoryIf: [LT] }),
-            offWaitTime: AsConditional(LevelControlForLightingComponent.attributes.offWaitTime, { mandatoryIf: [LT] }),
-            startUpOnOff: AsConditional(
+            onTime: ClusterFactory.AsConditional(
+                LevelControlForLightingComponent.attributes.onTime,
+                { mandatoryIf: [LT] }
+            ),
+            offWaitTime: ClusterFactory.AsConditional(
+                LevelControlForLightingComponent.attributes.offWaitTime,
+                { mandatoryIf: [LT] }
+            ),
+            startUpOnOff: ClusterFactory.AsConditional(
                 LevelControlForLightingComponent.attributes.startUpOnOff,
                 { mandatoryIf: [LT] }
             )
@@ -348,15 +342,15 @@ export namespace OnOff {
 
         commands: {
             ...Cluster.commands,
-            offWithEffect: AsConditional(
+            offWithEffect: ClusterFactory.AsConditional(
                 LevelControlForLightingComponent.commands.offWithEffect,
                 { mandatoryIf: [LT] }
             ),
-            onWithRecallGlobalScene: AsConditional(
+            onWithRecallGlobalScene: ClusterFactory.AsConditional(
                 LevelControlForLightingComponent.commands.onWithRecallGlobalScene,
                 { mandatoryIf: [LT] }
             ),
-            onWithTimedOff: AsConditional(
+            onWithTimedOff: ClusterFactory.AsConditional(
                 LevelControlForLightingComponent.commands.onWithTimedOff,
                 { mandatoryIf: [LT] }
             )

--- a/packages/matter.js/src/cluster/definitions/OnOffSwitchConfigurationCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/OnOffSwitchConfigurationCluster.ts
@@ -6,7 +6,8 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import { Cluster as CreateCluster, Attribute, WritableAttribute } from "../../cluster/Cluster.js";
+import { ClusterFactory } from "../../cluster/ClusterFactory.js";
+import { Attribute, WritableAttribute } from "../../cluster/Cluster.js";
 import { TlvEnum } from "../../tlv/TlvNumber.js";
 
 export namespace OnOffSwitchConfiguration {
@@ -33,7 +34,7 @@ export namespace OnOffSwitchConfiguration {
      *
      * Attributes and commands for configuring On/Off switching devices.
      */
-    export const Cluster = CreateCluster({
+    export const Cluster = ClusterFactory.Definition({
         id: 0x7,
         name: "OnOffSwitchConfiguration",
         revision: 1,

--- a/packages/matter.js/src/cluster/definitions/OperationalCredentialsCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/OperationalCredentialsCluster.ts
@@ -6,8 +6,9 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
+import { ClusterFactory } from "../../cluster/ClusterFactory.js";
+import { MatterCoreSpecificationV1_1 } from "../../spec/Specifications.js";
 import {
-    Cluster as CreateCluster,
     FabricScopedAttribute,
     AccessLevel,
     FixedAttribute,
@@ -15,7 +16,6 @@ import {
     Command,
     TlvNoResponse
 } from "../../cluster/Cluster.js";
-import { MatterCoreSpecificationV1_1 } from "../../spec/Specifications.js";
 import { TlvArray } from "../../tlv/TlvArray.js";
 import { TlvObject, TlvField, TlvOptionalField } from "../../tlv/TlvObject.js";
 import { TlvByteString, TlvString } from "../../tlv/TlvString.js";
@@ -512,7 +512,7 @@ export namespace OperationalCredentials {
      *
      * @see {@link MatterCoreSpecificationV1_1} § 11.17
      */
-    export const Cluster = CreateCluster({
+    export const Cluster = ClusterFactory.Definition({
         id: 0x3e,
         name: "OperationalCredentials",
         revision: 1,

--- a/packages/matter.js/src/cluster/definitions/OtaSoftwareUpdateProviderCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/OtaSoftwareUpdateProviderCluster.ts
@@ -6,8 +6,9 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import { Cluster as CreateCluster, Command, TlvNoResponse } from "../../cluster/Cluster.js";
+import { ClusterFactory } from "../../cluster/ClusterFactory.js";
 import { MatterCoreSpecificationV1_1 } from "../../spec/Specifications.js";
+import { Command, TlvNoResponse } from "../../cluster/Cluster.js";
 import { TlvObject, TlvField, TlvOptionalField } from "../../tlv/TlvObject.js";
 import { TlvVendorId } from "../../datatype/VendorId.js";
 import { TlvUInt16, TlvUInt32, TlvEnum } from "../../tlv/TlvNumber.js";
@@ -160,7 +161,7 @@ export namespace OtaSoftwareUpdateProvider {
      *
      * @see {@link MatterCoreSpecificationV1_1} § 11.19.6
      */
-    export const Cluster = CreateCluster({
+    export const Cluster = ClusterFactory.Definition({
         id: 0x29,
         name: "OtaSoftwareUpdateProvider",
         revision: 1,

--- a/packages/matter.js/src/cluster/definitions/OtaSoftwareUpdateRequestorCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/OtaSoftwareUpdateRequestorCluster.ts
@@ -6,8 +6,9 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
+import { ClusterFactory } from "../../cluster/ClusterFactory.js";
+import { MatterCoreSpecificationV1_1 } from "../../spec/Specifications.js";
 import {
-    Cluster as CreateCluster,
     WritableFabricScopedAttribute,
     AccessLevel,
     Attribute,
@@ -16,7 +17,6 @@ import {
     Event,
     EventPriority
 } from "../../cluster/Cluster.js";
-import { MatterCoreSpecificationV1_1 } from "../../spec/Specifications.js";
 import { TlvArray } from "../../tlv/TlvArray.js";
 import { TlvObject, TlvField, TlvOptionalField } from "../../tlv/TlvObject.js";
 import { TlvNodeId } from "../../datatype/NodeId.js";
@@ -199,7 +199,7 @@ export namespace OtaSoftwareUpdateRequestor {
      *
      * @see {@link MatterCoreSpecificationV1_1} § 11.19.7
      */
-    export const Cluster = CreateCluster({
+    export const Cluster = ClusterFactory.Definition({
         id: 0x2a,
         name: "OtaSoftwareUpdateRequestor",
         revision: 1,

--- a/packages/matter.js/src/cluster/definitions/PowerSourceConfigurationCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/PowerSourceConfigurationCluster.ts
@@ -6,8 +6,9 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import { Cluster as CreateCluster, Attribute } from "../../cluster/Cluster.js";
+import { ClusterFactory } from "../../cluster/ClusterFactory.js";
 import { MatterCoreSpecificationV1_1 } from "../../spec/Specifications.js";
+import { Attribute } from "../../cluster/Cluster.js";
 import { TlvArray } from "../../tlv/TlvArray.js";
 import { TlvEndpointNumber } from "../../datatype/EndpointNumber.js";
 
@@ -20,7 +21,7 @@ export namespace PowerSourceConfiguration {
      *
      * @see {@link MatterCoreSpecificationV1_1} § 11.6
      */
-    export const Cluster = CreateCluster({
+    export const Cluster = ClusterFactory.Definition({
         id: 0x2e,
         name: "PowerSourceConfiguration",
         revision: 1,

--- a/packages/matter.js/src/cluster/definitions/PressureMeasurementCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/PressureMeasurementCluster.ts
@@ -6,18 +6,10 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
+import { ClusterFactory } from "../../cluster/ClusterFactory.js";
 import { MatterApplicationClusterSpecificationV1_1 } from "../../spec/Specifications.js";
-import {
-    BaseClusterComponent,
-    ClusterComponent,
-    ExtensibleCluster,
-    validateFeatureSelection,
-    extendCluster,
-    ClusterForBaseCluster,
-    AsConditional
-} from "../../cluster/ClusterFactory.js";
 import { BitFlag, BitFlags, TypeFromPartialBitSchema } from "../../schema/BitmapSchema.js";
-import { Attribute, OptionalAttribute, Cluster as CreateCluster } from "../../cluster/Cluster.js";
+import { Attribute, OptionalAttribute } from "../../cluster/Cluster.js";
 import { TlvInt16, TlvUInt16, TlvInt8 } from "../../tlv/TlvNumber.js";
 import { TlvNullable } from "../../tlv/TlvNullable.js";
 
@@ -39,7 +31,7 @@ export namespace PressureMeasurement {
     /**
      * These elements and properties are present in all PressureMeasurement clusters.
      */
-    export const Base = BaseClusterComponent({
+    export const Base = ClusterFactory.Definition({
         id: 0x403,
         name: "PressureMeasurement",
         revision: 3,
@@ -99,7 +91,7 @@ export namespace PressureMeasurement {
     /**
      * A PressureMeasurementCluster supports these elements if it supports feature Extended.
      */
-    export const ExtendedComponent = ClusterComponent({
+    export const ExtendedComponent = ClusterFactory.Component({
         attributes: {
             /**
              * ScaledValue represents the pressure in Pascals as follows:
@@ -160,8 +152,8 @@ export namespace PressureMeasurement {
      *
      * @see {@link MatterApplicationClusterSpecificationV1_1} § 2.4
      */
-    export const Cluster = ExtensibleCluster({
-        ...Base,
+    export const Cluster = ClusterFactory.Extensible(
+        Base,
 
         /**
          * Use this factory method to create a PressureMeasurement cluster with support for optional features. Include
@@ -171,16 +163,19 @@ export namespace PressureMeasurement {
          * @returns a PressureMeasurement cluster with specified features enabled
          * @throws {IllegalClusterError} if the feature combination is disallowed by the Matter specification
          */
-        factory: <T extends `${Feature}`[]>(...features: [...T]) => {
-            validateFeatureSelection(features, Feature);
-            const cluster = CreateCluster({ ...Base, supportedFeatures: BitFlags(Base.features, ...features) });
-            extendCluster(cluster, ExtendedComponent, { extended: true });
+        <T extends `${Feature}`[]>(...features: [...T]) => {
+            ClusterFactory.validateFeatureSelection(features, Feature);
+            const cluster = ClusterFactory.Definition({
+                ...Base,
+                supportedFeatures: BitFlags(Base.features, ...features)
+            });
+            ClusterFactory.extend(cluster, ExtendedComponent, { extended: true });
             return cluster as unknown as Extension<BitFlags<typeof Base.features, T>>;
         }
-    });
+    );
 
     export type Extension<SF extends TypeFromPartialBitSchema<typeof Base.features>> =
-        ClusterForBaseCluster<typeof Base, SF>
+        Omit<typeof Base, "supportedFeatures">
         & { supportedFeatures: SF }
         & (SF extends { extended: true } ? typeof ExtendedComponent : {});
 
@@ -192,7 +187,7 @@ export namespace PressureMeasurement {
      * If you use this cluster you must manually specify which features are active and ensure the set of active
      * features is legal per the Matter specification.
      */
-    export const Complete = CreateCluster({
+    export const Complete = ClusterFactory.Definition({
         id: Cluster.id,
         name: Cluster.name,
         revision: Cluster.revision,
@@ -200,11 +195,20 @@ export namespace PressureMeasurement {
 
         attributes: {
             ...Cluster.attributes,
-            scaledValue: AsConditional(ExtendedComponent.attributes.scaledValue, { mandatoryIf: [EXT] }),
-            minScaledValue: AsConditional(ExtendedComponent.attributes.minScaledValue, { mandatoryIf: [EXT] }),
-            maxScaledValue: AsConditional(ExtendedComponent.attributes.maxScaledValue, { mandatoryIf: [EXT] }),
-            scaledTolerance: AsConditional(ExtendedComponent.attributes.scaledTolerance, { optionalIf: [EXT] }),
-            scale: AsConditional(ExtendedComponent.attributes.scale, { mandatoryIf: [EXT] })
+            scaledValue: ClusterFactory.AsConditional(ExtendedComponent.attributes.scaledValue, { mandatoryIf: [EXT] }),
+            minScaledValue: ClusterFactory.AsConditional(
+                ExtendedComponent.attributes.minScaledValue,
+                { mandatoryIf: [EXT] }
+            ),
+            maxScaledValue: ClusterFactory.AsConditional(
+                ExtendedComponent.attributes.maxScaledValue,
+                { mandatoryIf: [EXT] }
+            ),
+            scaledTolerance: ClusterFactory.AsConditional(
+                ExtendedComponent.attributes.scaledTolerance,
+                { optionalIf: [EXT] }
+            ),
+            scale: ClusterFactory.AsConditional(ExtendedComponent.attributes.scale, { mandatoryIf: [EXT] })
         }
     });
 }

--- a/packages/matter.js/src/cluster/definitions/ProxyConfigurationCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/ProxyConfigurationCluster.ts
@@ -6,8 +6,9 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import { Cluster as CreateCluster, WritableAttribute } from "../../cluster/Cluster.js";
+import { ClusterFactory } from "../../cluster/ClusterFactory.js";
 import { MatterCoreSpecificationV1_1 } from "../../spec/Specifications.js";
+import { WritableAttribute } from "../../cluster/Cluster.js";
 import { TlvArray } from "../../tlv/TlvArray.js";
 import { TlvObject, TlvField } from "../../tlv/TlvObject.js";
 import { TlvBoolean } from "../../tlv/TlvBoolean.js";
@@ -39,7 +40,7 @@ export namespace ProxyConfiguration {
      *
      * @see {@link MatterCoreSpecificationV1_1} § 9.15.14
      */
-    export const Cluster = CreateCluster({
+    export const Cluster = ClusterFactory.Definition({
         id: 0x42,
         name: "ProxyConfiguration",
         revision: 1,

--- a/packages/matter.js/src/cluster/definitions/ProxyDiscoveryCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/ProxyDiscoveryCluster.ts
@@ -6,8 +6,9 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import { Cluster as CreateCluster, Command, TlvNoResponse } from "../../cluster/Cluster.js";
+import { ClusterFactory } from "../../cluster/ClusterFactory.js";
 import { MatterCoreSpecificationV1_1 } from "../../spec/Specifications.js";
+import { Command, TlvNoResponse } from "../../cluster/Cluster.js";
 import { TlvNoArguments } from "../../tlv/TlvNoArguments.js";
 
 export namespace ProxyDiscovery {
@@ -20,7 +21,7 @@ export namespace ProxyDiscovery {
      *
      * @see {@link MatterCoreSpecificationV1_1} § 9.15.13
      */
-    export const Cluster = CreateCluster({
+    export const Cluster = ClusterFactory.Definition({
         id: 0x43,
         name: "ProxyDiscovery",
         revision: 1,

--- a/packages/matter.js/src/cluster/definitions/PulseWidthModulationCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/PulseWidthModulationCluster.ts
@@ -6,16 +6,8 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
+import { ClusterFactory } from "../../cluster/ClusterFactory.js";
 import { MatterApplicationClusterSpecificationV1_1 } from "../../spec/Specifications.js";
-import {
-    BaseClusterComponent,
-    ClusterComponent,
-    ExtensibleCluster,
-    validateFeatureSelection,
-    extendCluster,
-    ClusterForBaseCluster,
-    AsConditional
-} from "../../cluster/ClusterFactory.js";
 import { BitFlag, BitFlags, TypeFromPartialBitSchema } from "../../schema/BitmapSchema.js";
 import {
     Attribute,
@@ -24,8 +16,7 @@ import {
     OptionalWritableAttribute,
     Command,
     TlvNoResponse,
-    AccessLevel,
-    Cluster as CreateCluster
+    AccessLevel
 } from "../../cluster/Cluster.js";
 import { TlvUInt8, TlvBitmap, TlvUInt16, TlvEnum } from "../../tlv/TlvNumber.js";
 import { TlvNullable } from "../../tlv/TlvNullable.js";
@@ -153,7 +144,7 @@ export namespace PulseWidthModulation {
     /**
      * These elements and properties are present in all PulseWidthModulation clusters.
      */
-    export const Base = BaseClusterComponent({
+    export const Base = ClusterFactory.Definition({
         id: 0x1c,
         name: "PulseWidthModulation",
         revision: 5,
@@ -332,7 +323,7 @@ export namespace PulseWidthModulation {
     /**
      * A PulseWidthModulationCluster supports these elements if it supports feature Lighting.
      */
-    export const LightingComponent = ClusterComponent({
+    export const LightingComponent = ClusterFactory.Component({
         attributes: {
             /**
              * The RemainingTime attribute represents the time remaining until the current command is complete - it is
@@ -365,7 +356,7 @@ export namespace PulseWidthModulation {
     /**
      * A PulseWidthModulationCluster supports these elements if it supports feature Frequency.
      */
-    export const FrequencyComponent = ClusterComponent({
+    export const FrequencyComponent = ClusterFactory.Component({
         attributes: {
             /**
              * The CurrentFrequency attribute represents the frequency at which the device is at CurrentLevel. A
@@ -411,9 +402,8 @@ export namespace PulseWidthModulation {
      *
      * @see {@link MatterApplicationClusterSpecificationV1_1} § 1.6
      */
-    export const Cluster = ExtensibleCluster({
-        ...Base,
-        supportedFeatures: { onOff: true },
+    export const Cluster = ClusterFactory.Extensible(
+        { ...Base, supportedFeatures: { onOff: true } },
 
         /**
          * Use this factory method to create a PulseWidthModulation cluster with support for optional features. Include
@@ -423,17 +413,20 @@ export namespace PulseWidthModulation {
          * @returns a PulseWidthModulation cluster with specified features enabled
          * @throws {IllegalClusterError} if the feature combination is disallowed by the Matter specification
          */
-        factory: <T extends `${Feature}`[]>(...features: [...T]) => {
-            validateFeatureSelection(features, Feature);
-            const cluster = CreateCluster({ ...Base, supportedFeatures: BitFlags(Base.features, ...features) });
-            extendCluster(cluster, LightingComponent, { lighting: true });
-            extendCluster(cluster, FrequencyComponent, { frequency: true });
+        <T extends `${Feature}`[]>(...features: [...T]) => {
+            ClusterFactory.validateFeatureSelection(features, Feature);
+            const cluster = ClusterFactory.Definition({
+                ...Base,
+                supportedFeatures: BitFlags(Base.features, ...features)
+            });
+            ClusterFactory.extend(cluster, LightingComponent, { lighting: true });
+            ClusterFactory.extend(cluster, FrequencyComponent, { frequency: true });
             return cluster as unknown as Extension<BitFlags<typeof Base.features, T>>;
         }
-    });
+    );
 
     export type Extension<SF extends TypeFromPartialBitSchema<typeof Base.features>> =
-        ClusterForBaseCluster<typeof Base, SF>
+        Omit<typeof Base, "supportedFeatures">
         & { supportedFeatures: SF }
         & (SF extends { lighting: true } ? typeof LightingComponent : {})
         & (SF extends { frequency: true } ? typeof FrequencyComponent : {});
@@ -446,7 +439,7 @@ export namespace PulseWidthModulation {
      * If you use this cluster you must manually specify which features are active and ensure the set of active
      * features is legal per the Matter specification.
      */
-    export const Complete = CreateCluster({
+    export const Complete = ClusterFactory.Definition({
         id: Cluster.id,
         name: Cluster.name,
         revision: Cluster.revision,
@@ -454,16 +447,31 @@ export namespace PulseWidthModulation {
 
         attributes: {
             ...Cluster.attributes,
-            remainingTime: AsConditional(LightingComponent.attributes.remainingTime, { mandatoryIf: [LT] }),
-            currentFrequency: AsConditional(FrequencyComponent.attributes.currentFrequency, { mandatoryIf: [FQ] }),
-            minFrequency: AsConditional(FrequencyComponent.attributes.minFrequency, { mandatoryIf: [FQ] }),
-            maxFrequency: AsConditional(FrequencyComponent.attributes.maxFrequency, { mandatoryIf: [FQ] }),
-            startUpCurrentLevel: AsConditional(LightingComponent.attributes.startUpCurrentLevel, { mandatoryIf: [LT] })
+            remainingTime: ClusterFactory.AsConditional(
+                LightingComponent.attributes.remainingTime,
+                { mandatoryIf: [LT] }
+            ),
+            currentFrequency: ClusterFactory.AsConditional(
+                FrequencyComponent.attributes.currentFrequency,
+                { mandatoryIf: [FQ] }
+            ),
+            minFrequency: ClusterFactory.AsConditional(
+                FrequencyComponent.attributes.minFrequency,
+                { mandatoryIf: [FQ] }
+            ),
+            maxFrequency: ClusterFactory.AsConditional(
+                FrequencyComponent.attributes.maxFrequency,
+                { mandatoryIf: [FQ] }
+            ),
+            startUpCurrentLevel: ClusterFactory.AsConditional(
+                LightingComponent.attributes.startUpCurrentLevel,
+                { mandatoryIf: [LT] }
+            )
         },
 
         commands: {
             ...Cluster.commands,
-            moveToClosestFrequency: AsConditional(
+            moveToClosestFrequency: ClusterFactory.AsConditional(
                 FrequencyComponent.commands.moveToClosestFrequency,
                 { mandatoryIf: [FQ] }
             )

--- a/packages/matter.js/src/cluster/definitions/PumpConfigurationAndControlCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/PumpConfigurationAndControlCluster.ts
@@ -6,17 +6,8 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
+import { ClusterFactory } from "../../cluster/ClusterFactory.js";
 import { MatterApplicationClusterSpecificationV1_1 } from "../../spec/Specifications.js";
-import {
-    BaseClusterComponent,
-    ClusterComponent,
-    ExtensibleCluster,
-    validateFeatureSelection,
-    extendCluster,
-    preventCluster,
-    ClusterForBaseCluster,
-    AsConditional
-} from "../../cluster/ClusterFactory.js";
 import { BitFlag, BitFlags, TypeFromPartialBitSchema } from "../../schema/BitmapSchema.js";
 import {
     FixedAttribute,
@@ -27,8 +18,7 @@ import {
     WritableAttribute,
     OptionalEvent,
     EventPriority,
-    OptionalFixedAttribute,
-    Cluster as CreateCluster
+    OptionalFixedAttribute
 } from "../../cluster/Cluster.js";
 import { TlvInt16, TlvUInt16, TlvBitmap, TlvEnum, TlvUInt24, TlvUInt32 } from "../../tlv/TlvNumber.js";
 import { TlvNullable } from "../../tlv/TlvNullable.js";
@@ -278,7 +268,7 @@ export namespace PumpConfigurationAndControl {
     /**
      * These elements and properties are present in all PumpConfigurationAndControl clusters.
      */
-    export const Base = BaseClusterComponent({
+    export const Base = ClusterFactory.Definition({
         id: 0x200,
         name: "PumpConfigurationAndControl",
         revision: 4,
@@ -644,7 +634,7 @@ export namespace PumpConfigurationAndControl {
     /**
      * A PumpConfigurationAndControlCluster supports these elements if it supports feature ConstantPressure.
      */
-    export const ConstantPressureComponent = ClusterComponent({
+    export const ConstantPressureComponent = ClusterFactory.Component({
         attributes: {
             /**
              * This attribute specifies the minimum pressure the pump can achieve when it is working with the
@@ -673,7 +663,7 @@ export namespace PumpConfigurationAndControl {
     /**
      * A PumpConfigurationAndControlCluster supports these elements if it supports feature Automatic.
      */
-    export const AutomaticComponent = ClusterComponent({
+    export const AutomaticComponent = ClusterFactory.Component({
         attributes: {
             /**
              * This attribute specifies the minimum pressure the pump can achieve when it is working with the
@@ -791,7 +781,7 @@ export namespace PumpConfigurationAndControl {
     /**
      * A PumpConfigurationAndControlCluster supports these elements if it supports feature CompensatedPressure.
      */
-    export const CompensatedPressureComponent = ClusterComponent({
+    export const CompensatedPressureComponent = ClusterFactory.Component({
         attributes: {
             /**
              * This attribute specifies the minimum compensated pressure the pump can achieve when it is working with
@@ -820,7 +810,7 @@ export namespace PumpConfigurationAndControl {
     /**
      * A PumpConfigurationAndControlCluster supports these elements if it supports feature ConstantSpeed.
      */
-    export const ConstantSpeedComponent = ClusterComponent({
+    export const ConstantSpeedComponent = ClusterFactory.Component({
         attributes: {
             /**
              * This attribute specifies the minimum speed the pump can achieve when it is working with the ControlMode
@@ -847,7 +837,7 @@ export namespace PumpConfigurationAndControl {
     /**
      * A PumpConfigurationAndControlCluster supports these elements if it supports feature ConstantFlow.
      */
-    export const ConstantFlowComponent = ClusterComponent({
+    export const ConstantFlowComponent = ClusterFactory.Component({
         attributes: {
             /**
              * This attribute specifies the minimum flow the pump can achieve when it is working with the Con
@@ -877,7 +867,7 @@ export namespace PumpConfigurationAndControl {
     /**
      * A PumpConfigurationAndControlCluster supports these elements if it supports feature ConstantTemperature.
      */
-    export const ConstantTemperatureComponent = ClusterComponent({
+    export const ConstantTemperatureComponent = ClusterFactory.Component({
         attributes: {
             /**
              * This attribute specifies the minimum temperature the pump can maintain in the system when it is working
@@ -917,8 +907,8 @@ export namespace PumpConfigurationAndControl {
      *
      * @see {@link MatterApplicationClusterSpecificationV1_1} § 4.2
      */
-    export const Cluster = ExtensibleCluster({
-        ...Base,
+    export const Cluster = ClusterFactory.Extensible(
+        Base,
 
         /**
          * Use this factory method to create a PumpConfigurationAndControl cluster with support for optional features.
@@ -928,17 +918,20 @@ export namespace PumpConfigurationAndControl {
          * @returns a PumpConfigurationAndControl cluster with specified features enabled
          * @throws {IllegalClusterError} if the feature combination is disallowed by the Matter specification
          */
-        factory: <T extends `${Feature}`[]>(...features: [...T]) => {
-            validateFeatureSelection(features, Feature);
-            const cluster = CreateCluster({ ...Base, supportedFeatures: BitFlags(Base.features, ...features) });
-            extendCluster(cluster, ConstantPressureComponent, { constantPressure: true });
-            extendCluster(cluster, AutomaticComponent, { automatic: true });
-            extendCluster(cluster, CompensatedPressureComponent, { compensatedPressure: true });
-            extendCluster(cluster, ConstantSpeedComponent, { constantSpeed: true });
-            extendCluster(cluster, ConstantFlowComponent, { constantFlow: true });
-            extendCluster(cluster, ConstantTemperatureComponent, { constantTemperature: true });
+        <T extends `${Feature}`[]>(...features: [...T]) => {
+            ClusterFactory.validateFeatureSelection(features, Feature);
+            const cluster = ClusterFactory.Definition({
+                ...Base,
+                supportedFeatures: BitFlags(Base.features, ...features)
+            });
+            ClusterFactory.extend(cluster, ConstantPressureComponent, { constantPressure: true });
+            ClusterFactory.extend(cluster, AutomaticComponent, { automatic: true });
+            ClusterFactory.extend(cluster, CompensatedPressureComponent, { compensatedPressure: true });
+            ClusterFactory.extend(cluster, ConstantSpeedComponent, { constantSpeed: true });
+            ClusterFactory.extend(cluster, ConstantFlowComponent, { constantFlow: true });
+            ClusterFactory.extend(cluster, ConstantTemperatureComponent, { constantTemperature: true });
 
-            preventCluster(
+            ClusterFactory.prevent(
                 cluster,
 
                 {
@@ -952,10 +945,10 @@ export namespace PumpConfigurationAndControl {
 
             return cluster as unknown as Extension<BitFlags<typeof Base.features, T>>;
         }
-    });
+    );
 
     export type Extension<SF extends TypeFromPartialBitSchema<typeof Base.features>> =
-        ClusterForBaseCluster<typeof Base, SF>
+        Omit<typeof Base, "supportedFeatures">
         & { supportedFeatures: SF }
         & (SF extends { constantPressure: true } ? typeof ConstantPressureComponent : {})
         & (SF extends { automatic: true } ? typeof AutomaticComponent : {})
@@ -978,7 +971,7 @@ export namespace PumpConfigurationAndControl {
      * If you use this cluster you must manually specify which features are active and ensure the set of active
      * features is legal per the Matter specification.
      */
-    export const Complete = CreateCluster({
+    export const Complete = ClusterFactory.Definition({
         id: Cluster.id,
         name: Cluster.name,
         revision: Cluster.revision,
@@ -986,43 +979,43 @@ export namespace PumpConfigurationAndControl {
 
         attributes: {
             ...Cluster.attributes,
-            minConstPressure: AsConditional(
+            minConstPressure: ClusterFactory.AsConditional(
                 ConstantPressureComponent.attributes.minConstPressure,
                 { mandatoryIf: [PRSCONST], optionalIf: [AUTO] }
             ),
-            maxConstPressure: AsConditional(
+            maxConstPressure: ClusterFactory.AsConditional(
                 ConstantPressureComponent.attributes.maxConstPressure,
                 { mandatoryIf: [PRSCONST], optionalIf: [AUTO] }
             ),
-            minCompPressure: AsConditional(
+            minCompPressure: ClusterFactory.AsConditional(
                 AutomaticComponent.attributes.minCompPressure,
                 { optionalIf: [AUTO], mandatoryIf: [PRSCOMP] }
             ),
-            maxCompPressure: AsConditional(
+            maxCompPressure: ClusterFactory.AsConditional(
                 AutomaticComponent.attributes.maxCompPressure,
                 { optionalIf: [AUTO], mandatoryIf: [PRSCOMP] }
             ),
-            minConstSpeed: AsConditional(
+            minConstSpeed: ClusterFactory.AsConditional(
                 AutomaticComponent.attributes.minConstSpeed,
                 { optionalIf: [AUTO], mandatoryIf: [SPD] }
             ),
-            maxConstSpeed: AsConditional(
+            maxConstSpeed: ClusterFactory.AsConditional(
                 AutomaticComponent.attributes.maxConstSpeed,
                 { optionalIf: [AUTO], mandatoryIf: [SPD] }
             ),
-            minConstFlow: AsConditional(
+            minConstFlow: ClusterFactory.AsConditional(
                 AutomaticComponent.attributes.minConstFlow,
                 { optionalIf: [AUTO], mandatoryIf: [FLW] }
             ),
-            maxConstFlow: AsConditional(
+            maxConstFlow: ClusterFactory.AsConditional(
                 AutomaticComponent.attributes.maxConstFlow,
                 { optionalIf: [AUTO], mandatoryIf: [FLW] }
             ),
-            minConstTemp: AsConditional(
+            minConstTemp: ClusterFactory.AsConditional(
                 AutomaticComponent.attributes.minConstTemp,
                 { optionalIf: [AUTO], mandatoryIf: [TEMP] }
             ),
-            maxConstTemp: AsConditional(
+            maxConstTemp: ClusterFactory.AsConditional(
                 AutomaticComponent.attributes.maxConstTemp,
                 { optionalIf: [AUTO], mandatoryIf: [TEMP] }
             )

--- a/packages/matter.js/src/cluster/definitions/RelativeHumidityMeasurementCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/RelativeHumidityMeasurementCluster.ts
@@ -6,8 +6,9 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import { Cluster as CreateCluster, Attribute, OptionalAttribute } from "../../cluster/Cluster.js";
+import { ClusterFactory } from "../../cluster/ClusterFactory.js";
 import { MatterApplicationClusterSpecificationV1_1 } from "../../spec/Specifications.js";
+import { Attribute, OptionalAttribute } from "../../cluster/Cluster.js";
 import { TlvUInt16 } from "../../tlv/TlvNumber.js";
 import { TlvNullable } from "../../tlv/TlvNullable.js";
 
@@ -21,7 +22,7 @@ export namespace RelativeHumidityMeasurement {
      *
      * @see {@link MatterApplicationClusterSpecificationV1_1} § 2.6
      */
-    export const Cluster = CreateCluster({
+    export const Cluster = ClusterFactory.Definition({
         id: 0x405,
         name: "RelativeHumidityMeasurement",
         revision: 3,

--- a/packages/matter.js/src/cluster/definitions/ScenesCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/ScenesCluster.ts
@@ -6,13 +6,8 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
+import { ClusterFactory } from "../../cluster/ClusterFactory.js";
 import { MatterApplicationClusterSpecificationV1_1 } from "../../spec/Specifications.js";
-import {
-    BaseClusterComponent,
-    ExtensibleCluster,
-    validateFeatureSelection,
-    ClusterForBaseCluster
-} from "../../cluster/ClusterFactory.js";
 import { BitFlag, BitField, BitFlags, TypeFromPartialBitSchema } from "../../schema/BitmapSchema.js";
 import {
     Attribute,
@@ -20,8 +15,7 @@ import {
     Command,
     AccessLevel,
     TlvNoResponse,
-    OptionalCommand,
-    Cluster as CreateCluster
+    OptionalCommand
 } from "../../cluster/Cluster.js";
 import { TlvUInt8, TlvBitmap, TlvUInt16, TlvEnum } from "../../tlv/TlvNumber.js";
 import { TlvGroupId, GroupId } from "../../datatype/GroupId.js";
@@ -341,7 +335,7 @@ export namespace Scenes {
     /**
      * These elements and properties are present in all Scenes clusters.
      */
-    export const Base = BaseClusterComponent({
+    export const Base = ClusterFactory.Definition({
         id: 0x5,
         name: "Scenes",
         revision: 4,
@@ -539,9 +533,8 @@ export namespace Scenes {
      *
      * @see {@link MatterApplicationClusterSpecificationV1_1} § 1.4
      */
-    export const Cluster = ExtensibleCluster({
-        ...Base,
-        supportedFeatures: { sceneNames: true },
+    export const Cluster = ClusterFactory.Extensible(
+        { ...Base, supportedFeatures: { sceneNames: true } },
 
         /**
          * Use this factory method to create a Scenes cluster with support for optional features. Include each
@@ -551,15 +544,18 @@ export namespace Scenes {
          * @returns a Scenes cluster with specified features enabled
          * @throws {IllegalClusterError} if the feature combination is disallowed by the Matter specification
          */
-        factory: <T extends `${Feature}`[]>(...features: [...T]) => {
-            validateFeatureSelection(features, Feature);
-            const cluster = CreateCluster({ ...Base, supportedFeatures: BitFlags(Base.features, ...features) });
+        <T extends `${Feature}`[]>(...features: [...T]) => {
+            ClusterFactory.validateFeatureSelection(features, Feature);
+            const cluster = ClusterFactory.Definition({
+                ...Base,
+                supportedFeatures: BitFlags(Base.features, ...features)
+            });
             return cluster as unknown as Extension<BitFlags<typeof Base.features, T>>;
         }
-    });
+    );
 
     export type Extension<SF extends TypeFromPartialBitSchema<typeof Base.features>> =
-        ClusterForBaseCluster<typeof Base, SF>
+        Omit<typeof Base, "supportedFeatures">
         & { supportedFeatures: SF };
 }
 

--- a/packages/matter.js/src/cluster/definitions/SoftwareDiagnosticsCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/SoftwareDiagnosticsCluster.ts
@@ -6,16 +6,8 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
+import { ClusterFactory } from "../../cluster/ClusterFactory.js";
 import { MatterCoreSpecificationV1_1 } from "../../spec/Specifications.js";
-import {
-    BaseClusterComponent,
-    ClusterComponent,
-    ExtensibleCluster,
-    validateFeatureSelection,
-    extendCluster,
-    ClusterForBaseCluster,
-    AsConditional
-} from "../../cluster/ClusterFactory.js";
 import { BitFlag, BitFlags, TypeFromPartialBitSchema } from "../../schema/BitmapSchema.js";
 import {
     OptionalAttribute,
@@ -24,8 +16,7 @@ import {
     Attribute,
     Command,
     TlvNoResponse,
-    AccessLevel,
-    Cluster as CreateCluster
+    AccessLevel
 } from "../../cluster/Cluster.js";
 import { TlvArray } from "../../tlv/TlvArray.js";
 import { TlvObject, TlvField, TlvOptionalField } from "../../tlv/TlvObject.js";
@@ -118,7 +109,7 @@ export namespace SoftwareDiagnostics {
     /**
      * These elements and properties are present in all SoftwareDiagnostics clusters.
      */
-    export const Base = BaseClusterComponent({
+    export const Base = ClusterFactory.Definition({
         id: 0x34,
         name: "SoftwareDiagnostics",
         revision: 1,
@@ -176,7 +167,7 @@ export namespace SoftwareDiagnostics {
     /**
      * A SoftwareDiagnosticsCluster supports these elements if it supports feature Watermarks.
      */
-    export const WatermarksComponent = ClusterComponent({
+    export const WatermarksComponent = ClusterFactory.Component({
         attributes: {
             /**
              * The CurrentHeapHighWatermark attribute shall indicate the maximum amount of heap memory, in bytes, that
@@ -224,8 +215,8 @@ export namespace SoftwareDiagnostics {
      *
      * @see {@link MatterCoreSpecificationV1_1} § 11.12
      */
-    export const Cluster = ExtensibleCluster({
-        ...Base,
+    export const Cluster = ClusterFactory.Extensible(
+        Base,
 
         /**
          * Use this factory method to create a SoftwareDiagnostics cluster with support for optional features. Include
@@ -235,16 +226,19 @@ export namespace SoftwareDiagnostics {
          * @returns a SoftwareDiagnostics cluster with specified features enabled
          * @throws {IllegalClusterError} if the feature combination is disallowed by the Matter specification
          */
-        factory: <T extends `${Feature}`[]>(...features: [...T]) => {
-            validateFeatureSelection(features, Feature);
-            const cluster = CreateCluster({ ...Base, supportedFeatures: BitFlags(Base.features, ...features) });
-            extendCluster(cluster, WatermarksComponent, { watermarks: true });
+        <T extends `${Feature}`[]>(...features: [...T]) => {
+            ClusterFactory.validateFeatureSelection(features, Feature);
+            const cluster = ClusterFactory.Definition({
+                ...Base,
+                supportedFeatures: BitFlags(Base.features, ...features)
+            });
+            ClusterFactory.extend(cluster, WatermarksComponent, { watermarks: true });
             return cluster as unknown as Extension<BitFlags<typeof Base.features, T>>;
         }
-    });
+    );
 
     export type Extension<SF extends TypeFromPartialBitSchema<typeof Base.features>> =
-        ClusterForBaseCluster<typeof Base, SF>
+        Omit<typeof Base, "supportedFeatures">
         & { supportedFeatures: SF }
         & (SF extends { watermarks: true } ? typeof WatermarksComponent : {});
     const WTRMRK = { watermarks: true };
@@ -255,7 +249,7 @@ export namespace SoftwareDiagnostics {
      * If you use this cluster you must manually specify which features are active and ensure the set of active
      * features is legal per the Matter specification.
      */
-    export const Complete = CreateCluster({
+    export const Complete = ClusterFactory.Definition({
         id: Cluster.id,
         name: Cluster.name,
         revision: Cluster.revision,
@@ -263,15 +257,19 @@ export namespace SoftwareDiagnostics {
 
         attributes: {
             ...Cluster.attributes,
-            currentHeapHighWatermark: AsConditional(
+            currentHeapHighWatermark: ClusterFactory.AsConditional(
                 WatermarksComponent.attributes.currentHeapHighWatermark,
                 { mandatoryIf: [WTRMRK] }
             )
         },
 
         commands: {
-            resetWatermarks: AsConditional(WatermarksComponent.commands.resetWatermarks, { mandatoryIf: [WTRMRK] })
+            resetWatermarks: ClusterFactory.AsConditional(
+                WatermarksComponent.commands.resetWatermarks,
+                { mandatoryIf: [WTRMRK] }
+            )
         },
+
         events: Cluster.events
     });
 }

--- a/packages/matter.js/src/cluster/definitions/SoilMoistureMeasurementCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/SoilMoistureMeasurementCluster.ts
@@ -6,8 +6,9 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import { Cluster as CreateCluster, Attribute, OptionalAttribute } from "../../cluster/Cluster.js";
+import { ClusterFactory } from "../../cluster/ClusterFactory.js";
 import { MatterApplicationClusterSpecificationV1_1 } from "../../spec/Specifications.js";
+import { Attribute, OptionalAttribute } from "../../cluster/Cluster.js";
 import { TlvUInt16 } from "../../tlv/TlvNumber.js";
 import { TlvNullable } from "../../tlv/TlvNullable.js";
 
@@ -19,7 +20,7 @@ export namespace SoilMoistureMeasurement {
      *
      * @see {@link MatterApplicationClusterSpecificationV1_1} § 2.6
      */
-    export const Cluster = CreateCluster({
+    export const Cluster = ClusterFactory.Definition({
         id: 0x408,
         name: "SoilMoistureMeasurement",
         revision: 3,

--- a/packages/matter.js/src/cluster/definitions/TargetNavigatorCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/TargetNavigatorCluster.ts
@@ -6,8 +6,9 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import { Cluster as CreateCluster, Attribute, OptionalAttribute, Command } from "../../cluster/Cluster.js";
+import { ClusterFactory } from "../../cluster/ClusterFactory.js";
 import { MatterApplicationClusterSpecificationV1_1 } from "../../spec/Specifications.js";
+import { Attribute, OptionalAttribute, Command } from "../../cluster/Cluster.js";
 import { TlvArray } from "../../tlv/TlvArray.js";
 import { TlvObject, TlvField, TlvOptionalField } from "../../tlv/TlvObject.js";
 import { TlvUInt8, TlvEnum } from "../../tlv/TlvNumber.js";
@@ -106,7 +107,7 @@ export namespace TargetNavigator {
      *
      * @see {@link MatterApplicationClusterSpecificationV1_1} § 6.11
      */
-    export const Cluster = CreateCluster({
+    export const Cluster = ClusterFactory.Definition({
         id: 0x505,
         name: "TargetNavigator",
         revision: 1,

--- a/packages/matter.js/src/cluster/definitions/TemperatureMeasurementCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/TemperatureMeasurementCluster.ts
@@ -6,8 +6,9 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import { Cluster as CreateCluster, Attribute, OptionalAttribute } from "../../cluster/Cluster.js";
+import { ClusterFactory } from "../../cluster/ClusterFactory.js";
 import { MatterApplicationClusterSpecificationV1_1 } from "../../spec/Specifications.js";
+import { Attribute, OptionalAttribute } from "../../cluster/Cluster.js";
 import { TlvInt16, TlvUInt16 } from "../../tlv/TlvNumber.js";
 import { TlvNullable } from "../../tlv/TlvNullable.js";
 
@@ -20,7 +21,7 @@ export namespace TemperatureMeasurement {
      *
      * @see {@link MatterApplicationClusterSpecificationV1_1} § 2.3
      */
-    export const Cluster = CreateCluster({
+    export const Cluster = ClusterFactory.Definition({
         id: 0x402,
         name: "TemperatureMeasurement",
         revision: 4,

--- a/packages/matter.js/src/cluster/definitions/ThermostatCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/ThermostatCluster.ts
@@ -6,17 +6,8 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
+import { ClusterFactory } from "../../cluster/ClusterFactory.js";
 import { MatterApplicationClusterSpecificationV1_1 } from "../../spec/Specifications.js";
-import {
-    BaseClusterComponent,
-    ClusterComponent,
-    ExtensibleCluster,
-    validateFeatureSelection,
-    extendCluster,
-    preventCluster,
-    ClusterForBaseCluster,
-    AsConditional
-} from "../../cluster/ClusterFactory.js";
 import { BitFlag, BitsFromPartial, BitFlags, TypeFromPartialBitSchema } from "../../schema/BitmapSchema.js";
 import {
     Attribute,
@@ -28,8 +19,7 @@ import {
     TlvNoResponse,
     OptionalCommand,
     OptionalFixedAttribute,
-    FixedAttribute,
-    Cluster as CreateCluster
+    FixedAttribute
 } from "../../cluster/Cluster.js";
 import { TlvInt16, TlvUInt8, TlvBitmap, TlvEnum, TlvUInt16, TlvUInt32, TlvInt8 } from "../../tlv/TlvNumber.js";
 import { TlvNullable } from "../../tlv/TlvNullable.js";
@@ -586,7 +576,7 @@ export namespace Thermostat {
     /**
      * These elements and properties are present in all Thermostat clusters.
      */
-    export const Base = BaseClusterComponent({
+    export const Base = ClusterFactory.Definition({
         id: 0x201,
         name: "Thermostat",
         revision: 6,
@@ -1006,7 +996,7 @@ export namespace Thermostat {
     /**
      * A ThermostatCluster supports these elements if it supports feature Occupancy.
      */
-    export const OccupancyComponent = ClusterComponent({
+    export const OccupancyComponent = ClusterFactory.Component({
         attributes: {
             /**
              * This attribute specifies whether the heated/cooled space is occupied or not, as measured locally or
@@ -1026,7 +1016,7 @@ export namespace Thermostat {
     /**
      * A ThermostatCluster supports these elements if it supports feature Heating.
      */
-    export const HeatingComponent = ClusterComponent({
+    export const HeatingComponent = ClusterFactory.Component({
         attributes: {
             /**
              * This attribute specifies the absolute minimum level that the heating setpoint may be set to. This is a
@@ -1118,7 +1108,7 @@ export namespace Thermostat {
     /**
      * A ThermostatCluster supports these elements if it supports feature Cooling.
      */
-    export const CoolingComponent = ClusterComponent({
+    export const CoolingComponent = ClusterFactory.Component({
         attributes: {
             /**
              * This attribute specifies the absolute minimum level that the cooling setpoint may be set to. This is a
@@ -1208,7 +1198,7 @@ export namespace Thermostat {
     /**
      * A ThermostatCluster supports these elements if doesn't support feature LTNE.
      */
-    export const NotLocalTemperatureNotExposedComponent = ClusterComponent({
+    export const NotLocalTemperatureNotExposedComponent = ClusterFactory.Component({
         attributes: {
             /**
              * This attribute specifies the offset the Thermostat server shall make to the measured temperature
@@ -1235,7 +1225,7 @@ export namespace Thermostat {
     /**
      * A ThermostatCluster supports these elements if it supports features Cooling and Occupancy.
      */
-    export const CoolingAndOccupancyComponent = ClusterComponent({
+    export const CoolingAndOccupancyComponent = ClusterFactory.Component({
         attributes: {
             /**
              * This attribute specifies the cooling mode setpoint when the room is unoccupied.
@@ -1258,7 +1248,7 @@ export namespace Thermostat {
     /**
      * A ThermostatCluster supports these elements if it supports features Heating and Occupancy.
      */
-    export const HeatingAndOccupancyComponent = ClusterComponent({
+    export const HeatingAndOccupancyComponent = ClusterFactory.Component({
         attributes: {
             /**
              * This attribute specifies the heating mode setpoint when the room is unoccupied.
@@ -1281,7 +1271,7 @@ export namespace Thermostat {
     /**
      * A ThermostatCluster supports these elements if it supports feature AutoMode.
      */
-    export const AutoModeComponent = ClusterComponent({
+    export const AutoModeComponent = ClusterFactory.Component({
         attributes: {
             /**
              * On devices which support the AUTO feature, this attribute specifies the minimum difference between the
@@ -1315,7 +1305,7 @@ export namespace Thermostat {
     /**
      * A ThermostatCluster supports these elements if it supports feature ScheduleConfiguration.
      */
-    export const ScheduleConfigurationComponent = ClusterComponent({
+    export const ScheduleConfigurationComponent = ClusterFactory.Component({
         attributes: {
             /**
              * This attribute represents the day of the week that this thermostat considers to be the start of week for
@@ -1372,7 +1362,7 @@ export namespace Thermostat {
     /**
      * A ThermostatCluster supports these elements if it supports feature Setback.
      */
-    export const SetbackComponent = ClusterComponent({
+    export const SetbackComponent = ClusterFactory.Component({
         attributes: {
             /**
              * This attribute specifies the amount that the Thermostat server will allow the LocalTemperature Value to
@@ -1433,7 +1423,7 @@ export namespace Thermostat {
     /**
      * A ThermostatCluster supports these elements if it supports features Setback and Occupancy.
      */
-    export const SetbackAndOccupancyComponent = ClusterComponent({
+    export const SetbackAndOccupancyComponent = ClusterFactory.Component({
         attributes: {
             /**
              * This attribute specifies the amount that the Thermostat server will allow the LocalTemperature Value to
@@ -1501,8 +1491,8 @@ export namespace Thermostat {
      *
      * @see {@link MatterApplicationClusterSpecificationV1_1} § 4.3
      */
-    export const Cluster = ExtensibleCluster({
-        ...Base,
+    export const Cluster = ClusterFactory.Extensible(
+        Base,
 
         /**
          * Use this factory method to create a Thermostat cluster with support for optional features. Include each
@@ -1512,21 +1502,28 @@ export namespace Thermostat {
          * @returns a Thermostat cluster with specified features enabled
          * @throws {IllegalClusterError} if the feature combination is disallowed by the Matter specification
          */
-        factory: <T extends `${Feature}`[]>(...features: [...T]) => {
-            validateFeatureSelection(features, Feature);
-            const cluster = CreateCluster({ ...Base, supportedFeatures: BitFlags(Base.features, ...features) });
-            extendCluster(cluster, OccupancyComponent, { occupancy: true });
-            extendCluster(cluster, HeatingComponent, { heating: true });
-            extendCluster(cluster, CoolingComponent, { cooling: true });
-            extendCluster(cluster, NotLocalTemperatureNotExposedComponent, { localTemperatureNotExposed: false });
-            extendCluster(cluster, CoolingAndOccupancyComponent, { cooling: true, occupancy: true });
-            extendCluster(cluster, HeatingAndOccupancyComponent, { heating: true, occupancy: true });
-            extendCluster(cluster, AutoModeComponent, { autoMode: true });
-            extendCluster(cluster, ScheduleConfigurationComponent, { scheduleConfiguration: true });
-            extendCluster(cluster, SetbackComponent, { setback: true });
-            extendCluster(cluster, SetbackAndOccupancyComponent, { setback: true, occupancy: true });
+        <T extends `${Feature}`[]>(...features: [...T]) => {
+            ClusterFactory.validateFeatureSelection(features, Feature);
+            const cluster = ClusterFactory.Definition({
+                ...Base,
+                supportedFeatures: BitFlags(Base.features, ...features)
+            });
+            ClusterFactory.extend(cluster, OccupancyComponent, { occupancy: true });
+            ClusterFactory.extend(cluster, HeatingComponent, { heating: true });
+            ClusterFactory.extend(cluster, CoolingComponent, { cooling: true });
+            ClusterFactory.extend(
+                cluster,
+                NotLocalTemperatureNotExposedComponent,
+                { localTemperatureNotExposed: false }
+            );
+            ClusterFactory.extend(cluster, CoolingAndOccupancyComponent, { cooling: true, occupancy: true });
+            ClusterFactory.extend(cluster, HeatingAndOccupancyComponent, { heating: true, occupancy: true });
+            ClusterFactory.extend(cluster, AutoModeComponent, { autoMode: true });
+            ClusterFactory.extend(cluster, ScheduleConfigurationComponent, { scheduleConfiguration: true });
+            ClusterFactory.extend(cluster, SetbackComponent, { setback: true });
+            ClusterFactory.extend(cluster, SetbackAndOccupancyComponent, { setback: true, occupancy: true });
 
-            preventCluster(
+            ClusterFactory.prevent(
                 cluster,
                 { autoMode: true, heating: false },
                 { autoMode: true, cooling: false },
@@ -1535,10 +1532,10 @@ export namespace Thermostat {
 
             return cluster as unknown as Extension<BitFlags<typeof Base.features, T>>;
         }
-    });
+    );
 
     export type Extension<SF extends TypeFromPartialBitSchema<typeof Base.features>> =
-        ClusterForBaseCluster<typeof Base, SF>
+        Omit<typeof Base, "supportedFeatures">
         & { supportedFeatures: SF }
         & (SF extends { occupancy: true } ? typeof OccupancyComponent : {})
         & (SF extends { heating: true } ? typeof HeatingComponent : {})
@@ -1570,7 +1567,7 @@ export namespace Thermostat {
      * If you use this cluster you must manually specify which features are active and ensure the set of active
      * features is legal per the Matter specification.
      */
-    export const Complete = CreateCluster({
+    export const Complete = ClusterFactory.Definition({
         id: Cluster.id,
         name: Cluster.name,
         revision: Cluster.revision,
@@ -1578,90 +1575,108 @@ export namespace Thermostat {
 
         attributes: {
             ...Cluster.attributes,
-            occupancy: AsConditional(OccupancyComponent.attributes.occupancy, { mandatoryIf: [OCC] }),
-            absMinHeatSetpointLimit: AsConditional(
+            occupancy: ClusterFactory.AsConditional(OccupancyComponent.attributes.occupancy, { mandatoryIf: [OCC] }),
+            absMinHeatSetpointLimit: ClusterFactory.AsConditional(
                 HeatingComponent.attributes.absMinHeatSetpointLimit,
                 { optionalIf: [HEAT] }
             ),
-            absMaxHeatSetpointLimit: AsConditional(
+            absMaxHeatSetpointLimit: ClusterFactory.AsConditional(
                 HeatingComponent.attributes.absMaxHeatSetpointLimit,
                 { optionalIf: [HEAT] }
             ),
-            absMinCoolSetpointLimit: AsConditional(
+            absMinCoolSetpointLimit: ClusterFactory.AsConditional(
                 CoolingComponent.attributes.absMinCoolSetpointLimit,
                 { optionalIf: [COOL] }
             ),
-            absMaxCoolSetpointLimit: AsConditional(
+            absMaxCoolSetpointLimit: ClusterFactory.AsConditional(
                 CoolingComponent.attributes.absMaxCoolSetpointLimit,
                 { optionalIf: [COOL] }
             ),
-            piCoolingDemand: AsConditional(CoolingComponent.attributes.piCoolingDemand, { optionalIf: [COOL] }),
-            piHeatingDemand: AsConditional(HeatingComponent.attributes.piHeatingDemand, { optionalIf: [HEAT] }),
-            localTemperatureCalibration: AsConditional(
+            piCoolingDemand: ClusterFactory.AsConditional(
+                CoolingComponent.attributes.piCoolingDemand,
+                { optionalIf: [COOL] }
+            ),
+            piHeatingDemand: ClusterFactory.AsConditional(
+                HeatingComponent.attributes.piHeatingDemand,
+                { optionalIf: [HEAT] }
+            ),
+            localTemperatureCalibration: ClusterFactory.AsConditional(
                 NotLocalTemperatureNotExposedComponent.attributes.localTemperatureCalibration,
                 { optionalIf: [] }
             ),
-            occupiedCoolingSetpoint: AsConditional(
+            occupiedCoolingSetpoint: ClusterFactory.AsConditional(
                 CoolingComponent.attributes.occupiedCoolingSetpoint,
                 { mandatoryIf: [COOL] }
             ),
-            occupiedHeatingSetpoint: AsConditional(
+            occupiedHeatingSetpoint: ClusterFactory.AsConditional(
                 HeatingComponent.attributes.occupiedHeatingSetpoint,
                 { mandatoryIf: [HEAT] }
             ),
-            unoccupiedCoolingSetpoint: AsConditional(
+            unoccupiedCoolingSetpoint: ClusterFactory.AsConditional(
                 CoolingAndOccupancyComponent.attributes.unoccupiedCoolingSetpoint,
                 { mandatoryIf: [COOL_OCC] }
             ),
-            unoccupiedHeatingSetpoint: AsConditional(
+            unoccupiedHeatingSetpoint: ClusterFactory.AsConditional(
                 HeatingAndOccupancyComponent.attributes.unoccupiedHeatingSetpoint,
                 { mandatoryIf: [HEAT_OCC] }
             ),
-            minHeatSetpointLimit: AsConditional(
+            minHeatSetpointLimit: ClusterFactory.AsConditional(
                 HeatingComponent.attributes.minHeatSetpointLimit,
                 { optionalIf: [HEAT] }
             ),
-            maxHeatSetpointLimit: AsConditional(
+            maxHeatSetpointLimit: ClusterFactory.AsConditional(
                 HeatingComponent.attributes.maxHeatSetpointLimit,
                 { optionalIf: [HEAT] }
             ),
-            minCoolSetpointLimit: AsConditional(
+            minCoolSetpointLimit: ClusterFactory.AsConditional(
                 CoolingComponent.attributes.minCoolSetpointLimit,
                 { optionalIf: [COOL] }
             ),
-            maxCoolSetpointLimit: AsConditional(
+            maxCoolSetpointLimit: ClusterFactory.AsConditional(
                 CoolingComponent.attributes.maxCoolSetpointLimit,
                 { optionalIf: [COOL] }
             ),
-            minSetpointDeadBand: AsConditional(
+            minSetpointDeadBand: ClusterFactory.AsConditional(
                 AutoModeComponent.attributes.minSetpointDeadBand,
                 { mandatoryIf: [AUTO] }
             ),
-            thermostatRunningMode: AsConditional(
+            thermostatRunningMode: ClusterFactory.AsConditional(
                 AutoModeComponent.attributes.thermostatRunningMode,
                 { optionalIf: [AUTO] }
             ),
-            startOfWeek: AsConditional(ScheduleConfigurationComponent.attributes.startOfWeek, { mandatoryIf: [SCH] }),
-            numberOfWeeklyTransitions: AsConditional(
+            startOfWeek: ClusterFactory.AsConditional(
+                ScheduleConfigurationComponent.attributes.startOfWeek,
+                { mandatoryIf: [SCH] }
+            ),
+            numberOfWeeklyTransitions: ClusterFactory.AsConditional(
                 ScheduleConfigurationComponent.attributes.numberOfWeeklyTransitions,
                 { mandatoryIf: [SCH] }
             ),
-            numberOfDailyTransitions: AsConditional(
+            numberOfDailyTransitions: ClusterFactory.AsConditional(
                 ScheduleConfigurationComponent.attributes.numberOfDailyTransitions,
                 { mandatoryIf: [SCH] }
             ),
-            occupiedSetback: AsConditional(SetbackComponent.attributes.occupiedSetback, { mandatoryIf: [SB] }),
-            occupiedSetbackMin: AsConditional(SetbackComponent.attributes.occupiedSetbackMin, { mandatoryIf: [SB] }),
-            occupiedSetbackMax: AsConditional(SetbackComponent.attributes.occupiedSetbackMax, { mandatoryIf: [SB] }),
-            unoccupiedSetback: AsConditional(
+            occupiedSetback: ClusterFactory.AsConditional(
+                SetbackComponent.attributes.occupiedSetback,
+                { mandatoryIf: [SB] }
+            ),
+            occupiedSetbackMin: ClusterFactory.AsConditional(
+                SetbackComponent.attributes.occupiedSetbackMin,
+                { mandatoryIf: [SB] }
+            ),
+            occupiedSetbackMax: ClusterFactory.AsConditional(
+                SetbackComponent.attributes.occupiedSetbackMax,
+                { mandatoryIf: [SB] }
+            ),
+            unoccupiedSetback: ClusterFactory.AsConditional(
                 SetbackAndOccupancyComponent.attributes.unoccupiedSetback,
                 { mandatoryIf: [SB_OCC] }
             ),
-            unoccupiedSetbackMin: AsConditional(
+            unoccupiedSetbackMin: ClusterFactory.AsConditional(
                 SetbackAndOccupancyComponent.attributes.unoccupiedSetbackMin,
                 { mandatoryIf: [SB_OCC] }
             ),
-            unoccupiedSetbackMax: AsConditional(
+            unoccupiedSetbackMax: ClusterFactory.AsConditional(
                 SetbackAndOccupancyComponent.attributes.unoccupiedSetbackMax,
                 { mandatoryIf: [SB_OCC] }
             )
@@ -1669,15 +1684,15 @@ export namespace Thermostat {
 
         commands: {
             ...Cluster.commands,
-            setWeeklySchedule: AsConditional(
+            setWeeklySchedule: ClusterFactory.AsConditional(
                 ScheduleConfigurationComponent.commands.setWeeklySchedule,
                 { mandatoryIf: [SCH] }
             ),
-            getWeeklySchedule: AsConditional(
+            getWeeklySchedule: ClusterFactory.AsConditional(
                 ScheduleConfigurationComponent.commands.getWeeklySchedule,
                 { mandatoryIf: [SCH] }
             ),
-            clearWeeklySchedule: AsConditional(
+            clearWeeklySchedule: ClusterFactory.AsConditional(
                 ScheduleConfigurationComponent.commands.clearWeeklySchedule,
                 { mandatoryIf: [SCH] }
             )

--- a/packages/matter.js/src/cluster/definitions/ThermostatUserInterfaceConfigurationCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/ThermostatUserInterfaceConfigurationCluster.ts
@@ -6,13 +6,9 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import {
-    Cluster as CreateCluster,
-    WritableAttribute,
-    AccessLevel,
-    OptionalWritableAttribute
-} from "../../cluster/Cluster.js";
+import { ClusterFactory } from "../../cluster/ClusterFactory.js";
 import { MatterApplicationClusterSpecificationV1_1 } from "../../spec/Specifications.js";
+import { WritableAttribute, AccessLevel, OptionalWritableAttribute } from "../../cluster/Cluster.js";
 import { TlvEnum } from "../../tlv/TlvNumber.js";
 
 export namespace ThermostatUserInterfaceConfiguration {
@@ -95,7 +91,7 @@ export namespace ThermostatUserInterfaceConfiguration {
      *
      * @see {@link MatterApplicationClusterSpecificationV1_1} § 4.5
      */
-    export const Cluster = CreateCluster({
+    export const Cluster = ClusterFactory.Definition({
         id: 0x204,
         name: "ThermostatUserInterfaceConfiguration",
         revision: 2,

--- a/packages/matter.js/src/cluster/definitions/ThreadNetworkDiagnosticsCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/ThreadNetworkDiagnosticsCluster.ts
@@ -6,16 +6,8 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
+import { ClusterFactory } from "../../cluster/ClusterFactory.js";
 import { MatterCoreSpecificationV1_1 } from "../../spec/Specifications.js";
-import {
-    BaseClusterComponent,
-    ClusterComponent,
-    ExtensibleCluster,
-    validateFeatureSelection,
-    extendCluster,
-    ClusterForBaseCluster,
-    AsConditional
-} from "../../cluster/ClusterFactory.js";
 import { BitFlag, BitFlags, TypeFromPartialBitSchema } from "../../schema/BitmapSchema.js";
 import {
     Attribute,
@@ -24,8 +16,7 @@ import {
     EventPriority,
     Command,
     TlvNoResponse,
-    AccessLevel,
-    Cluster as CreateCluster
+    AccessLevel
 } from "../../cluster/Cluster.js";
 import { TlvUInt16, TlvEnum, TlvUInt64, TlvUInt32, TlvUInt8, TlvInt8 } from "../../tlv/TlvNumber.js";
 import { TlvNullable } from "../../tlv/TlvNullable.js";
@@ -486,7 +477,7 @@ export namespace ThreadNetworkDiagnostics {
     /**
      * These elements and properties are present in all ThreadNetworkDiagnostics clusters.
      */
-    export const Base = BaseClusterComponent({
+    export const Base = ClusterFactory.Definition({
         id: 0x35,
         name: "ThreadNetworkDiagnostics",
         revision: 1,
@@ -720,7 +711,7 @@ export namespace ThreadNetworkDiagnostics {
     /**
      * A ThreadNetworkDiagnosticsCluster supports these elements if it supports feature ErrorCounts.
      */
-    export const ErrorCountsComponent = ClusterComponent({
+    export const ErrorCountsComponent = ClusterFactory.Component({
         attributes: {
             /**
              * The OverrunCount attribute shall indicate the number of packets dropped either at ingress or egress, due
@@ -750,7 +741,7 @@ export namespace ThreadNetworkDiagnostics {
     /**
      * A ThreadNetworkDiagnosticsCluster supports these elements if it supports feature MleCounts.
      */
-    export const MleCountsComponent = ClusterComponent({
+    export const MleCountsComponent = ClusterFactory.Component({
         attributes: {
             /**
              * The DetachedRoleCount attribute shall indicate the number of times the Node entered the
@@ -827,7 +818,7 @@ export namespace ThreadNetworkDiagnostics {
     /**
      * A ThreadNetworkDiagnosticsCluster supports these elements if it supports feature MacCounts.
      */
-    export const MacCountsComponent = ClusterComponent({
+    export const MacCountsComponent = ClusterFactory.Component({
         attributes: {
             /**
              * The TxTotalCount attribute shall indicate the total number of unique MAC frame transmission requests.
@@ -1156,8 +1147,8 @@ export namespace ThreadNetworkDiagnostics {
      *
      * @see {@link MatterCoreSpecificationV1_1} § 11.13
      */
-    export const Cluster = ExtensibleCluster({
-        ...Base,
+    export const Cluster = ClusterFactory.Extensible(
+        Base,
 
         /**
          * Use this factory method to create a ThreadNetworkDiagnostics cluster with support for optional features.
@@ -1167,18 +1158,21 @@ export namespace ThreadNetworkDiagnostics {
          * @returns a ThreadNetworkDiagnostics cluster with specified features enabled
          * @throws {IllegalClusterError} if the feature combination is disallowed by the Matter specification
          */
-        factory: <T extends `${Feature}`[]>(...features: [...T]) => {
-            validateFeatureSelection(features, Feature);
-            const cluster = CreateCluster({ ...Base, supportedFeatures: BitFlags(Base.features, ...features) });
-            extendCluster(cluster, ErrorCountsComponent, { errorCounts: true });
-            extendCluster(cluster, MleCountsComponent, { mleCounts: true });
-            extendCluster(cluster, MacCountsComponent, { macCounts: true });
+        <T extends `${Feature}`[]>(...features: [...T]) => {
+            ClusterFactory.validateFeatureSelection(features, Feature);
+            const cluster = ClusterFactory.Definition({
+                ...Base,
+                supportedFeatures: BitFlags(Base.features, ...features)
+            });
+            ClusterFactory.extend(cluster, ErrorCountsComponent, { errorCounts: true });
+            ClusterFactory.extend(cluster, MleCountsComponent, { mleCounts: true });
+            ClusterFactory.extend(cluster, MacCountsComponent, { macCounts: true });
             return cluster as unknown as Extension<BitFlags<typeof Base.features, T>>;
         }
-    });
+    );
 
     export type Extension<SF extends TypeFromPartialBitSchema<typeof Base.features>> =
-        ClusterForBaseCluster<typeof Base, SF>
+        Omit<typeof Base, "supportedFeatures">
         & { supportedFeatures: SF }
         & (SF extends { errorCounts: true } ? typeof ErrorCountsComponent : {})
         & (SF extends { mleCounts: true } ? typeof MleCountsComponent : {})
@@ -1194,7 +1188,7 @@ export namespace ThreadNetworkDiagnostics {
      * If you use this cluster you must manually specify which features are active and ensure the set of active
      * features is legal per the Matter specification.
      */
-    export const Complete = CreateCluster({
+    export const Complete = ClusterFactory.Definition({
         id: Cluster.id,
         name: Cluster.name,
         revision: Cluster.revision,
@@ -1202,94 +1196,187 @@ export namespace ThreadNetworkDiagnostics {
 
         attributes: {
             ...Cluster.attributes,
-            overrunCount: AsConditional(ErrorCountsComponent.attributes.overrunCount, { mandatoryIf: [ERRCNT] }),
-            detachedRoleCount: AsConditional(MleCountsComponent.attributes.detachedRoleCount, { optionalIf: [MLECNT] }),
-            childRoleCount: AsConditional(MleCountsComponent.attributes.childRoleCount, { optionalIf: [MLECNT] }),
-            routerRoleCount: AsConditional(MleCountsComponent.attributes.routerRoleCount, { optionalIf: [MLECNT] }),
-            leaderRoleCount: AsConditional(MleCountsComponent.attributes.leaderRoleCount, { optionalIf: [MLECNT] }),
-            attachAttemptCount: AsConditional(
+            overrunCount: ClusterFactory.AsConditional(
+                ErrorCountsComponent.attributes.overrunCount,
+                { mandatoryIf: [ERRCNT] }
+            ),
+            detachedRoleCount: ClusterFactory.AsConditional(
+                MleCountsComponent.attributes.detachedRoleCount,
+                { optionalIf: [MLECNT] }
+            ),
+            childRoleCount: ClusterFactory.AsConditional(
+                MleCountsComponent.attributes.childRoleCount,
+                { optionalIf: [MLECNT] }
+            ),
+            routerRoleCount: ClusterFactory.AsConditional(
+                MleCountsComponent.attributes.routerRoleCount,
+                { optionalIf: [MLECNT] }
+            ),
+            leaderRoleCount: ClusterFactory.AsConditional(
+                MleCountsComponent.attributes.leaderRoleCount,
+                { optionalIf: [MLECNT] }
+            ),
+            attachAttemptCount: ClusterFactory.AsConditional(
                 MleCountsComponent.attributes.attachAttemptCount,
                 { optionalIf: [MLECNT] }
             ),
-            partitionIdChangeCount: AsConditional(
+            partitionIdChangeCount: ClusterFactory.AsConditional(
                 MleCountsComponent.attributes.partitionIdChangeCount,
                 { optionalIf: [MLECNT] }
             ),
-            betterPartitionAttachAttemptCount: AsConditional(
+            betterPartitionAttachAttemptCount: ClusterFactory.AsConditional(
                 MleCountsComponent.attributes.betterPartitionAttachAttemptCount,
                 { optionalIf: [MLECNT] }
             ),
-            parentChangeCount: AsConditional(MleCountsComponent.attributes.parentChangeCount, { optionalIf: [MLECNT] }),
-            txTotalCount: AsConditional(MacCountsComponent.attributes.txTotalCount, { optionalIf: [MACCNT] }),
-            txUnicastCount: AsConditional(MacCountsComponent.attributes.txUnicastCount, { optionalIf: [MACCNT] }),
-            txBroadcastCount: AsConditional(MacCountsComponent.attributes.txBroadcastCount, { optionalIf: [MACCNT] }),
-            txAckRequestedCount: AsConditional(
+            parentChangeCount: ClusterFactory.AsConditional(
+                MleCountsComponent.attributes.parentChangeCount,
+                { optionalIf: [MLECNT] }
+            ),
+            txTotalCount: ClusterFactory.AsConditional(
+                MacCountsComponent.attributes.txTotalCount,
+                { optionalIf: [MACCNT] }
+            ),
+            txUnicastCount: ClusterFactory.AsConditional(
+                MacCountsComponent.attributes.txUnicastCount,
+                { optionalIf: [MACCNT] }
+            ),
+            txBroadcastCount: ClusterFactory.AsConditional(
+                MacCountsComponent.attributes.txBroadcastCount,
+                { optionalIf: [MACCNT] }
+            ),
+            txAckRequestedCount: ClusterFactory.AsConditional(
                 MacCountsComponent.attributes.txAckRequestedCount,
                 { optionalIf: [MACCNT] }
             ),
-            txAckedCount: AsConditional(MacCountsComponent.attributes.txAckedCount, { optionalIf: [MACCNT] }),
-            txNoAckRequestedCount: AsConditional(
+            txAckedCount: ClusterFactory.AsConditional(
+                MacCountsComponent.attributes.txAckedCount,
+                { optionalIf: [MACCNT] }
+            ),
+            txNoAckRequestedCount: ClusterFactory.AsConditional(
                 MacCountsComponent.attributes.txNoAckRequestedCount,
                 { optionalIf: [MACCNT] }
             ),
-            txDataCount: AsConditional(MacCountsComponent.attributes.txDataCount, { optionalIf: [MACCNT] }),
-            txDataPollCount: AsConditional(MacCountsComponent.attributes.txDataPollCount, { optionalIf: [MACCNT] }),
-            txBeaconCount: AsConditional(MacCountsComponent.attributes.txBeaconCount, { optionalIf: [MACCNT] }),
-            txBeaconRequestCount: AsConditional(
+            txDataCount: ClusterFactory.AsConditional(
+                MacCountsComponent.attributes.txDataCount,
+                { optionalIf: [MACCNT] }
+            ),
+            txDataPollCount: ClusterFactory.AsConditional(
+                MacCountsComponent.attributes.txDataPollCount,
+                { optionalIf: [MACCNT] }
+            ),
+            txBeaconCount: ClusterFactory.AsConditional(
+                MacCountsComponent.attributes.txBeaconCount,
+                { optionalIf: [MACCNT] }
+            ),
+            txBeaconRequestCount: ClusterFactory.AsConditional(
                 MacCountsComponent.attributes.txBeaconRequestCount,
                 { optionalIf: [MACCNT] }
             ),
-            txOtherCount: AsConditional(MacCountsComponent.attributes.txOtherCount, { optionalIf: [MACCNT] }),
-            txRetryCount: AsConditional(MacCountsComponent.attributes.txRetryCount, { optionalIf: [MACCNT] }),
-            txDirectMaxRetryExpiryCount: AsConditional(
+            txOtherCount: ClusterFactory.AsConditional(
+                MacCountsComponent.attributes.txOtherCount,
+                { optionalIf: [MACCNT] }
+            ),
+            txRetryCount: ClusterFactory.AsConditional(
+                MacCountsComponent.attributes.txRetryCount,
+                { optionalIf: [MACCNT] }
+            ),
+            txDirectMaxRetryExpiryCount: ClusterFactory.AsConditional(
                 MacCountsComponent.attributes.txDirectMaxRetryExpiryCount,
                 { optionalIf: [MACCNT] }
             ),
-            txIndirectMaxRetryExpiryCount: AsConditional(
+            txIndirectMaxRetryExpiryCount: ClusterFactory.AsConditional(
                 MacCountsComponent.attributes.txIndirectMaxRetryExpiryCount,
                 { optionalIf: [MACCNT] }
             ),
-            txErrCcaCount: AsConditional(MacCountsComponent.attributes.txErrCcaCount, { optionalIf: [MACCNT] }),
-            txErrAbortCount: AsConditional(MacCountsComponent.attributes.txErrAbortCount, { optionalIf: [MACCNT] }),
-            txErrBusyChannelCount: AsConditional(
+            txErrCcaCount: ClusterFactory.AsConditional(
+                MacCountsComponent.attributes.txErrCcaCount,
+                { optionalIf: [MACCNT] }
+            ),
+            txErrAbortCount: ClusterFactory.AsConditional(
+                MacCountsComponent.attributes.txErrAbortCount,
+                { optionalIf: [MACCNT] }
+            ),
+            txErrBusyChannelCount: ClusterFactory.AsConditional(
                 MacCountsComponent.attributes.txErrBusyChannelCount,
                 { optionalIf: [MACCNT] }
             ),
-            rxTotalCount: AsConditional(MacCountsComponent.attributes.rxTotalCount, { optionalIf: [MACCNT] }),
-            rxUnicastCount: AsConditional(MacCountsComponent.attributes.rxUnicastCount, { optionalIf: [MACCNT] }),
-            rxBroadcastCount: AsConditional(MacCountsComponent.attributes.rxBroadcastCount, { optionalIf: [MACCNT] }),
-            rxDataCount: AsConditional(MacCountsComponent.attributes.rxDataCount, { optionalIf: [MACCNT] }),
-            rxDataPollCount: AsConditional(MacCountsComponent.attributes.rxDataPollCount, { optionalIf: [MACCNT] }),
-            rxBeaconCount: AsConditional(MacCountsComponent.attributes.rxBeaconCount, { optionalIf: [MACCNT] }),
-            rxBeaconRequestCount: AsConditional(
+            rxTotalCount: ClusterFactory.AsConditional(
+                MacCountsComponent.attributes.rxTotalCount,
+                { optionalIf: [MACCNT] }
+            ),
+            rxUnicastCount: ClusterFactory.AsConditional(
+                MacCountsComponent.attributes.rxUnicastCount,
+                { optionalIf: [MACCNT] }
+            ),
+            rxBroadcastCount: ClusterFactory.AsConditional(
+                MacCountsComponent.attributes.rxBroadcastCount,
+                { optionalIf: [MACCNT] }
+            ),
+            rxDataCount: ClusterFactory.AsConditional(
+                MacCountsComponent.attributes.rxDataCount,
+                { optionalIf: [MACCNT] }
+            ),
+            rxDataPollCount: ClusterFactory.AsConditional(
+                MacCountsComponent.attributes.rxDataPollCount,
+                { optionalIf: [MACCNT] }
+            ),
+            rxBeaconCount: ClusterFactory.AsConditional(
+                MacCountsComponent.attributes.rxBeaconCount,
+                { optionalIf: [MACCNT] }
+            ),
+            rxBeaconRequestCount: ClusterFactory.AsConditional(
                 MacCountsComponent.attributes.rxBeaconRequestCount,
                 { optionalIf: [MACCNT] }
             ),
-            rxOtherCount: AsConditional(MacCountsComponent.attributes.rxOtherCount, { optionalIf: [MACCNT] }),
-            rxAddressFilteredCount: AsConditional(
+            rxOtherCount: ClusterFactory.AsConditional(
+                MacCountsComponent.attributes.rxOtherCount,
+                { optionalIf: [MACCNT] }
+            ),
+            rxAddressFilteredCount: ClusterFactory.AsConditional(
                 MacCountsComponent.attributes.rxAddressFilteredCount,
                 { optionalIf: [MACCNT] }
             ),
-            rxDestAddrFilteredCount: AsConditional(
+            rxDestAddrFilteredCount: ClusterFactory.AsConditional(
                 MacCountsComponent.attributes.rxDestAddrFilteredCount,
                 { optionalIf: [MACCNT] }
             ),
-            rxDuplicatedCount: AsConditional(MacCountsComponent.attributes.rxDuplicatedCount, { optionalIf: [MACCNT] }),
-            rxErrNoFrameCount: AsConditional(MacCountsComponent.attributes.rxErrNoFrameCount, { optionalIf: [MACCNT] }),
-            rxErrUnknownNeighborCount: AsConditional(
+            rxDuplicatedCount: ClusterFactory.AsConditional(
+                MacCountsComponent.attributes.rxDuplicatedCount,
+                { optionalIf: [MACCNT] }
+            ),
+            rxErrNoFrameCount: ClusterFactory.AsConditional(
+                MacCountsComponent.attributes.rxErrNoFrameCount,
+                { optionalIf: [MACCNT] }
+            ),
+            rxErrUnknownNeighborCount: ClusterFactory.AsConditional(
                 MacCountsComponent.attributes.rxErrUnknownNeighborCount,
                 { optionalIf: [MACCNT] }
             ),
-            rxErrInvalidScrAddrCount: AsConditional(
+            rxErrInvalidScrAddrCount: ClusterFactory.AsConditional(
                 MacCountsComponent.attributes.rxErrInvalidScrAddrCount,
                 { optionalIf: [MACCNT] }
             ),
-            rxErrSecCount: AsConditional(MacCountsComponent.attributes.rxErrSecCount, { optionalIf: [MACCNT] }),
-            rxErrFcsCount: AsConditional(MacCountsComponent.attributes.rxErrFcsCount, { optionalIf: [MACCNT] }),
-            rxErrOtherCount: AsConditional(MacCountsComponent.attributes.rxErrOtherCount, { optionalIf: [MACCNT] })
+            rxErrSecCount: ClusterFactory.AsConditional(
+                MacCountsComponent.attributes.rxErrSecCount,
+                { optionalIf: [MACCNT] }
+            ),
+            rxErrFcsCount: ClusterFactory.AsConditional(
+                MacCountsComponent.attributes.rxErrFcsCount,
+                { optionalIf: [MACCNT] }
+            ),
+            rxErrOtherCount: ClusterFactory.AsConditional(
+                MacCountsComponent.attributes.rxErrOtherCount,
+                { optionalIf: [MACCNT] }
+            )
         },
 
-        commands: { resetCounts: AsConditional(ErrorCountsComponent.commands.resetCounts, { mandatoryIf: [ERRCNT] }) },
+        commands: {
+            resetCounts: ClusterFactory.AsConditional(
+                ErrorCountsComponent.commands.resetCounts,
+                { mandatoryIf: [ERRCNT] }
+            )
+        },
+
         events: Cluster.events
     });
 }

--- a/packages/matter.js/src/cluster/definitions/TimeFormatLocalizationCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/TimeFormatLocalizationCluster.ts
@@ -6,18 +6,10 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
+import { ClusterFactory } from "../../cluster/ClusterFactory.js";
 import { MatterCoreSpecificationV1_1 } from "../../spec/Specifications.js";
-import {
-    BaseClusterComponent,
-    ClusterComponent,
-    ExtensibleCluster,
-    validateFeatureSelection,
-    extendCluster,
-    ClusterForBaseCluster,
-    AsConditional
-} from "../../cluster/ClusterFactory.js";
 import { BitFlag, BitFlags, TypeFromPartialBitSchema } from "../../schema/BitmapSchema.js";
-import { WritableAttribute, AccessLevel, FixedAttribute, Cluster as CreateCluster } from "../../cluster/Cluster.js";
+import { WritableAttribute, AccessLevel, FixedAttribute } from "../../cluster/Cluster.js";
 import { TlvEnum } from "../../tlv/TlvNumber.js";
 import { TlvNullable } from "../../tlv/TlvNullable.js";
 import { TlvArray } from "../../tlv/TlvArray.js";
@@ -120,7 +112,7 @@ export namespace TimeFormatLocalization {
     /**
      * These elements and properties are present in all TimeFormatLocalization clusters.
      */
-    export const Base = BaseClusterComponent({
+    export const Base = ClusterFactory.Definition({
         id: 0x2c,
         name: "TimeFormatLocalization",
         revision: 1,
@@ -154,7 +146,7 @@ export namespace TimeFormatLocalization {
     /**
      * A TimeFormatLocalizationCluster supports these elements if it supports feature CalendarFormat.
      */
-    export const CalendarFormatComponent = ClusterComponent({
+    export const CalendarFormatComponent = ClusterFactory.Component({
         attributes: {
             /**
              * The ActiveCalendarType attribute shall represent the calendar format that the Node is currently
@@ -196,8 +188,8 @@ export namespace TimeFormatLocalization {
      *
      * @see {@link MatterCoreSpecificationV1_1} § 11.4
      */
-    export const Cluster = ExtensibleCluster({
-        ...Base,
+    export const Cluster = ClusterFactory.Extensible(
+        Base,
 
         /**
          * Use this factory method to create a TimeFormatLocalization cluster with support for optional features.
@@ -207,16 +199,19 @@ export namespace TimeFormatLocalization {
          * @returns a TimeFormatLocalization cluster with specified features enabled
          * @throws {IllegalClusterError} if the feature combination is disallowed by the Matter specification
          */
-        factory: <T extends `${Feature}`[]>(...features: [...T]) => {
-            validateFeatureSelection(features, Feature);
-            const cluster = CreateCluster({ ...Base, supportedFeatures: BitFlags(Base.features, ...features) });
-            extendCluster(cluster, CalendarFormatComponent, { calendarFormat: true });
+        <T extends `${Feature}`[]>(...features: [...T]) => {
+            ClusterFactory.validateFeatureSelection(features, Feature);
+            const cluster = ClusterFactory.Definition({
+                ...Base,
+                supportedFeatures: BitFlags(Base.features, ...features)
+            });
+            ClusterFactory.extend(cluster, CalendarFormatComponent, { calendarFormat: true });
             return cluster as unknown as Extension<BitFlags<typeof Base.features, T>>;
         }
-    });
+    );
 
     export type Extension<SF extends TypeFromPartialBitSchema<typeof Base.features>> =
-        ClusterForBaseCluster<typeof Base, SF>
+        Omit<typeof Base, "supportedFeatures">
         & { supportedFeatures: SF }
         & (SF extends { calendarFormat: true } ? typeof CalendarFormatComponent : {});
     const CALFMT = { calendarFormat: true };
@@ -227,7 +222,7 @@ export namespace TimeFormatLocalization {
      * If you use this cluster you must manually specify which features are active and ensure the set of active
      * features is legal per the Matter specification.
      */
-    export const Complete = CreateCluster({
+    export const Complete = ClusterFactory.Definition({
         id: Cluster.id,
         name: Cluster.name,
         revision: Cluster.revision,
@@ -235,11 +230,11 @@ export namespace TimeFormatLocalization {
 
         attributes: {
             ...Cluster.attributes,
-            activeCalendarType: AsConditional(
+            activeCalendarType: ClusterFactory.AsConditional(
                 CalendarFormatComponent.attributes.activeCalendarType,
                 { mandatoryIf: [CALFMT] }
             ),
-            supportedCalendarTypes: AsConditional(
+            supportedCalendarTypes: ClusterFactory.AsConditional(
                 CalendarFormatComponent.attributes.supportedCalendarTypes,
                 { mandatoryIf: [CALFMT] }
             )

--- a/packages/matter.js/src/cluster/definitions/UnitLocalizationCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/UnitLocalizationCluster.ts
@@ -6,18 +6,10 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
+import { ClusterFactory } from "../../cluster/ClusterFactory.js";
 import { MatterCoreSpecificationV1_1 } from "../../spec/Specifications.js";
-import {
-    BaseClusterComponent,
-    ClusterComponent,
-    ExtensibleCluster,
-    validateFeatureSelection,
-    extendCluster,
-    ClusterForBaseCluster,
-    AsConditional
-} from "../../cluster/ClusterFactory.js";
 import { BitFlag, BitFlags, TypeFromPartialBitSchema } from "../../schema/BitmapSchema.js";
-import { WritableAttribute, AccessLevel, Cluster as CreateCluster } from "../../cluster/Cluster.js";
+import { WritableAttribute, AccessLevel } from "../../cluster/Cluster.js";
 import { TlvEnum } from "../../tlv/TlvNumber.js";
 import { TlvNullable } from "../../tlv/TlvNullable.js";
 
@@ -59,7 +51,7 @@ export namespace UnitLocalization {
     /**
      * These elements and properties are present in all UnitLocalization clusters.
      */
-    export const Base = BaseClusterComponent({
+    export const Base = ClusterFactory.Definition({
         id: 0x2d,
         name: "UnitLocalization",
         revision: 1,
@@ -77,7 +69,7 @@ export namespace UnitLocalization {
     /**
      * A UnitLocalizationCluster supports these elements if it supports feature TemperatureUnit.
      */
-    export const TemperatureUnitComponent = ClusterComponent({
+    export const TemperatureUnitComponent = ClusterFactory.Component({
         attributes: {
             /**
              * The TemperatureUnit attribute shall indicate the unit for the Node to use only when conveying
@@ -110,8 +102,8 @@ export namespace UnitLocalization {
      *
      * @see {@link MatterCoreSpecificationV1_1} § 11.5
      */
-    export const Cluster = ExtensibleCluster({
-        ...Base,
+    export const Cluster = ClusterFactory.Extensible(
+        Base,
 
         /**
          * Use this factory method to create an UnitLocalization cluster with support for optional features. Include
@@ -121,16 +113,19 @@ export namespace UnitLocalization {
          * @returns an UnitLocalization cluster with specified features enabled
          * @throws {IllegalClusterError} if the feature combination is disallowed by the Matter specification
          */
-        factory: <T extends `${Feature}`[]>(...features: [...T]) => {
-            validateFeatureSelection(features, Feature);
-            const cluster = CreateCluster({ ...Base, supportedFeatures: BitFlags(Base.features, ...features) });
-            extendCluster(cluster, TemperatureUnitComponent, { temperatureUnit: true });
+        <T extends `${Feature}`[]>(...features: [...T]) => {
+            ClusterFactory.validateFeatureSelection(features, Feature);
+            const cluster = ClusterFactory.Definition({
+                ...Base,
+                supportedFeatures: BitFlags(Base.features, ...features)
+            });
+            ClusterFactory.extend(cluster, TemperatureUnitComponent, { temperatureUnit: true });
             return cluster as unknown as Extension<BitFlags<typeof Base.features, T>>;
         }
-    });
+    );
 
     export type Extension<SF extends TypeFromPartialBitSchema<typeof Base.features>> =
-        ClusterForBaseCluster<typeof Base, SF>
+        Omit<typeof Base, "supportedFeatures">
         & { supportedFeatures: SF }
         & (SF extends { temperatureUnit: true } ? typeof TemperatureUnitComponent : {});
     const TEMP = { temperatureUnit: true };
@@ -141,14 +136,14 @@ export namespace UnitLocalization {
      * If you use this cluster you must manually specify which features are active and ensure the set of active
      * features is legal per the Matter specification.
      */
-    export const Complete = CreateCluster({
+    export const Complete = ClusterFactory.Definition({
         id: Cluster.id,
         name: Cluster.name,
         revision: Cluster.revision,
         features: Cluster.features,
 
         attributes: {
-            temperatureUnit: AsConditional(
+            temperatureUnit: ClusterFactory.AsConditional(
                 TemperatureUnitComponent.attributes.temperatureUnit,
                 { mandatoryIf: [TEMP] }
             )

--- a/packages/matter.js/src/cluster/definitions/UserLabelCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/UserLabelCluster.ts
@@ -6,8 +6,9 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import { Cluster as CreateCluster, WritableAttribute, AccessLevel } from "../../cluster/Cluster.js";
+import { ClusterFactory } from "../../cluster/ClusterFactory.js";
 import { MatterCoreSpecificationV1_1 } from "../../spec/Specifications.js";
+import { WritableAttribute, AccessLevel } from "../../cluster/Cluster.js";
 import { TlvArray } from "../../tlv/TlvArray.js";
 import { Label } from "../../cluster/definitions/LabelCluster.js";
 
@@ -19,7 +20,7 @@ export namespace UserLabel {
      *
      * @see {@link MatterCoreSpecificationV1_1} § 9.9
      */
-    export const Cluster = CreateCluster({
+    export const Cluster = ClusterFactory.Definition({
         id: 0x41,
         name: "UserLabel",
         revision: 1,

--- a/packages/matter.js/src/cluster/definitions/ValidProxiesCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/ValidProxiesCluster.ts
@@ -6,8 +6,9 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import { Cluster as CreateCluster, WritableFixedAttribute, Command } from "../../cluster/Cluster.js";
+import { ClusterFactory } from "../../cluster/ClusterFactory.js";
 import { MatterCoreSpecificationV1_1 } from "../../spec/Specifications.js";
+import { WritableFixedAttribute, Command } from "../../cluster/Cluster.js";
 import { TlvArray } from "../../tlv/TlvArray.js";
 import { TlvObject, TlvField } from "../../tlv/TlvObject.js";
 import { TlvNodeId } from "../../datatype/NodeId.js";
@@ -29,7 +30,7 @@ export namespace ValidProxies {
      *
      * @see {@link MatterCoreSpecificationV1_1} § 9.15.15
      */
-    export const Cluster = CreateCluster({
+    export const Cluster = ClusterFactory.Definition({
         id: 0x44,
         name: "ValidProxies",
         revision: 1,

--- a/packages/matter.js/src/cluster/definitions/WakeOnLanCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/WakeOnLanCluster.ts
@@ -6,8 +6,9 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import { Cluster as CreateCluster, OptionalFixedAttribute } from "../../cluster/Cluster.js";
+import { ClusterFactory } from "../../cluster/ClusterFactory.js";
 import { MatterApplicationClusterSpecificationV1_1 } from "../../spec/Specifications.js";
+import { OptionalFixedAttribute } from "../../cluster/Cluster.js";
 import { TlvByteString } from "../../tlv/TlvString.js";
 
 export namespace WakeOnLan {
@@ -19,7 +20,7 @@ export namespace WakeOnLan {
      *
      * @see {@link MatterApplicationClusterSpecificationV1_1} § 1.10
      */
-    export const Cluster = CreateCluster({
+    export const Cluster = ClusterFactory.Definition({
         id: 0x503,
         name: "WakeOnLan",
         revision: 1,

--- a/packages/matter.js/src/cluster/definitions/WindowCoveringCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/WindowCoveringCluster.ts
@@ -6,17 +6,8 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
+import { ClusterFactory } from "../../cluster/ClusterFactory.js";
 import { MatterApplicationClusterSpecificationV1_1 } from "../../spec/Specifications.js";
-import {
-    BaseClusterComponent,
-    ClusterComponent,
-    ExtensibleCluster,
-    validateFeatureSelection,
-    extendCluster,
-    preventCluster,
-    ClusterForBaseCluster,
-    AsConditional
-} from "../../cluster/ClusterFactory.js";
 import {
     BitFlag,
     BitsFromPartial,
@@ -33,8 +24,7 @@ import {
     Command,
     TlvNoResponse,
     OptionalFixedAttribute,
-    OptionalCommand,
-    Cluster as CreateCluster
+    OptionalCommand
 } from "../../cluster/Cluster.js";
 import { TlvEnum, TlvUInt8, TlvBitmap, TlvUInt16, TlvPercent, TlvPercent100ths } from "../../tlv/TlvNumber.js";
 import { TlvNoArguments } from "../../tlv/TlvNoArguments.js";
@@ -372,7 +362,7 @@ export namespace WindowCovering {
     /**
      * These elements and properties are present in all WindowCovering clusters.
      */
-    export const Base = BaseClusterComponent({
+    export const Base = ClusterFactory.Definition({
         id: 0x102,
         name: "WindowCovering",
         revision: 5,
@@ -569,7 +559,7 @@ export namespace WindowCovering {
      * A WindowCoveringCluster supports these elements if it supports features Lift, PositionAwareLift and
      * AbsolutePosition.
      */
-    export const LiftAndPositionAwareLiftAndAbsolutePositionComponent = ClusterComponent({
+    export const LiftAndPositionAwareLiftAndAbsolutePositionComponent = ClusterFactory.Component({
         attributes: {
             /**
              * The PhysicalClosedLimitLift attribute identifies the maximum possible encoder position possible (in
@@ -617,7 +607,7 @@ export namespace WindowCovering {
      * A WindowCoveringCluster supports these elements if it supports features Tilt, PositionAwareTilt and
      * AbsolutePosition.
      */
-    export const TiltAndPositionAwareTiltAndAbsolutePositionComponent = ClusterComponent({
+    export const TiltAndPositionAwareTiltAndAbsolutePositionComponent = ClusterFactory.Component({
         attributes: {
             /**
              * The PhysicalClosedLimitTilt attribute identifies the maximum possible encoder position possible (tenth
@@ -664,7 +654,7 @@ export namespace WindowCovering {
     /**
      * A WindowCoveringCluster supports these elements if it supports feature Lift.
      */
-    export const LiftComponent = ClusterComponent({
+    export const LiftComponent = ClusterFactory.Component({
         attributes: {
             /**
              * The NumberOfActuationsLift attribute identifies the total number of lift/slide actuations applied to the
@@ -702,7 +692,7 @@ export namespace WindowCovering {
     /**
      * A WindowCoveringCluster supports these elements if it supports feature Tilt.
      */
-    export const TiltComponent = ClusterComponent({
+    export const TiltComponent = ClusterFactory.Component({
         attributes: {
             /**
              * The NumberOfActuationsTilt attribute identifies the total number of tilt actuations applied to the
@@ -741,7 +731,7 @@ export namespace WindowCovering {
     /**
      * A WindowCoveringCluster supports these elements if it supports features Lift and PositionAwareLift.
      */
-    export const LiftAndPositionAwareLiftComponent = ClusterComponent({
+    export const LiftAndPositionAwareLiftComponent = ClusterFactory.Component({
         attributes: {
             /**
              * The CurrentPositionLiftPercentage attribute identifies the actual position as a percentage from 0% to
@@ -808,7 +798,7 @@ export namespace WindowCovering {
     /**
      * A WindowCoveringCluster supports these elements if it supports features Tilt and PositionAwareTilt.
      */
-    export const TiltAndPositionAwareTiltComponent = ClusterComponent({
+    export const TiltAndPositionAwareTiltComponent = ClusterFactory.Component({
         attributes: {
             /**
              * The CurrentPositionTiltPercentage attribute identifies the actual position as a percentage from 0% to
@@ -876,7 +866,7 @@ export namespace WindowCovering {
     /**
      * A WindowCoveringCluster supports these elements if it supports features Lift and AbsolutePosition.
      */
-    export const LiftAndAbsolutePositionComponent = ClusterComponent({
+    export const LiftAndAbsolutePositionComponent = ClusterFactory.Component({
         commands: {
             /**
              * Upon receipt of this command, the Window Covering will adjust the window so the physical lift/slide is
@@ -894,7 +884,7 @@ export namespace WindowCovering {
     /**
      * A WindowCoveringCluster supports these elements if it supports features Tilt and AbsolutePosition.
      */
-    export const TiltAndAbsolutePositionComponent = ClusterComponent({
+    export const TiltAndAbsolutePositionComponent = ClusterFactory.Component({
         commands: {
             /**
              * Upon receipt of this command, the Window Covering will adjust the window so the physical tilt is at the
@@ -920,8 +910,8 @@ export namespace WindowCovering {
      *
      * @see {@link MatterApplicationClusterSpecificationV1_1} § 5.3
      */
-    export const Cluster = ExtensibleCluster({
-        ...Base,
+    export const Cluster = ClusterFactory.Extensible(
+        Base,
 
         /**
          * Use this factory method to create a WindowCovering cluster with support for optional features. Include each
@@ -931,27 +921,30 @@ export namespace WindowCovering {
          * @returns a WindowCovering cluster with specified features enabled
          * @throws {IllegalClusterError} if the feature combination is disallowed by the Matter specification
          */
-        factory: <T extends `${Feature}`[]>(...features: [...T]) => {
-            validateFeatureSelection(features, Feature);
-            const cluster = CreateCluster({ ...Base, supportedFeatures: BitFlags(Base.features, ...features) });
-            extendCluster(
+        <T extends `${Feature}`[]>(...features: [...T]) => {
+            ClusterFactory.validateFeatureSelection(features, Feature);
+            const cluster = ClusterFactory.Definition({
+                ...Base,
+                supportedFeatures: BitFlags(Base.features, ...features)
+            });
+            ClusterFactory.extend(
                 cluster,
                 LiftAndPositionAwareLiftAndAbsolutePositionComponent,
                 { lift: true, positionAwareLift: true, absolutePosition: true }
             );
-            extendCluster(
+            ClusterFactory.extend(
                 cluster,
                 TiltAndPositionAwareTiltAndAbsolutePositionComponent,
                 { tilt: true, positionAwareTilt: true, absolutePosition: true }
             );
-            extendCluster(cluster, LiftComponent, { lift: true });
-            extendCluster(cluster, TiltComponent, { tilt: true });
-            extendCluster(cluster, LiftAndPositionAwareLiftComponent, { lift: true, positionAwareLift: true });
-            extendCluster(cluster, TiltAndPositionAwareTiltComponent, { tilt: true, positionAwareTilt: true });
-            extendCluster(cluster, LiftAndAbsolutePositionComponent, { lift: true, absolutePosition: true });
-            extendCluster(cluster, TiltAndAbsolutePositionComponent, { tilt: true, absolutePosition: true });
+            ClusterFactory.extend(cluster, LiftComponent, { lift: true });
+            ClusterFactory.extend(cluster, TiltComponent, { tilt: true });
+            ClusterFactory.extend(cluster, LiftAndPositionAwareLiftComponent, { lift: true, positionAwareLift: true });
+            ClusterFactory.extend(cluster, TiltAndPositionAwareTiltComponent, { tilt: true, positionAwareTilt: true });
+            ClusterFactory.extend(cluster, LiftAndAbsolutePositionComponent, { lift: true, absolutePosition: true });
+            ClusterFactory.extend(cluster, TiltAndAbsolutePositionComponent, { tilt: true, absolutePosition: true });
 
-            preventCluster(
+            ClusterFactory.prevent(
                 cluster,
                 { positionAwareLift: true, lift: false },
                 { positionAwareTilt: true, tilt: false },
@@ -960,10 +953,10 @@ export namespace WindowCovering {
 
             return cluster as unknown as Extension<BitFlags<typeof Base.features, T>>;
         }
-    });
+    );
 
     export type Extension<SF extends TypeFromPartialBitSchema<typeof Base.features>> =
-        ClusterForBaseCluster<typeof Base, SF>
+        Omit<typeof Base, "supportedFeatures">
         & { supportedFeatures: SF }
         & (SF extends { lift: true, positionAwareLift: true, absolutePosition: true } ? typeof LiftAndPositionAwareLiftAndAbsolutePositionComponent : {})
         & (SF extends { tilt: true, positionAwareTilt: true, absolutePosition: true } ? typeof TiltAndPositionAwareTiltAndAbsolutePositionComponent : {})
@@ -992,7 +985,7 @@ export namespace WindowCovering {
      * If you use this cluster you must manually specify which features are active and ensure the set of active
      * features is legal per the Matter specification.
      */
-    export const Complete = CreateCluster({
+    export const Complete = ClusterFactory.Definition({
         id: Cluster.id,
         name: Cluster.name,
         revision: Cluster.revision,
@@ -1000,67 +993,67 @@ export namespace WindowCovering {
 
         attributes: {
             ...Cluster.attributes,
-            physicalClosedLimitLift: AsConditional(
+            physicalClosedLimitLift: ClusterFactory.AsConditional(
                 LiftAndPositionAwareLiftAndAbsolutePositionComponent.attributes.physicalClosedLimitLift,
                 { optionalIf: [LF_PA_LF_ABS] }
             ),
-            physicalClosedLimitTilt: AsConditional(
+            physicalClosedLimitTilt: ClusterFactory.AsConditional(
                 TiltAndPositionAwareTiltAndAbsolutePositionComponent.attributes.physicalClosedLimitTilt,
                 { optionalIf: [TL_PA_TL_ABS] }
             ),
-            currentPositionLift: AsConditional(
+            currentPositionLift: ClusterFactory.AsConditional(
                 LiftAndPositionAwareLiftAndAbsolutePositionComponent.attributes.currentPositionLift,
                 { optionalIf: [LF_PA_LF_ABS] }
             ),
-            currentPositionTilt: AsConditional(
+            currentPositionTilt: ClusterFactory.AsConditional(
                 TiltAndPositionAwareTiltAndAbsolutePositionComponent.attributes.currentPositionTilt,
                 { optionalIf: [TL_PA_TL_ABS] }
             ),
-            numberOfActuationsLift: AsConditional(
+            numberOfActuationsLift: ClusterFactory.AsConditional(
                 LiftComponent.attributes.numberOfActuationsLift,
                 { optionalIf: [LF] }
             ),
-            numberOfActuationsTilt: AsConditional(
+            numberOfActuationsTilt: ClusterFactory.AsConditional(
                 TiltComponent.attributes.numberOfActuationsTilt,
                 { optionalIf: [TL] }
             ),
-            currentPositionLiftPercentage: AsConditional(
+            currentPositionLiftPercentage: ClusterFactory.AsConditional(
                 LiftAndPositionAwareLiftComponent.attributes.currentPositionLiftPercentage,
                 { optionalIf: [LF_PA_LF] }
             ),
-            currentPositionTiltPercentage: AsConditional(
+            currentPositionTiltPercentage: ClusterFactory.AsConditional(
                 TiltAndPositionAwareTiltComponent.attributes.currentPositionTiltPercentage,
                 { optionalIf: [TL_PA_TL] }
             ),
-            targetPositionLiftPercent100ths: AsConditional(
+            targetPositionLiftPercent100ths: ClusterFactory.AsConditional(
                 LiftAndPositionAwareLiftComponent.attributes.targetPositionLiftPercent100ths,
                 { mandatoryIf: [LF_PA_LF] }
             ),
-            targetPositionTiltPercent100ths: AsConditional(
+            targetPositionTiltPercent100ths: ClusterFactory.AsConditional(
                 TiltAndPositionAwareTiltComponent.attributes.targetPositionTiltPercent100ths,
                 { mandatoryIf: [TL_PA_TL] }
             ),
-            currentPositionLiftPercent100ths: AsConditional(
+            currentPositionLiftPercent100ths: ClusterFactory.AsConditional(
                 LiftAndPositionAwareLiftComponent.attributes.currentPositionLiftPercent100ths,
                 { mandatoryIf: [LF_PA_LF] }
             ),
-            currentPositionTiltPercent100ths: AsConditional(
+            currentPositionTiltPercent100ths: ClusterFactory.AsConditional(
                 TiltAndPositionAwareTiltComponent.attributes.currentPositionTiltPercent100ths,
                 { mandatoryIf: [TL_PA_TL] }
             ),
-            installedOpenLimitLift: AsConditional(
+            installedOpenLimitLift: ClusterFactory.AsConditional(
                 LiftAndPositionAwareLiftAndAbsolutePositionComponent.attributes.installedOpenLimitLift,
                 { mandatoryIf: [LF_PA_LF_ABS] }
             ),
-            installedClosedLimitLift: AsConditional(
+            installedClosedLimitLift: ClusterFactory.AsConditional(
                 LiftAndPositionAwareLiftAndAbsolutePositionComponent.attributes.installedClosedLimitLift,
                 { mandatoryIf: [LF_PA_LF_ABS] }
             ),
-            installedOpenLimitTilt: AsConditional(
+            installedOpenLimitTilt: ClusterFactory.AsConditional(
                 TiltAndPositionAwareTiltAndAbsolutePositionComponent.attributes.installedOpenLimitTilt,
                 { mandatoryIf: [TL_PA_TL_ABS] }
             ),
-            installedClosedLimitTilt: AsConditional(
+            installedClosedLimitTilt: ClusterFactory.AsConditional(
                 TiltAndPositionAwareTiltAndAbsolutePositionComponent.attributes.installedClosedLimitTilt,
                 { mandatoryIf: [TL_PA_TL_ABS] }
             )
@@ -1068,19 +1061,19 @@ export namespace WindowCovering {
 
         commands: {
             ...Cluster.commands,
-            goToLiftValue: AsConditional(
+            goToLiftValue: ClusterFactory.AsConditional(
                 LiftAndAbsolutePositionComponent.commands.goToLiftValue,
                 { optionalIf: [LF_ABS] }
             ),
-            goToLiftPercentage: AsConditional(
+            goToLiftPercentage: ClusterFactory.AsConditional(
                 LiftComponent.commands.goToLiftPercentage,
                 { optionalIf: [LF], mandatoryIf: [LF_PA_LF] }
             ),
-            goToTiltValue: AsConditional(
+            goToTiltValue: ClusterFactory.AsConditional(
                 TiltAndAbsolutePositionComponent.commands.goToTiltValue,
                 { optionalIf: [TL_ABS] }
             ),
-            goToTiltPercentage: AsConditional(
+            goToTiltPercentage: ClusterFactory.AsConditional(
                 TiltComponent.commands.goToTiltPercentage,
                 { optionalIf: [TL], mandatoryIf: [TL_PA_TL] }
             )

--- a/packages/matter.js/src/device/EndpointStructureLogger.ts
+++ b/packages/matter.js/src/device/EndpointStructureLogger.ts
@@ -17,7 +17,7 @@ import {
 import { asClusterServerInternal, ClusterServerObj } from "../cluster/server/ClusterServerTypes.js";
 import { Endpoint } from "../device/Endpoint.js";
 import { Logger } from "../log/Logger.js";
-import { toHexString } from "./Number.js";
+import { toHexString } from "../util/Number.js";
 
 const logger = Logger.get("EndpointStructureLogger");
 

--- a/packages/matter.js/src/device/export.ts
+++ b/packages/matter.js/src/device/export.ts
@@ -10,4 +10,5 @@ export * from "./Device.js";
 export * from "./DeviceTypes.js";
 export * from "./DimmableDevices.js";
 export * from "./Endpoint.js";
+export * from "./EndpointStructureLogger.js";
 export * from "./OnOffDevices.js";

--- a/packages/matter.js/src/util/Type.ts
+++ b/packages/matter.js/src/util/Type.ts
@@ -56,5 +56,13 @@ export type MakeMandatory<T> = Exclude<T, undefined>;
 
 /** Create a branded type */
 declare const __brand: unique symbol;
-type Brand<B> = { [__brand]: B };
+// Don't think it should be necessary to export Brand<B> but it will cause
+// the following error under some circumstances:
+//
+//   Exported variable 'XXX' has or is using name '__brand' from external
+//   module "../src/util/Type" but cannot be named.ts(4023)
+//
+// Specifically this occurs with the reference to Cluster.id in the "complete"
+// cluster definitions
+export type Brand<B> = { [__brand]: B };
 export type Branded<T, B> = T & Brand<B>;

--- a/packages/matter.js/src/util/export.ts
+++ b/packages/matter.js/src/util/export.ts
@@ -9,7 +9,6 @@ export * from "./Cache.js";
 export * from "./DataReader.js";
 export * from "./DataWriter.js";
 export * from "./DeepEqual.js";
-export * from "./EndpointStructureLogger.js";
 export * from "./Ip.js";
 export * from "./Number.js";
 export * from "./Promises.js";

--- a/tools/src/building/project.ts
+++ b/tools/src/building/project.ts
@@ -92,7 +92,6 @@ export class Project {
             // Find key text
             let pos = map.indexOf('"sources":["../');
             if (pos === -1) {
-                console.log(map.toString());
                 throw new Error(
                     `Could not find sources position in declaration map ${source}, format may have changed`,
                 );

--- a/tools/src/testing/mocha.ts
+++ b/tools/src/testing/mocha.ts
@@ -156,23 +156,13 @@ function parseError(error: Error) {
     }
 
     if (error.stack) {
-        const index = error.stack.indexOf("\n");
-        if (index !== -1) {
-            if (!message) {
-                message = error.stack.slice(0, index);
-            }
-            stack = error.stack
-                .slice(index + 1)
-
-                // Node's assert helpfully puts entire objects in the
-                // message and thus in the stack.  We do diffs ourselves,
-                // we just want the stack.  This does a rough cleanup
-                .replace(/.*?\n {4}at/s, "    at")
-
-                .trim()
-                .replace(/\n\s+/gm, "\n");
-        } else {
-            stack = error.stack;
+        let lines = error.stack.trim().split("\n");
+        if (!message) {
+            message = lines[0];
+        }
+        lines = lines.filter(line => line.match(/:\d+:\d+\)?/));
+        if (lines.length) {
+            stack = lines.map(line => line.trim()).join("\n");
         }
     } else if (error.message) {
         message = error.message;


### PR DESCRIPTION
Please see individual commits for details.  The following is from the main one:

The current Cluster type is somewhat cryptic/cumbersome due to the long list
of generic parameters.  Additionally, we lose type information for any fields
that aren't covered by the generic parameters.

The most immediate need for ongoing device work is access to the cluster
name in the cluster type.

Rather than add yet another generic parameter, this commit rewrites cluster
factory with alternate cluster types that preserve all information from the
cluster down to the element level.

The new types do not require a long list of generic parameters.  This works
using the new "const generic parameter" that's available now that we're on TS5.

We could conceivably migrate all existing references to Cluster<> to this new
approach but to keep things wieldly this commit only uses the new types for
defining clusters.  That unblocks the device API without inflicting changes
that are too massive.

Includes new generated clusters.  Also fixes a couple of places where the old
definitions seem to have been too permissive.