### PR TITLE
Add Commissioning Failsafe Request Timeout Handling (Client)

### DIFF
--- a/packages/matter.js/src/cluster/client/ClusterClient.ts
+++ b/packages/matter.js/src/cluster/client/ClusterClient.ts
@@ -284,9 +284,13 @@ export function ClusterClient<F extends BitSchema, A extends Attributes, C exten
         commandToId[requestId] = commandName;
         commands[commandName] = async <RequestT, ResponseT>(
             request: RequestT,
-            options: { asTimedRequest?: boolean; timedRequestTimeoutMs?: number } = {},
+            options: {
+                asTimedRequest?: boolean;
+                timedRequestTimeoutMs?: number;
+                useExtendedFailSafeMessageResponseTimeout?: boolean;
+            } = {},
         ) => {
-            const { asTimedRequest, timedRequestTimeoutMs } = options;
+            const { asTimedRequest, timedRequestTimeoutMs, useExtendedFailSafeMessageResponseTimeout } = options;
             return interactionClient.invoke<Command<RequestT, ResponseT, any>>({
                 endpointId,
                 clusterId,
@@ -294,6 +298,7 @@ export function ClusterClient<F extends BitSchema, A extends Attributes, C exten
                 request,
                 asTimedRequest,
                 timedRequestTimeoutMs,
+                useExtendedFailSafeMessageResponseTimeout,
             });
         };
         result[commandName] = result.commands[commandName];

--- a/packages/matter.js/src/cluster/client/ClusterClientTypes.ts
+++ b/packages/matter.js/src/cluster/client/ClusterClientTypes.ts
@@ -52,7 +52,19 @@ export type EventClients<E extends Events> = Merge<
 
 export type SignatureFromCommandSpec<C extends Command<any, any, any>> = (
     request: RequestType<C>,
-    options?: { asTimedRequest?: boolean; timedRequestTimeoutMs?: number },
+    options?: {
+        /** Send this command as a timed request also when not required. Default timeout are 10 seconds. */
+        asTimedRequest?: boolean;
+
+        /** Override the request timeout when the command is sent as times request. Default are 10s. */
+        timedRequestTimeoutMs?: number;
+
+        /**
+         * Use the extended fail-safe message response timeout of 30 seconds. Use this for all commands
+         * executed during an activated FailSafe context!
+         */
+        useExtendedFailSafeMessageResponseTimeout?: boolean;
+    },
 ) => Promise<ResponseType<C>>;
 type GetterTypeFromSpec<A extends Attribute<any, any>> = A extends OptionalAttribute<infer T, any>
     ? T | undefined

