### PR TITLE
Make sure Event initial-data and updates are processed correctly

### DIFF
--- a/packages/matter.js/src/cluster/client/ClusterClient.ts
+++ b/packages/matter.js/src/cluster/client/ClusterClient.ts
@@ -225,17 +225,26 @@ export function ClusterClient<F extends BitSchema, A extends Attributes, C exten
                 logger.warn("Unknown attribute id", attributeId);
                 return;
             }
-            (attributes as any)[attributeName].update(value);
+            if ((attributes as any)[attributeName] !== undefined) {
+                (attributes as any)[attributeName].update(value);
+            } else {
+                logger.warn("Attribute not found", attributeName, "in list", Object.keys(attributes));
+            }
         },
 
         /** Trigger a value change for an Event, used by subscriptions. */
-        _triggerEventUpdate(eventId: EventId, events: DecodedEventData<any>[]) {
+        _triggerEventUpdate(eventId: EventId, eventData: DecodedEventData<any>[]) {
             const eventName = eventToId[eventId];
             if (eventName === undefined) {
                 logger.warn("Unknown event id", eventId);
                 return;
             }
-            events.forEach(event => (events as any)[eventName].update(event));
+            if ((events as any)[eventName] !== undefined) {
+                const event = (events as any)[eventName];
+                eventData.forEach(data => event.update(data));
+            } else {
+                logger.warn("Event not found", eventName, "in list", Object.keys(events));
+            }
         },
     };
 

--- a/packages/matter.js/src/protocol/interaction/InteractionMessenger.ts
+++ b/packages/matter.js/src/protocol/interaction/InteractionMessenger.ts
@@ -32,6 +32,7 @@ import {
     TlvAttributeReport,
     TlvDataReport,
     TlvDataReportForSend,
+    TlvEventReport,
     TlvInvokeRequest,
     TlvInvokeResponse,
     TlvReadRequest,
@@ -341,7 +342,8 @@ export class InteractionServerMessenger extends InteractionMessenger<MatterDevic
 export class IncomingInteractionClientMessenger extends InteractionMessenger<MatterController> {
     async readDataReport(): Promise<DataReport> {
         let subscriptionId: number | undefined;
-        const values: TypeFromSchema<typeof TlvAttributeReport>[] = [];
+        const attributeValues: TypeFromSchema<typeof TlvAttributeReport>[] = [];
+        const eventValues: TypeFromSchema<typeof TlvEventReport>[] = [];
 
         while (true) {
             const dataReportMessage = await this.exchange.waitFor(MessageType.ReportData);
@@ -356,10 +358,14 @@ export class IncomingInteractionClientMessenger extends InteractionMessenger<Mat
             }
 
             if (Array.isArray(report.attributeReports) && report.attributeReports.length > 0) {
-                values.push(...report.attributeReports);
+                attributeValues.push(...report.attributeReports);
+            }
+            if (Array.isArray(report.eventReports) && report.eventReports.length > 0) {
+                eventValues.push(...report.eventReports);
             }
             if (!report.moreChunkedMessages) {
-                report.attributeReports = values;
+                report.attributeReports = attributeValues;
+                report.eventReports = eventValues;
                 return report;
             }
 


### PR DESCRIPTION
There was a variable name overlapping which caused the effect that events were not updated. Additionally, eventReports were not returned on subscription seed. The test was hiding this behaviour because another event update came in from another global subscription and so was handles as ok but indeed was not. test adjusted to check behaviour. An additional test (testing event responses from initial subscription seed will be added in next PR because of code conflicts.