### PR TITLE
MatterServer enhancements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,13 +20,15 @@ The main work (all changes without a GitHub username in brackets in the below li
   * Feature: Added detection of missing Subscription updates from a device and allow to react to such a timeout with callback
   * Feature: Added generation method for random passcodes to PaseClient
   * Feature: Generalized Discovery logic and allow discoveries via different methods (BLE+IP) in parallel
+  * Feature: Added functionality to clear session contexts including data in sub-contexts or not
 * matter.js API:
   * Breaking: Restructure the CommissioningController to allow pairing with multiple nodes
-    * Adjust some property and structure namings to be more consistent
+    * Adjusts some property and structure namings to be more consistent
     * Introducing class PairedNode with the High level API for a paired Node
-    * Restructure CommissioningController to handle multiple nodes and offer new high level API
-    * Change name of the unique storage id for servers or controllers added to MatterServer to "uniqueStorageKey"
-  * Feature: Make Port for CommissioningServer optional and add automatic port handling in MatterServer
+    * Restructured CommissioningController to handle multiple nodes and offer new high level API
+    * Changed name of the unique storage id for servers or controllers added to MatterServer to "uniqueStorageKey"
+  * Feature: Makes Port for CommissioningServer optional and add automatic port handling in MatterServer
+  * Feature: Allows removal of Controller or Server instances from Matter server, optionally with deleting the storage
 * matter-node-shell.js
   * Feature: Completely refactored and enhances shell to support commissioning, identify and many more new commands. See Readme, try it
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ The main work (all changes without a GitHub username in brackets in the below li
     * Adjust some property and structure namings to be more consistent
     * Introducing class PairedNode with the High level API for a paired Node
     * Restructure CommissioningController to handle multiple nodes and offer new high level API
+    * Change name of the unique storage id for servers or controllers added to MatterServer to "uniqueStorageKey"
+  * Feature: Make Port for CommissioningServer optional and add automatic port handling in MatterServer
 * matter-node-shell.js
   * Feature: Completely refactored and enhances shell to support commissioning, identify and many more new commands. See Readme, try it
 

--- a/packages/matter-node-shell.js/src/MatterNode.ts
+++ b/packages/matter-node-shell.js/src/MatterNode.ts
@@ -25,7 +25,7 @@ export class MatterNode {
 
     constructor(private nodeNum: number) {}
 
-    async initialize() {
+    async initialize(resetStorage: boolean) {
         /**
          * Initialize the storage system.
          *
@@ -39,6 +39,9 @@ export class MatterNode {
         this.storageManager = new StorageManager(this.storage);
         await this.storageManager.initialize();
         this.storageContext = this.storageManager.createContext("Node");
+        if (resetStorage) {
+            this.storage.clearAll([]);
+        }
     }
 
     get Store() {

--- a/packages/matter-node-shell.js/src/app.ts
+++ b/packages/matter-node-shell.js/src/app.ts
@@ -67,15 +67,26 @@ async function main() {
                         choices: ["controller"],
                         default: "controller",
                         type: "string",
+                    })
+                    .options({
+                        ble: {
+                            description: "Enable BLE support",
+                            type: "boolean",
+                        },
+                        resetStorage: {
+                            description: "Reset storage of this node",
+                            default: false,
+                            type: "boolean",
+                        },
                     });
             },
             async argv => {
                 if (argv.help) return;
 
-                const { nodeNum, ble, nodeType } = argv;
+                const { nodeNum, ble, nodeType, resetStorage } = argv;
 
                 const theNode = new MatterNode(nodeNum);
-                await theNode.initialize();
+                await theNode.initialize(resetStorage);
                 const theShell = new Shell(theNode, PROMPT);
 
                 if (ble) {
@@ -94,12 +105,6 @@ async function main() {
                 theShell.start();
             },
         )
-        .options({
-            ble: {
-                description: "Enable BLE support",
-                type: "boolean",
-            },
-        })
         .version(false)
         .scriptName("shell");
     await yargsInstance.wrap(yargsInstance.terminalWidth()).parseAsync();

--- a/packages/matter-node-shell.js/src/app.ts
+++ b/packages/matter-node-shell.js/src/app.ts
@@ -73,7 +73,7 @@ async function main() {
                             description: "Enable BLE support",
                             type: "boolean",
                         },
-                        resetStorage: {
+                        "reset-storage": {
                             description: "Reset storage of this node",
                             default: false,
                             type: "boolean",

--- a/packages/matter-node-shell.js/src/shell/cmd_nodes.ts
+++ b/packages/matter-node-shell.js/src/shell/cmd_nodes.ts
@@ -19,7 +19,7 @@ import { MatterNode } from "../MatterNode";
 
 export default function commands(theNode: MatterNode) {
     return {
-        command: "nodes",
+        command: ["nodes", "node"],
         describe: "Manage nodes",
         builder: (yargs: Argv) =>
             yargs
@@ -62,7 +62,7 @@ export default function commands(theNode: MatterNode) {
                     "Log the Structure of one node",
                     yargs => {
                         return yargs.positional("node-id", {
-                            describe: "node id to log - if ommited the first node is logged.",
+                            describe: "node id to log - if omitted the first node is logged.",
                             default: undefined,
                             type: "string",
                         });

--- a/packages/matter-node.js/src/storage/StorageBackendDisk.ts
+++ b/packages/matter-node.js/src/storage/StorageBackendDisk.ts
@@ -75,11 +75,10 @@ export class StorageBackendDisk implements Storage {
     }
 
     clearAll(contexts: string[]): void {
-        if (!contexts.length) throw new StorageError("Context must not be empty!");
         const contextKey = contexts.join(".");
         if (contextKey.includes("..") || contextKey.startsWith(".") || contextKey.endsWith("."))
             throw new StorageError("Context must not contain dots!");
-        const startContextKey = `${contextKey}.`;
+        const startContextKey = contextKey.length ? `${contextKey}.` : "";
         for (const key of Object.keys(this.localStorage)) {
             if (key.startsWith(startContextKey)) {
                 this.localStorage.removeItem(key);

--- a/packages/matter-node.js/src/storage/StorageBackendDisk.ts
+++ b/packages/matter-node.js/src/storage/StorageBackendDisk.ts
@@ -57,4 +57,20 @@ export class StorageBackendDisk implements Storage {
         if (!contexts.length || !key.length) throw new StorageError("Context and key must not be empty strings!");
         this.localStorage.removeItem(this.buildStorageKey(contexts, key));
     }
+
+    /** Returns all keys of a storage context without keys of sub-contexts */
+    keys(contexts: string[]): string[] {
+        if (!contexts.length) throw new StorageError("Context must not be an empty string!");
+        const contextKey = contexts.join(".");
+        if (contextKey.includes("..") || contextKey.startsWith(".") || contextKey.endsWith("."))
+            throw new StorageError("Context must not contain dots!");
+        const keys = [];
+        const contextKeyStart = `${contextKey}.`;
+        for (const key of Object.keys(this.localStorage)) {
+            if (key.startsWith(contextKeyStart) && key.indexOf(".", contextKeyStart.length) === -1) {
+                keys.push(key.substring(contextKeyStart.length));
+            }
+        }
+        return keys;
+    }
 }

--- a/packages/matter-node.js/src/storage/StorageBackendDisk.ts
+++ b/packages/matter-node.js/src/storage/StorageBackendDisk.ts
@@ -73,4 +73,17 @@ export class StorageBackendDisk implements Storage {
         }
         return keys;
     }
+
+    clearAll(contexts: string[]): void {
+        if (!contexts.length) throw new StorageError("Context must not be empty!");
+        const contextKey = contexts.join(".");
+        if (contextKey.includes("..") || contextKey.startsWith(".") || contextKey.endsWith("."))
+            throw new StorageError("Context must not contain dots!");
+        const startContextKey = `${contextKey}.`;
+        for (const key of Object.keys(this.localStorage)) {
+            if (key.startsWith(startContextKey)) {
+                this.localStorage.removeItem(key);
+            }
+        }
+    }
 }

--- a/packages/matter-node.js/src/storage/StorageBackendDisk.ts
+++ b/packages/matter-node.js/src/storage/StorageBackendDisk.ts
@@ -28,42 +28,43 @@ export class StorageBackendDisk implements Storage {
         this.localStorage.clear();
     }
 
-    buildStorageKey(contexts: string[], key: string): string {
+    getContextBaseKey(contexts: string[], allowEmptyContext = false): string {
         const contextKey = contexts.join(".");
         if (
-            !key.length ||
-            !contextKey.length ||
+            (!contextKey.length && !allowEmptyContext) ||
             contextKey.includes("..") ||
             contextKey.startsWith(".") ||
             contextKey.endsWith(".")
         )
-            throw new StorageError("Context must not be an empty string!");
+            throw new StorageError("Context must not be an empty and not contain dots.");
+        return contextKey;
+    }
+
+    buildStorageKey(contexts: string[], key: string): string {
+        if (!key.length) {
+            throw new StorageError("Key must not be an empty string.");
+        }
+        const contextKey = this.getContextBaseKey(contexts);
         return `${contextKey}.${key}`;
     }
 
     get<T extends SupportedStorageTypes>(contexts: string[], key: string): T | undefined {
-        if (!contexts.length || !key.length) throw new StorageError("Context and key must not be empty strings!");
         const value = this.localStorage.getItem(this.buildStorageKey(contexts, key));
         if (value === null) return undefined;
         return fromJson(value) as T;
     }
 
     set<T extends SupportedStorageTypes>(contexts: string[], key: string, value: T): void {
-        if (!contexts.length || !key.length) throw new StorageError("Context and key must not be empty strings!");
         this.localStorage.setItem(this.buildStorageKey(contexts, key), toJson(value));
     }
 
     delete(contexts: string[], key: string): void {
-        if (!contexts.length || !key.length) throw new StorageError("Context and key must not be empty strings!");
         this.localStorage.removeItem(this.buildStorageKey(contexts, key));
     }
 
     /** Returns all keys of a storage context without keys of sub-contexts */
     keys(contexts: string[]): string[] {
-        if (!contexts.length) throw new StorageError("Context must not be an empty string!");
-        const contextKey = contexts.join(".");
-        if (contextKey.includes("..") || contextKey.startsWith(".") || contextKey.endsWith("."))
-            throw new StorageError("Context must not contain dots!");
+        const contextKey = this.getContextBaseKey(contexts);
         const keys = [];
         const contextKeyStart = `${contextKey}.`;
         for (const key of Object.keys(this.localStorage)) {
@@ -75,9 +76,7 @@ export class StorageBackendDisk implements Storage {
     }
 
     clearAll(contexts: string[]): void {
-        const contextKey = contexts.join(".");
-        if (contextKey.includes("..") || contextKey.startsWith(".") || contextKey.endsWith("."))
-            throw new StorageError("Context must not contain dots!");
+        const contextKey = this.getContextBaseKey(contexts, true);
         const startContextKey = contextKey.length ? `${contextKey}.` : "";
         for (const key of Object.keys(this.localStorage)) {
             if (key.startsWith(startContextKey)) {

--- a/packages/matter-node.js/test/IntegrationTest.ts
+++ b/packages/matter-node.js/test/IntegrationTest.ts
@@ -117,7 +117,6 @@ describe("Integration Test", () => {
         matterServer = new MatterServer(serverStorageManager, { disableIpv4: true });
 
         commissioningServer = new CommissioningServer({
-            port: matterPort,
             listeningAddressIpv6: SERVER_IPv6,
             deviceName,
             deviceType,
@@ -135,6 +134,7 @@ describe("Integration Test", () => {
             },
             delayedAnnouncement: true, // delay because we need to override Mdns classes
         });
+        assert.equal(commissioningServer.getPort(), undefined);
 
         onOffLightDeviceServer = new OnOffLightDevice();
         commissioningServer.addDevice(onOffLightDeviceServer);
@@ -188,6 +188,7 @@ describe("Integration Test", () => {
         );
 
         matterServer.addCommissioningServer(commissioningServer);
+        assert.equal(commissioningServer.getPort(), matterPort);
 
         // override the mdns scanner to avoid the client to try to resolve the server's address
         serverMdnsScanner = await MdnsScanner.create({ enableIpv4: false, netInterface: SERVER_IPv6 });
@@ -1128,7 +1129,6 @@ describe("Integration Test", () => {
             Network.get = () => serverNetwork;
 
             commissioningServer2 = new CommissioningServer({
-                port: matterPort2,
                 listeningAddressIpv6: SERVER_IPv6,
                 deviceName: `${deviceName} 2`,
                 deviceType,
@@ -1150,9 +1150,11 @@ describe("Integration Test", () => {
             onOffLightDeviceServer = new OnOffLightDevice();
             commissioningServer2.addDevice(onOffLightDeviceServer);
 
+            matterServer.addCommissioningServer(commissioningServer2, { uniqueStorageKey: "second" });
+            assert.equal(commissioningServer2.getPort(), matterPort2);
+
             commissioningServer2.setMdnsScanner(serverMdnsScanner);
             commissioningServer2.setMdnsBroadcaster(mdnsBroadcaster);
-            matterServer.addCommissioningServer(commissioningServer2);
 
             await assert.doesNotReject(async () => commissioningServer2.advertise());
         });
@@ -1326,7 +1328,7 @@ describe("Integration Test", () => {
                 adminFabricIndex: FabricIndex(1001),
                 adminVendorId: VendorId(0x1234),
             });
-            matterClient.addCommissioningController(commissioningController2);
+            matterClient.addCommissioningController(commissioningController2, { uniqueStorageKey: "another-second" });
             commissioningController2.setMdnsScanner(clientMdnsScanner);
 
             Network.get = () => serverNetwork;
@@ -1376,7 +1378,7 @@ describe("Integration Test", () => {
             assert.equal(storedControllerResumptionRecords.length, 2);
 
             const storedControllerResumptionRecords2 = fakeServerStorage.get(
-                ["1", "SessionManager"],
+                ["second", "SessionManager"],
                 "resumptionRecords",
             );
             assert.ok(Array.isArray(storedControllerResumptionRecords2));
@@ -1403,7 +1405,7 @@ describe("Integration Test", () => {
             });
 
             const nodeData2 = fakeControllerStorage.get<[NodeId, any][]>(
-                ["1", "MatterController"],
+                ["another-second", "MatterController"],
                 "commissionedNodes",
             );
             assert.ok(nodeData2);
@@ -1417,7 +1419,7 @@ describe("Integration Test", () => {
             });
 
             const storedControllerFabrics = fakeControllerStorage.get<FabricJsonObject>(
-                ["1", "MatterController"],
+                ["another-second", "MatterController"],
                 "fabric",
             );
             assert.ok(typeof storedControllerFabrics === "object");
@@ -1470,7 +1472,7 @@ describe("Integration Test", () => {
             assert.equal(result.statusCode, OperationalCredentials.NodeOperationalCertStatus.Ok);
             assert.deepEqual(result.fabricIndex, fabricIndex);
 
-            // For next test we need to use the read Time implementation
+            // For next test we need to use the real Time implementation
             const mockTimeInstance = Time.get();
             Time.get = singleton(() => new TimeNode());
 
@@ -1505,29 +1507,15 @@ describe("Integration Test", () => {
     });
 
     after(async () => {
-        const promise = mdnsBroadcaster.expireAllAnnouncements(matterPort);
-
-        await MockTime.yield();
-        await MockTime.yield();
-        await MockTime.yield();
-        await MockTime.yield();
-        await MockTime.advance(150);
-        await MockTime.advance(150);
-        await MockTime.yield();
-
-        await MockTime.yield();
-        await MockTime.yield();
-        await MockTime.yield();
-        await MockTime.yield();
-        await MockTime.advance(150);
-        await MockTime.advance(150);
-        await MockTime.yield();
-
-        await promise;
+        // For closing all down we need to use the real Time implementation
+        const mockTimeInstance = Time.get();
+        Time.get = singleton(() => new TimeNode());
 
         await matterServer.close();
         await matterClient.close();
         await fakeControllerStorage.close();
         await fakeServerStorage.close();
+
+        Time.get = () => mockTimeInstance;
     });
 });

--- a/packages/matter-node.js/test/storage/StorageBackendDiskTest.ts
+++ b/packages/matter-node.js/test/storage/StorageBackendDiskTest.ts
@@ -83,6 +83,19 @@ describe("Storage node-localstorage", () => {
         expect(value).deep.equal(["key"]);
     });
 
+    it("clear all keys with multiple contextes", () => {
+        const storage = new StorageBackendDisk(TEST_STORAGE_LOCATION);
+
+        storage.set(["context"], "key1", "value");
+        storage.set(["context", "subcontext"], "key2", "value");
+        storage.set(["context", "subcontext", "subsubcontext"], "key3", "value");
+
+        storage.clearAll(["context", "subcontext"]);
+        expect(storage.keys(["context"])).deep.equal(["key1"]);
+        expect(storage.keys(["context", "subcontext"])).deep.equal([]);
+        expect(storage.keys(["context", "subcontext", "subsubcontext"])).deep.equal([]);
+    });
+
     it("Throws error when context is empty on set", () => {
         assert.throws(
             () => {

--- a/packages/matter-node.js/test/storage/StorageBackendDiskTest.ts
+++ b/packages/matter-node.js/test/storage/StorageBackendDiskTest.ts
@@ -103,7 +103,7 @@ describe("Storage node-localstorage", () => {
                 storage.set([""], "key", "value");
             },
             {
-                message: "Context must not be an empty string!",
+                message: "Context must not be an empty and not contain dots.",
             },
         );
     });
@@ -115,7 +115,7 @@ describe("Storage node-localstorage", () => {
                 storage.set(["context"], "", "value");
             },
             {
-                message: "Context and key must not be empty strings!",
+                message: "Key must not be an empty string.",
             },
         );
     });
@@ -127,7 +127,7 @@ describe("Storage node-localstorage", () => {
                 storage.get([""], "key");
             },
             {
-                message: "Context must not be an empty string!",
+                message: "Context must not be an empty and not contain dots.",
             },
         );
     });
@@ -139,7 +139,7 @@ describe("Storage node-localstorage", () => {
                 storage.get(["ok", ""], "key");
             },
             {
-                message: "Context must not be an empty string!",
+                message: "Context must not be an empty and not contain dots.",
             },
         );
     });
@@ -151,7 +151,7 @@ describe("Storage node-localstorage", () => {
                 storage.get(["context"], "");
             },
             {
-                message: "Context and key must not be empty strings!",
+                message: "Key must not be an empty string.",
             },
         );
     });

--- a/packages/matter-node.js/test/storage/StorageBackendDiskTest.ts
+++ b/packages/matter-node.js/test/storage/StorageBackendDiskTest.ts
@@ -64,6 +64,25 @@ describe("Storage node-localstorage", () => {
         assert.equal(keyContent.toString(), `"value"`);
     });
 
+    it("return keys with storage values", () => {
+        const storage = new StorageBackendDisk(TEST_STORAGE_LOCATION);
+
+        storage.set(["context", "subcontext", "subsubcontext"], "key", "value");
+
+        const value = storage.keys(["context", "subcontext", "subsubcontext"]);
+        expect(value).deep.equal(["key"]);
+    });
+
+    it("return keys with storage without subcontexts values", () => {
+        const storage = new StorageBackendDisk(TEST_STORAGE_LOCATION);
+
+        storage.set(["context", "subcontext"], "key", "value");
+        storage.set(["context", "subcontext", "subsubcontext"], "key", "value");
+
+        const value = storage.keys(["context", "subcontext"]);
+        expect(value).deep.equal(["key"]);
+    });
+
     it("Throws error when context is empty on set", () => {
         assert.throws(
             () => {

--- a/packages/matter-node.js/test/storage/StorageBackendJsonFileTest.ts
+++ b/packages/matter-node.js/test/storage/StorageBackendJsonFileTest.ts
@@ -95,7 +95,7 @@ describe("Storage in JSON File", () => {
                 storage.set([""], "key", "value");
             },
             {
-                message: "Context must not be an empty string!",
+                message: "Context must not be an empty string.",
             },
         );
     });
@@ -107,7 +107,7 @@ describe("Storage in JSON File", () => {
                 storage.set(["context"], "", "value");
             },
             {
-                message: "Context and key must not be empty!",
+                message: "Context and key must not be empty.",
             },
         );
     });
@@ -119,7 +119,7 @@ describe("Storage in JSON File", () => {
                 storage.get([""], "key");
             },
             {
-                message: "Context must not be an empty string!",
+                message: "Context must not be an empty string.",
             },
         );
     });
@@ -131,7 +131,7 @@ describe("Storage in JSON File", () => {
                 storage.get(["context"], "");
             },
             {
-                message: "Context and key must not be empty!",
+                message: "Context and key must not be empty.",
             },
         );
     });

--- a/packages/matter.js/src/CommissioningController.ts
+++ b/packages/matter.js/src/CommissioningController.ts
@@ -33,13 +33,16 @@ const logger = new Logger("CommissioningController");
  * Constructor options for the CommissioningController class
  */
 export type CommissioningControllerOptions = CommissioningControllerNodeOptions & {
-    /** Local port number to use for the UDP interface. By default a random port number will be generated. */
+    /**
+     * Local port number to use for the UDP interface. By default, a random port number will be generated
+     * (strongly recommended!).
+     */
     readonly localPort?: number;
 
-    /** Listening address for IPv4. By default the interface will listen on all IPv4 addresses. */
+    /** Listening address for IPv4. By default, the interface will listen on all IPv4 addresses. */
     readonly listeningAddressIpv4?: string;
 
-    /** Listening address for IPv6. By default the interface will listen on all IPv6 addresses. */
+    /** Listening address for IPv6. By default, the interface will listen on all IPv6 addresses. */
     readonly listeningAddressIpv6?: string;
 
     /**
@@ -122,7 +125,7 @@ export class CommissioningController extends MatterNode {
     /** Internal method to initialize a MatterController instance. */
     private async initializeController() {
         if (this.mdnsScanner === undefined || this.storage === undefined) {
-            throw new ImplementationError("Add the node to the Matter instance before!");
+            throw new ImplementationError("Add the node to the Matter instance before.");
         }
         if (this.controllerInstance !== undefined) {
             return this.controllerInstance;
@@ -153,10 +156,10 @@ export class CommissioningController extends MatterNode {
      */
     async commissionNode(nodeOptions: NodeCommissioningOptions) {
         if (this.mdnsScanner === undefined || this.storage === undefined) {
-            throw new ImplementationError("Add the node to the Matter instance before!");
+            throw new ImplementationError("Add the node to the Matter instance before.");
         }
         if (this.controllerInstance === undefined) {
-            throw new ImplementationError("Controller instance not yet started. Please call start() first!");
+            throw new ImplementationError("Controller instance not yet started. Please call start() first.");
         }
 
         const nodeId = await this.controllerInstance?.commission(nodeOptions);
@@ -173,7 +176,7 @@ export class CommissioningController extends MatterNode {
     /** Check if a given node id is commissioned on this controller. */
     isNodeCommissioned(nodeId: NodeId) {
         if (this.controllerInstance === undefined) {
-            throw new ImplementationError("Controller instance not yet started. Please call start() first!");
+            throw new ImplementationError("Controller instance not yet started. Please call start() first.");
         }
         return this.controllerInstance.getCommissionedNodes().includes(nodeId) ?? false;
     }
@@ -186,13 +189,13 @@ export class CommissioningController extends MatterNode {
      */
     async removeNode(nodeId: NodeId, tryDecommissioning = true) {
         if (this.controllerInstance === undefined) {
-            throw new ImplementationError("Controller instance not yet started. Please call start() first!");
+            throw new ImplementationError("Controller instance not yet started. Please call start() first.");
         }
         if (tryDecommissioning) {
             try {
                 const node = this.connectedNodes.get(nodeId);
                 if (node == undefined) {
-                    throw new ImplementationError(`Node ${nodeId} is not connected!`);
+                    throw new ImplementationError(`Node ${nodeId} is not connected.`);
                 }
                 await node.decommission();
             } catch (error) {
@@ -209,7 +212,7 @@ export class CommissioningController extends MatterNode {
      */
     async connectNode(nodeId: NodeId, connectOptions?: CommissioningControllerNodeOptions) {
         if (this.controllerInstance === undefined) {
-            throw new ImplementationError("Controller instance not yet started. Please call start() first!");
+            throw new ImplementationError("Controller instance not yet started. Please call start() first.");
         }
 
         if (!this.controllerInstance.getCommissionedNodes().includes(nodeId)) {
@@ -238,12 +241,12 @@ export class CommissioningController extends MatterNode {
      */
     async connect() {
         if (this.controllerInstance === undefined) {
-            throw new ImplementationError("Controller instance not yet started. Please call start() first!");
+            throw new ImplementationError("Controller instance not yet started. Please call start() first.");
         }
 
         if (!this.controllerInstance.isCommissioned()) {
             throw new ImplementationError(
-                "Controller instance not yet paired with any device, so nothing to connect to!",
+                "Controller instance not yet paired with any device, so nothing to connect to.",
             );
         }
 
@@ -283,7 +286,7 @@ export class CommissioningController extends MatterNode {
     /** Returns true if t least one node is commissioned/paired with this controller instance. */
     isCommissioned() {
         if (this.controllerInstance === undefined) {
-            throw new ImplementationError("Controller instance not yet started. Please call start() first!");
+            throw new ImplementationError("Controller instance not yet started. Please call start() first.");
         }
 
         return this.controllerInstance.isCommissioned();
@@ -295,7 +298,7 @@ export class CommissioningController extends MatterNode {
      */
     async createInteractionClient(nodeId: NodeId): Promise<InteractionClient> {
         if (this.controllerInstance === undefined) {
-            throw new ImplementationError("Controller instance not yet started. Please call start() first!");
+            throw new ImplementationError("Controller instance not yet started. Please call start() first.");
         }
         return this.controllerInstance.connect(nodeId);
     }
@@ -308,7 +311,7 @@ export class CommissioningController extends MatterNode {
     /** Returns an array with the Node Ids for all commissioned nodes. */
     getCommissionedNodes() {
         if (this.controllerInstance === undefined) {
-            throw new ImplementationError("Controller instance not yet started. Please call start() first!");
+            throw new ImplementationError("Controller instance not yet started. Please call start() first.");
         }
 
         return this.controllerInstance.getCommissionedNodes() ?? [];
@@ -321,8 +324,8 @@ export class CommissioningController extends MatterNode {
         this.connectedNodes.clear();
     }
 
-    getPort() {
-        return undefined; // TODO Add later if UDC is used
+    getPort(): number | undefined {
+        return this.options.localPort;
     }
 
     /** Initialize the controller and connect to all commissioned nodes if autoConnect is not set to false. */

--- a/packages/matter.js/src/CommissioningController.ts
+++ b/packages/matter.js/src/CommissioningController.ts
@@ -338,6 +338,20 @@ export class CommissioningController extends MatterNode {
         }
     }
 
+    resetStorage() {
+        if (this.controllerInstance !== undefined) {
+            throw new ImplementationError(
+                "Storage can not be reset while the controller is operating! Please close the controller first.",
+            );
+        }
+        if (this.storage === undefined) {
+            throw new ImplementationError(
+                "Storage not initialized. The instance was not added to a Matter instance yet.",
+            );
+        }
+        this.storage.clearAll();
+    }
+
     /** Returns active session information for all connected nodes. */
     getActiveSessionInformation() {
         return this.controllerInstance?.getActiveSessionInformation() ?? [];

--- a/packages/matter.js/src/CommissioningServer.ts
+++ b/packages/matter.js/src/CommissioningServer.ts
@@ -820,7 +820,23 @@ export class CommissioningServer extends MatterNode {
     async close() {
         this.rootEndpoint.getClusterServer(BasicInformationCluster)?.triggerShutDownEvent?.();
         await this.interactionServer?.close();
+        this.interactionServer = undefined;
         await this.deviceInstance?.stop();
+        this.deviceInstance = undefined;
+    }
+
+    resetStorage() {
+        if (this.interactionServer !== undefined || this.deviceInstance !== undefined) {
+            throw new ImplementationError(
+                "Storage can not be reset after while the device is operating! Please close the server first.",
+            );
+        }
+        if (this.storage === undefined) {
+            throw new ImplementationError(
+                "Storage not initialized. The instance was not added to a Matter instance yet.",
+            );
+        }
+        this.storage.clear();
     }
 
     /**

--- a/packages/matter.js/src/storage/Storage.ts
+++ b/packages/matter.js/src/storage/Storage.ts
@@ -15,4 +15,5 @@ export abstract class Storage {
     abstract set<T extends SupportedStorageTypes>(contexts: string[], key: string, value: T): void;
     abstract delete(contexts: string[], key: string): void;
     abstract keys(contexts: string[]): string[];
+    abstract clearAll(contexts: string[]): void;
 }

--- a/packages/matter.js/src/storage/Storage.ts
+++ b/packages/matter.js/src/storage/Storage.ts
@@ -14,4 +14,5 @@ export abstract class Storage {
     abstract get<T extends SupportedStorageTypes>(contexts: string[], key: string): T | undefined;
     abstract set<T extends SupportedStorageTypes>(contexts: string[], key: string, value: T): void;
     abstract delete(contexts: string[], key: string): void;
+    abstract keys(contexts: string[]): string[];
 }

--- a/packages/matter.js/src/storage/StorageBackendMemory.ts
+++ b/packages/matter.js/src/storage/StorageBackendMemory.ts
@@ -52,4 +52,16 @@ export class StorageBackendMemory implements Storage {
         if (!contexts.length) throw new StorageError("Context must not be empty!");
         return Object.keys(this.store[this.createContextKey(contexts)] ?? {});
     }
+
+    clearAll(contexts: string[]): void {
+        if (!contexts.length) throw new StorageError("Context must not be empty!");
+        const contextKey = this.createContextKey(contexts);
+        delete this.store[contextKey];
+        const startContextKey = `${contextKey}.`;
+        Object.keys(this.store).forEach(key => {
+            if (key.startsWith(startContextKey)) {
+                delete this.store[key];
+            }
+        });
+    }
 }

--- a/packages/matter.js/src/storage/StorageBackendMemory.ts
+++ b/packages/matter.js/src/storage/StorageBackendMemory.ts
@@ -54,10 +54,11 @@ export class StorageBackendMemory implements Storage {
     }
 
     clearAll(contexts: string[]): void {
-        if (!contexts.length) throw new StorageError("Context must not be empty!");
         const contextKey = this.createContextKey(contexts);
-        delete this.store[contextKey];
-        const startContextKey = `${contextKey}.`;
+        if (contextKey.length) {
+            delete this.store[contextKey];
+        }
+        const startContextKey = contextKey.length ? `${contextKey}.` : "";
         Object.keys(this.store).forEach(key => {
             if (key.startsWith(startContextKey)) {
                 delete this.store[key];

--- a/packages/matter.js/src/storage/StorageBackendMemory.ts
+++ b/packages/matter.js/src/storage/StorageBackendMemory.ts
@@ -47,4 +47,9 @@ export class StorageBackendMemory implements Storage {
         if (!contexts.length || !key.length) throw new StorageError("Context and key must not be empty!");
         delete this.store[this.createContextKey(contexts)]?.[key];
     }
+
+    keys(contexts: string[]): string[] {
+        if (!contexts.length) throw new StorageError("Context must not be empty!");
+        return Object.keys(this.store[this.createContextKey(contexts)] ?? {});
+    }
 }

--- a/packages/matter.js/src/storage/StorageBackendMemory.ts
+++ b/packages/matter.js/src/storage/StorageBackendMemory.ts
@@ -13,7 +13,7 @@ export class StorageBackendMemory implements Storage {
     private createContextKey(contexts: string[]) {
         const key = contexts.join(".");
         if (!key.length || key.includes("..") || key.startsWith(".") || key.endsWith("."))
-            throw new StorageError("Context must not be an empty string!");
+            throw new StorageError("Context must not be an empty string.");
         return key;
     }
 
@@ -30,12 +30,12 @@ export class StorageBackendMemory implements Storage {
     }
 
     get<T extends SupportedStorageTypes>(contexts: string[], key: string): T | undefined {
-        if (!contexts.length || !key.length) throw new StorageError("Context and key must not be empty!");
+        if (!contexts.length || !key.length) throw new StorageError("Context and key must not be empty.");
         return this.store[this.createContextKey(contexts)]?.[key];
     }
 
     set<T extends SupportedStorageTypes>(contexts: string[], key: string, value: T): void {
-        if (!contexts.length || !key.length) throw new StorageError("Context and key must not be empty!");
+        if (!contexts.length || !key.length) throw new StorageError("Context and key must not be empty.");
         const contextKey = this.createContextKey(contexts);
         if (this.store[contextKey] === undefined) {
             this.store[contextKey] = {};
@@ -44,7 +44,7 @@ export class StorageBackendMemory implements Storage {
     }
 
     delete(contexts: string[], key: string): void {
-        if (!contexts.length || !key.length) throw new StorageError("Context and key must not be empty!");
+        if (!contexts.length || !key.length) throw new StorageError("Context and key must not be empty.");
         delete this.store[this.createContextKey(contexts)]?.[key];
     }
 

--- a/packages/matter.js/src/storage/StorageContext.ts
+++ b/packages/matter.js/src/storage/StorageContext.ts
@@ -8,8 +8,6 @@ import { Storage, StorageError } from "./Storage.js";
 import { SupportedStorageTypes } from "./StringifyTools.js";
 
 export class StorageContext {
-    private readonly existingContexts = new Map<string, StorageContext>();
-
     constructor(
         private readonly storage: Storage,
         private readonly contexts: string[],
@@ -41,10 +39,7 @@ export class StorageContext {
     createContext(context: string) {
         if (context.length === 0) throw new StorageError("Context must not be an empty string");
         if (context.includes(".")) throw new StorageError("Context must not contain dots!");
-        const contextInstance =
-            this.existingContexts.get(context) ?? new StorageContext(this.storage, [...this.contexts, context]);
-        this.existingContexts.set(context, contextInstance);
-        return contextInstance;
+        return new StorageContext(this.storage, [...this.contexts, context]);
     }
 
     keys(): string[] {
@@ -60,9 +55,6 @@ export class StorageContext {
 
     /** Clears all keys in this context and all created sub-contexts. */
     clearAll(): void {
-        this.clear();
-        for (const context of this.existingContexts.values()) {
-            context.clearAll();
-        }
+        this.storage.clearAll(this.contexts);
     }
 }

--- a/packages/matter.js/test/storage/StorageBackendMemoryTest.ts
+++ b/packages/matter.js/test/storage/StorageBackendMemoryTest.ts
@@ -36,6 +36,25 @@ describe("StorageBackendMemory", () => {
         expect(value).equal("value");
     });
 
+    it("return keys with storage values", () => {
+        const storage = new StorageBackendMemory();
+
+        storage.set(["context", "subcontext", "subsubcontext"], "key", "value");
+
+        const value = storage.keys(["context", "subcontext", "subsubcontext"]);
+        expect(value).deep.equal(["key"]);
+    });
+
+    it("return keys with storage without subcontexts values", () => {
+        const storage = new StorageBackendMemory();
+
+        storage.set(["context", "subcontext"], "key", "value");
+        storage.set(["context", "subcontext", "subsubcontext"], "key", "value");
+
+        const value = storage.keys(["context", "subcontext"]);
+        expect(value).deep.equal(["key"]);
+    });
+
     it("Throws error when context is empty on set", () => {
         expect(() => {
             const storage = new StorageBackendMemory();

--- a/packages/matter.js/test/storage/StorageBackendMemoryTest.ts
+++ b/packages/matter.js/test/storage/StorageBackendMemoryTest.ts
@@ -45,6 +45,19 @@ describe("StorageBackendMemory", () => {
         expect(value).deep.equal(["key"]);
     });
 
+    it("clear all keys with multiple contextes", () => {
+        const storage = new StorageBackendMemory();
+
+        storage.set(["context"], "key1", "value");
+        storage.set(["context", "subcontext"], "key2", "value");
+        storage.set(["context", "subcontext", "subsubcontext"], "key3", "value");
+
+        storage.clearAll(["context", "subcontext"]);
+        expect(storage.keys(["context"])).deep.equal(["key1"]);
+        expect(storage.keys(["context", "subcontext"])).deep.equal([]);
+        expect(storage.keys(["context", "subcontext", "subsubcontext"])).deep.equal([]);
+    });
+
     it("return keys with storage without subcontexts values", () => {
         const storage = new StorageBackendMemory();
 

--- a/packages/matter.js/test/storage/StorageBackendMemoryTest.ts
+++ b/packages/matter.js/test/storage/StorageBackendMemoryTest.ts
@@ -72,34 +72,34 @@ describe("StorageBackendMemory", () => {
         expect(() => {
             const storage = new StorageBackendMemory();
             storage.set([], "key", "value");
-        }).throw(StorageError, "Context and key must not be empty!");
+        }).throw(StorageError, "Context and key must not be empty.");
     });
 
     it("Throws error when context is empty on set", () => {
         expect(() => {
             const storage = new StorageBackendMemory();
             storage.set([""], "key", "value");
-        }).throw(StorageError, "Context must not be an empty string!");
+        }).throw(StorageError, "Context must not be an empty string.");
     });
 
     it("Throws error when key is empty on set", () => {
         expect(() => {
             const storage = new StorageBackendMemory();
             storage.set(["context"], "", "value");
-        }).throw(StorageError, "Context and key must not be empty!");
+        }).throw(StorageError, "Context and key must not be empty.");
     });
 
     it("Throws error when context is empty on get with subcontext", () => {
         expect(() => {
             const storage = new StorageBackendMemory();
             storage.get(["ok", ""], "key");
-        }).throw(StorageError, "Context must not be an empty string!");
+        }).throw(StorageError, "Context must not be an empty string.");
     });
 
     it("Throws error when key is empty on get", () => {
         expect(() => {
             const storage = new StorageBackendMemory();
             storage.get(["context", "subcontext"], "");
-        }).throw(StorageError, "Context and key must not be empty!");
+        }).throw(StorageError, "Context and key must not be empty.");
     });
 });

--- a/packages/matter.js/test/storage/StorageContextTest.ts
+++ b/packages/matter.js/test/storage/StorageContextTest.ts
@@ -176,4 +176,79 @@ describe("StorageContext", () => {
         const valueFromStorage2 = storageContext.get("subcontext");
         expect(valueFromStorage2).equal("value2");
     });
+
+    it("getting all keys in a context works", () => {
+        const storage = new StorageBackendMemory();
+
+        const storageContext = new StorageContext(storage, ["context", "subcontext", "subsubcontext"]);
+
+        storageContext.set("key", "value");
+        storageContext.set("key2", "value2");
+        storageContext.set("key3", "value3");
+        storageContext.set("key4", "value4");
+
+        const result = storageContext.keys();
+
+        expect(result).deep.equal(["key", "key2", "key3", "key4"]);
+    });
+
+    it("getting all keys in a context works also with sub contexts", () => {
+        const storage = new StorageBackendMemory();
+
+        const storageContext = new StorageContext(storage, ["context", "subcontext"]);
+
+        storageContext.set("key", "value");
+        storageContext.set("key2", "value2");
+        storageContext.set("key3", "value3");
+        storageContext.set("key4", "value4");
+
+        const storageContext2 = new StorageContext(storage, ["context", "subcontext", "subsubcontext"]);
+
+        storageContext2.set("subkey", "value");
+
+        const result = storageContext.keys();
+
+        expect(result).deep.equal(["key", "key2", "key3", "key4"]);
+    });
+
+    it("clearing keys in a context works", () => {
+        const storage = new StorageBackendMemory();
+
+        const storageContext = new StorageContext(storage, ["context", "subcontext", "subsubcontext"]);
+
+        storageContext.set("key", "value");
+        storageContext.set("key2", "value2");
+        storageContext.set("key3", "value3");
+        storageContext.set("key4", "value4");
+
+        storageContext.clear();
+
+        expect(storageContext.has("key")).equal(false);
+        expect(storageContext.has("ke2")).equal(false);
+        expect(storageContext.has("key3")).equal(false);
+        expect(storageContext.has("key4")).equal(false);
+    });
+
+    it("clearing all keys in a context with subcontext works", () => {
+        const storage = new StorageBackendMemory();
+
+        const storageContext = new StorageContext(storage, ["context", "subcontext"]);
+
+        storageContext.set("key", "value");
+        storageContext.set("key2", "value2");
+        storageContext.set("key3", "value3");
+        storageContext.set("key4", "value4");
+
+        const subContext = storageContext.createContext("subsubcontext");
+
+        subContext.set("subkey", "value");
+
+        storageContext.clearAll();
+
+        expect(storageContext.has("key")).equal(false);
+        expect(storageContext.has("ke2")).equal(false);
+        expect(storageContext.has("key3")).equal(false);
+        expect(storageContext.has("key4")).equal(false);
+        expect(subContext.has("subkey")).equal(false);
+    });
 });


### PR DESCRIPTION
This PR is changing the following:
* Ports for Commissioningservers are now handled automaticaly if wanted and generating port numbers starting 5540 and increasing. Own ports can still be provided and are used if not conflicting
* Add property "uniqueStorageKey" to the addCommissioningServer and addCommissioningController methods to allow to specify a unique storage key
* Allow to remove Server and Controllers from MatterServer instance, including with the option to kill the storage