### PR TITLE
Add reading Queue timeout to prevent hanging processes

### DIFF
--- a/packages/matter.js/src/util/Queue.ts
+++ b/packages/matter.js/src/util/Queue.ts
@@ -6,28 +6,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { MatterFlowError } from "../common/MatterError.js";
+import { Time, Timer } from "../time/Time.js";
 import { createPromise } from "./Promises.js";
-import { EndOfStreamError, Stream } from "./Stream.js";
+import { EndOfStreamError, NoResponseTimeoutError, Stream } from "./Stream.js";
 
 export class Queue<T> implements Stream<T> {
     private readonly queue = new Array<T>();
-    private pendingRead?: { resolver: (data: T) => void; rejecter: (reason: any) => void };
+    private pendingRead?: { resolver: (data: T) => void; rejecter: (reason: any) => void; timeoutTimer?: Timer };
     private closed = false;
 
-    async read(): Promise<T> {
+    async read(timeoutMs = 60_000): Promise<T> {
         const { promise, resolver, rejecter } = createPromise<T>();
         if (this.closed) throw new EndOfStreamError();
         const data = this.queue.shift();
         if (data !== undefined) {
             return data;
         }
-        this.pendingRead = { resolver, rejecter };
+        if (this.pendingRead !== undefined) throw new MatterFlowError("Only one pending read is supported");
+        this.pendingRead = {
+            resolver,
+            rejecter,
+            timeoutTimer: Time.getTimer(timeoutMs, () => rejecter(new NoResponseTimeoutError())).start(),
+        };
         return promise;
     }
 
     async write(data: T) {
         if (this.closed) throw new EndOfStreamError();
         if (this.pendingRead !== undefined) {
+            this.pendingRead.timeoutTimer?.stop();
             this.pendingRead.resolver(data);
             this.pendingRead = undefined;
             return;
@@ -39,6 +47,7 @@ export class Queue<T> implements Stream<T> {
         if (this.closed) return;
         this.closed = true;
         if (this.pendingRead === undefined) return;
+        this.pendingRead.timeoutTimer?.stop();
         this.pendingRead.rejecter(new EndOfStreamError());
     }
 }

--- a/packages/matter.js/src/util/Stream.ts
+++ b/packages/matter.js/src/util/Stream.ts
@@ -6,6 +6,7 @@
 import { MatterError } from "../common/MatterError.js";
 
 export class EndOfStreamError extends MatterError {}
+export class NoResponseTimeoutError extends MatterError {}
 
 export interface Stream<T> {
     read(): Promise<T>;


### PR DESCRIPTION
While testing with Meross device I had cases where the device started to send subscription "seed" DataReports but then stopped. This ended in a deadlock "waiting forever" on our controller side. This PR adds a timeout of /default) 60 seconds and a No Response error class.