### PR TITLE
Client/Controller optimizations

### DIFF
--- a/packages/matter.js/src/protocol/interaction/InteractionClient.ts
+++ b/packages/matter.js/src/protocol/interaction/InteractionClient.ts
@@ -76,9 +76,12 @@ export class SubscriptionClient implements ProtocolHandler<MatterController> {
         const listener = this.subscriptionListeners.get(subscriptionId);
         if (listener === undefined) {
             await messenger.sendStatus(StatusCode.InvalidSubscription);
-            throw new UnexpectedDataError(`Unknown subscription ID ${subscriptionId}`);
+            logger.info(`Received data for unknown subscription ID ${subscriptionId}. Cancel this subscription.`);
+            await messenger.close();
+            return;
         }
         await messenger.sendStatus(StatusCode.Success);
+        await messenger.close();
 
         listener(dataReport);
     }
@@ -189,6 +192,13 @@ export class InteractionClient {
         } = options;
         if (attributeRequests === undefined && eventRequests === undefined) {
             throw new ImplementationError("When reading attributes and events, at least one must be specified.");
+        }
+
+        const readPathsCount = (attributeRequests?.length ?? 0) + (eventRequests?.length ?? 0);
+        if (readPathsCount > 9) {
+            logger.debug(
+                "Read interactions with more then 9 paths might be not allowed by the device. Consider splitting then into several read requests.",
+            );
         }
 
         return this.withMessenger<{
@@ -635,6 +645,12 @@ export class InteractionClient {
             eventFilters,
             dataVersionFilters,
         } = options;
+
+        const subscriptionPathsCount = (attributeRequests?.length ?? 0) + (eventRequests?.length ?? 0);
+        if (subscriptionPathsCount > 3) {
+            logger.debug("Subscribe interactions with more then 3 paths might be not allowed by the device.");
+        }
+
         return this.withMessenger<{
             attributeReports?: DecodedAttributeReportValue<any>[];
             eventReports?: DecodedEventReportValue<any>[];


### PR DESCRIPTION
This PR adds informative logging when too many subscription or read paths are sent, because the Matter1.0/1.1 Interaction model only requires a defined number, rest would be optional depending on device. Additionally close the messenger for subscriptions correctly.