### PR TITLE
Optimize Subscription reconnections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,22 @@ All Changes without a GitHub Username in brackets are from the core team: @Apoll
 ## 0.6.0 WIP
 * Matter-Core functionality:
   * Fix: Adjusted Event Priority definition to match to specs
-  * Fix: Prevented crashes when Bleno could not be initialized (e.g. on Windows)
   * Fix: Adjusted Bleno and Noble to be optional Dependencies to allow building the Monorepo also when these are failing (e.g. on Windows)
   * Feature: Implemented TimedInteractions for Write/Invoke request s as required by specs
   * Feature: Added support for generic Response suppression if requested or needed for group communication
   * Feature (orlenkoo) Implemented first OnOff Cluster Lighting feature command handlers (WIP)
   * Feature: Also publishes matter-node.js packages as ESM in parallel to CJS
+  * Feature: Add clear method to the storage classes to allow factory reset of the storage
+  * Feature: Add ICAC (Intermediate CA Certificate) decoding
   * Enhance: Memory footprint optimizations
   * Enhance: Introduced building and building, running and test executions scripts to not use ts-node anymore and many more optimizations to test and build processes
   * Enhance: ClusterFactory internally uses a simplified method of CLuster types that are compatible to the current ones but soon might replace them
+  * Enhance: Using longer response timeouts when Failsafe timer is active during commissioning (Controller)
+  * Enhance: Optimize Commissioning logic of Controller implementation regarding failsafe timers and network commissioning
+  * Enhance: Add timeout handing to the Message queue to prevent reading DataReports get stuck if device do not send anymore
+  * Enhance: Add support in StatusResponseError to also handle a cluster specific status code (for write and invoke)
+  * Enhance: Add init and destroy methods to the Cluster-handlers to allow to build proper cluster logics and also to free resources (e.g. stop timers on cluster destroy)
+  * Enhance: Re-Announce the device when a subscription was cancelled by a peer in order to have a fast reconnect of the peer 
 * matter.js API:
   * Breaking: Move "disableIpv4" from CommissioningController/Server options to MatterServer to also consider it for MDNS scanning and broadcasting
   * Breaking: Change MatterServer constructor second parameter to be an options object

--- a/packages/matter.js/src/protocol/interaction/SubscriptionHandler.ts
+++ b/packages/matter.js/src/protocol/interaction/SubscriptionHandler.ts
@@ -547,7 +547,7 @@ export class SubscriptionHandler {
         }
     }
 
-    async cancel(flush = false) {
+    async cancel(flush = false, cancelledByPeer = false) {
         this.sendUpdatesActivated = false;
         this.updateTimer.stop();
         this.sendDelayTimer.stop();
@@ -558,6 +558,9 @@ export class SubscriptionHandler {
         }
         this.session.removeSubscription(this.subscriptionId);
         this.cancelCallback();
+        if (cancelledByPeer) {
+            await this.session.getContext().startAnnouncement();
+        }
     }
 
     private async sendUpdateMessage(
@@ -616,7 +619,7 @@ export class SubscriptionHandler {
                 async error => {
                     if (error.code === StatusCode.InvalidSubscription || error.code === StatusCode.Failure) {
                         logger.info(`Subscription ${this.subscriptionId} cancelled by peer.`);
-                        await this.cancel();
+                        await this.cancel(false, true);
                     } else {
                         throw error;
                     }

--- a/packages/matter.js/src/session/case/CaseServer.ts
+++ b/packages/matter.js/src/session/case/CaseServer.ts
@@ -12,7 +12,7 @@ import { Logger } from "../../log/Logger.js";
 import { MatterDevice } from "../../MatterDevice.js";
 import { MessageExchange } from "../../protocol/MessageExchange.js";
 import { ProtocolHandler } from "../../protocol/ProtocolHandler.js";
-import { SECURE_CHANNEL_PROTOCOL_ID } from "../../protocol/securechannel/SecureChannelMessages.js";
+import { ProtocolStatusCode, SECURE_CHANNEL_PROTOCOL_ID } from "../../protocol/securechannel/SecureChannelMessages.js";
 import { ByteArray } from "../../util/ByteArray.js";
 import {
     KDFSR1_KEY_INFO,
@@ -38,7 +38,7 @@ export class CaseServer implements ProtocolHandler<MatterDevice> {
             await this.handleSigma1(exchange.session.getContext(), messenger);
         } catch (error) {
             logger.error("An error occurred during the commissioning", error);
-            await messenger.sendError();
+            await messenger.sendError(ProtocolStatusCode.InvalidParam);
         }
     }
 

--- a/packages/matter.js/src/session/case/CaseServer.ts
+++ b/packages/matter.js/src/session/case/CaseServer.ts
@@ -12,7 +12,7 @@ import { Logger } from "../../log/Logger.js";
 import { MatterDevice } from "../../MatterDevice.js";
 import { MessageExchange } from "../../protocol/MessageExchange.js";
 import { ProtocolHandler } from "../../protocol/ProtocolHandler.js";
-import { ProtocolStatusCode, SECURE_CHANNEL_PROTOCOL_ID } from "../../protocol/securechannel/SecureChannelMessages.js";
+import { SECURE_CHANNEL_PROTOCOL_ID } from "../../protocol/securechannel/SecureChannelMessages.js";
 import { ByteArray } from "../../util/ByteArray.js";
 import {
     KDFSR1_KEY_INFO,
@@ -38,7 +38,7 @@ export class CaseServer implements ProtocolHandler<MatterDevice> {
             await this.handleSigma1(exchange.session.getContext(), messenger);
         } catch (error) {
             logger.error("An error occurred during the commissioning", error);
-            await messenger.sendError(ProtocolStatusCode.InvalidParam);
+            await messenger.sendError();
         }
     }
 


### PR DESCRIPTION
When a subscription DataReport is declined by the peer with an Error then cancel the subscription but also re-announce the device in order for the peer to discover and potentially directly reconnect

@vves This makes the subscription reconnection s from eg Apple rock solid in my tests - especially with the default "very fast Apple subscription intervals of some seconds). 