### PR TITLE
Small housekeeping

### DIFF
--- a/packages/matter.js/src/protocol/MessageExchange.ts
+++ b/packages/matter.js/src/protocol/MessageExchange.ts
@@ -280,8 +280,8 @@ export class MessageExchange<ContextT> {
         return this.messagesQueue.read();
     }
 
-    async waitFor(messageType: number) {
-        const message = await this.messagesQueue.read();
+    async waitFor(messageType: number, timeoutMs = 60_000) {
+        const message = await this.messagesQueue.read(timeoutMs);
         const {
             payloadHeader: { messageType: receivedMessageType },
         } = message;

--- a/packages/matter.js/src/protocol/interaction/InteractionServer.ts
+++ b/packages/matter.js/src/protocol/interaction/InteractionServer.ts
@@ -647,15 +647,15 @@ export class InteractionServer implements ProtocolHandler<MatterDevice> {
             await subscriptionHandler.sendInitialReport(messenger);
         } catch (error: any) {
             logger.error(
-                `Subscription ${subscriptionId} for Session ${session.getId()}: Error while sending initial data reports: ${
-                    error.message
-                }`,
+                `Subscription ${subscriptionId} for Session ${session.getId()}: Error while sending initial data reports`,
+                error,
             );
             await subscriptionHandler.cancel(); // Cleanup
             if (error instanceof StatusResponseError) {
                 logger.info(`Sending status response ${error.code} for interaction error: ${error.message}`);
                 await messenger.sendStatus(error.code);
             }
+            await messenger.close();
             return; // Make sure to not bubble up the exception
         }
 


### PR DESCRIPTION
Closing messenger/exchange on initial subscription errors and make waitFor-timeout configurable when reading DataReports (was missing from #335)