### PR TITLE
Refactor DataReport logic and add dynamic array chunking

### DIFF
--- a/packages/matter-node.js/test/interaction/InteractionProtocolTest.ts
+++ b/packages/matter-node.js/test/interaction/InteractionProtocolTest.ts
@@ -27,13 +27,15 @@ import {
     FabricId,
     FabricIndex,
     NodeId,
+    TlvClusterId,
     TlvFabricIndex,
+    TlvVendorId,
     VendorId,
 } from "@project-chip/matter.js/datatype";
 import { DeviceClasses, DeviceTypeDefinition, Endpoint } from "@project-chip/matter.js/device";
 import { Fabric } from "@project-chip/matter.js/fabric";
 import {
-    DataReport,
+    DataReportPayload,
     InteractionServer,
     InteractionServerMessenger,
     InvokeRequest,
@@ -54,6 +56,7 @@ import {
     TlvObject,
     TlvOptionalField,
     TlvString,
+    TlvUInt16,
     TlvUInt8,
 } from "@project-chip/matter.js/tlv";
 import { ByteArray } from "@project-chip/matter.js/util";
@@ -77,6 +80,7 @@ const READ_REQUEST: ReadRequest = {
         { endpointId: EndpointNumber(1), clusterId: ClusterId(0x28), attributeId: AttributeId(1) }, // unsupported endpoint
         { endpointId: undefined, clusterId: ClusterId(0x28), attributeId: AttributeId(3) },
         { endpointId: undefined, clusterId: ClusterId(0x99), attributeId: AttributeId(3) }, // ignore
+        { endpointId: EndpointNumber(0), clusterId: ClusterId(0x1d), attributeId: AttributeId(1) },
     ],
 };
 
@@ -91,6 +95,7 @@ const READ_REQUEST_WITH_UNUSED_FILTER: ReadRequest = {
         { endpointId: EndpointNumber(1), clusterId: ClusterId(0x28), attributeId: AttributeId(1) }, // unsupported endpoint
         { endpointId: undefined, clusterId: ClusterId(0x28), attributeId: AttributeId(3) },
         { endpointId: undefined, clusterId: ClusterId(0x99), attributeId: AttributeId(3) }, // ignore
+        { endpointId: EndpointNumber(0), clusterId: ClusterId(0x1d), attributeId: AttributeId(1) },
     ],
     dataVersionFilters: [{ path: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x28) }, dataVersion: 1 }],
 };
@@ -106,26 +111,29 @@ const READ_REQUEST_WITH_FILTER: ReadRequest = {
         { endpointId: EndpointNumber(1), clusterId: ClusterId(0x28), attributeId: AttributeId(1) }, // unsupported endpoint
         { endpointId: undefined, clusterId: ClusterId(0x28), attributeId: AttributeId(3) },
         { endpointId: undefined, clusterId: ClusterId(0x99), attributeId: AttributeId(3) }, // ignore
+        { endpointId: EndpointNumber(0), clusterId: ClusterId(0x1d), attributeId: AttributeId(1) },
     ],
     dataVersionFilters: [{ path: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x28) }, dataVersion: 0 }],
 };
 
-const READ_RESPONSE: DataReport = {
+const READ_RESPONSE: DataReportPayload = {
     interactionModelRevision: 10,
     suppressResponse: false,
-    eventReports: undefined,
-    attributeReports: [
+    eventReportsPayload: undefined,
+    attributeReportsPayload: [
         {
             attributeData: {
                 path: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x28), attributeId: AttributeId(2) },
-                data: TlvUInt8.encodeTlv(1),
+                schema: TlvVendorId,
+                payload: 1,
                 dataVersion: 0,
             },
         },
         {
             attributeData: {
                 path: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x28), attributeId: AttributeId(4) },
-                data: TlvUInt8.encodeTlv(2),
+                schema: TlvUInt16,
+                payload: 2,
                 dataVersion: 0,
             },
         },
@@ -150,18 +158,31 @@ const READ_RESPONSE: DataReport = {
         {
             attributeData: {
                 path: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x28), attributeId: AttributeId(3) },
-                data: TlvString.encodeTlv("product"),
+                schema: TlvString.bound({ maxLength: 32 }),
+                payload: "product",
+                dataVersion: 0,
+            },
+        },
+        {
+            attributeData: {
+                path: {
+                    endpointId: EndpointNumber(0),
+                    clusterId: ClusterId(0x1d),
+                    attributeId: AttributeId(1),
+                },
+                schema: TlvArray(TlvClusterId),
+                payload: [ClusterId(29), ClusterId(40)],
                 dataVersion: 0,
             },
         },
     ],
 };
 
