### PR TITLE
Mention bundling to matter-node.js-examples

### DIFF
--- a/packages/matter-node.js-examples/README.md
+++ b/packages/matter-node.js-examples/README.md
@@ -20,11 +20,29 @@ For BLE usage please also see the [matter-node-ble.js README.md](../matter-node-
 npm i -g @project-chip/matter-node.js-examples
 ```
 
-### Use from Cloned MatterServer.js Repository
+### Use from Cloned Matter.js Repository
 
 When you clone the matter.js repository you can also use matter-node.js. To do this you need to execute `npm install` in the matter.js root directory once to install all dependencies and build all packages.
 
 Then after `cd packages/matter-node.js-examples` you can use `npm run matter-device` to run the matter-node.js server. Please see the next section for more details.
+
+### Bundling
+
+For production environments where space and/or CPU is at a premium, you might consider using a bundler to distribute your application.  This project includes an example demonstrating how to create such a bundle using [esbuild](https://esbuild.github.io/).
+
+To run the example, first install as described in [From NPM](#from-npm) or [Use from Cloned Matter.js Repository](#use-from-cloned-matterjs-repository).
+
+Then in the `matter-node.js-examples` installation directory, run:
+
+```bash
+npm bundle-device
+```
+
+This creates a single JavaScript file containing the application and dependencies.
+
+To view the example commands for bundling and running, see scripts `bundle-device` and `matter-device-bundled` in [package.json](package.json).
+
+Note that you cannot include native dependencies in this way so those will still need to be installed locally using NPM.  In this example, those are the dependencies flagged as `--external` in the `esbuild` command line.
 
 ## CLI usage
 

--- a/packages/matter-node.js-examples/package.json
+++ b/packages/matter-node.js-examples/package.json
@@ -31,7 +31,9 @@
         "matter-bridge": "run src/examples/BridgedDevicesNode.ts",
         "matter-composeddevice": "run src/examples/ComposedDeviceNode.ts",
         "matter-multidevice": "run src/examples/MultiDeviceNode.ts",
-        "matter-controller": "run src/examples/ControllerNode.ts"
+        "matter-controller": "run src/examples/ControllerNode.ts",
+        "bundle-device": "esbuild dist/cjs/examples/DeviceNode.js --bundle --platform=node --external:@abandonware/bleno --external:@abandonware/bluetooth-hci-socket --sourcemap --minify --outfile=build/bundle/DeviceNode.js",
+        "matter-device-bundled": "node --enable-source-maps dist/cjs/examples/DeviceNode.js"
     },
     "bin": {
         "matter-device": "./dist/cjs/examples/DeviceNode.js",


### PR DESCRIPTION
Includes example scripts and updates to "Installing" section of README.md.

FWIW bundle is 2.1 MB with a 6.5 MB sourcemap.