### PR TITLE
Fix run script path on Windows

### DIFF
--- a/tools/src/running/cli.ts
+++ b/tools/src/running/cli.ts
@@ -53,7 +53,7 @@ export async function main(argv = process.argv) {
         project.pkg
             .relative(script)
             .replace(/\.ts$/, ".js")
-            .replace(/^src\//, `dist/${format}/`),
+            .replace(/^src[\\/]/, `dist/${format}/`),
     );
 
     await executeNode(script, argv);


### PR DESCRIPTION
Currently the running cli failed to replace `src` directory on Windows due to using platform specific separator:

```
PS C:\Users\vilicvane\Projects\project-chip\matter.js> npm run shell

> shell
> run packages/matter-node-shell.js/src/app.ts

node:internal/modules/cjs/loader:1051
  throw err;
  ^

Error: Cannot find module 'C:\Users\vilicvane\Projects\project-chip\matter.js\packages\matter-node-shell.js\src\app.js'
```

And this PR fixes it by replacing both `/` and `\` (`[\\/]`).