--- a/packages/matter.js/src/protocol/interaction/InteractionMessenger.ts
+++ b/packages/matter.js/src/protocol/interaction/InteractionMessenger.ts
@@ -276,7 +276,10 @@ export class InteractionServerMessenger extends InteractionMessenger<MatterDevic
         if (dataReport.suppressResponse) {
             // We do not expect a response other than a Standalone Ack, so if we receive anything else, we throw an error
             await tryCatchAsync(
-                async () => await this.exchange.send(MessageType.ReportData, TlvDataReport.encode(dataReport), true),
+                async () =>
+                    await this.exchange.send(MessageType.ReportData, TlvDataReport.encode(dataReport), {
+                        expectAckOnly: true,
+                    }),
                 UnexpectedMessageError,
                 async error => {
                     const { receivedMessage } = error;

--- a/packages/matter.js/src/protocol/interaction/InteractionMessenger.ts
+++ b/packages/matter.js/src/protocol/interaction/InteractionMessenger.ts
@@ -12,6 +12,7 @@ import { MatterController } from "../../MatterController.js";
 import { MatterDevice } from "../../MatterDevice.js";
 import { ExchangeProvider } from "../../protocol/ExchangeManager.js";
 import {
+    ExchangeSendOptions,
     MessageExchange,
     RetransmissionLimitReachedError,
     UnexpectedMessageError,
@@ -76,8 +77,8 @@ const logger = Logger.get("InteractionMessenger");
 class InteractionMessenger<ContextT> {
     constructor(protected exchange: MessageExchange<ContextT>) {}
 
-    async send(messageType: number, payload: ByteArray) {
-        return this.exchange.send(messageType, payload);
+    async send(messageType: number, payload: ByteArray, options?: ExchangeSendOptions) {
+        return this.exchange.send(messageType, payload, options);
     }
 
     sendStatus(status: StatusCode) {
@@ -328,9 +329,9 @@ export class InteractionClientMessenger extends IncomingInteractionClientMesseng
     }
 
     /** Implements a send method with an automatic reconnection mechanism */
-    override async send(messageType: number, payload: ByteArray, expectAckOnly = false) {
+    override async send(messageType: number, payload: ByteArray, options?: ExchangeSendOptions) {
         try {
-            return await this.exchange.send(messageType, payload, expectAckOnly);
+            return await this.exchange.send(messageType, payload, options);
         } catch (error) {
             // When retransmission failed (most likely due to a lost connection or invalid session),
             // try to reconnect if possible and resend the message once
@@ -382,9 +383,14 @@ export class InteractionClientMessenger extends IncomingInteractionClientMesseng
         };
     }
 
-    async sendInvokeCommand(invokeRequest: InvokeRequest) {
+    async sendInvokeCommand(invokeRequest: InvokeRequest, minimumResponseTimeoutMs?: number) {
         if (invokeRequest.suppressResponse) {
-            await this.requestWithSuppressedResponse(MessageType.InvokeCommandRequest, TlvInvokeRequest, invokeRequest);
+            await this.requestWithSuppressedResponse(
+                MessageType.InvokeCommandRequest,
+                TlvInvokeRequest,
+                invokeRequest,
+                minimumResponseTimeoutMs,
+            );
         } else {
             return await this.request(
                 MessageType.InvokeCommandRequest,
@@ -392,6 +398,7 @@ export class InteractionClientMessenger extends IncomingInteractionClientMesseng
                 MessageType.InvokeCommandResponse,
                 TlvInvokeResponse,
                 invokeRequest,
+                minimumResponseTimeoutMs,
             );
         }
     }
@@ -421,8 +428,12 @@ export class InteractionClientMessenger extends IncomingInteractionClientMesseng
         requestMessageType: number,
         requestSchema: TlvSchema<RequestT>,
         request: RequestT,
+        minimumResponseTimeoutMs?: number,
     ): Promise<void> {
-        await this.send(requestMessageType, requestSchema.encode(request), true);
+        await this.send(requestMessageType, requestSchema.encode(request), {
+            expectAckOnly: true,
+            minimumResponseTimeoutMs,
+        });
     }
 
     private async request<RequestT, ResponseT>(
@@ -431,8 +442,12 @@ export class InteractionClientMessenger extends IncomingInteractionClientMesseng
         responseMessageType: number,
         responseSchema: TlvSchema<ResponseT>,
         request: RequestT,
+        minimumResponseTimeoutMs?: number,
     ): Promise<ResponseT> {
-        await this.send(requestMessageType, requestSchema.encode(request));
+        await this.send(requestMessageType, requestSchema.encode(request), {
+            expectAckOnly: false,
+            minimumResponseTimeoutMs,
+        });
         const responseMessage = await this.nextMessage(responseMessageType);
         return responseSchema.decode(responseMessage.payload);
     }


### PR DESCRIPTION
This PR adds the correct handling of extended response timeouts during an armed failsafe timer. In this case a request can take up to 30s to respond which means that the normal "4 retransmissions" timeframe (maximum 4.2s in total) needs to be extended. I realized this by adding another parameter to define a minimum response timeout. because of the fact that the specification do not fully describe how to realize this extended waiting time I decided to simply continue to send retransmissions with default increasing backoff time and check the timout once such a retransmission triggers. The Commissioner class knows when failsafe is enabled and so manually uses this flag whenever it makes sense.

I did not add an integration test for this, but manually tested it via a Meross EU device which needs 6+ seconds to connect to a Wifi network and so the normal 4 times retransmissions was always failing. Should I add a test or do we accept that for now? I could also add a TODO for adding test later