### PR TITLE
Use the run script to start (most) utility scripts

### DIFF
--- a/codegen/bin/dump-model-names.js
+++ b/codegen/bin/dump-model-names.js
@@ -1,3 +1,3 @@
-#!/usr/bin/env -S node --enable-source-maps
+#!/usr/bin/env run
 import { main } from "../dist/esm/dump-model-names.js";
 await main();

--- a/codegen/bin/generate-chip.js
+++ b/codegen/bin/generate-chip.js
@@ -1,3 +1,3 @@
-#!/usr/bin/env -S node --enable-source-maps
+#!/usr/bin/env run
 import { main } from "../dist/esm/generate-chip.js";
 await main();

--- a/codegen/bin/generate-clusters.js
+++ b/codegen/bin/generate-clusters.js
@@ -1,3 +1,3 @@
-#!/usr/bin/env -S node --enable-source-maps
+#!/usr/bin/env run
 import { main } from "../dist/esm/generate-clusters.js";
 await main();

--- a/codegen/bin/generate-model.js
+++ b/codegen/bin/generate-model.js
@@ -1,3 +1,3 @@
-#!/usr/bin/env -S node --enable-source-maps
+#!/usr/bin/env run
 import { main } from "../dist/esm/generate-model.js";
 await main();

--- a/codegen/bin/generate-spec.js
+++ b/codegen/bin/generate-spec.js
@@ -1,3 +1,3 @@
-#!/usr/bin/env -S node --enable-source-maps
+#!/usr/bin/env run
 import { main } from "../dist/esm/generate-spec.js";
 await main();

--- a/codegen/bin/repl.js
+++ b/codegen/bin/repl.js
@@ -1,3 +1,3 @@
-#!/usr/bin/env -S node --enable-source-maps
+#!/usr/bin/env run
 import { main } from "../dist/esm/repl.js";
 await main();

--- a/codegen/package.json
+++ b/codegen/package.json
@@ -8,12 +8,12 @@
     "clean": "build clean",
     "build": "build",
     "build-clean": "build --clean",
-    "console": "build esm && node dist/esm/repl.ts",
-    "generate-spec": "build esm && node bin/generate-spec.js",
-    "generate-chip": "build esm && node bin/generate-chip.js",
-    "generate-model": "build --prefix=../models && build esm && node bin/generate-model.js",
-    "generate-clusters": "build --prefix=../packages/matter.js && build esm && node bin/generate-clusters.js",
-    "dump-model-names": "build --prefix=../models && build esm && node bin/dump-model-names.ts",
+    "console": "run dist/esm/repl.ts",
+    "generate-spec": "run bin/generate-spec.js",
+    "generate-chip": "run bin/generate-chip.js",
+    "generate-model": "build --prefix=../models && run bin/generate-model.js",
+    "generate-clusters": "build --prefix=../packages/matter.js && run bin/generate-clusters.js",
+    "dump-model-names": "build --prefix=../models && run bin/dump-model-names.ts",
     "generate": "npm run generate-model && npm run generate-clusters"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
         "build": "npm -s run build --workspaces",
         "build-clean": "npm -s run build-clean --workspaces",
         "build-doc": "npm run build-doc --workspaces --if-present",
-        "test": "npm -s run test --workspaces --if-present",
+        "test": "npm run -s test --workspaces --if-present",
         "lint": "eslint --cache --cache-strategy content 'packages/**/*.ts' 'tools/**/*.ts' 'codegen/**/*.ts' 'models/src/local/**/*.ts' 'chip-testing/**/*.ts'",
         "lint-fix": "eslint --cache --cache-strategy content --fix 'packages/**/*.ts' 'tools/**/*.ts' 'codegen/**/*.ts' 'models/src/local/**/*.ts' 'chip-testing/**/*.ts'",
         "format": "prettier --write 'packages/**/*.ts' 'tools/**/*.ts' 'models/**/*.ts' 'codegen/**/*.ts' 'chip-testing/**/*.ts'",

--- a/tools/bin/build.js
+++ b/tools/bin/build.js
@@ -1,3 +1,7 @@
-#!/usr/bin/env -S node --enable-source-maps
+#!/usr/bin/env node
+
+// We do not use run script to avoid the performance hit so source maps are
+// not enabled for the build script itself
+
 import { main } from "../dist/esm/building/cli.js"
 await main();

--- a/tools/bin/test.js
+++ b/tools/bin/test.js
@@ -1,3 +1,3 @@
-#!/usr/bin/env -S node --enable-source-maps
+#!/usr/bin/env run
 import { main } from "../dist/esm/testing/cli.js"
 await main();

--- a/tools/src/running/cli.ts
+++ b/tools/src/running/cli.ts
@@ -22,7 +22,19 @@ export async function main(argv = process.argv) {
     }
 
     script = resolve(script);
-    const project = new Project(dirname(script));
+    let dir;
+    if (script.match(/[\\/]node_modules[\\/].bin[\\/]/)) {
+        // When executing a script linked under node_modules, search for the
+        // project from cwd.  This occurs when running tooling such as
+        // "matter-test"
+        dir = process.cwd();
+    } else {
+        // When executing outside of node modules we want to build the project
+        // containing the script
+        dir = dirname(script);
+    }
+
+    const project = new Project(dir);
 
     let format: "esm" | "cjs";
     if (project.pkg.esm) {

--- a/tools/src/running/execute.ts
+++ b/tools/src/running/execute.ts
@@ -6,6 +6,8 @@
 
 import { spawn } from "child_process";
 
+import colors from "ansi-colors";
+
 export async function execute(bin: string, argv: string[]) {
     return new Promise<void>((resolve, reject) => {
         const proc = spawn(bin, argv, {
@@ -22,5 +24,10 @@ export async function execute(bin: string, argv: string[]) {
 }
 
 export async function executeNode(script: string, argv: string[]) {
-    return execute("node", ["--enable-source-maps", script, ...argv]);
+    argv = ["--enable-source-maps", script, ...argv];
+    if (process.env.MATTER_RUN_ECHO) {
+        const command = colors.whiteBright(`node ${argv.join(" ")}`);
+        process.stdout.write(`${colors.greenBright("Matter execute:")} ${command}\n`);
+    }
+    return execute("node", argv);
 }


### PR DESCRIPTION
Previously we were using "env -S" to enable source maps but in #314 @UncleSamSwiss points out this isn't well supported everywhere yet.

So instead use the "run" utility script which enables source maps by default.
