### PR TITLE
Enable preserveConstEnums for tsc

### DIFF
--- a/tools/tsconfig.base.json
+++ b/tools/tsconfig.base.json
@@ -22,6 +22,9 @@
         // Do not load globals from node_modules by default
         "types": [],
 
+        // Preserve const enums with tsc (esbuild does this by default)
+        "preserveConstEnums": true,
+
         // Emit source/declaration maps to align the behavior of esbuild setup.
         "sourceMap": true,
         "declarationMap": true,


### PR DESCRIPTION
When compile with `tsc`, `const enum`s are omitted by default (which cause error with the `tsc --build` workflow).