### PR TITLE
Add initializer and destroyer for ClusterServerHandlers

### DIFF
--- a/packages/matter.js/src/cluster/server/ClusterServer.ts
+++ b/packages/matter.js/src/cluster/server/ClusterServer.ts
@@ -90,6 +90,19 @@ export function ClusterServer<
             for (const name in events) {
                 (events as any)[name].assignToEndpoint(endpoint);
             }
+            if (typeof handlers.initializeClusterServer === "function") {
+                handlers.initializeClusterServer({
+                    attributes,
+                    events,
+                    endpoint,
+                });
+            }
+        },
+
+        _destroy: () => {
+            if (typeof handlers.destroyClusterServer === "function") {
+                handlers.destroyClusterServer();
+            }
         },
 
         _setStorage: (storageContext: StorageContext) => {

--- a/packages/matter.js/src/cluster/server/ClusterServerTypes.ts
+++ b/packages/matter.js/src/cluster/server/ClusterServerTypes.ts
@@ -131,7 +131,17 @@ type AttributeHandlers<A extends Attributes> = Merge<
 >;
 export type ClusterServerHandlers<C extends Cluster<any, any, any, any, any>> = Merge<
     CommandHandlers<C["commands"], AttributeServers<C["attributes"]>, EventServers<C["events"]>>,
-    AttributeHandlers<C["attributes"]>
+    Merge<
+        AttributeHandlers<C["attributes"]>,
+        {
+            initializeClusterServer?: (args: {
+                attributes: AttributeServers<C["attributes"]>;
+                events: EventServers<C["events"]>;
+                endpoint: Endpoint;
+            }) => void;
+            destroyClusterServer?: () => void;
+        }
+    >
 >;
 
 export type CommandServers<C extends Commands> = Merge<
@@ -303,7 +313,7 @@ export type ClusterServerObjInternal<A extends Attributes, C extends Commands, E
     readonly _events: EventServers<E>;
 
     /**
-     * Assign this cluster to a specific endpoint
+     * Assign this cluster to a specific endpoint. This method also initializes the internal Cluster logics
      * @private
      *
      * @param endpoint Endpoint to assign to
@@ -344,6 +354,12 @@ export type ClusterServerObjInternal<A extends Attributes, C extends Commands, E
      * @private
      */
     readonly _verifySceneExtensionFieldSets: (values: TypeFromSchema<typeof Scenes.TlvAttributeValuePair>[]) => boolean;
+
+    /**
+     * Destroy internal cluster logics, timers and such
+     * @private
+     */
+    readonly _destroy: () => void;
 };
 
 export function isClusterServer<F extends BitSchema, A extends Attributes, C extends Commands, E extends Events>(

--- a/packages/matter.js/src/protocol/interaction/InteractionEndpointStructure.ts
+++ b/packages/matter.js/src/protocol/interaction/InteractionEndpointStructure.ts
@@ -54,6 +54,12 @@ export class InteractionEndpointStructure {
         this.commandPaths.length = 0;
     }
 
+    public destroy() {
+        for (const endpoint of this.endpoints.values()) {
+            endpoint.destroy();
+        }
+    }
+
     public initializeFromEndpoint(endpoint: Endpoint) {
         this.clear();
 

--- a/packages/matter.js/src/protocol/interaction/InteractionServer.ts
+++ b/packages/matter.js/src/protocol/interaction/InteractionServer.ts
@@ -847,6 +847,7 @@ export class InteractionServer implements ProtocolHandler<MatterDevice> {
 
     async close() {
         this.isClosing = true;
+        this.endpointStructure.destroy();
         for (const subscription of this.subscriptionMap.values()) {
             await subscription.cancel(true);
         }

--- a/packages/matter.js/test/cluster/ClusterServerTest.ts
+++ b/packages/matter.js/test/cluster/ClusterServerTest.ts
@@ -13,6 +13,7 @@ import { Identify, IdentifyCluster } from "../../src/cluster/definitions/Identif
 import { WindowCovering } from "../../src/cluster/definitions/WindowCoveringCluster.js";
 import { AttributeServer, FixedAttributeServer } from "../../src/cluster/server/AttributeServer.js";
 import { ClusterServer } from "../../src/cluster/server/ClusterServer.js";
+import { asClusterServerInternal } from "../../src/cluster/server/ClusterServerTypes.js";
 import { ImplementationError } from "../../src/common/MatterError.js";
 import { AttributeId } from "../../src/datatype/AttributeId.js";
 import { CommandId } from "../../src/datatype/CommandId.js";
@@ -562,6 +563,54 @@ describe("ClusterServer structure", () => {
             ]);
             expect((server.attributes as any).acceptedCommandList.get()).deep.equal([CommandId(0)]);
             expect((server.attributes as any).generatedCommandList.get()).deep.equal([]);
+        });
+
+        it("Verify init/destroy is called on CLusterServe when definedr", () => {
+            let initCalled = false;
+            let destroyCalled = false;
+            const server = ClusterServer(
+                IdentifyCluster,
+                {
+                    identifyTime: 100,
+                    identifyType: Identify.IdentifyType.None,
+                },
+                {
+                    identify: async () => {
+                        /* dummy */
+                    },
+                    initializeClusterServer: async () => {
+                        initCalled = true;
+                    },
+                    destroyClusterServer: async () => {
+                        destroyCalled = true;
+                    },
+                },
+            );
+            expect(server).ok;
+
+            asClusterServerInternal(server)._assignToEndpoint({} as any);
+            expect(initCalled).true;
+            asClusterServerInternal(server)._destroy();
+            expect(destroyCalled).true;
+        });
+
+        it("Verify not used init/destroy are not making issues", () => {
+            const server = ClusterServer(
+                IdentifyCluster,
+                {
+                    identifyTime: 100,
+                    identifyType: Identify.IdentifyType.None,
+                },
+                {
+                    identify: async () => {
+                        /* dummy */
+                    },
+                },
+            );
+            expect(server).ok;
+
+            asClusterServerInternal(server)._assignToEndpoint({} as any);
+            asClusterServerInternal(server)._destroy();
         });
 
         it("GroupsCluster", () => {


### PR DESCRIPTION
Some clusters need more complex logic than just some functions and also require e.g. timer to be stopped when the ClusterServe is no longer needed or the device is stopped.
This PR introduces two new commandHandlers that can optionally be used. One to initialize the cluster Handlers - this one also gets attributes and events of the cluster. The second one is to destroy the logic and cleanup used resources.

With this we can really have a clean way to code the cluster logic and also clean it up