### PR TITLE
Make sure Disable IPv4 disables it also for MDNS (and Windows GHA build optimization)

### DIFF
--- a/.github/workflows/build-test.js.yml
+++ b/.github/workflows/build-test.js.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-      - run: npm ci
+      - run: npm install
 
   test:
     needs: [ check-and-lint ]

--- a/.github/workflows/build-test.js.yml
+++ b/.github/workflows/build-test.js.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - name: patch node gyp on windows to support Visual Studio 2019
-        if: matrix.os == 'windows-latest'
+        if: ${{ matrix.os == 'windows-latest' || matrix.os == 'windows-2019' }}
         shell: powershell
         run: |
           npm install --global node-gyp@latest

--- a/.github/workflows/build-test.js.yml
+++ b/.github/workflows/build-test.js.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-      - run: npm ci --loglevel verbose
+      - run: npm install --loglevel verbose --no-package-lock
 
   test:
     needs: [ check-and-lint ]

--- a/.github/workflows/build-test.js.yml
+++ b/.github/workflows/build-test.js.yml
@@ -42,7 +42,7 @@ jobs:
           npm install --global node-gyp@latest
           npm prefix -g | % {npm config set node_gyp "$_\node_modules\node-gyp\bin\node-gyp.js"}
       - name: Install dependencies and build project
-        run: npm ci
+        run: npm ci --foreground-scripts
 
   test:
     needs: [ check-and-lint ]

--- a/.github/workflows/build-test.js.yml
+++ b/.github/workflows/build-test.js.yml
@@ -49,7 +49,14 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-      - run: npm ci
+      - name: patch node gyp on windows to support Visual Studio 2019
+        if: matrix.os == 'windows-latest'
+        shell: powershell
+        run: |
+          npm install --global node-gyp@latest
+          npm prefix -g | % {npm config set node_gyp "$_\node_modules\node-gyp\bin\node-gyp.js"}
+      - name: Install dependencies
+        run: npm ci
       - name: Get installed Playwright version
         id: playwright-version
         run: echo "PLAYWRIGHT_VERSION=$(npx playwright --version)" >> $GITHUB_ENV
@@ -60,8 +67,11 @@ jobs:
           path: |
             ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
-      - run: npx playwright install --with-deps
+      - name: Install Playwright with dependencies
+        run: npx playwright install --with-deps
         if: steps.playwright-cache.outputs.cache-hit != 'true'
-      - run: npx playwright install-deps
+      - name: Install Playwright dependencies
+        run: npx playwright install-deps
         if: steps.playwright-cache.outputs.cache-hit == 'true'
-      - run: npm run test
+      - name: Execute tests
+        run: npm run test

--- a/.github/workflows/build-test.js.yml
+++ b/.github/workflows/build-test.js.yml
@@ -35,7 +35,14 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-      - run: npm install --loglevel verbose --no-package-lock
+      - name: patch node gyp on windows to support Visual Studio 2019
+        if: matrix.os == 'windows-latest'
+        shell: powershell
+        run: |
+          npm install --global node-gyp@latest
+          npm prefix -g | % {npm config set node_gyp "$_\node_modules\node-gyp\bin\node-gyp.js"}
+      - name: Install dependencies and build project
+        run: npm install --loglevel verbose --no-package-lock
 
   test:
     needs: [ check-and-lint ]
@@ -49,13 +56,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-      - name: patch node gyp on windows to support Visual Studio 2019
-        if: matrix.os == 'windows-latest'
-        shell: powershell
-        run: |
-          npm install --global node-gyp@latest
-          npm prefix -g | % {npm config set node_gyp "$_\node_modules\node-gyp\bin\node-gyp.js"}
-      - name: Install dependencies
+      - name: Install dependencies and build project
         run: npm ci
       - name: Get installed Playwright version
         id: playwright-version

--- a/.github/workflows/build-test.js.yml
+++ b/.github/workflows/build-test.js.yml
@@ -42,7 +42,7 @@ jobs:
           npm install --global node-gyp@latest
           npm prefix -g | % {npm config set node_gyp "$_\node_modules\node-gyp\bin\node-gyp.js"}
       - name: Install dependencies and build project
-        run: npm install --loglevel verbose --no-package-lock
+        run: npm ci
 
   test:
     needs: [ check-and-lint ]