-const READ_RESPONSE_WITH_FILTER: DataReport = {
+const READ_RESPONSE_WITH_FILTER: DataReportPayload = {
     interactionModelRevision: 10,
     suppressResponse: false,
-    eventReports: undefined,
-    attributeReports: [
+    eventReportsPayload: undefined,
+    attributeReportsPayload: [
         {
             attributeStatus: {
                 path: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x28), attributeId: AttributeId(400) },
@@ -178,6 +199,18 @@ const READ_RESPONSE_WITH_FILTER: DataReport = {
             attributeStatus: {
                 path: { endpointId: EndpointNumber(1), clusterId: ClusterId(0x28), attributeId: AttributeId(1) },
                 status: { status: 127 },
+            },
+        },
+        {
+            attributeData: {
+                path: {
+                    endpointId: EndpointNumber(0),
+                    clusterId: ClusterId(0x1d),
+                    attributeId: AttributeId(1),
+                },
+                schema: TlvArray(TlvClusterId),
+                payload: [ClusterId(29), ClusterId(40)],
+                dataVersion: 0,
             },
         },
     ],

--- a/packages/matter.js/src/protocol/interaction/AttributeDataDecoder.ts
+++ b/packages/matter.js/src/protocol/interaction/AttributeDataDecoder.ts
@@ -20,7 +20,8 @@ import { TlvAttributeData, TlvAttributeReport } from "./InteractionProtocol.js";
 
 const logger = Logger.get("AttributeDataDecoder");
 
-export interface DecodedAttributeReportValue<T> {
+/** Represents a fully qualified and decoded attribute value from a received DataReport */
+export type DecodedAttributeReportValue<T> = {
     path: {
         nodeId?: NodeId;
         endpointId: EndpointNumber;
@@ -30,20 +31,17 @@ export interface DecodedAttributeReportValue<T> {
     };
     version: number;
     value: T;
-}
+};
 
-export interface DecodedAttributeValue<T> {
-    path: {
-        nodeId?: NodeId;
-        endpointId: EndpointNumber;
-        clusterId: ClusterId;
-        attributeId: AttributeId;
-        attributeName: string;
-    };
+/** Represents a decoded attribute value from a received DataReport where data version could be optional. */
+export type DecodedAttributeValue<T> = Omit<DecodedAttributeReportValue<T>, "version"> & {
     version?: number;
-    value: T;
-}
+};
 
+/**
+ * Parses, normalizes (e.g. un-chunk arrays and resolve Tag compression if used) and decodes the attribute data from
+ * a received DataReport.
+ */
 export function normalizeAndDecodeReadAttributeReport(
     data: TypeFromSchema<typeof TlvAttributeReport>[],
 ): DecodedAttributeReportValue<any>[] {
@@ -53,6 +51,10 @@ export function normalizeAndDecodeReadAttributeReport(
     return normalizeAndDecodeAttributeData(dataValues) as DecodedAttributeReportValue<any>[]; // dataVersion existing in incoming data, so must also in outgoing data
 }
 
+/**
+ * Normalizes (e.g. prepare data for array un-chinking and resolve Tag compression if used) the attribute details from
+ * a received DataReport.
+ */
 export function normalizeAttributeData(
     data: TypeFromSchema<typeof TlvAttributeData>[],
     acceptWildcardPaths = false,
@@ -98,6 +100,10 @@ export function normalizeAttributeData(
     return Array.from(responseList.values());
 }
 
+/**
+ * Normalizes (e.g. un-chunk arrays and resolve Tag compression if used) and decodes the attribute data from a received
+ * DataReport.
+ */
 export function normalizeAndDecodeAttributeData(
     data: TypeFromSchema<typeof TlvAttributeData>[],
 ): DecodedAttributeValue<any>[] {
@@ -148,7 +154,8 @@ export function normalizeAndDecodeAttributeData(
     return result;
 }
 
-export function decodeValueForAttribute<A extends Attribute<any, any>>(
+/** Decodes the data for one known attribute identified by its Attribute definition including array un-chunking. */
+function decodeValueForAttribute<A extends Attribute<any, any>>(
     attribute: A,
     values: TypeFromSchema<typeof TlvAttributeData>[],
 ): AttributeJsType<A> | undefined {
@@ -164,6 +171,7 @@ export function decodeValueForAttribute<A extends Attribute<any, any>>(
     return decodeAttributeValueWithSchema(schema, values);
 }
 
+/** Decodes the data for one attribute via a schema including array un-chunking. */
 export function decodeAttributeValueWithSchema<T>(
     schema: TlvSchema<T>,
     values: TypeFromSchema<typeof TlvAttributeData>[],
@@ -188,6 +196,7 @@ export function decodeAttributeValueWithSchema<T>(
     ) as T;
 }
 
+/** Decodes the data for one unknown attribute via the AnySchema including array un-chunking. */
 export function decodeUnknownAttributeValue(values: TypeFromSchema<typeof TlvAttributeData>[]): any {
     const schema = TlvAny;
     // No values, so use default value if available
@@ -208,6 +217,7 @@ export function decodeUnknownAttributeValue(values: TypeFromSchema<typeof TlvAtt
     }
 }
 
+/** Structure the data of a received DataReport into an endpointId/clusterId/attributeName object structure. */
 export function structureReadAttributeDataToClusterObject(data: DecodedAttributeReportValue<any>[]) {
     const structure: { [key: number]: { [key: number]: { [key: string]: any } } } = {};
     for (const {

--- a/packages/matter.js/src/protocol/interaction/AttributeDataDecoder.ts
+++ b/packages/matter.js/src/protocol/interaction/AttributeDataDecoder.ts
@@ -59,9 +59,15 @@ export function normalizeAttributeData(
     data: TypeFromSchema<typeof TlvAttributeData>[],
     acceptWildcardPaths = false,
 ): TypeFromSchema<typeof TlvAttributeData>[][] {
-    // Fill in missing path elements when tag compression is used
+    // Fill in missing path elements and restore dataVersion when tag compression is used
     let lastPath:
-        | { nodeId?: NodeId; endpointId: EndpointNumber; clusterId: ClusterId; attributeId: AttributeId }
+        | {
+              nodeId?: NodeId;
+              endpointId: EndpointNumber;
+              clusterId: ClusterId;
+              attributeId: AttributeId;
+              dataVersion?: number;
+          }
         | undefined;
     data.forEach(value => {
         if (value === undefined) return;
@@ -72,12 +78,15 @@ export function normalizeAttributeData(
             if (path.endpointId === undefined) path.endpointId = lastPath.endpointId;
             if (path.clusterId === undefined) path.clusterId = lastPath.clusterId;
             if (path.attributeId === undefined) path.attributeId = lastPath.attributeId;
+            if (value.dataVersion === undefined && lastPath.dataVersion !== undefined)
+                value.dataVersion = lastPath.dataVersion;
         } else if (path.endpointId !== undefined && path.clusterId !== undefined && path.attributeId !== undefined) {
             lastPath = {
                 nodeId: path.nodeId,
                 endpointId: path.endpointId,
                 clusterId: path.clusterId,
                 attributeId: path.attributeId,
+                dataVersion: value.dataVersion,
             };
         } else if (!acceptWildcardPaths) {
             throw new UnexpectedDataError("Tag compression disabled, but path is incomplete: " + Logger.toJSON(path));

--- a/packages/matter.js/src/protocol/interaction/AttributeDataEncoder.ts
+++ b/packages/matter.js/src/protocol/interaction/AttributeDataEncoder.ts
@@ -3,10 +3,12 @@
  * Copyright 2022-2023 Project CHIP Authors
  * SPDX-License-Identifier: Apache-2.0
  */
+import { MatterFlowError } from "../../common/MatterError.js";
 import { AttributeId } from "../../datatype/AttributeId.js";
 import { ClusterId } from "../../datatype/ClusterId.js";
 import { EndpointNumber } from "../../datatype/EndpointNumber.js";
 import { NodeId } from "../../datatype/NodeId.js";
+import { Logger } from "../../log/Logger.js";
 import { ArraySchema } from "../../tlv/TlvArray.js";
 import { TlvSchema, TlvStream, TypeFromSchema } from "../../tlv/TlvSchema.js";
 import {
@@ -115,13 +117,17 @@ export function canAttributePayloadBeChunked(attributePayload: AttributeReportPa
 export function chunkAttributePayload(attributePayload: AttributeReportPayload): AttributeReportPayload[] {
     const { attributeData } = attributePayload;
     if (attributeData === undefined) {
-        // Should never happen, but we can make sure it do not break
-        return [attributePayload];
+        throw new MatterFlowError(
+            `Can not chunk an AttributePayload with just a attributeStatus: ${Logger.toJSON(attributePayload)}`,
+        );
     }
     const { schema, path, dataVersion, payload } = attributeData;
     if (!(schema instanceof ArraySchema) || !Array.isArray(payload)) {
-        // Should never happen, but we can make sure it do not break
-        return [attributePayload];
+        throw new MatterFlowError(
+            `Can not chunk an AttributePayload with attributeData that is not an array: ${Logger.toJSON(
+                attributePayload,
+            )}`,
+        );
     }
     const chunks = new Array<AttributeReportPayload>();
     chunks.push({ attributeData: { schema, path: { ...path, listIndex: undefined }, payload: [], dataVersion } });

--- a/packages/matter.js/src/protocol/interaction/AttributeDataEncoder.ts
+++ b/packages/matter.js/src/protocol/interaction/AttributeDataEncoder.ts
@@ -1,0 +1,249 @@
+/**
+ * @license
+ * Copyright 2022-2023 Project CHIP Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { AttributeId } from "../../datatype/AttributeId.js";
+import { ClusterId } from "../../datatype/ClusterId.js";
+import { EndpointNumber } from "../../datatype/EndpointNumber.js";
+import { NodeId } from "../../datatype/NodeId.js";
+import { ArraySchema } from "../../tlv/TlvArray.js";
+import { TlvSchema, TlvStream, TypeFromSchema } from "../../tlv/TlvSchema.js";
+import {
+    TlvAttributePath,
+    TlvAttributeReport,
+    TlvAttributeReportData,
+    TlvDataReport,
+    TlvEventData,
+    TlvEventReport,
+} from "./InteractionProtocol.js";
+
+type FullAttributePath = {
+    nodeId?: NodeId;
+    endpointId: EndpointNumber;
+    clusterId: ClusterId;
+    attributeId: AttributeId;
+    dataVersion?: number;
+};
+
+/** Type for TlvAttributeReport where the real data are represented with the schema and the JS value. */
+export type AttributeReportPayload = Omit<TypeFromSchema<typeof TlvAttributeReport>, "attributeData"> & {
+    attributeData?: AttributeDataPayload;
+};
+
+/** Type for TlvAttributeReportData where the real data are represented with the schema and the JS value. */
+type AttributeDataPayload = Omit<TypeFromSchema<typeof TlvAttributeReportData>, "data"> & {
+    schema: TlvSchema<any>;
+    payload: any;
+};
+
+/** Type for TlvEventReport where the real data are represented with the schema and the JS value. */
+export type EventReportPayload = Omit<TypeFromSchema<typeof TlvEventReport>, "eventData"> & {
+    eventData?: EventDataPayload;
+};
+
+/** Type for TlvEventData where the real data are represented with the schema and the JS value. */
+type EventDataPayload = Omit<TypeFromSchema<typeof TlvEventData>, "data"> & {
+    schema: TlvSchema<any>;
+    payload: any;
+};
+
+/** Type for TlvDataReport where the real data are represented with the schema and the JS value. */
+export type DataReportPayload = Omit<TypeFromSchema<typeof TlvDataReport>, "attributeReports" | "eventReports"> & {
+    attributeReportsPayload?: AttributeReportPayload[];
+    eventReportsPayload?: EventReportPayload[];
+};
+
+/** Encodes an AttributeReportPayload into a TlvStream (used for TlvAny type). */
+export function encodeAttributePayload(attributePayload: AttributeReportPayload): TlvStream {
+    const { attributeData, attributeStatus } = attributePayload;
+    if (attributeData === undefined) {
+        return TlvAttributeReport.encodeTlv({ attributeStatus });
+    }
+
+    const { path, schema, payload, dataVersion } = attributeData;
+    return TlvAttributeReport.encodeTlv({ attributeData: { path, data: schema.encodeTlv(payload), dataVersion } });
+}
+
+/** Encodes an EventReportPayload into a TlvStream (used for TlvAny type). */
+export function encodeEventPayload(eventPayload: EventReportPayload): TlvStream {
+    const { eventData, eventStatus } = eventPayload;
+    if (eventData === undefined) {
+        return TlvEventReport.encodeTlv({ eventStatus });
+    }
+
+    const {
+        path,
+        schema,
+        payload,
+        eventNumber,
+        deltaEpochTimestamp,
+        epochTimestamp,
+        deltaSystemTimestamp,
+        systemTimestamp,
+        priority,
+    } = eventData;
+    return TlvEventReport.encodeTlv({
+        eventData: {
+            path,
+            data: schema.encodeTlv(payload),
+            priority,
+            systemTimestamp,
+            deltaSystemTimestamp,
+            deltaEpochTimestamp,
+            epochTimestamp,
+            eventNumber,
+        },
+    });
+}
+
+/** Return if an AttributeReportPayload can be chunked or not. */
+export function canAttributePayloadBeChunked(attributePayload: AttributeReportPayload): boolean {
+    const { attributeData } = attributePayload;
+    if (attributeData === undefined) {
+        return false;
+    }
+    const {
+        schema,
+        payload,
+        path: { listIndex },
+    } = attributeData;
+    return schema instanceof ArraySchema && Array.isArray(payload) && payload.length > 0 && listIndex === undefined;
+}
+
+/** Chunk an AttributeReportPayload into multiple AttributeReportPayloads. */
+export function chunkAttributePayload(attributePayload: AttributeReportPayload): AttributeReportPayload[] {
+    const { attributeData } = attributePayload;
+    if (attributeData === undefined) {
+        // Should never happen, but we can make sure it do not break
+        return [attributePayload];
+    }
+    const { schema, path, dataVersion, payload } = attributeData;
+    if (!(schema instanceof ArraySchema) || !Array.isArray(payload)) {
+        // Should never happen, but we can make sure it do not break
+        return [attributePayload];
+    }
+    const chunks = new Array<AttributeReportPayload>();
+    chunks.push({ attributeData: { schema, path: { ...path, listIndex: undefined }, payload: [], dataVersion } });
+    payload.forEach(element => {
+        chunks.push({
+            attributeData: {
+                schema: schema.elementSchema,
+                path: { ...path, listIndex: null },
+                payload: element,
+                dataVersion,
+            },
+        });
+    });
+
+    // If the path of the initial AttributePayload was not compressed, we should compress the chunked data
+    // TODO Enable once Tag Compression is supported https://github.com/project-chip/connectedhomeip/issues/29359
+    /*
+    if (path.enableTagCompression !== true) {
+        return compressAttributeDataReportTags(chunks);
+    }
+    */
+
+    return chunks;
+}
+
+/**
+ * Sort function to sort AttributeReportPayloads by nodeId/EndpointId/clusterId/attributeId to generate an ideal
+ * ground for tag compression.
+ */
+export function sortAttributeDataByPath(data1: AttributeReportPayload, data2: AttributeReportPayload) {
+    const { path: path1 } = data1.attributeData ?? data1.attributeStatus ?? {};
+    const { path: path2 } = data2.attributeData ?? data2.attributeStatus ?? {};
+    if (path1?.nodeId !== undefined && path2?.nodeId !== undefined && path1.nodeId !== path2.nodeId) {
+        return path1.nodeId < path2.nodeId ? -1 : 1;
+    }
+    if (path1?.endpointId !== undefined && path2?.endpointId !== undefined && path1.endpointId !== path2.endpointId) {
+        return path1.endpointId < path2.endpointId ? -1 : 1;
+    }
+    if (path1?.clusterId !== undefined && path2?.clusterId !== undefined && path1.clusterId !== path2.clusterId) {
+        return path1.clusterId < path2.clusterId ? -1 : 1;
+    }
+    if (
+        path1?.attributeId !== undefined &&
+        path2?.attributeId !== undefined &&
+        path1.attributeId !== path2.attributeId
+    ) {
+        return path1.attributeId < path2.attributeId ? -1 : 1;
+    }
+    return 0;
+}
+
+/** Sort and use Tag compression to compress a list of AttributeReportPayloads. */
+export function compressAttributeDataReportTags(data: AttributeReportPayload[]) {
+    let lastFullPath: FullAttributePath | undefined;
+
+    return data.sort(sortAttributeDataByPath).map(({ attributeData, attributeStatus }) => {
+        if (attributeData !== undefined) {
+            const { path, dataVersion } = attributeData;
+            const compressedPath = compressPath(path, dataVersion, lastFullPath);
+            const { enableTagCompression } = compressedPath.path;
+            attributeData = {
+                ...attributeData,
+                path: compressedPath.path,
+                dataVersion: enableTagCompression ? undefined : dataVersion,
+            };
+            lastFullPath = compressedPath.lastFullPath;
+        }
+        if (attributeStatus !== undefined) {
+            const { path } = attributeStatus;
+            const compressedPath = compressPath(path, undefined, lastFullPath);
+            attributeStatus = { ...attributeStatus, path: compressedPath.path };
+            lastFullPath = compressedPath.lastFullPath;
+        }
+        return { attributeData, attributeStatus };
+    });
+}
+
+/** Helper method to compress one path and preserve the state for the next path. */
+function compressPath(
+    path: TypeFromSchema<typeof TlvAttributePath>,
+    dataVersion: number | undefined,
+    lastFullPath: FullAttributePath | undefined,
+): { path: TypeFromSchema<typeof TlvAttributePath>; lastFullPath?: FullAttributePath } {
+    const { nodeId, endpointId, clusterId, attributeId } = path;
+
+    // Should never happen but typing likes it better that way
+    if (endpointId === undefined || clusterId === undefined || attributeId === undefined) {
+        return { path, lastFullPath };
+    }
+
+    const newFullPath = {
+        path: { ...path, enableTagCompression: undefined },
+        lastFullPath: { nodeId, endpointId, clusterId, attributeId, dataVersion },
+    };
+    // We have no stored Full path, so we take this as starting point
+    if (lastFullPath === undefined) {
+        return newFullPath;
+    }
+
+    // When dataVersion differs we can't compress
+    if (dataVersion !== undefined && dataVersion !== lastFullPath.dataVersion) {
+        return newFullPath;
+    }
+
+    // Based on Specs in DataReports AttributeId and CLusterId SHALL always be present in the path
+    let compressedElements = 0;
+    // Assume we can compress elements in the path
+    const compressedPath = { ...path, enableTagCompression: true };
+    if (endpointId === lastFullPath.endpointId) {
+        delete compressedPath.endpointId;
+        compressedElements++;
+    }
+    if (nodeId === lastFullPath.nodeId && nodeId !== undefined) {
+        // No need to count if undefined
+        delete compressedPath.nodeId;
+        compressedElements++;
+    }
+
+    // Nothing was compressed, so we use this as new full path
+    if (compressedElements === 0) {
+        return newFullPath;
+    }
+
+    return { path: compressedPath, lastFullPath };
+}

--- a/packages/matter.js/src/protocol/interaction/InteractionMessenger.ts
+++ b/packages/matter.js/src/protocol/interaction/InteractionMessenger.ts
@@ -252,7 +252,7 @@ export class InteractionServerMessenger extends InteractionMessenger<MatterDevic
                     if (attributeReport !== undefined) {
                         if (!firstAttributeAddedToReportMessage) {
                             firstAttributeAddedToReportMessage = true;
-                            messageSize += 3; // Array element with is added now with length needs 3 bytes
+                            messageSize += 3; // Array element is added now which needs 3 bytes
                         }
                         const encodedAttribute = encodeAttributePayload(attributeReport);
                         const attributeReportBytes = TlvAny.getEncodedByteLength(encodedAttribute);
@@ -277,7 +277,7 @@ export class InteractionServerMessenger extends InteractionMessenger<MatterDevic
                     }
                     if (!firstEventAddedToReportMessage) {
                         firstEventAddedToReportMessage = true;
-                        messageSize += 3; // Array element with is added now with length needs 3 bytes
+                        messageSize += 3; // Array element is added now which needs 3 bytes
                     }
                     const encodedEvent = encodeEventPayload(eventReport);
                     const eventReportBytes = TlvAny.getEncodedByteLength(encodedEvent);

--- a/packages/matter.js/src/protocol/interaction/InteractionMessenger.ts
+++ b/packages/matter.js/src/protocol/interaction/InteractionMessenger.ts
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { MatterController } from "../../MatterController.js";
+import { MatterDevice } from "../../MatterDevice.js";
 import { Message, SessionType } from "../../codec/MessageCodec.js";
 import { MatterError, MatterFlowError, NotImplementedError, UnexpectedDataError } from "../../common/MatterError.js";
 import { tryCatchAsync } from "../../common/TryCatchHandler.js";
 import { Logger } from "../../log/Logger.js";
-import { MatterController } from "../../MatterController.js";
-import { MatterDevice } from "../../MatterDevice.js";
 import { ExchangeProvider } from "../../protocol/ExchangeManager.js";
 import {
     ExchangeSendOptions,
@@ -17,12 +17,21 @@ import {
     RetransmissionLimitReachedError,
     UnexpectedMessageError,
 } from "../../protocol/MessageExchange.js";
+import { TlvAny } from "../../tlv/TlvAny.js";
 import { TlvSchema, TypeFromSchema } from "../../tlv/TlvSchema.js";
 import { ByteArray } from "../../util/ByteArray.js";
+import {
+    DataReportPayload,
+    canAttributePayloadBeChunked,
+    chunkAttributePayload,
+    encodeAttributePayload,
+    encodeEventPayload,
+} from "./AttributeDataEncoder.js";
 import {
     StatusCode,
     TlvAttributeReport,
     TlvDataReport,
+    TlvDataReportForSend,
     TlvInvokeRequest,
     TlvInvokeResponse,
     TlvReadRequest,
@@ -198,46 +207,66 @@ export class InteractionServerMessenger extends InteractionMessenger<MatterDevic
         }
     }
 
-    async sendDataReport(dataReport: DataReport) {
-        const messageBytes = TlvDataReport.encode(dataReport);
-        if (
-            (dataReport.attributeReports !== undefined || dataReport.eventReports !== undefined) &&
-            messageBytes.length > MAX_SPDU_LENGTH
-        ) {
-            // DataReport is too long, it needs to be sent in chunks
-            const attributeReportsToSend = [...(dataReport.attributeReports ?? [])];
-            const eventReportsToSend = [...(dataReport.eventReports ?? [])];
-            dataReport.attributeReports = undefined;
-            dataReport.eventReports = undefined;
-            dataReport.moreChunkedMessages = true;
+    /**
+     * Handle DataReportPayload with the content of a DataReport to send, split them into multiple DataReport
+     * messages and send them out based on the size.
+     */
+    async sendDataReport(dataReportPayload: DataReportPayload) {
+        const {
+            subscriptionId,
+            attributeReportsPayload,
+            eventReportsPayload,
+            suppressResponse,
+            interactionModelRevision,
+        } = dataReportPayload;
+        const dataReport: TypeFromSchema<typeof TlvDataReportForSend> = {
+            subscriptionId,
+            suppressResponse,
+            interactionModelRevision,
+            attributeReports: undefined,
+            eventReports: undefined,
+        };
 
-            const emptyDataReportBytes = TlvDataReport.encode(dataReport);
+        if (attributeReportsPayload !== undefined || eventReportsPayload !== undefined) {
+            const attributeReportsToSend = [...(attributeReportsPayload ?? [])];
+            const eventReportsToSend = [...(eventReportsPayload ?? [])];
 
-            // TODO reduce code duplication in below blocks
+            dataReport.moreChunkedMessages = true; // Assume we have multiple chunks, also for size calculation
+            const emptyDataReportBytes = TlvDataReportForSend.encode(dataReport);
+
+            let firstAttributeAddedToReportMessage = false;
+            let firstEventAddedToReportMessage = false;
+            const sendAndResetReport = async () => {
+                await this.sendDataReportMessage(dataReport);
+                dataReport.attributeReports = undefined;
+                dataReport.eventReports = undefined;
+                messageSize = emptyDataReportBytes.length;
+                firstAttributeAddedToReportMessage = false;
+                firstEventAddedToReportMessage = false;
+            };
+
             let messageSize = emptyDataReportBytes.length;
             while (true) {
                 if (attributeReportsToSend.length > 0) {
                     const attributeReport = attributeReportsToSend.shift();
                     if (attributeReport !== undefined) {
-                        const attributeReportBytes = TlvAttributeReport.encode(attributeReport).length;
+                        if (!firstAttributeAddedToReportMessage) {
+                            firstAttributeAddedToReportMessage = true;
+                            messageSize += 3; // Array element with is added now with length needs 3 bytes
+                        }
+                        const encodedAttribute = encodeAttributePayload(attributeReport);
+                        const attributeReportBytes = TlvAny.getEncodedByteLength(encodedAttribute);
                         if (messageSize + attributeReportBytes > MAX_SPDU_LENGTH) {
-                            if (messageSize === emptyDataReportBytes.length) {
-                                throw new NotImplementedError(
-                                    `Attribute report is too long to fit in a single chunk, Array chunking not yet supported.`,
-                                );
+                            if (canAttributePayloadBeChunked(attributeReport)) {
+                                // Attribute is a non-empty array: chunk it and add the chunks to the beginning of the queue
+                                attributeReportsToSend.unshift(...chunkAttributePayload(attributeReport));
+                                continue;
                             }
-                            // Report doesn't fit, sending this chunk
-                            logger.debug(
-                                `Sending DataReport chunk with ${dataReport.attributeReports?.length} attributes: ${messageSize} bytes`,
-                            );
-                            await this.send(MessageType.ReportData, TlvDataReport.encode(dataReport));
-                            await this.waitForSuccess();
-                            dataReport.attributeReports = undefined;
-                            messageSize = emptyDataReportBytes.length;
+                            await sendAndResetReport();
                         }
                         messageSize += attributeReportBytes;
                         if (dataReport.attributeReports === undefined) dataReport.attributeReports = [];
-                        dataReport.attributeReports.push(attributeReport);
+                        dataReport.attributeReports.push(encodedAttribute);
                     }
                 } else if (eventReportsToSend.length > 0) {
                     const eventReport = eventReportsToSend.shift();
@@ -246,26 +275,18 @@ export class InteractionServerMessenger extends InteractionMessenger<MatterDevic
                         dataReport.moreChunkedMessages = undefined;
                         break;
                     }
-                    const eventReportBytes = TlvAttributeReport.encode(eventReport).length;
+                    if (!firstEventAddedToReportMessage) {
+                        firstEventAddedToReportMessage = true;
+                        messageSize += 3; // Array element with is added now with length needs 3 bytes
+                    }
+                    const encodedEvent = encodeEventPayload(eventReport);
+                    const eventReportBytes = TlvAny.getEncodedByteLength(encodedEvent);
                     if (messageSize + eventReportBytes > MAX_SPDU_LENGTH) {
-                        if (messageSize === emptyDataReportBytes.length) {
-                            throw new NotImplementedError(
-                                `Event report is too long to fit in a single chunk, Array chunking not yet supported.`,
-                            );
-                        }
-                        // Report doesn't fit, sending this chunk
-                        logger.debug(
-                            `Sending DataReport chunk with ${dataReport.attributeReports?.length} attributes and ${dataReport.eventReports?.length} events: ${messageSize} bytes`,
-                        );
-                        await this.send(MessageType.ReportData, TlvDataReport.encode(dataReport));
-                        await this.waitForSuccess();
-                        dataReport.attributeReports = undefined;
-                        dataReport.eventReports = undefined;
-                        messageSize = emptyDataReportBytes.length;
+                        await sendAndResetReport();
                     }
                     messageSize += eventReportBytes;
                     if (dataReport.eventReports === undefined) dataReport.eventReports = [];
-                    dataReport.eventReports.push(eventReport);
+                    dataReport.eventReports.push(encodedEvent);
                 } else {
                     // No more chunks to send
                     dataReport.moreChunkedMessages = undefined;
@@ -274,11 +295,32 @@ export class InteractionServerMessenger extends InteractionMessenger<MatterDevic
             }
         }
 
+        await this.sendDataReportMessage(dataReport);
+    }
+
+    async sendDataReportMessage(dataReport: TypeFromSchema<typeof TlvDataReportForSend>) {
+        const encodedMessage = TlvDataReportForSend.encode(dataReport);
+        if (encodedMessage.length > MAX_SPDU_LENGTH) {
+            throw new MatterFlowError(
+                `DataReport is too long to fit in a single chunk, This should not happen! Data: ${Logger.toJSON(
+                    dataReport,
+                )}`,
+            );
+        }
+        logger.debug(
+            `Sending DataReport chunk with ${dataReport.attributeReports?.length ?? 0} attributes and ${
+                dataReport.eventReports?.length ?? 0
+            } events: ${encodedMessage.length} bytes`,
+        );
+
+        const checkDecode = TlvDataReport.decode(encodedMessage);
+        logger.debug("checkDecode", Logger.toJSON(checkDecode));
+
         if (dataReport.suppressResponse) {
             // We do not expect a response other than a Standalone Ack, so if we receive anything else, we throw an error
             await tryCatchAsync(
                 async () =>
-                    await this.exchange.send(MessageType.ReportData, TlvDataReport.encode(dataReport), {
+                    await this.exchange.send(MessageType.ReportData, encodedMessage, {
                         expectAckOnly: true,
                     }),
                 UnexpectedMessageError,
@@ -288,10 +330,7 @@ export class InteractionServerMessenger extends InteractionMessenger<MatterDevic
                 },
             );
         } else {
-            logger.debug(
-                `Sending (final) data report with ${dataReport.attributeReports?.length} attributes and ${dataReport.eventReports?.length} events`,
-            );
-            await this.exchange.send(MessageType.ReportData, TlvDataReport.encode(dataReport));
+            await this.exchange.send(MessageType.ReportData, encodedMessage);
             await this.waitForSuccess();
         }
     }

--- a/packages/matter.js/src/protocol/interaction/InteractionProtocol.ts
+++ b/packages/matter.js/src/protocol/interaction/InteractionProtocol.ts
@@ -132,7 +132,7 @@ export const TlvAttributeData = TlvObject({
 
 export const TlvAttributeReportData = TlvObject({
     // AttributeDataIB version for Reports
-    dataVersion: TlvField(0, TlvUInt32),
+    dataVersion: TlvOptionalField(0, TlvUInt32),
     path: TlvField(1, TlvAttributePath),
     data: TlvField(2, TlvAny),
 });

--- a/packages/matter.js/src/protocol/interaction/InteractionProtocol.ts
+++ b/packages/matter.js/src/protocol/interaction/InteractionProtocol.ts
@@ -215,6 +215,16 @@ export const TlvDataReport = TlvObject({
     interactionModelRevision: TlvField(0xff, TlvUInt8),
 });
 
+/** Special version of the DataReport Message with pre-encoded report entries used by Send logic */
+export const TlvDataReportForSend = TlvObject({
+    subscriptionId: TlvOptionalField(0, TlvUInt32),
+    attributeReports: TlvOptionalField(1, TlvArray(TlvAny)),
+    eventReports: TlvOptionalField(2, TlvArray(TlvAny)),
+    moreChunkedMessages: TlvOptionalField(3, TlvBoolean),
+    suppressResponse: TlvOptionalField(4, TlvBoolean),
+    interactionModelRevision: TlvField(0xff, TlvUInt8),
+});
+
 /** @see {@link MatterCoreSpecificationV1_0}, section 10.6.4 */
 export const TlvSubscribeRequest = TlvObject({
     keepSubscriptions: TlvField(0, TlvBoolean),

--- a/packages/matter.js/src/protocol/interaction/export.ts
+++ b/packages/matter.js/src/protocol/interaction/export.ts
@@ -7,6 +7,7 @@
 // Export Protocol types
 // Export Interaction Classes
 export * from "./AttributeDataDecoder.js";
+export * from "./AttributeDataEncoder.js";
 export * from "./EventDataDecoder.js";
 export * from "./InteractionClient.js";
 export * from "./InteractionEndpointStructure.js";

--- a/packages/matter.js/test/protocol/interaction/AttributeDataEncoderTest.ts
+++ b/packages/matter.js/test/protocol/interaction/AttributeDataEncoderTest.ts
@@ -1,0 +1,256 @@
+/**
+ * @license
+ * Copyright 2022-2023 Project CHIP Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { AttributeId } from "../../../src/datatype/AttributeId.js";
+import { ClusterId, TlvClusterId } from "../../../src/datatype/ClusterId.js";
+import { EndpointNumber } from "../../../src/datatype/EndpointNumber.js";
+import {
+    AttributeReportPayload,
+    chunkAttributePayload,
+    compressAttributeDataReportTags,
+} from "../../../src/protocol/interaction/AttributeDataEncoder.js";
+import { TlvArray } from "../../../src/tlv/TlvArray.js";
+import { TlvUInt8 } from "../../../src/tlv/TlvNumber.js";
+import { TlvString } from "../../../src/tlv/TlvString.js";
+
+describe("AttributeDataEncoder", () => {
+    describe("tag compression for attribute DataReport payloads", () => {
+        it("tag compress with dataVersion handling", () => {
+            const data: AttributeReportPayload[] = [
+                {
+                    attributeData: {
+                        path: {
+                            endpointId: EndpointNumber(0),
+                            clusterId: ClusterId(0x1d),
+                            attributeId: AttributeId(1),
+                        },
+                        schema: TlvArray(TlvClusterId),
+                        payload: [ClusterId(29), ClusterId(40)],
+                        dataVersion: 12345678,
+                    },
+                },
+                {
+                    attributeData: {
+                        path: {
+                            endpointId: EndpointNumber(0),
+                            clusterId: ClusterId(0x28),
+                            attributeId: AttributeId(2),
+                        },
+                        schema: TlvUInt8,
+                        payload: 1,
+                        dataVersion: 12345678,
+                    },
+                    attributeStatus: undefined,
+                },
+                {
+                    attributeData: {
+                        path: {
+                            endpointId: EndpointNumber(0),
+                            clusterId: ClusterId(0x28),
+                            attributeId: AttributeId(3),
+                        },
+                        schema: TlvString,
+                        payload: "product",
+                        dataVersion: 12345678,
+                    },
+                },
+                {
+                    attributeData: {
+                        path: {
+                            endpointId: EndpointNumber(0),
+                            clusterId: ClusterId(0x29),
+                            attributeId: AttributeId(4),
+                        },
+                        schema: TlvUInt8,
+                        payload: 2,
+                        dataVersion: 12345678,
+                    },
+                },
+                {
+                    attributeStatus: {
+                        path: {
+                            endpointId: EndpointNumber(0),
+                            clusterId: ClusterId(0x28),
+                            attributeId: AttributeId(400),
+                        },
+                        status: { status: 134 },
+                    },
+                },
+                {
+                    attributeStatus: {
+                        path: {
+                            endpointId: EndpointNumber(0),
+                            clusterId: ClusterId(0x99),
+                            attributeId: AttributeId(4),
+                        },
+                        status: { status: 195 },
+                    },
+                },
+                {
+                    attributeStatus: {
+                        path: {
+                            endpointId: EndpointNumber(1),
+                            clusterId: ClusterId(0x28),
+                            attributeId: AttributeId(1),
+                        },
+                        status: { status: 127 },
+                    },
+                },
+            ];
+            const compressedData = compressAttributeDataReportTags(data);
+
+            expect(compressedData).deep.equal([
+                {
+                    attributeData: {
+                        path: {
+                            endpointId: EndpointNumber(0),
+                            clusterId: ClusterId(0x1d),
+                            attributeId: AttributeId(1),
+                            enableTagCompression: undefined,
+                        },
+                        schema: TlvArray(TlvClusterId),
+                        payload: [ClusterId(29), ClusterId(40)],
+                        dataVersion: 12345678,
+                    },
+                    attributeStatus: undefined,
+                },
+                {
+                    attributeData: {
+                        path: {
+                            clusterId: ClusterId(0x28),
+                            attributeId: AttributeId(2),
+                            enableTagCompression: true,
+                        },
+                        schema: TlvUInt8,
+                        payload: 1,
+                        dataVersion: undefined,
+                    },
+                    attributeStatus: undefined,
+                },
+                {
+                    attributeData: {
+                        path: {
+                            clusterId: ClusterId(0x28),
+                            attributeId: AttributeId(3),
+                            enableTagCompression: true,
+                        },
+                        schema: TlvString,
+                        payload: "product",
+                        dataVersion: undefined,
+                    },
+                    attributeStatus: undefined,
+                },
+                {
+                    attributeStatus: {
+                        path: {
+                            clusterId: ClusterId(0x28),
+                            attributeId: AttributeId(400),
+                            enableTagCompression: true,
+                        },
+                        status: { status: 134 },
+                    },
+                    attributeData: undefined,
+                },
+                {
+                    attributeData: {
+                        path: {
+                            clusterId: ClusterId(0x29),
+                            attributeId: AttributeId(4),
+                            enableTagCompression: true,
+                        },
+                        schema: TlvUInt8,
+                        payload: 2,
+                        dataVersion: undefined,
+                    },
+                    attributeStatus: undefined,
+                },
+                {
+                    attributeStatus: {
+                        path: {
+                            clusterId: ClusterId(0x99),
+                            attributeId: AttributeId(4),
+                            enableTagCompression: true,
+                        },
+                        status: { status: 195 },
+                    },
+                    attributeData: undefined,
+                },
+                {
+                    attributeStatus: {
+                        path: {
+                            endpointId: EndpointNumber(1),
+                            clusterId: ClusterId(0x28),
+                            attributeId: AttributeId(1),
+                            enableTagCompression: undefined,
+                        },
+                        status: { status: 127 },
+                    },
+                    attributeData: undefined,
+                },
+            ]);
+        });
+    });
+
+    describe("chunk arrays for DataReports", () => {
+        it("chunk array", () => {
+            const data: AttributeReportPayload = {
+                attributeData: {
+                    path: {
+                        endpointId: EndpointNumber(0),
+                        clusterId: ClusterId(0x1d),
+                        attributeId: AttributeId(1),
+                    },
+                    schema: TlvArray(TlvClusterId),
+                    payload: [ClusterId(29), ClusterId(40)],
+                    dataVersion: 12345678,
+                },
+            };
+            const chunkedData = chunkAttributePayload(data);
+
+            expect(chunkedData).deep.equal([
+                {
+                    attributeData: {
+                        path: {
+                            endpointId: EndpointNumber(0),
+                            clusterId: ClusterId(0x1d),
+                            attributeId: AttributeId(1),
+                            listIndex: undefined,
+                        },
+                        schema: TlvArray(TlvClusterId),
+                        payload: [],
+                        dataVersion: 12345678,
+                    },
+                },
+                {
+                    attributeData: {
+                        path: {
+                            endpointId: EndpointNumber(0),
+                            clusterId: ClusterId(0x1d),
+                            attributeId: AttributeId(1),
+                            listIndex: null,
+                        },
+                        schema: TlvClusterId,
+                        payload: ClusterId(29),
+                        dataVersion: 12345678,
+                    },
+                },
+                {
+                    attributeData: {
+                        path: {
+                            endpointId: EndpointNumber(0),
+                            clusterId: ClusterId(0x1d),
+                            attributeId: AttributeId(1),
+                            listIndex: null,
+                        },
+                        schema: TlvClusterId,
+                        payload: ClusterId(40),
+                        dataVersion: 12345678,
+                    },
+                },
+            ]);
+        });
+    });
+});

--- a/packages/matter.js/test/tlv/TlvAnyTest.ts
+++ b/packages/matter.js/test/tlv/TlvAnyTest.ts
@@ -11,6 +11,7 @@ import { ByteArray } from "../../src/util/ByteArray.js";
 
 type CodecVector<I, E> = { [valueDescription: string]: { encoded: I; decoded: E } };
 
+// TODO Add some more test cases
 const testVector: CodecVector<string, any> = {
     null: { encoded: "14", decoded: [{ tag: undefined, typeLength: { type: TlvType.Null }, value: null }] },
     array: {
@@ -38,6 +39,15 @@ describe("TlvAny", () => {
             const { encoded, decoded } = testVector[valueDescription];
             it(`encodes ${valueDescription}`, () => {
                 expect(TlvAny.encode(decoded).toHex()).equal(encoded);
+            });
+        }
+    });
+
+    describe("calculates size ", () => {
+        for (const valueDescription in testVector) {
+            const { encoded, decoded } = testVector[valueDescription];
+            it(`calculates size  ${valueDescription}`, () => {
+                expect(TlvAny.getEncodedByteLength(decoded)).equal(encoded.length / 2);
             });
         }
     });

--- a/packages/matter.js/test/tlv/TlvArrayTest.ts
+++ b/packages/matter.js/test/tlv/TlvArrayTest.ts
@@ -28,6 +28,11 @@ describe("TlvArray", () => {
             expect(result.toHex()).equal("160c01610c01620c016318");
         });
 
+        it(`calculate array byte length`, () => {
+            const tlvEncoded = schema.encodeTlv(["a", "b", "c"]);
+            expect(TlvAny.getEncodedByteLength(tlvEncoded)).equal(11);
+        });
+
         it("encodes an array to chunks", () => {
             const result = schema.encodeAsChunkedArray(["a", "b", "c"]);
 

--- a/packages/matter.js/test/tlv/TlvBooleanTest.ts
+++ b/packages/matter.js/test/tlv/TlvBooleanTest.ts
@@ -5,6 +5,7 @@
  */
 
 import { ValidationError } from "../../src/common/MatterError.js";
+import { TlvAny } from "../../src/tlv/TlvAny.js";
 import { TlvBoolean } from "../../src/tlv/TlvBoolean.js";
 import { ByteArray } from "../../src/util/ByteArray.js";
 
@@ -30,6 +31,16 @@ describe("TlvBoolean", () => {
             const { encoded, decoded } = testVector[valueDescription];
             it(`decodes ${valueDescription}`, () => {
                 expect(TlvBoolean.decode(ByteArray.fromHex(encoded))).equal(decoded);
+            });
+        }
+    });
+
+    describe("calculate byte length", () => {
+        for (const valueDescription in testVector) {
+            const { encoded, decoded } = testVector[valueDescription];
+            it(`calculate byte length ${valueDescription}`, () => {
+                const tlvEncoded = TlvBoolean.encodeTlv(decoded);
+                expect(TlvAny.getEncodedByteLength(tlvEncoded)).equal(encoded.length / 2);
             });
         }
     });

--- a/packages/matter.js/test/tlv/TlvComplexTest.ts
+++ b/packages/matter.js/test/tlv/TlvComplexTest.ts
@@ -6,6 +6,7 @@
 
 import { FabricId, TlvFabricId } from "../../src/datatype/FabricId.js";
 import { FabricIndex, TlvFabricIndex } from "../../src/datatype/FabricIndex.js";
+import { TlvAny } from "../../src/tlv/TlvAny.js";
 import { TlvArray } from "../../src/tlv/TlvArray.js";
 import { TlvBoolean } from "../../src/tlv/TlvBoolean.js";
 import { TlvNullable } from "../../src/tlv/TlvNullable.js";
@@ -152,6 +153,16 @@ describe("TlvObject", () => {
             const { encoded, decoded } = codecVector[valueDescription];
             it(`decodes ${valueDescription}`, () => {
                 expect(schema.decode(ByteArray.fromHex(encoded))).deep.equal(decoded);
+            });
+        }
+    });
+
+    describe("calculate byte length", () => {
+        for (const valueDescription in codecVector) {
+            const { encoded, decoded } = codecVector[valueDescription];
+            it(`calculate byte length ${valueDescription}`, () => {
+                const tlvEncoded = schema.encodeTlv(decoded);
+                expect(TlvAny.getEncodedByteLength(tlvEncoded)).equal(encoded.length / 2);
             });
         }
     });

--- a/packages/matter.js/test/tlv/TlvNullableTest.ts
+++ b/packages/matter.js/test/tlv/TlvNullableTest.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { TlvAny } from "../../src/tlv/TlvAny.js";
 import { TlvNullable } from "../../src/tlv/TlvNullable.js";
 import { TlvString } from "../../src/tlv/TlvString.js";
 import { ByteArray } from "../../src/util/ByteArray.js";
@@ -23,6 +24,16 @@ describe("TlvNullable", () => {
             const { encoded, decoded } = codecVector[valueDescription];
             it(`encodes ${valueDescription}`, () => {
                 expect(schema.encode(decoded).toHex()).equal(encoded);
+            });
+        }
+    });
+
+    describe("calculate byte length", () => {
+        for (const valueDescription in codecVector) {
+            const { encoded, decoded } = codecVector[valueDescription];
+            it(`calculate byte length ${valueDescription}`, () => {
+                const tlvEncoded = schema.encodeTlv(decoded);
+                expect(TlvAny.getEncodedByteLength(tlvEncoded)).equal(encoded.length / 2);
             });
         }
     });

--- a/packages/matter.js/test/tlv/TlvObjectTest.ts
+++ b/packages/matter.js/test/tlv/TlvObjectTest.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { TlvAny } from "../../src/tlv/TlvAny.js";
 import { TlvArray } from "../../src/tlv/TlvArray.js";
 import { TlvNullable } from "../../src/tlv/TlvNullable.js";
 import { TlvUInt8 } from "../../src/tlv/TlvNumber.js";
@@ -57,6 +58,16 @@ describe("TlvObject", () => {
 
             expect(result).deep.equal({ optionalField: "test" });
         });
+    });
+
+    describe("calculate byte length", () => {
+        for (const valueDescription in codecVector) {
+            const { encoded, decoded } = codecVector[valueDescription];
+            it(`calculate byte length ${valueDescription}`, () => {
+                const tlvEncoded = schema.encodeTlv(decoded);
+                expect(TlvAny.getEncodedByteLength(tlvEncoded)).equal(encoded.length / 2);
+            });
+        }
     });
 
     describe("encodeTlv with decodeTlv", () => {

--- a/packages/matter.js/test/tlv/TlvSchemaTest.ts
+++ b/packages/matter.js/test/tlv/TlvSchemaTest.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { TlvAny } from "../../src/tlv/TlvAny.js";
 import { TlvArray } from "../../src/tlv/TlvArray.js";
 import { TlvBoolean } from "../../src/tlv/TlvBoolean.js";
 import {
@@ -153,6 +154,16 @@ function testTlvSchemaEncode(testEntry: TestEntry<any>) {
     });
 }
 
+function testTlvSchemaCalculateByteLength(testEntry: TestEntry<any>) {
+    const { name, schema, tlv, jsObj } = testEntry;
+    const testName = "TlvSchema.calculateByteLength " + name;
+
+    it(testName, () => {
+        const tlvEncoded = schema.encodeTlv(jsObj);
+        expect(TlvAny.getEncodedByteLength(tlvEncoded)).equal(tlv.length / 2);
+    });
+}
+
 function testTlvSchemaDecode(testEntry: TestEntry<any>) {
     const { name, schema, tlv, jsObj } = testEntry;
     const testName = "TlvSchema.decode " + name;
@@ -167,6 +178,7 @@ function testTlvSchemaDecode(testEntry: TestEntry<any>) {
 describe("Test TlvSchema", () => {
     theTestTlvVector.forEach(testEntry => {
         testTlvSchemaEncode(testEntry);
+        testTlvSchemaCalculateByteLength(testEntry);
         testTlvSchemaDecode(testEntry);
     });
 });

--- a/packages/matter.js/test/tlv/TlvStringTest.ts
+++ b/packages/matter.js/test/tlv/TlvStringTest.ts
@@ -5,6 +5,7 @@
  */
 
 import { ValidationError } from "../../src/common/MatterError.js";
+import { TlvAny } from "../../src/tlv/TlvAny.js";
 import { TlvByteString, TlvString } from "../../src/tlv/TlvString.js";
 import { ByteArray } from "../../src/util/ByteArray.js";
 
@@ -48,6 +49,18 @@ describe("TlvString", () => {
             const result = TlvString.decode(ByteArray.fromHex("0c0674657374c3a8"));
 
             expect(result).equal("testè");
+        });
+    });
+
+    describe("calculate byte size", () => {
+        it("calculate byte size a string", () => {
+            const tlvEncoded = TlvString.encodeTlv("test");
+            expect(TlvAny.getEncodedByteLength(tlvEncoded)).equal(6);
+        });
+
+        it("calculate byte size a string that was utf8", () => {
+            const tlvEncoded = TlvString.encodeTlv("testè");
+            expect(TlvAny.getEncodedByteLength(tlvEncoded)).equal(8);
         });
     });
 

--- a/packages/matter.js/test/tlv/TlvVoidTest.ts
+++ b/packages/matter.js/test/tlv/TlvVoidTest.ts
@@ -5,12 +5,20 @@
  */
 
 import { ValidationError } from "../../src/common/MatterError.js";
+import { TlvAny } from "../../src/tlv/TlvAny.js";
 import { TlvVoid } from "../../src/tlv/TlvVoid.js";
 
 describe("TlvVoid", () => {
     describe("encode", () => {
         it("encodes undefined", () => {
             expect(TlvVoid.encode(undefined).toHex()).equal("");
+        });
+    });
+
+    describe("calculate bytesize", () => {
+        it("calculate bytesize undefined", () => {
+            const tlvEncoded = TlvVoid.encodeTlv(undefined);
+            expect(TlvAny.getEncodedByteLength(tlvEncoded)).equal(0);
         });
     });
 


### PR DESCRIPTION
... and also implement tag compression, but keep disabled because not yet supported.

This PR does:
* Enhance existing DataDecoding Logic
* Make dataVersion in types optional and handle tag-compressed dataVersions (restore them)
* Add DataEncoder to allow dynamic chunking and tag-compression. This also introduces new intermediate types for data formats used internally to allow dynamic compression and chunking
* Enhance AnySchema to allow the calculation of the bytesize of a TlvStream (used to encode data)
* Use the new encoder for reads and subscriptions
* Refactor the DataReport sending logic

Beside the added tests and many manual tests with Apple, Google and Tuya (and amazon) the Integratiintest was unachanged, so proofed via this that we ourself at löeast can decode what we send.