### PR TITLE
Add ClusterStatus field for Status Responses

### DIFF
--- a/packages/matter-node.js/test/interaction/InteractionProtocolTest.ts
+++ b/packages/matter-node.js/test/interaction/InteractionProtocolTest.ts
@@ -241,27 +241,27 @@ const WRITE_RESPONSE: WriteResponse = {
     writeResponses: [
         {
             path: { attributeId: AttributeId(100), clusterId: ClusterId(40), endpointId: EndpointNumber(0) },
-            status: { status: 134 },
+            status: { clusterStatus: undefined, status: 134 },
         },
         {
             path: { attributeId: AttributeId(4), clusterId: ClusterId(0x99), endpointId: EndpointNumber(0) },
-            status: { status: 195 },
+            status: { clusterStatus: undefined, status: 195 },
         },
         {
             path: { attributeId: AttributeId(4), clusterId: ClusterId(40), endpointId: EndpointNumber(1) },
-            status: { status: 127 },
+            status: { clusterStatus: undefined, status: 127 },
         },
         {
             path: { attributeId: AttributeId(5), clusterId: ClusterId(40), endpointId: EndpointNumber(0) },
-            status: { status: 0 },
+            status: { clusterStatus: undefined, status: 0 },
         },
         {
             path: { attributeId: AttributeId(6), clusterId: ClusterId(40), endpointId: EndpointNumber(0) },
-            status: { status: 146 },
+            status: { clusterStatus: undefined, status: 146 },
         },
         {
             path: { attributeId: AttributeId(3), clusterId: ClusterId(40), endpointId: EndpointNumber(0) },
-            status: { status: 136 },
+            status: { clusterStatus: undefined, status: 136 },
         },
     ],
 };
@@ -285,7 +285,7 @@ const WRITE_RESPONSE_TIMED_REQUIRED: WriteResponse = {
     writeResponses: [
         {
             path: { attributeId: AttributeId(5), clusterId: ClusterId(40), endpointId: EndpointNumber(0) },
-            status: { status: 0 },
+            status: { clusterStatus: undefined, status: 0 },
         },
     ],
 };
@@ -295,7 +295,7 @@ const WRITE_RESPONSE_TIMED_ERROR: WriteResponse = {
     writeResponses: [
         {
             path: { attributeId: AttributeId(5), clusterId: ClusterId(40), endpointId: EndpointNumber(0) },
-            status: { status: 198 },
+            status: { clusterStatus: undefined, status: 198 },
         },
     ],
 };
@@ -329,15 +329,15 @@ const MASS_WRITE_RESPONSE: WriteResponse = {
     writeResponses: [
         {
             path: { attributeId: AttributeId(5), clusterId: ClusterId(40), endpointId: EndpointNumber(0) },
-            status: { status: 0 },
+            status: { clusterStatus: undefined, status: 0 },
         },
         {
             path: { attributeId: AttributeId(6), clusterId: ClusterId(40), endpointId: EndpointNumber(0) },
-            status: { status: 0 },
+            status: { clusterStatus: undefined, status: 0 },
         },
         {
             path: { attributeId: AttributeId(16), clusterId: ClusterId(40), endpointId: EndpointNumber(0) },
-            status: { status: 0 },
+            status: { clusterStatus: undefined, status: 0 },
         },
     ],
 };
@@ -416,7 +416,7 @@ const CHUNKED_ARRAY_WRITE_RESPONSE: WriteResponse = {
     writeResponses: [
         {
             path: { attributeId: AttributeId(0), clusterId: ClusterId(31), endpointId: EndpointNumber(0) },
-            status: { status: 0 },
+            status: { clusterStatus: undefined, status: 0 },
         },
     ],
 };
@@ -473,7 +473,7 @@ const INVOKE_COMMAND_RESPONSE_TIMED_REQUIRED_SUCCESS: InvokeResponse = {
         {
             status: {
                 commandPath: { clusterId: ClusterId(0x3c), commandId: CommandId(2), endpointId: EndpointNumber(0) },
-                status: { status: 0 },
+                status: { clusterStatus: undefined, status: 0 },
             },
         },
     ],