--- a/.github/workflows/build-test.js.yml
+++ b/.github/workflows/build-test.js.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-      - run: npm install
+      - run: npm ci --loglevel verbose
 
   test:
     needs: [ check-and-lint ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@ All Changes without a GitHub Username in brackets are from the core team: @Apoll
   * Enhance: Introduced building and building, running and test executions scripts to not use ts-node anymore and many more optimizations to test and build processes
   * Enhance: ClusterFactory internally uses a simplified method of CLuster types that are compatible to the current ones but soon might replace them
 * matter.js API:
-  * Breaking: Remove "disableIpv4" from CommissioningController/Server options to MatterServer to also consider it for MDNS scanning and broadcasting
+  * Breaking: Move "disableIpv4" from CommissioningController/Server options to MatterServer to also consider it for MDNS scanning and broadcasting
+  * Breaking: Change MatterServer constructor second parameter to be an options object
   * Breaking: Streamline Device API and rename onOff/isOnOff -> get/setOnOff
   * Breaking: EndpointStructureLogger (method logEndpointStructure) was moved from util to device export!
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,19 @@ All Changes without a GitHub Username in brackets are from the core team: @Apoll
 ## 0.6.0 WIP
 * Matter-Core functionality:
   * Fix: Adjusted Event Priority definition to match to specs
+  * Fix: Prevented crashes when Bleno could not be initialized (e.g. on Windows)
+  * Fix: Adjusted Bleno and Noble to be optional Dependencies to allow building the Monorepo also when these are failing (e.g. on Windows)
   * Feature: Implemented TimedInteractions for Write/Invoke request s as required by specs
   * Feature: Added support for generic Response suppression if requested or needed for group communication
   * Feature (orlenkoo) Implemented first OnOff Cluster Lighting feature command handlers (WIP)
   * Feature: Also publishes matter-node.js packages as ESM in parallel to CJS
   * Enhance: Memory footprint optimizations
-  * Enhance: Adjusted building, test executions and such to not use ts-node anymore and many more optimizations to test and build processes
+  * Enhance: Introduced building and building, running and test executions scripts to not use ts-node anymore and many more optimizations to test and build processes
+  * Enhance: ClusterFactory internally uses a simplified method of CLuster types that are compatible to the current ones but soon might replace them
 * matter.js API:
+  * Breaking: Remove "disableIpv4" from CommissioningController/Server options to MatterServer to also consider it for MDNS scanning and broadcasting
   * Breaking: Streamline Device API and rename onOff/isOnOff -> get/setOnOff
+  * Breaking: EndpointStructureLogger (method logEndpointStructure) was moved from util to device export!
 
 ## 0.5.0 (2023-08-22)
 * Matter-Core functionality:

--- a/packages/matter-node.js-examples/src/examples/BridgedDevicesNode.ts
+++ b/packages/matter-node.js-examples/src/examples/BridgedDevicesNode.ts
@@ -130,7 +130,7 @@ class BridgedDevice {
          * are called.
          */
 
-        this.matterServer = new MatterServer(storageManager, netAnnounceInterface);
+        this.matterServer = new MatterServer(storageManager, { mdnsAnnounceInterface: netAnnounceInterface });
 
         const commissioningServer = new CommissioningServer({
             port,

--- a/packages/matter-node.js-examples/src/examples/ComposedDeviceNode.ts
+++ b/packages/matter-node.js-examples/src/examples/ComposedDeviceNode.ts
@@ -138,7 +138,7 @@ class ComposedDevice {
          * are called.
          */
 
-        this.matterServer = new MatterServer(storageManager, netAnnounceInterface);
+        this.matterServer = new MatterServer(storageManager, { mdnsAnnounceInterface: netAnnounceInterface });
 
         const commissioningServer = new CommissioningServer({
             port,

--- a/packages/matter-node.js-examples/src/examples/DeviceNode.ts
+++ b/packages/matter-node.js-examples/src/examples/DeviceNode.ts
@@ -168,7 +168,7 @@ class Device {
          * are called.
          */
 
-        this.matterServer = new MatterServer(storageManager, netAnnounceInterface);
+        this.matterServer = new MatterServer(storageManager, { mdnsAnnounceInterface: netAnnounceInterface });
 
         const commissioningServer = new CommissioningServer({
             port,

--- a/packages/matter-node.js-examples/src/examples/MultiDeviceNode.ts
+++ b/packages/matter-node.js-examples/src/examples/MultiDeviceNode.ts
@@ -112,7 +112,7 @@ class Device {
          * are called.
          */
 
-        this.matterServer = new MatterServer(storageManager, netAnnounceInterface);
+        this.matterServer = new MatterServer(storageManager, { mdnsAnnounceInterface: netAnnounceInterface });
 
         /**
          * Create Device instance and add needed Listener

--- a/packages/matter.js/src/CommissioningController.ts
+++ b/packages/matter.js/src/CommissioningController.ts
@@ -60,7 +60,6 @@ const logger = new Logger("CommissioningController");
 export interface CommissioningControllerOptions {
     serverAddress?: ServerAddressIp;
     readonly localPort?: number;
-    readonly disableIpv4?: boolean;
     readonly listeningAddressIpv4?: string;
     readonly listeningAddressIpv6?: string;
 
@@ -115,9 +114,7 @@ export class CommissioningController extends MatterNode {
         const { localPort, passcode, longDiscriminator, shortDiscriminator } = this.options;
         this.controllerInstance = await MatterController.create(
             this.mdnsScanner,
-            this.options.disableIpv4 !== true
-                ? undefined
-                : await UdpInterface.create("udp4", localPort, this.listeningAddressIpv4),
+            this.ipv4Disabled ? undefined : await UdpInterface.create("udp4", localPort, this.listeningAddressIpv4),
             await UdpInterface.create("udp6", localPort, this.listeningAddressIpv6),
             this.storage,
             this.serverAddress,

--- a/packages/matter.js/src/CommissioningServer.ts
+++ b/packages/matter.js/src/CommissioningServer.ts
@@ -91,9 +91,6 @@ export interface CommissioningServerOptions {
     /** Port of the server, normally automatically managed. */
     port: number;
 
-    /** If set to true no IPv4 socket listener is sed and only IPv6 is supported. */
-    disableIpv4?: boolean;
-
     /** IPv4 listener address, defaults to all interfaces.*/
     listeningAddressIpv4?: string;
 
@@ -497,7 +494,7 @@ export class CommissioningServer extends MatterNode {
             .addScanner(this.mdnsScanner)
             .addProtocolHandler(secureChannelProtocol)
             .addProtocolHandler(this.interactionServer);
-        if (this.options.disableIpv4 !== true) {
+        if (!this.ipv4Disabled) {
             this.deviceInstance.addTransportInterface(
                 await UdpInterface.create("udp4", this.port, this.options.listeningAddressIpv4),
             );

--- a/packages/matter.js/src/MatterController.ts
+++ b/packages/matter.js/src/MatterController.ts
@@ -298,7 +298,7 @@ export class MatterController {
             const isIpv6Address = isIPv6(ip);
             const paseInterface = isIpv6Address ? this.netInterfaceIpv6 : this.netInterfaceIpv4;
             if (paseInterface === undefined) {
-                // mainly IPv4 address when IPv4 is disabled
+                // mainly IPv6 address when IPv4 is disabled
                 throw new PairRetransmissionLimitReachedError(
                     `IPv${isIpv6Address ? "6" : "4"} interface not initialized. Cannot use ${ip} for commissioning.`,
                 );

--- a/packages/matter.js/src/MatterNode.ts
+++ b/packages/matter.js/src/MatterNode.ts
@@ -19,6 +19,7 @@ import { BitSchema, TypeFromPartialBitSchema } from "./schema/BitmapSchema.js";
  */
 export abstract class MatterNode {
     protected readonly rootEndpoint = new RootEndpoint();
+    ipv4Disabled: boolean = false;
 
     /**
      * Add a cluster to the root endpoint. This is mainly used internally and not needed to be called by the user.

--- a/packages/matter.js/src/mdns/MdnsBroadcaster.ts
+++ b/packages/matter.js/src/mdns/MdnsBroadcaster.ts
@@ -50,13 +50,20 @@ const DEFAULT_PAIRING_HINT = {
  * This class is handing MDNS Announcements for multiple instances/devices
  */
 export class MdnsBroadcaster {
-    static async create(multicastInterface?: string) {
-        return new MdnsBroadcaster(await MdnsServer.create(multicastInterface));
+    static async create(options?: { enableIpv4?: boolean; multicastInterface?: string }) {
+        const { enableIpv4, multicastInterface } = options ?? {};
+        return new MdnsBroadcaster(
+            await MdnsServer.create({ enableIpv4, netInterface: multicastInterface }),
+            enableIpv4,
+        );
     }
 
     private readonly network = Network.get();
 
-    constructor(private readonly mdnsServer: MdnsServer) {}
+    constructor(
+        private readonly mdnsServer: MdnsServer,
+        private readonly enableIpv4?: boolean,
+    ) {}
 
     validatePairingInstructions(
         pairingHint: TypeFromPartialBitSchema<typeof PairingHintBitmap>,
@@ -157,7 +164,7 @@ export class MdnsBroadcaster {
                 ]),
             ];
             ips.forEach(ip => {
-                if (isIPv4(ip)) {
+                if (isIPv4(ip) && this.enableIpv4) {
                     records.push(ARecord(hostname, ip));
                 } else {
                     records.push(AAAARecord(hostname, ip));
@@ -212,7 +219,7 @@ export class MdnsBroadcaster {
                 records.push(...fabricRecords);
             });
             ips.forEach(ip => {
-                if (isIPv4(ip)) {
+                if (isIPv4(ip) && this.enableIpv4) {
                     records.push(ARecord(hostname, ip));
                 } else {
                     records.push(AAAARecord(hostname, ip));
@@ -272,7 +279,7 @@ export class MdnsBroadcaster {
             }
 
             ips.forEach(ip => {
-                if (isIPv4(ip)) {
+                if (isIPv4(ip) && this.enableIpv4) {
                     records.push(ARecord(hostname, ip));
                 } else {
                     records.push(AAAARecord(hostname, ip));

--- a/packages/matter.js/src/mdns/MdnsServer.ts
+++ b/packages/matter.js/src/mdns/MdnsServer.ts
@@ -16,11 +16,12 @@ export const MDNS_BROADCAST_IPV6 = "ff02::fb";
 export const MDNS_BROADCAST_PORT = 5353;
 
 export class MdnsServer {
-    static async create(netInterface?: string) {
+    static async create(options?: { enableIpv4?: boolean; netInterface?: string }) {
+        const { enableIpv4 = true, netInterface } = options ?? {};
         return new MdnsServer(
             await UdpMulticastServer.create({
                 netInterface: netInterface,
-                broadcastAddressIpv4: MDNS_BROADCAST_IPV4,
+                broadcastAddressIpv4: enableIpv4 ? MDNS_BROADCAST_IPV4 : undefined,
                 broadcastAddressIpv6: MDNS_BROADCAST_IPV6,
                 listeningPort: MDNS_BROADCAST_PORT,
             }),

--- a/packages/matter.js/src/net/UdpMulticastServer.ts
+++ b/packages/matter.js/src/net/UdpMulticastServer.ts
@@ -78,7 +78,7 @@ export class UdpMulticastServer {
                         const broadcastTarget = iPv4 ? this.broadcastAddressIpv4 : this.broadcastAddressIpv6;
                         if (broadcastTarget == undefined) {
                             // IPv4 but disabled, so just resolve
-                            return Promise.resolve();
+                            return;
                         }
                         try {
                             await (

--- a/packages/matter.js/test/mdns/MdnsTest.ts
+++ b/packages/matter.js/test/mdns/MdnsTest.ts
@@ -21,901 +21,884 @@ import { createPromise } from "../../src/util/Promises.js";
 const SERVER_IPv4 = "192.168.200.1";
 const SERVER_IPv6 = "fe80::e777:4f5e:c61e:7314";
 const SERVER_MAC = "00:B0:D0:63:C2:26";
-const CLIENT_IP = "192.168.200.2";
+const CLIENT_IPv4 = "192.168.200.2";
+const CLIENT_IPv6 = "fe80::e777:4f5e:c61e:7315";
 const CLIENT_MAC = "CA:FE:00:00:BE:EF";
 const PORT = 5540;
 const PORT2 = 5541;
 const PORT3 = 5542;
 
-const serverNetwork = new NetworkFake(SERVER_MAC, [SERVER_IPv4, SERVER_IPv6]);
-const clientNetwork = new NetworkFake(CLIENT_MAC, [CLIENT_IP]);
-
 const OPERATIONAL_ID = ByteArray.fromHex("0000000000000018");
 const NODE_ID = NodeId(BigInt(1));
 
-describe("MDNS Scanner and Broadcaster", () => {
-    let broadcaster: MdnsBroadcaster;
-    let scanner: MdnsScanner;
-    let scannerChannel: UdpChannel;
-    let broadcasterChannel: UdpChannel;
+[false, true].forEach(testIpv4Enabled => {
+    const serverIps = testIpv4Enabled ? [SERVER_IPv4, SERVER_IPv6] : [SERVER_IPv6];
+    const clientIps = testIpv4Enabled ? [CLIENT_IPv4] : [CLIENT_IPv6];
+    const serverNetwork = new NetworkFake(SERVER_MAC, serverIps);
+    const clientNetwork = new NetworkFake(CLIENT_MAC, clientIps);
 
-    beforeEach(async () => {
-        Network.get = () => clientNetwork;
-        scanner = await MdnsScanner.create(FAKE_INTERFACE_NAME);
-        scannerChannel = await UdpChannelFake.create(serverNetwork, {
-            listeningPort: 5353,
-            listeningAddress: "224.0.0.251",
-            type: "udp4",
+    const IPDnsRecords = [
+        {
+            name: "00B0D063C2260000.local",
+            recordType: 28,
+            recordClass: 1,
+            ttl: 120,
+            value: "fe80::e777:4f5e:c61e:7314",
+        },
+    ];
+    if (testIpv4Enabled) {
+        IPDnsRecords.unshift({
+            name: "00B0D063C2260000.local",
+            recordType: 1,
+            recordClass: 1,
+            ttl: 120,
+            value: "192.168.200.1",
+        });
+    }
+
+    const IPIntegrationResultsPort1 = [{ ip: `${SERVER_IPv6}%fakeInterface`, port: PORT, type: "udp" }];
+    const IPIntegrationResultsPort2 = [{ ip: `${SERVER_IPv6}%fakeInterface`, port: PORT2, type: "udp" }];
+    if (testIpv4Enabled) {
+        IPIntegrationResultsPort1.push({ ip: SERVER_IPv4, port: PORT, type: "udp" });
+        IPIntegrationResultsPort2.push({ ip: SERVER_IPv4, port: PORT2, type: "udp" });
+    }
+
+    describe(`MDNS Scanner and Broadcaster ${testIpv4Enabled ? "with" : "without"} IPv4`, () => {
+        let broadcaster: MdnsBroadcaster;
+        let scanner: MdnsScanner;
+        let scannerChannel: UdpChannel;
+        let broadcasterChannel: UdpChannel;
+
+        beforeEach(async () => {
+            Network.get = () => clientNetwork;
+            scanner = await MdnsScanner.create({ enableIpv4: testIpv4Enabled, netInterface: FAKE_INTERFACE_NAME });
+            scannerChannel = await UdpChannelFake.create(serverNetwork, {
+                listeningPort: 5353,
+                listeningAddress: testIpv4Enabled ? "224.0.0.251" : "ff02::fb",
+                type: testIpv4Enabled ? "udp4" : "udp6",
+            });
+
+            Network.get = () => serverNetwork;
+            broadcaster = await MdnsBroadcaster.create({
+                enableIpv4: testIpv4Enabled,
+                multicastInterface: FAKE_INTERFACE_NAME,
+            });
+            broadcasterChannel = await UdpChannelFake.create(clientNetwork, {
+                listeningPort: 5353,
+                listeningAddress: testIpv4Enabled ? "224.0.0.251" : "ff02::fb",
+                type: testIpv4Enabled ? "udp4" : "udp6",
+            });
+
+            Network.get = () => {
+                throw new Error("Network should not be requested post creation");
+            };
         });
 
-        Network.get = () => serverNetwork;
-        broadcaster = await MdnsBroadcaster.create(FAKE_INTERFACE_NAME);
-        broadcasterChannel = await UdpChannelFake.create(clientNetwork, {
-            listeningPort: 5353,
-            listeningAddress: "224.0.0.251",
-            type: "udp4",
+        afterEach(async () => {
+            await broadcaster.close();
+            await scanner.close();
+            scannerChannel.close();
         });
 
-        Network.get = () => {
-            throw new Error("Network should not be requested post creation");
-        };
-    });
+        describe("broadcaster", () => {
+            it("it broadcasts the device fabric on one port", async () => {
+                const { promise, resolver } = createPromise<ByteArray>();
+                scannerChannel.onData((_netInterface, _peerAddress, _peerPort, data) => resolver(data));
 
-    afterEach(async () => {
-        await broadcaster.close();
-        await scanner.close();
-        scannerChannel.close();
-    });
+                await broadcaster.setFabrics(PORT, [{ operationalId: OPERATIONAL_ID, nodeId: NODE_ID } as Fabric], {
+                    sleepIdleInterval: 100,
+                    sleepActiveInterval: 200,
+                });
+                await broadcaster.announce(PORT);
 
-    describe("broadcaster", () => {
-        it("it broadcasts the device fabric on one port", async () => {
-            const { promise, resolver } = createPromise<ByteArray>();
-            scannerChannel.onData((_netInterface, _peerAddress, _peerPort, data) => resolver(data));
+                const result = DnsCodec.decode(await promise);
 
-            await broadcaster.setFabrics(PORT, [{ operationalId: OPERATIONAL_ID, nodeId: NODE_ID } as Fabric], {
-                sleepIdleInterval: 100,
-                sleepActiveInterval: 200,
+                expect(result).deep.equal({
+                    transactionId: 0,
+                    messageType: 33792,
+                    queries: [],
+                    answers: [
+                        {
+                            name: "_services._dns-sd._udp.local",
+                            recordType: 12,
+                            recordClass: 1,
+                            ttl: 120,
+                            value: "_matter._tcp.local",
+                        },
+                        {
+                            name: "_services._dns-sd._udp.local",
+                            recordType: 12,
+                            recordClass: 1,
+                            ttl: 120,
+                            value: "_I0000000000000018._sub._matter._tcp.local",
+                        },
+                        {
+                            name: "_matter._tcp.local",
+                            recordType: 12,
+                            recordClass: 1,
+                            ttl: 120,
+                            value: "0000000000000018-0000000000000001._matter._tcp.local",
+                        },
+                        {
+                            name: "_I0000000000000018._sub._matter._tcp.local",
+                            recordType: 12,
+                            recordClass: 1,
+                            ttl: 120,
+                            value: "0000000000000018-0000000000000001._matter._tcp.local",
+                        },
+                    ],
+                    authorities: [],
+                    additionalRecords: [
+                        {
+                            name: "0000000000000018-0000000000000001._matter._tcp.local",
+                            recordType: 33,
+                            recordClass: 1,
+                            ttl: 120,
+                            value: { priority: 0, weight: 0, port: PORT, target: "00B0D063C2260000.local" },
+                        },
+                        {
+                            name: "0000000000000018-0000000000000001._matter._tcp.local",
+                            recordType: 16,
+                            recordClass: 1,
+                            ttl: 120,
+                            value: ["SII=100", "SAI=200", "T=0"],
+                        },
+                        ...IPDnsRecords,
+                    ],
+                });
             });
-            await broadcaster.announce(PORT);
 
-            const result = DnsCodec.decode(await promise);
+            it("it broadcasts the device commissionable info on one port", async () => {
+                const { promise, resolver } = createPromise<ByteArray>();
+                scannerChannel.onData((_netInterface, _peerAddress, _peerPort, data) => resolver(data));
 
-            expect(result).deep.equal({
-                transactionId: 0,
-                messageType: 33792,
-                queries: [],
-                answers: [
-                    {
-                        name: "_services._dns-sd._udp.local",
-                        recordType: 12,
-                        recordClass: 1,
-                        ttl: 120,
-                        value: "_matter._tcp.local",
-                    },
-                    {
-                        name: "_services._dns-sd._udp.local",
-                        recordType: 12,
-                        recordClass: 1,
-                        ttl: 120,
-                        value: "_I0000000000000018._sub._matter._tcp.local",
-                    },
-                    {
-                        name: "_matter._tcp.local",
-                        recordType: 12,
-                        recordClass: 1,
-                        ttl: 120,
-                        value: "0000000000000018-0000000000000001._matter._tcp.local",
-                    },
-                    {
-                        name: "_I0000000000000018._sub._matter._tcp.local",
-                        recordType: 12,
-                        recordClass: 1,
-                        ttl: 120,
-                        value: "0000000000000018-0000000000000001._matter._tcp.local",
-                    },
-                ],
-                authorities: [],
-                additionalRecords: [
-                    {
-                        name: "0000000000000018-0000000000000001._matter._tcp.local",
-                        recordType: 33,
-                        recordClass: 1,
-                        ttl: 120,
-                        value: { priority: 0, weight: 0, port: PORT, target: "00B0D063C2260000.local" },
-                    },
-                    {
-                        name: "0000000000000018-0000000000000001._matter._tcp.local",
-                        recordType: 16,
-                        recordClass: 1,
-                        ttl: 120,
-                        value: ["SII=100", "SAI=200", "T=0"],
-                    },
-                    { name: "00B0D063C2260000.local", recordType: 1, recordClass: 1, ttl: 120, value: "192.168.200.1" },
-                    {
-                        name: "00B0D063C2260000.local",
-                        recordType: 28,
-                        recordClass: 1,
-                        ttl: 120,
-                        value: "fe80::e777:4f5e:c61e:7314",
-                    },
-                ],
+                await broadcaster.setCommissionMode(PORT, 1, {
+                    deviceName: "Test Device",
+                    deviceType: 1,
+                    vendorId: VendorId(1),
+                    productId: 0x8000,
+                    discriminator: 1234,
+                });
+                await broadcaster.announce(PORT);
+
+                const result = DnsCodec.decode(await promise);
+
+                expect(result).deep.equal({
+                    additionalRecords: [
+                        {
+                            name: "0000000000000000._matterc._udp.local",
+                            recordClass: 1,
+                            recordType: 33,
+                            ttl: 120,
+                            value: { port: PORT, priority: 0, target: "00B0D063C2260000.local", weight: 0 },
+                        },
+                        {
+                            name: "0000000000000000._matterc._udp.local",
+                            recordClass: 1,
+                            recordType: 16,
+                            ttl: 120,
+                            value: [
+                                "VP=1+32768",
+                                "DT=1",
+                                "DN=Test Device",
+                                "SII=5000",
+                                "SAI=300",
+                                "T=0",
+                                "D=1234",
+                                "CM=1",
+                                "PH=33",
+                                "PI=",
+                            ],
+                        },
+                        ...IPDnsRecords,
+                    ],
+                    answers: [
+                        {
+                            name: "_services._dns-sd._udp.local",
+                            recordClass: 1,
+                            recordType: 12,
+                            ttl: 120,
+                            value: "_matterc._udp.local",
+                        },
+                        {
+                            name: "_services._dns-sd._udp.local",
+                            recordClass: 1,
+                            recordType: 12,
+                            ttl: 120,
+                            value: "_V1._sub._matterc._udp.local",
+                        },
+                        {
+                            name: "_services._dns-sd._udp.local",
+                            recordClass: 1,
+                            recordType: 12,
+                            ttl: 120,
+                            value: "_T1._sub._matterc._udp.local",
+                        },
+                        {
+                            name: "_services._dns-sd._udp.local",
+                            recordClass: 1,
+                            recordType: 12,
+                            ttl: 120,
+                            value: "_S4._sub._matterc._udp.local",
+                        },
+                        {
+                            name: "_services._dns-sd._udp.local",
+                            recordClass: 1,
+                            recordType: 12,
+                            ttl: 120,
+                            value: "_L1234._sub._matterc._udp.local",
+                        },
+                        {
+                            name: "_services._dns-sd._udp.local",
+                            recordClass: 1,
+                            recordType: 12,
+                            ttl: 120,
+                            value: "_CM._sub._matterc._udp.local",
+                        },
+                        {
+                            name: "_matterc._udp.local",
+                            recordClass: 1,
+                            recordType: 12,
+                            ttl: 120,
+                            value: "0000000000000000._matterc._udp.local",
+                        },
+                        {
+                            name: "_V1._sub._matterc._udp.local",
+                            recordClass: 1,
+                            recordType: 12,
+                            ttl: 120,
+                            value: "0000000000000000._matterc._udp.local",
+                        },
+                        {
+                            name: "_T1._sub._matterc._udp.local",
+                            recordClass: 1,
+                            recordType: 12,
+                            ttl: 120,
+                            value: "0000000000000000._matterc._udp.local",
+                        },
+                        {
+                            name: "_S4._sub._matterc._udp.local",
+                            recordClass: 1,
+                            recordType: 12,
+                            ttl: 120,
+                            value: "0000000000000000._matterc._udp.local",
+                        },
+                        {
+                            name: "_L1234._sub._matterc._udp.local",
+                            recordClass: 1,
+                            recordType: 12,
+                            ttl: 120,
+                            value: "0000000000000000._matterc._udp.local",
+                        },
+                        {
+                            name: "_CM._sub._matterc._udp.local",
+                            recordClass: 1,
+                            recordType: 12,
+                            ttl: 120,
+                            value: "0000000000000000._matterc._udp.local",
+                        },
+                    ],
+                    authorities: [],
+                    messageType: 33792,
+                    queries: [],
+                    transactionId: 0,
+                });
+            });
+
+            it("it broadcasts the controller commissioner on one port", async () => {
+                const { promise, resolver } = createPromise<ByteArray>();
+                scannerChannel.onData((_netInterface, _peerAddress, _peerPort, data) => resolver(data));
+
+                await broadcaster.setCommissionerInfo(PORT, {
+                    deviceName: "Test Commissioner",
+                    deviceType: 1,
+                    vendorId: VendorId(1),
+                    productId: 0x8000,
+                });
+                await broadcaster.announce(PORT);
+
+                const result = DnsCodec.decode(await promise);
+
+                expect(result).deep.equal({
+                    additionalRecords: [
+                        {
+                            name: "0000000000000000._matterd._udp.local",
+                            recordClass: 1,
+                            recordType: 33,
+                            ttl: 120,
+                            value: { port: PORT, priority: 0, target: "00B0D063C2260000.local", weight: 0 },
+                        },
+                        {
+                            name: "0000000000000000._matterd._udp.local",
+                            recordClass: 1,
+                            recordType: 16,
+                            ttl: 120,
+                            value: ["VP=1+32768", "DT=1", "DN=Test Commissioner", "SII=5000", "SAI=300", "T=0"],
+                        },
+                        ...IPDnsRecords,
+                    ],
+                    answers: [
+                        {
+                            name: "_services._dns-sd._udp.local",
+                            recordClass: 1,
+                            recordType: 12,
+                            ttl: 120,
+                            value: "_matterd._udp.local",
+                        },
+                        {
+                            name: "_matterd._udp.local",
+                            recordClass: 1,
+                            recordType: 12,
+                            ttl: 120,
+                            value: "_V1._sub._matterd._udp.local",
+                        },
+                        {
+                            name: "_V1._sub._matterd._udp.local",
+                            recordClass: 1,
+                            recordType: 12,
+                            ttl: 120,
+                            value: "0000000000000000._matterd._udp.local",
+                        },
+                        {
+                            name: "_services._dns-sd._udp.local",
+                            recordClass: 1,
+                            recordType: 12,
+                            ttl: 120,
+                            value: "_T1._sub._matterd._udp.local",
+                        },
+                        {
+                            name: "_T1._sub._matterd._udp.local",
+                            recordClass: 1,
+                            recordType: 12,
+                            ttl: 120,
+                            value: "0000000000000000._matterd._udp.local",
+                        },
+                    ],
+                    authorities: [],
+                    messageType: 33792,
+                    queries: [],
+                    transactionId: 0,
+                });
+            });
+
+            it("it allows announcements of multiple devices on different ports", async () => {
+                const { promise, resolver } = createPromise<void>();
+                const dataArr: ByteArray[] = [];
+                scannerChannel.onData((_netInterface, _peerAddress, _peerPort, data) => {
+                    dataArr.push(data);
+                    if (dataArr.length === 3) resolver();
+                });
+
+                await broadcaster.setFabrics(PORT, [{ operationalId: OPERATIONAL_ID, nodeId: NODE_ID } as Fabric]);
+                await broadcaster.setCommissionMode(PORT2, 1, {
+                    deviceName: "Test Device",
+                    deviceType: 1,
+                    vendorId: VendorId(1),
+                    productId: 0x8000,
+                    discriminator: 1234,
+                });
+                await broadcaster.setCommissionerInfo(PORT3, {
+                    deviceName: "Test Commissioner",
+                    deviceType: 1,
+                    vendorId: VendorId(1),
+                    productId: 0x8000,
+                });
+                await broadcaster.announce(PORT);
+                await broadcaster.announce(PORT2);
+                await broadcaster.announce(PORT3);
+
+                await promise;
+
+                const result1 = DnsCodec.decode(dataArr[0]);
+                expect(result1).deep.equal({
+                    transactionId: 0,
+                    messageType: 33792,
+                    queries: [],
+                    answers: [
+                        {
+                            name: "_services._dns-sd._udp.local",
+                            recordType: 12,
+                            recordClass: 1,
+                            ttl: 120,
+                            value: "_matter._tcp.local",
+                        },
+                        {
+                            name: "_services._dns-sd._udp.local",
+                            recordType: 12,
+                            recordClass: 1,
+                            ttl: 120,
+                            value: "_I0000000000000018._sub._matter._tcp.local",
+                        },
+                        {
+                            name: "_matter._tcp.local",
+                            recordType: 12,
+                            recordClass: 1,
+                            ttl: 120,
+                            value: "0000000000000018-0000000000000001._matter._tcp.local",
+                        },
+                        {
+                            name: "_I0000000000000018._sub._matter._tcp.local",
+                            recordType: 12,
+                            recordClass: 1,
+                            ttl: 120,
+                            value: "0000000000000018-0000000000000001._matter._tcp.local",
+                        },
+                    ],
+                    authorities: [],
+                    additionalRecords: [
+                        {
+                            name: "0000000000000018-0000000000000001._matter._tcp.local",
+                            recordType: 33,
+                            recordClass: 1,
+                            ttl: 120,
+                            value: { priority: 0, weight: 0, port: PORT, target: "00B0D063C2260000.local" },
+                        },
+                        {
+                            name: "0000000000000018-0000000000000001._matter._tcp.local",
+                            recordType: 16,
+                            recordClass: 1,
+                            ttl: 120,
+                            value: ["SII=5000", "SAI=300", "T=0"],
+                        },
+                        ...IPDnsRecords,
+                    ],
+                });
+
+                const result2 = DnsCodec.decode(dataArr[1]);
+                expect(result2).deep.equal({
+                    additionalRecords: [
+                        {
+                            name: "0000000000000000._matterc._udp.local",
+                            recordClass: 1,
+                            recordType: 33,
+                            ttl: 120,
+                            value: { port: PORT2, priority: 0, target: "00B0D063C2260000.local", weight: 0 },
+                        },
+                        {
+                            name: "0000000000000000._matterc._udp.local",
+                            recordClass: 1,
+                            recordType: 16,
+                            ttl: 120,
+                            value: [
+                                "VP=1+32768",
+                                "DT=1",
+                                "DN=Test Device",
+                                "SII=5000",
+                                "SAI=300",
+                                "T=0",
+                                "D=1234",
+                                "CM=1",
+                                "PH=33",
+                                "PI=",
+                            ],
+                        },
+                        ...IPDnsRecords,
+                    ],
+                    answers: [
+                        {
+                            name: "_services._dns-sd._udp.local",
+                            recordClass: 1,
+                            recordType: 12,
+                            ttl: 120,
+                            value: "_matterc._udp.local",
+                        },
+                        {
+                            name: "_services._dns-sd._udp.local",
+                            recordClass: 1,
+                            recordType: 12,
+                            ttl: 120,
+                            value: "_V1._sub._matterc._udp.local",
+                        },
+                        {
+                            name: "_services._dns-sd._udp.local",
+                            recordClass: 1,
+                            recordType: 12,
+                            ttl: 120,
+                            value: "_T1._sub._matterc._udp.local",
+                        },
+                        {
+                            name: "_services._dns-sd._udp.local",
+                            recordClass: 1,
+                            recordType: 12,
+                            ttl: 120,
+                            value: "_S4._sub._matterc._udp.local",
+                        },
+                        {
+                            name: "_services._dns-sd._udp.local",
+                            recordClass: 1,
+                            recordType: 12,
+                            ttl: 120,
+                            value: "_L1234._sub._matterc._udp.local",
+                        },
+                        {
+                            name: "_services._dns-sd._udp.local",
+                            recordClass: 1,
+                            recordType: 12,
+                            ttl: 120,
+                            value: "_CM._sub._matterc._udp.local",
+                        },
+                        {
+                            name: "_matterc._udp.local",
+                            recordClass: 1,
+                            recordType: 12,
+                            ttl: 120,
+                            value: "0000000000000000._matterc._udp.local",
+                        },
+                        {
+                            name: "_V1._sub._matterc._udp.local",
+                            recordClass: 1,
+                            recordType: 12,
+                            ttl: 120,
+                            value: "0000000000000000._matterc._udp.local",
+                        },
+                        {
+                            name: "_T1._sub._matterc._udp.local",
+                            recordClass: 1,
+                            recordType: 12,
+                            ttl: 120,
+                            value: "0000000000000000._matterc._udp.local",
+                        },
+                        {
+                            name: "_S4._sub._matterc._udp.local",
+                            recordClass: 1,
+                            recordType: 12,
+                            ttl: 120,
+                            value: "0000000000000000._matterc._udp.local",
+                        },
+                        {
+                            name: "_L1234._sub._matterc._udp.local",
+                            recordClass: 1,
+                            recordType: 12,
+                            ttl: 120,
+                            value: "0000000000000000._matterc._udp.local",
+                        },
+                        {
+                            name: "_CM._sub._matterc._udp.local",
+                            recordClass: 1,
+                            recordType: 12,
+                            ttl: 120,
+                            value: "0000000000000000._matterc._udp.local",
+                        },
+                    ],
+                    authorities: [],
+                    messageType: 33792,
+                    queries: [],
+                    transactionId: 0,
+                });
+
+                const result3 = DnsCodec.decode(dataArr[2]);
+                expect(result3).deep.equal({
+                    additionalRecords: [
+                        {
+                            name: "0000000000000000._matterd._udp.local",
+                            recordClass: 1,
+                            recordType: 33,
+                            ttl: 120,
+                            value: { port: PORT3, priority: 0, target: "00B0D063C2260000.local", weight: 0 },
+                        },
+                        {
+                            name: "0000000000000000._matterd._udp.local",
+                            recordClass: 1,
+                            recordType: 16,
+                            ttl: 120,
+                            value: ["VP=1+32768", "DT=1", "DN=Test Commissioner", "SII=5000", "SAI=300", "T=0"],
+                        },
+                        ...IPDnsRecords,
+                    ],
+                    answers: [
+                        {
+                            name: "_services._dns-sd._udp.local",
+                            recordClass: 1,
+                            recordType: 12,
+                            ttl: 120,
+                            value: "_matterd._udp.local",
+                        },
+                        {
+                            name: "_matterd._udp.local",
+                            recordClass: 1,
+                            recordType: 12,
+                            ttl: 120,
+                            value: "_V1._sub._matterd._udp.local",
+                        },
+                        {
+                            name: "_V1._sub._matterd._udp.local",
+                            recordClass: 1,
+                            recordType: 12,
+                            ttl: 120,
+                            value: "0000000000000000._matterd._udp.local",
+                        },
+                        {
+                            name: "_services._dns-sd._udp.local",
+                            recordClass: 1,
+                            recordType: 12,
+                            ttl: 120,
+                            value: "_T1._sub._matterd._udp.local",
+                        },
+                        {
+                            name: "_T1._sub._matterd._udp.local",
+                            recordClass: 1,
+                            recordType: 12,
+                            ttl: 120,
+                            value: "0000000000000000._matterd._udp.local",
+                        },
+                    ],
+                    authorities: [],
+                    messageType: 33792,
+                    queries: [],
+                    transactionId: 0,
+                });
             });
         });
 
-        it("it broadcasts the device commissionable info on one port", async () => {
-            const { promise, resolver } = createPromise<ByteArray>();
-            scannerChannel.onData((_netInterface, _peerAddress, _peerPort, data) => resolver(data));
+        describe("integration", () => {
+            it("the client directly returns server record if it has been announced before", async () => {
+                let queryReceived = false;
+                let dataWereSent = false;
+                scannerChannel.onData((_netInterface, _peerAddress, _peerPort, data) => {
+                    dataWereSent = true;
+                    const dataDecoded = DnsCodec.decode(data);
+                    if (dataDecoded?.messageType === DnsMessageType.Query) {
+                        queryReceived = true;
+                    }
+                });
+                await broadcaster.setFabrics(PORT, [{ operationalId: OPERATIONAL_ID, nodeId: NODE_ID } as Fabric]);
+                await broadcaster.announce(PORT);
 
-            await broadcaster.setCommissionMode(PORT, 1, {
-                deviceName: "Test Device",
-                deviceType: 1,
-                vendorId: VendorId(1),
-                productId: 0x8000,
-                discriminator: 1234,
+                await MockTime.yield3(); // Make sure data were broadcasted async
+                await MockTime.yield3(); // Make sure data were received and processed async
+
+                const result = await scanner.findOperationalDevice(
+                    { operationalId: OPERATIONAL_ID } as Fabric,
+                    NODE_ID,
+                    1,
+                );
+
+                expect(dataWereSent).equal(true);
+                expect(queryReceived).equal(false);
+                expect(result).deep.equal(IPIntegrationResultsPort1);
             });
-            await broadcaster.announce(PORT);
 
-            const result = DnsCodec.decode(await promise);
+            it("the client queries the server record if it has not been announced before", async () => {
+                const sentData = new Array<ByteArray>();
+                scannerChannel.onData((_netInterface, _peerAddress, _peerPort, data) => sentData.push(data));
 
-            expect(result).deep.equal({
-                additionalRecords: [
-                    {
-                        name: "0000000000000000._matterc._udp.local",
-                        recordClass: 1,
-                        recordType: 33,
-                        ttl: 120,
-                        value: { port: PORT, priority: 0, target: "00B0D063C2260000.local", weight: 0 },
-                    },
-                    {
-                        name: "0000000000000000._matterc._udp.local",
-                        recordClass: 1,
-                        recordType: 16,
-                        ttl: 120,
-                        value: [
-                            "VP=1+32768",
-                            "DT=1",
-                            "DN=Test Device",
-                            "SII=5000",
-                            "SAI=300",
-                            "T=0",
-                            "D=1234",
-                            "CM=1",
-                            "PH=33",
-                            "PI=",
+                await broadcaster.setFabrics(PORT, [{ operationalId: OPERATIONAL_ID, nodeId: NODE_ID } as Fabric]);
+
+                const findPromise = scanner.findOperationalDevice({ operationalId: OPERATIONAL_ID } as Fabric, NODE_ID);
+
+                await MockTime.yield3(); // make sure responding promise is created
+                await MockTime.advance(1); // Trigger timer to send query (0ms timer)
+                await MockTime.yield3(); // make sure responding promise is created
+
+                expect(DnsCodec.decode(sentData[0])).deep.equal({
+                    additionalRecords: [],
+                    answers: [],
+                    authorities: [],
+                    messageType: 0,
+                    queries: [
+                        {
+                            name: "0000000000000018-0000000000000001._matter._tcp.local",
+                            recordClass: 1,
+                            recordType: 33,
+                        },
+                    ],
+                    transactionId: 0,
+                });
+
+                const result = await findPromise;
+
+                expect(result).deep.equal(IPIntegrationResultsPort1);
+            });
+
+            it("the client queries the server record and get correct response also with multiple announced instances", async () => {
+                const netData = new Array<ByteArray>();
+                broadcasterChannel.onData((_netInterface, _peerAddress, _peerPort, data) => {
+                    netData.push(data);
+                });
+
+                await broadcaster.setCommissionMode(PORT, 1, {
+                    deviceName: "Test Device",
+                    deviceType: 1,
+                    vendorId: VendorId(1),
+                    productId: 0x8000,
+                    discriminator: 1234,
+                });
+                await broadcaster.setFabrics(PORT2, [{ operationalId: OPERATIONAL_ID, nodeId: NODE_ID } as Fabric]);
+
+                const findPromise = scanner.findOperationalDevice({ operationalId: OPERATIONAL_ID } as Fabric, NODE_ID);
+
+                await MockTime.yield3(); // make sure responding promise is created
+                await MockTime.advance(1); // Trigger timer to send query (0ms timer)
+                await MockTime.yield3(); // Make sure data were queried async
+
+                expect(netData.length).equal(testIpv4Enabled ? 3 : 2);
+
+                const query = DnsCodec.decode(netData[0]);
+                expect(query).deep.equal({
+                    additionalRecords: [],
+                    answers: [],
+                    authorities: [],
+                    messageType: 0,
+                    queries: [
+                        {
+                            name: "0000000000000018-0000000000000001._matter._tcp.local",
+                            recordClass: 1,
+                            recordType: 33,
+                        },
+                    ],
+                    transactionId: 0,
+                });
+                const response2 = DnsCodec.decode(netData[1]);
+                expect(response2).deep.equal({
+                    additionalRecords: [
+                        {
+                            name: "_services._dns-sd._udp.local",
+                            recordClass: 1,
+                            recordType: 12,
+                            ttl: 120,
+                            value: "_matter._tcp.local",
+                        },
+                        {
+                            name: "_services._dns-sd._udp.local",
+                            recordClass: 1,
+                            recordType: 12,
+                            ttl: 120,
+                            value: "_I0000000000000018._sub._matter._tcp.local",
+                        },
+                        {
+                            name: "_matter._tcp.local",
+                            recordClass: 1,
+                            recordType: 12,
+                            ttl: 120,
+                            value: "0000000000000018-0000000000000001._matter._tcp.local",
+                        },
+                        {
+                            name: "_I0000000000000018._sub._matter._tcp.local",
+                            recordClass: 1,
+                            recordType: 12,
+                            ttl: 120,
+                            value: "0000000000000018-0000000000000001._matter._tcp.local",
+                        },
+                        {
+                            name: "0000000000000018-0000000000000001._matter._tcp.local",
+                            recordClass: 1,
+                            recordType: 16,
+                            ttl: 120,
+                            value: ["SII=5000", "SAI=300", "T=0"],
+                        },
+                        ...IPDnsRecords,
+                    ],
+                    answers: [
+                        {
+                            name: "0000000000000018-0000000000000001._matter._tcp.local",
+                            recordClass: 1,
+                            recordType: 33,
+                            ttl: 120,
+                            value: { port: PORT2, priority: 0, target: "00B0D063C2260000.local", weight: 0 },
+                        },
+                    ],
+                    authorities: [],
+                    messageType: 33792,
+                    queries: [],
+                    transactionId: 0,
+                });
+
+                if (testIpv4Enabled) {
+                    const response = DnsCodec.decode(netData[2]);
+                    expect(response).deep.equal({
+                        additionalRecords: [
+                            {
+                                name: "_services._dns-sd._udp.local",
+                                recordClass: 1,
+                                recordType: 12,
+                                ttl: 120,
+                                value: "_matter._tcp.local",
+                            },
+                            {
+                                name: "_services._dns-sd._udp.local",
+                                recordClass: 1,
+                                recordType: 12,
+                                ttl: 120,
+                                value: "_I0000000000000018._sub._matter._tcp.local",
+                            },
+                            {
+                                name: "_matter._tcp.local",
+                                recordClass: 1,
+                                recordType: 12,
+                                ttl: 120,
+                                value: "0000000000000018-0000000000000001._matter._tcp.local",
+                            },
+                            {
+                                name: "_I0000000000000018._sub._matter._tcp.local",
+                                recordClass: 1,
+                                recordType: 12,
+                                ttl: 120,
+                                value: "0000000000000018-0000000000000001._matter._tcp.local",
+                            },
+                            {
+                                name: "0000000000000018-0000000000000001._matter._tcp.local",
+                                recordClass: 1,
+                                recordType: 16,
+                                ttl: 120,
+                                value: ["SII=5000", "SAI=300", "T=0"],
+                            },
+                            ...IPDnsRecords,
                         ],
-                    },
-                    { name: "00B0D063C2260000.local", recordClass: 1, recordType: 1, ttl: 120, value: "192.168.200.1" },
-                    {
-                        name: "00B0D063C2260000.local",
-                        recordClass: 1,
-                        recordType: 28,
-                        ttl: 120,
-                        value: "fe80::e777:4f5e:c61e:7314",
-                    },
-                ],
-                answers: [
-                    {
-                        name: "_services._dns-sd._udp.local",
-                        recordClass: 1,
-                        recordType: 12,
-                        ttl: 120,
-                        value: "_matterc._udp.local",
-                    },
-                    {
-                        name: "_services._dns-sd._udp.local",
-                        recordClass: 1,
-                        recordType: 12,
-                        ttl: 120,
-                        value: "_V1._sub._matterc._udp.local",
-                    },
-                    {
-                        name: "_services._dns-sd._udp.local",
-                        recordClass: 1,
-                        recordType: 12,
-                        ttl: 120,
-                        value: "_T1._sub._matterc._udp.local",
-                    },
-                    {
-                        name: "_services._dns-sd._udp.local",
-                        recordClass: 1,
-                        recordType: 12,
-                        ttl: 120,
-                        value: "_S4._sub._matterc._udp.local",
-                    },
-                    {
-                        name: "_services._dns-sd._udp.local",
-                        recordClass: 1,
-                        recordType: 12,
-                        ttl: 120,
-                        value: "_L1234._sub._matterc._udp.local",
-                    },
-                    {
-                        name: "_services._dns-sd._udp.local",
-                        recordClass: 1,
-                        recordType: 12,
-                        ttl: 120,
-                        value: "_CM._sub._matterc._udp.local",
-                    },
-                    {
-                        name: "_matterc._udp.local",
-                        recordClass: 1,
-                        recordType: 12,
-                        ttl: 120,
-                        value: "0000000000000000._matterc._udp.local",
-                    },
-                    {
-                        name: "_V1._sub._matterc._udp.local",
-                        recordClass: 1,
-                        recordType: 12,
-                        ttl: 120,
-                        value: "0000000000000000._matterc._udp.local",
-                    },
-                    {
-                        name: "_T1._sub._matterc._udp.local",
-                        recordClass: 1,
-                        recordType: 12,
-                        ttl: 120,
-                        value: "0000000000000000._matterc._udp.local",
-                    },
-                    {
-                        name: "_S4._sub._matterc._udp.local",
-                        recordClass: 1,
-                        recordType: 12,
-                        ttl: 120,
-                        value: "0000000000000000._matterc._udp.local",
-                    },
-                    {
-                        name: "_L1234._sub._matterc._udp.local",
-                        recordClass: 1,
-                        recordType: 12,
-                        ttl: 120,
-                        value: "0000000000000000._matterc._udp.local",
-                    },
-                    {
-                        name: "_CM._sub._matterc._udp.local",
-                        recordClass: 1,
-                        recordType: 12,
-                        ttl: 120,
-                        value: "0000000000000000._matterc._udp.local",
-                    },
-                ],
-                authorities: [],
-                messageType: 33792,
-                queries: [],
-                transactionId: 0,
-            });
-        });
-
-        it("it broadcasts the controller commissioner on one port", async () => {
-            const { promise, resolver } = createPromise<ByteArray>();
-            scannerChannel.onData((_netInterface, _peerAddress, _peerPort, data) => resolver(data));
-
-            await broadcaster.setCommissionerInfo(PORT, {
-                deviceName: "Test Commissioner",
-                deviceType: 1,
-                vendorId: VendorId(1),
-                productId: 0x8000,
-            });
-            await broadcaster.announce(PORT);
-
-            const result = DnsCodec.decode(await promise);
-
-            expect(result).deep.equal({
-                additionalRecords: [
-                    {
-                        name: "0000000000000000._matterd._udp.local",
-                        recordClass: 1,
-                        recordType: 33,
-                        ttl: 120,
-                        value: { port: PORT, priority: 0, target: "00B0D063C2260000.local", weight: 0 },
-                    },
-                    {
-                        name: "0000000000000000._matterd._udp.local",
-                        recordClass: 1,
-                        recordType: 16,
-                        ttl: 120,
-                        value: ["VP=1+32768", "DT=1", "DN=Test Commissioner", "SII=5000", "SAI=300", "T=0"],
-                    },
-                    { name: "00B0D063C2260000.local", recordClass: 1, recordType: 1, ttl: 120, value: "192.168.200.1" },
-                    {
-                        name: "00B0D063C2260000.local",
-                        recordClass: 1,
-                        recordType: 28,
-                        ttl: 120,
-                        value: "fe80::e777:4f5e:c61e:7314",
-                    },
-                ],
-                answers: [
-                    {
-                        name: "_services._dns-sd._udp.local",
-                        recordClass: 1,
-                        recordType: 12,
-                        ttl: 120,
-                        value: "_matterd._udp.local",
-                    },
-                    {
-                        name: "_matterd._udp.local",
-                        recordClass: 1,
-                        recordType: 12,
-                        ttl: 120,
-                        value: "_V1._sub._matterd._udp.local",
-                    },
-                    {
-                        name: "_V1._sub._matterd._udp.local",
-                        recordClass: 1,
-                        recordType: 12,
-                        ttl: 120,
-                        value: "0000000000000000._matterd._udp.local",
-                    },
-                    {
-                        name: "_services._dns-sd._udp.local",
-                        recordClass: 1,
-                        recordType: 12,
-                        ttl: 120,
-                        value: "_T1._sub._matterd._udp.local",
-                    },
-                    {
-                        name: "_T1._sub._matterd._udp.local",
-                        recordClass: 1,
-                        recordType: 12,
-                        ttl: 120,
-                        value: "0000000000000000._matterd._udp.local",
-                    },
-                ],
-                authorities: [],
-                messageType: 33792,
-                queries: [],
-                transactionId: 0,
-            });
-        });
-
-        it("it allows announcements of multiple devices on different ports", async () => {
-            const { promise, resolver } = createPromise<void>();
-            const dataArr: ByteArray[] = [];
-            scannerChannel.onData((_netInterface, _peerAddress, _peerPort, data) => {
-                dataArr.push(data);
-                if (dataArr.length === 3) resolver();
-            });
-
-            await broadcaster.setFabrics(PORT, [{ operationalId: OPERATIONAL_ID, nodeId: NODE_ID } as Fabric]);
-            await broadcaster.setCommissionMode(PORT2, 1, {
-                deviceName: "Test Device",
-                deviceType: 1,
-                vendorId: VendorId(1),
-                productId: 0x8000,
-                discriminator: 1234,
-            });
-            await broadcaster.setCommissionerInfo(PORT3, {
-                deviceName: "Test Commissioner",
-                deviceType: 1,
-                vendorId: VendorId(1),
-                productId: 0x8000,
-            });
-            await broadcaster.announce(PORT);
-            await broadcaster.announce(PORT2);
-            await broadcaster.announce(PORT3);
-
-            await promise;
-
-            const result1 = DnsCodec.decode(dataArr[0]);
-            expect(result1).deep.equal({
-                transactionId: 0,
-                messageType: 33792,
-                queries: [],
-                answers: [
-                    {
-                        name: "_services._dns-sd._udp.local",
-                        recordType: 12,
-                        recordClass: 1,
-                        ttl: 120,
-                        value: "_matter._tcp.local",
-                    },
-                    {
-                        name: "_services._dns-sd._udp.local",
-                        recordType: 12,
-                        recordClass: 1,
-                        ttl: 120,
-                        value: "_I0000000000000018._sub._matter._tcp.local",
-                    },
-                    {
-                        name: "_matter._tcp.local",
-                        recordType: 12,
-                        recordClass: 1,
-                        ttl: 120,
-                        value: "0000000000000018-0000000000000001._matter._tcp.local",
-                    },
-                    {
-                        name: "_I0000000000000018._sub._matter._tcp.local",
-                        recordType: 12,
-                        recordClass: 1,
-                        ttl: 120,
-                        value: "0000000000000018-0000000000000001._matter._tcp.local",
-                    },
-                ],
-                authorities: [],
-                additionalRecords: [
-                    {
-                        name: "0000000000000018-0000000000000001._matter._tcp.local",
-                        recordType: 33,
-                        recordClass: 1,
-                        ttl: 120,
-                        value: { priority: 0, weight: 0, port: PORT, target: "00B0D063C2260000.local" },
-                    },
-                    {
-                        name: "0000000000000018-0000000000000001._matter._tcp.local",
-                        recordType: 16,
-                        recordClass: 1,
-                        ttl: 120,
-                        value: ["SII=5000", "SAI=300", "T=0"],
-                    },
-                    { name: "00B0D063C2260000.local", recordType: 1, recordClass: 1, ttl: 120, value: "192.168.200.1" },
-                    {
-                        name: "00B0D063C2260000.local",
-                        recordType: 28,
-                        recordClass: 1,
-                        ttl: 120,
-                        value: "fe80::e777:4f5e:c61e:7314",
-                    },
-                ],
-            });
-
-            const result2 = DnsCodec.decode(dataArr[1]);
-            expect(result2).deep.equal({
-                additionalRecords: [
-                    {
-                        name: "0000000000000000._matterc._udp.local",
-                        recordClass: 1,
-                        recordType: 33,
-                        ttl: 120,
-                        value: { port: PORT2, priority: 0, target: "00B0D063C2260000.local", weight: 0 },
-                    },
-                    {
-                        name: "0000000000000000._matterc._udp.local",
-                        recordClass: 1,
-                        recordType: 16,
-                        ttl: 120,
-                        value: [
-                            "VP=1+32768",
-                            "DT=1",
-                            "DN=Test Device",
-                            "SII=5000",
-                            "SAI=300",
-                            "T=0",
-                            "D=1234",
-                            "CM=1",
-                            "PH=33",
-                            "PI=",
+                        answers: [
+                            {
+                                name: "0000000000000018-0000000000000001._matter._tcp.local",
+                                recordClass: 1,
+                                recordType: 33,
+                                ttl: 120,
+                                value: { port: PORT2, priority: 0, target: "00B0D063C2260000.local", weight: 0 },
+                            },
                         ],
-                    },
-                    { name: "00B0D063C2260000.local", recordClass: 1, recordType: 1, ttl: 120, value: "192.168.200.1" },
-                    {
-                        name: "00B0D063C2260000.local",
-                        recordClass: 1,
-                        recordType: 28,
-                        ttl: 120,
-                        value: "fe80::e777:4f5e:c61e:7314",
-                    },
-                ],
-                answers: [
-                    {
-                        name: "_services._dns-sd._udp.local",
-                        recordClass: 1,
-                        recordType: 12,
-                        ttl: 120,
-                        value: "_matterc._udp.local",
-                    },
-                    {
-                        name: "_services._dns-sd._udp.local",
-                        recordClass: 1,
-                        recordType: 12,
-                        ttl: 120,
-                        value: "_V1._sub._matterc._udp.local",
-                    },
-                    {
-                        name: "_services._dns-sd._udp.local",
-                        recordClass: 1,
-                        recordType: 12,
-                        ttl: 120,
-                        value: "_T1._sub._matterc._udp.local",
-                    },
-                    {
-                        name: "_services._dns-sd._udp.local",
-                        recordClass: 1,
-                        recordType: 12,
-                        ttl: 120,
-                        value: "_S4._sub._matterc._udp.local",
-                    },
-                    {
-                        name: "_services._dns-sd._udp.local",
-                        recordClass: 1,
-                        recordType: 12,
-                        ttl: 120,
-                        value: "_L1234._sub._matterc._udp.local",
-                    },
-                    {
-                        name: "_services._dns-sd._udp.local",
-                        recordClass: 1,
-                        recordType: 12,
-                        ttl: 120,
-                        value: "_CM._sub._matterc._udp.local",
-                    },
-                    {
-                        name: "_matterc._udp.local",
-                        recordClass: 1,
-                        recordType: 12,
-                        ttl: 120,
-                        value: "0000000000000000._matterc._udp.local",
-                    },
-                    {
-                        name: "_V1._sub._matterc._udp.local",
-                        recordClass: 1,
-                        recordType: 12,
-                        ttl: 120,
-                        value: "0000000000000000._matterc._udp.local",
-                    },
-                    {
-                        name: "_T1._sub._matterc._udp.local",
-                        recordClass: 1,
-                        recordType: 12,
-                        ttl: 120,
-                        value: "0000000000000000._matterc._udp.local",
-                    },
-                    {
-                        name: "_S4._sub._matterc._udp.local",
-                        recordClass: 1,
-                        recordType: 12,
-                        ttl: 120,
-                        value: "0000000000000000._matterc._udp.local",
-                    },
-                    {
-                        name: "_L1234._sub._matterc._udp.local",
-                        recordClass: 1,
-                        recordType: 12,
-                        ttl: 120,
-                        value: "0000000000000000._matterc._udp.local",
-                    },
-                    {
-                        name: "_CM._sub._matterc._udp.local",
-                        recordClass: 1,
-                        recordType: 12,
-                        ttl: 120,
-                        value: "0000000000000000._matterc._udp.local",
-                    },
-                ],
-                authorities: [],
-                messageType: 33792,
-                queries: [],
-                transactionId: 0,
-            });
-
-            const result3 = DnsCodec.decode(dataArr[2]);
-            expect(result3).deep.equal({
-                additionalRecords: [
-                    {
-                        name: "0000000000000000._matterd._udp.local",
-                        recordClass: 1,
-                        recordType: 33,
-                        ttl: 120,
-                        value: { port: PORT3, priority: 0, target: "00B0D063C2260000.local", weight: 0 },
-                    },
-                    {
-                        name: "0000000000000000._matterd._udp.local",
-                        recordClass: 1,
-                        recordType: 16,
-                        ttl: 120,
-                        value: ["VP=1+32768", "DT=1", "DN=Test Commissioner", "SII=5000", "SAI=300", "T=0"],
-                    },
-                    { name: "00B0D063C2260000.local", recordClass: 1, recordType: 1, ttl: 120, value: "192.168.200.1" },
-                    {
-                        name: "00B0D063C2260000.local",
-                        recordClass: 1,
-                        recordType: 28,
-                        ttl: 120,
-                        value: "fe80::e777:4f5e:c61e:7314",
-                    },
-                ],
-                answers: [
-                    {
-                        name: "_services._dns-sd._udp.local",
-                        recordClass: 1,
-                        recordType: 12,
-                        ttl: 120,
-                        value: "_matterd._udp.local",
-                    },
-                    {
-                        name: "_matterd._udp.local",
-                        recordClass: 1,
-                        recordType: 12,
-                        ttl: 120,
-                        value: "_V1._sub._matterd._udp.local",
-                    },
-                    {
-                        name: "_V1._sub._matterd._udp.local",
-                        recordClass: 1,
-                        recordType: 12,
-                        ttl: 120,
-                        value: "0000000000000000._matterd._udp.local",
-                    },
-                    {
-                        name: "_services._dns-sd._udp.local",
-                        recordClass: 1,
-                        recordType: 12,
-                        ttl: 120,
-                        value: "_T1._sub._matterd._udp.local",
-                    },
-                    {
-                        name: "_T1._sub._matterd._udp.local",
-                        recordClass: 1,
-                        recordType: 12,
-                        ttl: 120,
-                        value: "0000000000000000._matterd._udp.local",
-                    },
-                ],
-                authorities: [],
-                messageType: 33792,
-                queries: [],
-                transactionId: 0,
-            });
-        });
-    });
-
-    describe("integration", () => {
-        it("the client directly returns server record if it has been announced before", async () => {
-            let queryReceived = false;
-            let dataWereSent = false;
-            scannerChannel.onData((_netInterface, _peerAddress, _peerPort, data) => {
-                dataWereSent = true;
-                const dataDecoded = DnsCodec.decode(data);
-                if (dataDecoded?.messageType === DnsMessageType.Query) {
-                    queryReceived = true;
+                        authorities: [],
+                        messageType: 33792,
+                        queries: [],
+                        transactionId: 0,
+                    });
                 }
-            });
-            await broadcaster.setFabrics(PORT, [{ operationalId: OPERATIONAL_ID, nodeId: NODE_ID } as Fabric]);
-            await broadcaster.announce(PORT);
+                const result = await findPromise;
 
-            await MockTime.yield3(); // Make sure data were broadcasted async
-            await MockTime.yield3(); // Make sure data were received and processed async
-
-            const result = await scanner.findOperationalDevice({ operationalId: OPERATIONAL_ID } as Fabric, NODE_ID, 1);
-
-            expect(dataWereSent).equal(true);
-            expect(queryReceived).equal(false);
-            expect(result).deep.equal([
-                { ip: `${SERVER_IPv6}%fakeInterface`, port: PORT, type: "udp" },
-                { ip: SERVER_IPv4, port: PORT, type: "udp" },
-            ]);
-        });
-
-        it("the client queries the server record if it has not been announced before", async () => {
-            const sentData = new Array<ByteArray>();
-            scannerChannel.onData((_netInterface, _peerAddress, _peerPort, data) => sentData.push(data));
-
-            await broadcaster.setFabrics(PORT, [{ operationalId: OPERATIONAL_ID, nodeId: NODE_ID } as Fabric]);
-
-            const findPromise = scanner.findOperationalDevice({ operationalId: OPERATIONAL_ID } as Fabric, NODE_ID);
-
-            await MockTime.yield3(); // make sure responding promise is created
-            await MockTime.advance(1); // Trigger timer to send query (0ms timer)
-            await MockTime.yield3(); // make sure responding promise is created
-
-            expect(DnsCodec.decode(sentData[0])).deep.equal({
-                additionalRecords: [],
-                answers: [],
-                authorities: [],
-                messageType: 0,
-                queries: [
-                    { name: "0000000000000018-0000000000000001._matter._tcp.local", recordClass: 1, recordType: 33 },
-                ],
-                transactionId: 0,
+                expect(result).deep.equal(IPIntegrationResultsPort2);
             });
 
-            const result = await findPromise;
+            it("the client queries the server record and get correct response when announced before", async () => {
+                let dataWereSent = false;
+                let queryReceived = false;
+                scannerChannel.onData((_netInterface, _peerAddress, _peerPort, data) => {
+                    dataWereSent = true;
+                    const dataDecoded = DnsCodec.decode(data);
+                    if (dataDecoded?.messageType === DnsMessageType.Query) {
+                        queryReceived = true;
+                    }
+                });
 
-            expect(result).deep.equal([
-                { ip: `${SERVER_IPv6}%fakeInterface`, port: PORT, type: "udp" },
-                { ip: SERVER_IPv4, port: PORT, type: "udp" },
-            ]);
-        });
+                await broadcaster.setCommissionMode(PORT, 1, {
+                    deviceName: "Test Device",
+                    deviceType: 1,
+                    vendorId: VendorId(1),
+                    productId: 0x8000,
+                    discriminator: 1234,
+                });
+                await broadcaster.setFabrics(PORT2, [{ operationalId: OPERATIONAL_ID, nodeId: NODE_ID } as Fabric]);
 
-        it("the client queries the server record and get correct response also with multiple announced instances", async () => {
-            const netData = new Array<ByteArray>();
-            broadcasterChannel.onData((_netInterface, _peerAddress, _peerPort, data) => {
-                netData.push(data);
+                await broadcaster.announce(PORT);
+                await broadcaster.announce(PORT2);
+
+                await MockTime.yield3();
+                await MockTime.yield3();
+
+                const result = await scanner.findOperationalDevice(
+                    { operationalId: OPERATIONAL_ID } as Fabric,
+                    NODE_ID,
+                );
+
+                expect(dataWereSent).equal(true);
+                expect(queryReceived).equal(false);
+                expect(result).deep.equal(IPIntegrationResultsPort2);
             });
-
-            await broadcaster.setCommissionMode(PORT, 1, {
-                deviceName: "Test Device",
-                deviceType: 1,
-                vendorId: VendorId(1),
-                productId: 0x8000,
-                discriminator: 1234,
-            });
-            await broadcaster.setFabrics(PORT2, [{ operationalId: OPERATIONAL_ID, nodeId: NODE_ID } as Fabric]);
-
-            const findPromise = scanner.findOperationalDevice({ operationalId: OPERATIONAL_ID } as Fabric, NODE_ID);
-
-            await MockTime.yield3(); // make sure responding promise is created
-            await MockTime.advance(1); // Trigger timer to send query (0ms timer)
-            await MockTime.yield3(); // Make sure data were queried async
-
-            expect(netData.length).equal(3);
-
-            const query = DnsCodec.decode(netData[0]);
-            expect(query).deep.equal({
-                additionalRecords: [],
-                answers: [],
-                authorities: [],
-                messageType: 0,
-                queries: [
-                    { name: "0000000000000018-0000000000000001._matter._tcp.local", recordClass: 1, recordType: 33 },
-                ],
-                transactionId: 0,
-            });
-            const response2 = DnsCodec.decode(netData[1]);
-            expect(response2).deep.equal({
-                additionalRecords: [
-                    {
-                        name: "_services._dns-sd._udp.local",
-                        recordClass: 1,
-                        recordType: 12,
-                        ttl: 120,
-                        value: "_matter._tcp.local",
-                    },
-                    {
-                        name: "_services._dns-sd._udp.local",
-                        recordClass: 1,
-                        recordType: 12,
-                        ttl: 120,
-                        value: "_I0000000000000018._sub._matter._tcp.local",
-                    },
-                    {
-                        name: "_matter._tcp.local",
-                        recordClass: 1,
-                        recordType: 12,
-                        ttl: 120,
-                        value: "0000000000000018-0000000000000001._matter._tcp.local",
-                    },
-                    {
-                        name: "_I0000000000000018._sub._matter._tcp.local",
-                        recordClass: 1,
-                        recordType: 12,
-                        ttl: 120,
-                        value: "0000000000000018-0000000000000001._matter._tcp.local",
-                    },
-                    {
-                        name: "0000000000000018-0000000000000001._matter._tcp.local",
-                        recordClass: 1,
-                        recordType: 16,
-                        ttl: 120,
-                        value: ["SII=5000", "SAI=300", "T=0"],
-                    },
-                    { name: "00B0D063C2260000.local", recordClass: 1, recordType: 1, ttl: 120, value: "192.168.200.1" },
-                    {
-                        name: "00B0D063C2260000.local",
-                        recordClass: 1,
-                        recordType: 28,
-                        ttl: 120,
-                        value: "fe80::e777:4f5e:c61e:7314",
-                    },
-                ],
-                answers: [
-                    {
-                        name: "0000000000000018-0000000000000001._matter._tcp.local",
-                        recordClass: 1,
-                        recordType: 33,
-                        ttl: 120,
-                        value: { port: PORT2, priority: 0, target: "00B0D063C2260000.local", weight: 0 },
-                    },
-                ],
-                authorities: [],
-                messageType: 33792,
-                queries: [],
-                transactionId: 0,
-            });
-
-            const response = DnsCodec.decode(netData[2]);
-            expect(response).deep.equal({
-                additionalRecords: [
-                    {
-                        name: "_services._dns-sd._udp.local",
-                        recordClass: 1,
-                        recordType: 12,
-                        ttl: 120,
-                        value: "_matter._tcp.local",
-                    },
-                    {
-                        name: "_services._dns-sd._udp.local",
-                        recordClass: 1,
-                        recordType: 12,
-                        ttl: 120,
-                        value: "_I0000000000000018._sub._matter._tcp.local",
-                    },
-                    {
-                        name: "_matter._tcp.local",
-                        recordClass: 1,
-                        recordType: 12,
-                        ttl: 120,
-                        value: "0000000000000018-0000000000000001._matter._tcp.local",
-                    },
-                    {
-                        name: "_I0000000000000018._sub._matter._tcp.local",
-                        recordClass: 1,
-                        recordType: 12,
-                        ttl: 120,
-                        value: "0000000000000018-0000000000000001._matter._tcp.local",
-                    },
-                    {
-                        name: "0000000000000018-0000000000000001._matter._tcp.local",
-                        recordClass: 1,
-                        recordType: 16,
-                        ttl: 120,
-                        value: ["SII=5000", "SAI=300", "T=0"],
-                    },
-                    { name: "00B0D063C2260000.local", recordClass: 1, recordType: 1, ttl: 120, value: "192.168.200.1" },
-                    {
-                        name: "00B0D063C2260000.local",
-                        recordClass: 1,
-                        recordType: 28,
-                        ttl: 120,
-                        value: "fe80::e777:4f5e:c61e:7314",
-                    },
-                ],
-                answers: [
-                    {
-                        name: "0000000000000018-0000000000000001._matter._tcp.local",
-                        recordClass: 1,
-                        recordType: 33,
-                        ttl: 120,
-                        value: { port: PORT2, priority: 0, target: "00B0D063C2260000.local", weight: 0 },
-                    },
-                ],
-                authorities: [],
-                messageType: 33792,
-                queries: [],
-                transactionId: 0,
-            });
-            const result = await findPromise;
-
-            expect(result).deep.equal([
-                { ip: `${SERVER_IPv6}%fakeInterface`, port: PORT2, type: "udp" },
-                { ip: SERVER_IPv4, port: PORT2, type: "udp" },
-            ]);
-        });
-
-        it("the client queries the server record and get correct response when announced before", async () => {
-            let dataWereSent = false;
-            let queryReceived = false;
-            scannerChannel.onData((_netInterface, _peerAddress, _peerPort, data) => {
-                dataWereSent = true;
-                const dataDecoded = DnsCodec.decode(data);
-                if (dataDecoded?.messageType === DnsMessageType.Query) {
-                    queryReceived = true;
-                }
-            });
-
-            await broadcaster.setCommissionMode(PORT, 1, {
-                deviceName: "Test Device",
-                deviceType: 1,
-                vendorId: VendorId(1),
-                productId: 0x8000,
-                discriminator: 1234,
-            });
-            await broadcaster.setFabrics(PORT2, [{ operationalId: OPERATIONAL_ID, nodeId: NODE_ID } as Fabric]);
-
-            await broadcaster.announce(PORT);
-            await broadcaster.announce(PORT2);
-
-            await MockTime.yield3();
-            await MockTime.yield3();
-
-            const result = await scanner.findOperationalDevice({ operationalId: OPERATIONAL_ID } as Fabric, NODE_ID);
-
-            expect(dataWereSent).equal(true);
-            expect(queryReceived).equal(false);
-            expect(result).deep.equal([
-                { ip: `${SERVER_IPv6}%fakeInterface`, port: PORT2, type: "udp" },
-                { ip: SERVER_IPv4, port: PORT2, type: "udp" },
-            ]);
         });
     });
 });


### PR DESCRIPTION
This PR does:
* Breaking: Move "disableIpv4" config options from the MatterNode classes to the MatterServer and also consider it for MDNS init
* I decided to leave "disableIPv4" notation for the main API because we can leave it enabled by default because it is optionally supported.
* Breaking: Adjust MatterServer second parameter to an options object
* Respect disabled IPv4 in MDNS Broadcaster and do not send own IPv4 addresses
* Respect disabled IPv4 in MDNS Scanner and do not return IPv4 addresses back to the code when received
* Adjust MDNS class factories to option object style rather than too many optional parameters
* make ipv4 interface names and addresses optional as parameter in some places
* It includes changelog entries from former PRs