### PR TITLE
Change ES target from ES5 to ES2018

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All Changes without a GitHub Username in brackets are from the core team: @Apoll
 	## __WORK IN PROGRESS__
 -->
 
+## __WORK_IN_PROGRESS__
+
+* Infrastructure
+  * Feature (vilic): Add project references and additional tsconfigs to support standard tsc development workflows
+  * Breaking: Change ES target from ES5 to ES2018 (affected environments probably already didn't support matter.js)
+
 ## 0.6.0 (2023-10-08)
 * Matter-Core functionality:
   * Fix: Adjusted Event Priority definition to match to specs

--- a/chip-testing/src/tsconfig.json
+++ b/chip-testing/src/tsconfig.json
@@ -2,9 +2,6 @@
     "extends": "../../tools/tsconfig.base.json",
     "compilerOptions": {
         "outDir": "../dist/cjs",
-        "target": "es2018",
-        "module": "nodenext",
-        "moduleResolution": "nodenext",
         "types": ["node"]
     }
 }

--- a/chip-testing/test/tsconfig.json
+++ b/chip-testing/test/tsconfig.json
@@ -2,9 +2,6 @@
     "extends": "../../tools/tsconfig.base.json",
     "compilerOptions": {
         "outDir": "../build/test",
-        "target": "es2018",
-        "module": "nodenext",
-        "moduleResolution": "nodenext",
         "types": ["node", "mocha"]
     },
     "references": [{ "path": "../src" }]

--- a/codegen/src/tsconfig.json
+++ b/codegen/src/tsconfig.json
@@ -2,9 +2,6 @@
     "extends": "../../tools/tsconfig.base.json",
     "compilerOptions": {
         "outDir": "../dist/esm",
-        "target": "es2018",
-        "module": "nodenext",
-        "moduleResolution": "nodenext",
         "types": ["node"]
     },
     "references": [{ "path": "../../models/src" }, { "path": "../../packages/matter.js/src" }]

--- a/tools/src/tsconfig.json
+++ b/tools/src/tsconfig.json
@@ -2,9 +2,6 @@
     "extends": "../tsconfig.base.json",
     "compilerOptions": {
         "outDir": "../dist/esm",
-        "target": "es2018",
-        "module": "nodenext",
-        "moduleResolution": "nodenext",
         "types": ["node"]
     },
     "include": ["**/*.ts", "testing/mocharc.cjs"]

--- a/tools/test/tsconfig.json
+++ b/tools/test/tsconfig.json
@@ -2,9 +2,6 @@
     "extends": "../tsconfig.base.json",
     "compilerOptions": {
         "outDir": "../build/test",
-        "target": "es2018",
-        "module": "nodenext",
-        "moduleResolution": "nodenext",
         "types": ["node", "mocha", "@project-chip/matter.js-tools"]
     },
     "references": [{ "path": "../src" }]

--- a/tools/tsconfig.base.json
+++ b/tools/tsconfig.base.json
@@ -10,8 +10,8 @@
         // Compile incrementally using tsbuildinfo state file
         "incremental": true,
 
-        // We should probably boost this at least to ES 2017
-        "target": "es2015",
+        // Matter.js most likely won't work with older versions of ES
+        "target": "es2018",
 
         // Generate modules as ES2020 or CommonJS
         "module": "node16",


### PR DESCRIPTION
Also updates changelog and removes some redundancy from tsconfigs.