@@ -534,7 +534,7 @@ const INVOKE_COMMAND_RESPONSE: InvokeResponse = {
         {
             status: {
                 commandPath: { clusterId: ClusterId(6), commandId: CommandId(1), endpointId: EndpointNumber(0) },
-                status: { status: 0 },
+                status: { clusterStatus: undefined, status: 0 },
             },
         },
     ],
@@ -578,13 +578,13 @@ const INVOKE_COMMAND_RESPONSE_MULTI: InvokeResponse = {
         {
             status: {
                 commandPath: { clusterId: ClusterId(6), commandId: CommandId(1), endpointId: EndpointNumber(0) },
-                status: { status: 0 },
+                status: { clusterStatus: undefined, status: 0 },
             },
         },
         {
             status: {
                 commandPath: { clusterId: ClusterId(6), commandId: CommandId(0), endpointId: EndpointNumber(0) },
-                status: { status: 0 },
+                status: { clusterStatus: undefined, status: 0 },
             },
         },
     ],

--- a/packages/matter.js/src/cluster/server/CommandServer.ts
+++ b/packages/matter.js/src/cluster/server/CommandServer.ts
@@ -36,7 +36,19 @@ export class CommandServer<RequestT, ResponseT> {
         args: TlvStream,
         message: Message,
         endpoint: Endpoint,
-    ): Promise<{ code: StatusCode; responseId: CommandId; response: TlvStream }> {
+    ): Promise<{
+        /** Primary StatusCode of the invoke request  as defined by Interaction proptocol. */
+        code: StatusCode;
+
+        /** Cluster specific StatusCode of the invoke request if required */
+        clusterCode?: number;
+
+        /** ID of the response */
+        responseId: CommandId;
+
+        /** Response data */
+        response: TlvStream;
+    }> {
         const request = this.requestSchema.decodeTlv(args);
         logger.debug(`Invoke ${this.name} with data ${Logger.toJSON(request)}`);
         const response = await this.handler(request, session, message, endpoint);

--- a/packages/matter.js/src/protocol/interaction/InteractionClient.ts
+++ b/packages/matter.js/src/protocol/interaction/InteractionClient.ts
@@ -14,7 +14,7 @@ import {
     TlvNoResponse,
 } from "../../cluster/Cluster.js";
 import { resolveAttributeName, resolveCommandName, resolveEventName } from "../../cluster/ClusterHelper.js";
-import { ImplementationError, MatterError, MatterFlowError, UnexpectedDataError } from "../../common/MatterError.js";
+import { ImplementationError, MatterFlowError, UnexpectedDataError } from "../../common/MatterError.js";
 import { AttributeId } from "../../datatype/AttributeId.js";
 import { ClusterId } from "../../datatype/ClusterId.js";
 import { EndpointNumber } from "../../datatype/EndpointNumber.js";
@@ -788,7 +788,11 @@ export class InteractionClient {
             if (status !== undefined) {
                 const resultCode = status.status.status;
                 if (resultCode !== StatusCode.Success)
-                    throw new MatterError(`Received non-success result: ${resultCode}`);
+                    throw new StatusResponseError(
+                        `Received non-success result: ${resultCode}`,
+                        resultCode ?? StatusCode.Failure,
+                        status.status.clusterStatus,
+                    );
                 if ((responseSchema as any) !== TlvNoResponse)
                     throw new MatterFlowError("A response was expected for this command.");
                 return undefined as unknown as ResponseType<C>; // ResponseType is void, force casting the empty result

--- a/packages/matter.js/src/protocol/interaction/InteractionMessenger.ts
+++ b/packages/matter.js/src/protocol/interaction/InteractionMessenger.ts
@@ -62,6 +62,7 @@ export class StatusResponseError extends MatterError {
     public constructor(
         message: string,
         public readonly code: StatusCode,
+        public readonly clusterCode?: number,
     ) {
         super();
 

--- a/packages/matter.js/src/protocol/interaction/InteractionServer.ts
+++ b/packages/matter.js/src/protocol/interaction/InteractionServer.ts
@@ -31,6 +31,7 @@ import { assertSecureSession, SecureSession } from "../../session/SecureSession.
 import { StorageContext } from "../../storage/StorageContext.js";
 import { TlvNoArguments } from "../../tlv/TlvNoArguments.js";
 import { TypeFromSchema } from "../../tlv/TlvSchema.js";
+import { toHexString } from "../../util/Number.js";
 import { decodeAttributeValueWithSchema, normalizeAttributeData } from "./AttributeDataDecoder.js";
 import { InteractionEndpointStructure } from "./InteractionEndpointStructure.js";
 import {

--- a/packages/matter.js/src/protocol/interaction/InteractionServer.ts
+++ b/packages/matter.js/src/protocol/interaction/InteractionServer.ts
@@ -373,7 +373,13 @@ export class InteractionServer implements ProtocolHandler<MatterDevice> {
         const writeData = normalizeAttributeData(writeRequests, true);
 
         const writeResults = writeData.flatMap(
-            (values): { path: TypeFromSchema<typeof TlvAttributePath>; statusCode: StatusCode }[] => {
+            (
+                values,
+            ): {
+                path: TypeFromSchema<typeof TlvAttributePath>;
+                statusCode: StatusCode;
+                clusterStatusCode?: number;
+            }[] => {
                 const { path, dataVersion } = values[0];
                 const attributes = this.endpointStructure.getAttributes([path], true);
                 const { endpointId, clusterId, attributeId } = path;
@@ -489,7 +495,7 @@ export class InteractionServer implements ProtocolHandler<MatterDevice> {
                                 } to ${this.endpointStructure.resolveAttributeName(path)}: ${error.message}`,
                             );
                             if (error instanceof StatusResponseError) {
-                                return { path, statusCode: error.code };
+                                return { path, statusCode: error.code, clusterStatusCode: error.clusterCode };
                             }
                             return { path, statusCode: StatusCode.ConstraintError };
                         } else {
@@ -522,7 +528,10 @@ export class InteractionServer implements ProtocolHandler<MatterDevice> {
 
         return {
             interactionModelRevision: INTERACTION_MODEL_REVISION,
-            writeResponses: writeResults.map(({ path, statusCode }) => ({ path, status: { status: statusCode } })),
+            writeResponses: writeResults.map(({ path, statusCode, clusterStatusCode }) => ({
+                path,
+                status: { status: statusCode, clusterStatus: clusterStatusCode },
+            })),
         };
     }
 
@@ -803,15 +812,25 @@ export class InteractionServer implements ProtocolHandler<MatterDevice> {
                                 endpoint,
                             ),
                         StatusResponseError,
-                        async error => ({
-                            code: error.code,
-                            responseId: command.responseId,
-                            response: TlvNoResponse.encodeTlv(),
-                        }),
+                        async error => {
+                            logger.info(
+                                `Error ${toHexString(error.code)}${
+                                    error.clusterCode !== undefined ? `/${toHexString(error.clusterCode)}` : ""
+                                } while invoking command: ${error.message}`,
+                            );
+                            return {
+                                code: error.code,
+                                clusterCode: error.clusterCode,
+                                responseId: command.responseId,
+                                response: TlvNoResponse.encodeTlv(),
+                            };
+                        },
                     );
-                    const { code, responseId, response } = result;
+                    const { code, clusterCode, responseId, response } = result;
                     if (response.length === 0) {
-                        invokeResponses.push({ status: { commandPath: path, status: { status: code } } });
+                        invokeResponses.push({
+                            status: { commandPath: path, status: { status: code, clusterStatus: clusterCode } },
+                        });
                     } else {
                         invokeResponses.push({
                             command: {


### PR DESCRIPTION
The StatusResponseError class got extended to also contain and transport a clusterStatus code for write and invoke responses. The handling in InteractionClient got enhanced to throw a StatusResponse error in such a case with both codes. Testing will be later included via chip tool tests because here invoke cases are tested. For Write no cluster is implemented with a clusterStatusCode.