### PR TITLE
Make sure Time intervals/timeouts are valid

### DIFF
--- a/packages/matter-node.js/src/time/TimeNode.ts
+++ b/packages/matter-node.js/src/time/TimeNode.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { ImplementationError } from "@project-chip/matter.js/common";
 import { Time, Timer, TimerCallback } from "@project-chip/matter.js/time";
 
 class TimerNode implements Timer {
@@ -14,7 +15,13 @@ class TimerNode implements Timer {
         private readonly intervalMs: number,
         private readonly callback: TimerCallback,
         private readonly periodic: boolean,
-    ) {}
+    ) {
+        if (intervalMs < 0 || intervalMs > 2147483647) {
+            throw new ImplementationError(
+                `Invalid intervalMs: ${intervalMs}. The value must be between 0 and 32-bit maximum value (2147483647)`,
+            );
+        }
+    }
 
     start() {
         if (this.isRunning) this.stop();


### PR DESCRIPTION
Node.js only supports timeout values in a signed 32 bit positive range. Else it uses to 0 instead of throwing an error! So we throw