### PR TITLE
Clean up some asynchronous handling

### DIFF
--- a/packages/matter-node-ble.js/src/ble/BleScanner.ts
+++ b/packages/matter-node-ble.js/src/ble/BleScanner.ts
@@ -16,7 +16,7 @@ import {
 import { VendorId } from "@project-chip/matter.js/datatype";
 import { Logger } from "@project-chip/matter.js/log";
 import { Time, Timer } from "@project-chip/matter.js/time";
-import { ByteArray, getPromiseResolver } from "@project-chip/matter.js/util";
+import { ByteArray, createPromise } from "@project-chip/matter.js/util";
 import { NobleBleClient } from "./NobleBleClient";
 
 const logger = Logger.get("BleScanner");
@@ -54,7 +54,7 @@ export class BleScanner implements Scanner {
      * The promise will be resolved when the timer runs out latest.
      */
     private async registerWaiterPromise(queryId: string, timeoutSeconds: number) {
-        const { promise, resolver } = await getPromiseResolver<void>();
+        const { promise, resolver } = createPromise<void>();
         const timer = Time.getTimer(timeoutSeconds * 1000, () => this.finishWaiter(queryId, true)).start();
         this.recordWaiters.set(queryId, { resolver, timer });
         logger.debug(`Registered waiter for query ${queryId} with timeout ${timeoutSeconds} seconds`);

--- a/packages/matter-node-ble.js/src/ble/BlenoBleServer.ts
+++ b/packages/matter-node-ble.js/src/ble/BlenoBleServer.ts
@@ -17,7 +17,7 @@ import {
 import { Channel, InternalError } from "@project-chip/matter.js/common";
 import { Logger } from "@project-chip/matter.js/log";
 import { Time } from "@project-chip/matter.js/time";
-import { ByteArray, getPromiseResolver } from "@project-chip/matter.js/util";
+import { ByteArray, createPromise } from "@project-chip/matter.js/util";
 import { BleOptions } from "./BleNode";
 
 const logger = Logger.get("BlenoBleServer");
@@ -267,7 +267,7 @@ export class BlenoBleServer implements Channel<ByteArray> {
             // callback to write data to characteristic C2
             async (data: ByteArray) => {
                 updateValueCallback(Buffer.from(data.buffer));
-                const { promise, resolver } = await getPromiseResolver<void>();
+                const { promise, resolver } = createPromise<void>();
                 this.writeConformationResolver = resolver;
 
                 return promise;

--- a/packages/matter-node-ble.js/src/ble/NobleBleChannel.ts
+++ b/packages/matter-node-ble.js/src/ble/NobleBleChannel.ts
@@ -24,7 +24,7 @@ import { Channel, InternalError, Listener, ServerAddress } from "@project-chip/m
 import { Logger } from "@project-chip/matter.js/log";
 import { NetInterface } from "@project-chip/matter.js/net";
 import { Time } from "@project-chip/matter.js/time";
-import { ByteArray, getPromiseResolver } from "@project-chip/matter.js/util";
+import { ByteArray, createPromise } from "@project-chip/matter.js/util";
 import { BleScanner } from "./BleScanner";
 
 const logger = Logger.get("BleChannel");
@@ -181,7 +181,7 @@ export class NobleBleChannel implements Channel<ByteArray> {
         logger.debug("subscribing to C2 characteristic");
         await characteristicC2ForSubscribe.subscribeAsync();
 
-        const { promise: handshakeResponseReceivedPromise, resolver } = await getPromiseResolver<Buffer>();
+        const { promise: handshakeResponseReceivedPromise, resolver } = createPromise<Buffer>();
 
         characteristicC2ForSubscribe.once("data", (data, isNotification) => {
             logger.debug(`received first data on C2: ${data.toString("hex")} (isNotification: ${isNotification})`);

--- a/packages/matter-node.js/test/cluster/GroupsServerTest.ts
+++ b/packages/matter-node.js/test/cluster/GroupsServerTest.ts
@@ -17,7 +17,7 @@ import { DeviceTypes, Endpoint } from "@project-chip/matter.js/device";
 import { Fabric, FabricJsonObject } from "@project-chip/matter.js/fabric";
 import { StatusCode } from "@project-chip/matter.js/interaction";
 import { SecureSession } from "@project-chip/matter.js/session";
-import { getPromiseResolver } from "@project-chip/matter.js/util";
+import { createPromise } from "@project-chip/matter.js/util";
 import * as assert from "assert";
 import { callCommandOnClusterServer, createTestSessionWithFabric } from "./ClusterServerTestingUtil.js";
 
@@ -60,7 +60,7 @@ describe("Groups Server test", () => {
         });
 
         it("add new group and verify storage", async () => {
-            const { promise: firstPromise, resolver: firstResolver } = await getPromiseResolver<FabricJsonObject>();
+            const { promise: firstPromise, resolver: firstResolver } = createPromise<FabricJsonObject>();
             testFabric?.setPersistCallback(() => firstResolver(testFabric!.toStorageObject()));
 
             const result = await callCommandOnClusterServer(
@@ -87,7 +87,7 @@ describe("Groups Server test", () => {
         });
 
         it("add another new group and verify storage", async () => {
-            const { promise: firstPromise, resolver: firstResolver } = await getPromiseResolver<FabricJsonObject>();
+            const { promise: firstPromise, resolver: firstResolver } = createPromise<FabricJsonObject>();
             testFabric?.setPersistCallback(() => firstResolver(testFabric!.toStorageObject()));
 
             const result = await callCommandOnClusterServer(
@@ -125,7 +125,7 @@ describe("Groups Server test", () => {
         });
 
         it("add another new group on other endpoint and verify storage", async () => {
-            const { promise: firstPromise, resolver: firstResolver } = await getPromiseResolver<FabricJsonObject>();
+            const { promise: firstPromise, resolver: firstResolver } = createPromise<FabricJsonObject>();
             testFabric?.setPersistCallback(() => firstResolver(testFabric!.toStorageObject()));
 
             const result = await callCommandOnClusterServer(
@@ -249,7 +249,7 @@ describe("Groups Server test", () => {
         });
 
         it("delete group and verify storage", async () => {
-            const { promise: firstPromise, resolver: firstResolver } = await getPromiseResolver<FabricJsonObject>();
+            const { promise: firstPromise, resolver: firstResolver } = createPromise<FabricJsonObject>();
             testFabric?.setPersistCallback(() => firstResolver(testFabric!.toStorageObject()));
 
             const result = await callCommandOnClusterServer(
@@ -282,7 +282,7 @@ describe("Groups Server test", () => {
         });
 
         it("delete all groups and verify storage", async () => {
-            const { promise: firstPromise, resolver: firstResolver } = await getPromiseResolver<FabricJsonObject>();
+            const { promise: firstPromise, resolver: firstResolver } = createPromise<FabricJsonObject>();
             testFabric?.setPersistCallback(() => firstResolver(testFabric!.toStorageObject()));
 
             const result = await callCommandOnClusterServer(
@@ -365,7 +365,7 @@ describe("Groups Server test", () => {
         });
 
         it("add group while identifying", async () => {
-            const { promise: firstPromise, resolver: firstResolver } = await getPromiseResolver<FabricJsonObject>();
+            const { promise: firstPromise, resolver: firstResolver } = createPromise<FabricJsonObject>();
             testFabric?.setPersistCallback(() => firstResolver(testFabric!.toStorageObject()));
 
             const result = await callCommandOnClusterServer(

--- a/packages/matter-node.js/test/cluster/ScenesServerTest.ts
+++ b/packages/matter-node.js/test/cluster/ScenesServerTest.ts
@@ -21,7 +21,7 @@ import { Fabric, FabricJsonObject } from "@project-chip/matter.js/fabric";
 import { StatusCode } from "@project-chip/matter.js/interaction";
 import { SecureSession } from "@project-chip/matter.js/session";
 import { TlvBoolean } from "@project-chip/matter.js/tlv";
-import { getPromiseResolver } from "@project-chip/matter.js/util";
+import { createPromise } from "@project-chip/matter.js/util";
 import * as assert from "assert";
 import { callCommandOnClusterServer, createTestSessionWithFabric } from "./ClusterServerTestingUtil.js";
 
@@ -74,7 +74,7 @@ describe("Scenes Server test", () => {
             );
             assert.ok(groupResult);
 
-            const { promise: firstPromise, resolver: firstResolver } = await getPromiseResolver<FabricJsonObject>();
+            const { promise: firstPromise, resolver: firstResolver } = createPromise<FabricJsonObject>();
             testFabric?.setPersistCallback(() => firstResolver(testFabric!.toStorageObject()));
 
             const result = await callCommandOnClusterServer(
@@ -157,7 +157,7 @@ describe("Scenes Server test", () => {
         });
 
         it("add another scene on group 1 and verify storage", async () => {
-            const { promise: firstPromise, resolver: firstResolver } = await getPromiseResolver<FabricJsonObject>();
+            const { promise: firstPromise, resolver: firstResolver } = createPromise<FabricJsonObject>();
             testFabric?.setPersistCallback(() => firstResolver(testFabric!.toStorageObject()));
 
             const result = await callCommandOnClusterServer(
@@ -276,7 +276,7 @@ describe("Scenes Server test", () => {
             );
             assert.ok(groupResult);
 
-            const { promise: firstPromise, resolver: firstResolver } = await getPromiseResolver<FabricJsonObject>();
+            const { promise: firstPromise, resolver: firstResolver } = createPromise<FabricJsonObject>();
             testFabric?.setPersistCallback(() => firstResolver(testFabric!.toStorageObject()));
 
             const result = await callCommandOnClusterServer(
@@ -470,7 +470,7 @@ describe("Scenes Server test", () => {
         });
 
         it("delete scene and verify storage", async () => {
-            const { promise: firstPromise, resolver: firstResolver } = await getPromiseResolver<FabricJsonObject>();
+            const { promise: firstPromise, resolver: firstResolver } = createPromise<FabricJsonObject>();
             testFabric?.setPersistCallback(() => firstResolver(testFabric!.toStorageObject()));
 
             const result = await callCommandOnClusterServer(
@@ -571,7 +571,7 @@ describe("Scenes Server test", () => {
         });
 
         it("delete all scenes on one group and verify storage", async () => {
-            const { promise: firstPromise, resolver: firstResolver } = await getPromiseResolver<FabricJsonObject>();
+            const { promise: firstPromise, resolver: firstResolver } = createPromise<FabricJsonObject>();
             testFabric?.setPersistCallback(() => firstResolver(testFabric!.toStorageObject()));
 
             const result = await callCommandOnClusterServer(
@@ -640,7 +640,7 @@ describe("Scenes Server test", () => {
         });
 
         it("delete one group and verify storage", async () => {
-            const { promise: firstPromise, resolver: firstResolver } = await getPromiseResolver<FabricJsonObject>();
+            const { promise: firstPromise, resolver: firstResolver } = createPromise<FabricJsonObject>();
             testFabric?.setPersistCallback(() => firstResolver(testFabric!.toStorageObject()));
 
             const result = await callCommandOnClusterServer(
@@ -819,7 +819,7 @@ describe("Scenes Server test", () => {
             );
             assert.ok(groupResult);
 
-            const { promise: firstPromise, resolver: firstResolver } = await getPromiseResolver<FabricJsonObject>();
+            const { promise: firstPromise, resolver: firstResolver } = createPromise<FabricJsonObject>();
             testFabric?.setPersistCallback(() => firstResolver(testFabric!.toStorageObject()));
 
             const result = await callCommandOnClusterServer(
@@ -920,7 +920,7 @@ describe("Scenes Server test", () => {
         });
 
         it("copy one Scene same group", async () => {
-            const { promise: firstPromise, resolver: firstResolver } = await getPromiseResolver<FabricJsonObject>();
+            const { promise: firstPromise, resolver: firstResolver } = createPromise<FabricJsonObject>();
             testFabric?.setPersistCallback(() => firstResolver(testFabric!.toStorageObject()));
 
             const result = await callCommandOnClusterServer(
@@ -1030,7 +1030,7 @@ describe("Scenes Server test", () => {
             );
             assert.ok(groupResult);
 
-            const { promise: firstPromise, resolver: firstResolver } = await getPromiseResolver<FabricJsonObject>();
+            const { promise: firstPromise, resolver: firstResolver } = createPromise<FabricJsonObject>();
             testFabric?.setPersistCallback(() => firstResolver(testFabric!.toStorageObject()));
 
             const result = await callCommandOnClusterServer(
@@ -1171,7 +1171,7 @@ describe("Scenes Server test", () => {
             );
             assert.ok(groupResult);
 
-            const { promise: firstPromise, resolver: firstResolver } = await getPromiseResolver<FabricJsonObject>();
+            const { promise: firstPromise, resolver: firstResolver } = createPromise<FabricJsonObject>();
             testFabric?.setPersistCallback(() => firstResolver(testFabric!.toStorageObject()));
 
             const result = await callCommandOnClusterServer(
@@ -1386,7 +1386,7 @@ describe("Scenes Server test", () => {
         });
 
         it("delete all groups and verify storage", async () => {
-            const { promise: firstPromise, resolver: firstResolver } = await getPromiseResolver<FabricJsonObject>();
+            const { promise: firstPromise, resolver: firstResolver } = createPromise<FabricJsonObject>();
             testFabric?.setPersistCallback(() => firstResolver(testFabric!.toStorageObject()));
 
             const result = await callCommandOnClusterServer(

--- a/packages/matter.js/src/mdns/MdnsScanner.ts
+++ b/packages/matter.js/src/mdns/MdnsScanner.ts
@@ -24,7 +24,7 @@ import { UdpMulticastServer } from "../net/UdpMulticastServer.js";
 import { Time, Timer } from "../time/Time.js";
 import { ByteArray } from "../util/ByteArray.js";
 import { isIPv6 } from "../util/Ip.js";
-import { getPromiseResolver } from "../util/Promises.js";
+import { createPromise } from "../util/Promises.js";
 import {
     MATTER_COMMISSION_SERVICE_QNAME,
     MATTER_SERVICE_QNAME,
@@ -254,7 +254,7 @@ export class MdnsScanner implements Scanner {
      * The promise will be resolved when the timer runs out latest.
      */
     private async registerWaiterPromise(queryId: string, timeoutSeconds: number) {
-        const { promise, resolver } = await getPromiseResolver<void>();
+        const { promise, resolver } = createPromise<void>();
         const timer = Time.getTimer(timeoutSeconds * 1000, () => this.finishWaiter(queryId, true)).start();
         this.recordWaiters.set(queryId, { resolver, timer });
         logger.debug(`Registered waiter for query ${queryId} with timeout ${timeoutSeconds} seconds`);

--- a/packages/matter.js/src/protocol/MessageExchange.ts
+++ b/packages/matter.js/src/protocol/MessageExchange.ts
@@ -12,7 +12,7 @@ import { SLEEPY_ACTIVE_INTERVAL_MS, SLEEPY_IDLE_INTERVAL_MS, Session } from "../
 import { MatterCoreSpecificationV1_0 } from "../spec/Specifications.js";
 import { Time, Timer } from "../time/Time.js";
 import { ByteArray } from "../util/ByteArray.js";
-import { getPromiseResolver } from "../util/Promises.js";
+import { createPromise } from "../util/Promises.js";
 import { Queue } from "../util/Queue.js";
 import { MessageChannel, MessageCounter } from "./ExchangeManager.js";
 import { StatusResponseError } from "./interaction/InteractionMessenger.js";
@@ -229,7 +229,7 @@ export class MessageExchange<ContextT> {
             this.retransmissionTimer = Time.getTimer(this.getResubmissionBackOffTime(0), () =>
                 this.retransmitMessage(message, 0),
             );
-            const { promise, resolver, rejecter } = await getPromiseResolver<Message>();
+            const { promise, resolver, rejecter } = createPromise<Message>();
             ackPromise = promise;
             this.sentMessageAckSuccess = resolver;
             this.sentMessageAckFailure = rejecter;

--- a/packages/matter.js/src/util/Queue.ts
+++ b/packages/matter.js/src/util/Queue.ts
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { getPromiseResolver } from "./Promises.js";
+import { createPromise } from "./Promises.js";
 import { EndOfStreamError, Stream } from "./Stream.js";
 
 export class Queue<T> implements Stream<T> {
@@ -15,7 +15,7 @@ export class Queue<T> implements Stream<T> {
     private closed = false;
 
     async read(): Promise<T> {
-        const { promise, resolver, rejecter } = await getPromiseResolver<T>();
+        const { promise, resolver, rejecter } = createPromise<T>();
         if (this.closed) throw new EndOfStreamError();
         const data = this.queue.shift();
         if (data !== undefined) {

--- a/packages/matter.js/test/ble/BtpSessionHandlerTest.ts
+++ b/packages/matter.js/test/ble/BtpSessionHandlerTest.ts
@@ -7,13 +7,13 @@
 import { BtpFlowError, BtpProtocolError, BtpSessionHandler } from "../../src/ble/BtpSessionHandler.js";
 import { BtpCodec } from "../../src/codec/BtpCodec.js";
 import { ByteArray } from "../../src/util/ByteArray.js";
-import { getPromiseResolver } from "../../src/util/Promises.js";
+import { createPromise } from "../../src/util/Promises.js";
 
 describe("BtpSessionHandler", () => {
     describe("Test Handshake", () => {
         it("handles a correct Handshake", async () => {
             const handshakeRequest = ByteArray.fromHex("656c04000000b90006");
-            const { promise: writeBlePromise, resolver } = await getPromiseResolver<ByteArray>();
+            const { promise: writeBlePromise, resolver } = createPromise<ByteArray>();
 
             let allowClose = false;
             const btpSession = await BtpSessionHandler.createFromHandshakeRequest(
@@ -40,7 +40,7 @@ describe("BtpSessionHandler", () => {
 
         it("handles a zero attMtu in Handshake", async () => {
             const handshakeRequest = ByteArray.fromHex("656c04000000000006");
-            const { promise: writeBlePromise, resolver } = await getPromiseResolver<ByteArray>();
+            const { promise: writeBlePromise, resolver } = createPromise<ByteArray>();
 
             let allowClose = false;
             const btpSession = await BtpSessionHandler.createFromHandshakeRequest(
@@ -67,7 +67,7 @@ describe("BtpSessionHandler", () => {
 
         it("handles a undefined maxDataSize in Handshake", async () => {
             const handshakeRequest = ByteArray.fromHex("656c04000000000006");
-            const { promise: writeBlePromise, resolver } = await getPromiseResolver<ByteArray>();
+            const { promise: writeBlePromise, resolver } = createPromise<ByteArray>();
 
             let allowClose = false;
             const btpSession = await BtpSessionHandler.createFromHandshakeRequest(
@@ -94,7 +94,7 @@ describe("BtpSessionHandler", () => {
 
         it("Client does not share the same supported BTP version", async () => {
             const handshakeRequest = ByteArray.fromHex("656c05000000000006");
-            const { promise: disconnectBlePromise, resolver: disconnectBleResolver } = await getPromiseResolver<void>();
+            const { promise: disconnectBlePromise, resolver: disconnectBleResolver } = createPromise<void>();
 
             // change to expect().rejects.throw() when no longer using jasmine expect
             let error;
@@ -140,8 +140,7 @@ describe("BtpSessionHandler", () => {
         // Each test gets his own btpSessionHandler with a successfully done handshake
         // callback can be overridden
         beforeEach(async () => {
-            const { promise: localWriteBlePromise, resolver: localWriteBleResolver } =
-                await getPromiseResolver<ByteArray>();
+            const { promise: localWriteBlePromise, resolver: localWriteBleResolver } = createPromise<ByteArray>();
 
             onWriteBleCallback = async (dataToWrite: ByteArray) => {
                 localWriteBleResolver(dataToWrite);
@@ -172,7 +171,7 @@ describe("BtpSessionHandler", () => {
         });
 
         it("disconnect when incoming message is another handshake", async () => {
-            const { promise: disconnectBlePromise, resolver: disconnectBleResolver } = await getPromiseResolver<void>();
+            const { promise: disconnectBlePromise, resolver: disconnectBleResolver } = createPromise<void>();
 
             const matterMessage = ByteArray.fromHex("656c04000000b90006");
 
@@ -186,7 +185,7 @@ describe("BtpSessionHandler", () => {
         });
 
         it("disconnect when incoming message has management opcode", async () => {
-            const { promise: disconnectBlePromise, resolver: disconnectBleResolver } = await getPromiseResolver<void>();
+            const { promise: disconnectBlePromise, resolver: disconnectBleResolver } = createPromise<void>();
 
             const matterMessage = ByteArray.fromHex("0d6c04000000b90006");
 
@@ -200,9 +199,9 @@ describe("BtpSessionHandler", () => {
         });
 
         it("handles a correct One segment long Matter Message", async () => {
-            const { promise: writeBlePromise, resolver: writeBleResolver } = await getPromiseResolver<ByteArray>();
+            const { promise: writeBlePromise, resolver: writeBleResolver } = createPromise<ByteArray>();
             const { promise: handleMatterMessagePromise, resolver: handleMatterMessageResolver } =
-                await getPromiseResolver<ByteArray>();
+                createPromise<ByteArray>();
 
             const segmentPayload = ByteArray.fromHex("010203040506070809");
             const matterMessage = BtpCodec.encodeBtpPacket({
@@ -241,7 +240,7 @@ describe("BtpSessionHandler", () => {
         });
 
         it("received bytes more than fragment size", async () => {
-            const { promise: disconnectBlePromise, resolver: disconnectBleResolver } = await getPromiseResolver<void>();
+            const { promise: disconnectBlePromise, resolver: disconnectBleResolver } = createPromise<void>();
 
             const segmentPayload = ByteArray.fromHex("01020304050607080901020304050607080901");
             const matterMessage = BtpCodec.encodeBtpPacket({
@@ -282,7 +281,7 @@ describe("BtpSessionHandler", () => {
 
         it("handles a correct two segment long Matter Message", async () => {
             const { promise: handleMatterMessagePromise, resolver: handleMatterMessageResolver } =
-                await getPromiseResolver<ByteArray>();
+                createPromise<ByteArray>();
 
             const segmentPayload = ByteArray.fromHex("01020304050607080901020304050607");
             const segmentPayload1 = ByteArray.fromHex("010203040506070809010203040506");
@@ -340,9 +339,9 @@ describe("BtpSessionHandler", () => {
         });
 
         it("triggers timeout as did not send ack within 5 sec", async () => {
-            const { promise: writeBlePromise, resolver: writeBleResolver } = await getPromiseResolver<ByteArray>();
+            const { promise: writeBlePromise, resolver: writeBleResolver } = createPromise<ByteArray>();
             const { promise: handleMatterMessagePromise, resolver: handleMatterMessageResolver } =
-                await getPromiseResolver<ByteArray>();
+                createPromise<ByteArray>();
 
             const segmentPayload = ByteArray.fromHex("010203040506070809");
             const matterMessage = BtpCodec.encodeBtpPacket({
@@ -385,9 +384,9 @@ describe("BtpSessionHandler", () => {
         });
 
         it("triggers timeout as did not receive ack within 15 sec", async () => {
-            const { promise: disconnectBlePromise, resolver: disconnectBleResolver } = await getPromiseResolver<void>();
+            const { promise: disconnectBlePromise, resolver: disconnectBleResolver } = createPromise<void>();
             const { promise: handleMatterMessagePromise, resolver: handleMatterMessageResolver } =
-                await getPromiseResolver<ByteArray>();
+                createPromise<ByteArray>();
 
             const segmentPayload = ByteArray.fromHex("010203040506070809");
             const matterMessage = BtpCodec.encodeBtpPacket({
@@ -424,7 +423,7 @@ describe("BtpSessionHandler", () => {
         });
 
         it("payload size and message Length does not match", async () => {
-            const { promise: disconnectBlePromise, resolver: disconnectBleResolver } = await getPromiseResolver<void>();
+            const { promise: disconnectBlePromise, resolver: disconnectBleResolver } = createPromise<void>();
 
             const segmentPayload = ByteArray.fromHex("010203040506070809");
             const matterMessage = BtpCodec.encodeBtpPacket({
@@ -452,9 +451,9 @@ describe("BtpSessionHandler", () => {
         });
 
         it("handles rounding off sequence numbers", async () => {
-            const { promise: writeBlePromise, resolver: writeBleResolver } = await getPromiseResolver<ByteArray>();
+            const { promise: writeBlePromise, resolver: writeBleResolver } = createPromise<ByteArray>();
             const { promise: handleMatterMessagePromise, resolver: handleMatterMessageResolver } =
-                await getPromiseResolver<ByteArray>();
+                createPromise<ByteArray>();
 
             for (let i = 0; i < 257; i++) {
                 const segmentPayload = ByteArray.fromHex("010203040506070809");

--- a/packages/matter.js/test/mdns/MdnsTest.ts
+++ b/packages/matter.js/test/mdns/MdnsTest.ts
@@ -16,7 +16,7 @@ import { UdpChannelFake } from "../../src/net/fake/UdpChannelFake.js";
 import { Network } from "../../src/net/Network.js";
 import { UdpChannel } from "../../src/net/UdpChannel.js";
 import { ByteArray } from "../../src/util/ByteArray.js";
-import { getPromiseResolver } from "../../src/util/Promises.js";
+import { createPromise } from "../../src/util/Promises.js";
 
 const SERVER_IPv4 = "192.168.200.1";
 const SERVER_IPv6 = "fe80::e777:4f5e:c61e:7314";
@@ -69,7 +69,7 @@ describe("MDNS Scanner and Broadcaster", () => {
 
     describe("broadcaster", () => {
         it("it broadcasts the device fabric on one port", async () => {
-            const { promise, resolver } = await getPromiseResolver<ByteArray>();
+            const { promise, resolver } = createPromise<ByteArray>();
             scannerChannel.onData((_netInterface, _peerAddress, _peerPort, data) => resolver(data));
 
             await broadcaster.setFabrics(PORT, [{ operationalId: OPERATIONAL_ID, nodeId: NODE_ID } as Fabric], {
@@ -143,7 +143,7 @@ describe("MDNS Scanner and Broadcaster", () => {
         });
 
         it("it broadcasts the device commissionable info on one port", async () => {
-            const { promise, resolver } = await getPromiseResolver<ByteArray>();
+            const { promise, resolver } = createPromise<ByteArray>();
             scannerChannel.onData((_netInterface, _peerAddress, _peerPort, data) => resolver(data));
 
             await broadcaster.setCommissionMode(PORT, 1, {
@@ -287,7 +287,7 @@ describe("MDNS Scanner and Broadcaster", () => {
         });
 
         it("it broadcasts the controller commissioner on one port", async () => {
-            const { promise, resolver } = await getPromiseResolver<ByteArray>();
+            const { promise, resolver } = createPromise<ByteArray>();
             scannerChannel.onData((_netInterface, _peerAddress, _peerPort, data) => resolver(data));
 
             await broadcaster.setCommissionerInfo(PORT, {
@@ -370,7 +370,7 @@ describe("MDNS Scanner and Broadcaster", () => {
         });
 
         it("it allows announcements of multiple devices on different ports", async () => {
-            const { promise, resolver } = await getPromiseResolver<void>();
+            const { promise, resolver } = createPromise<void>();
             const dataArr: ByteArray[] = [];
             scannerChannel.onData((_netInterface, _peerAddress, _peerPort, data) => {
                 dataArr.push(data);


### PR DESCRIPTION
Added a method interception utility to MockTime (sort of time related) that allows tests to trigger logic at specific code points.  Used this to remove a few uses of yield3() in IntegrationTest.

Removed some additional uses of yield3() in IntegrationTest that didn't seem necessary.

Replaced the dark-magic "getPromiseResolver" with magic-free "createPromise".

Removed time reset in IntegrationTest as it was erronious based on how the test was designed.

Was attempting to isolate an intermittent issue in IntegrationTest.  Don't feel like I did but it no longer fails on my box after a couple hundred iterations.