### PR TITLE
Only run the nightly tests on the main repo not on local forks

### DIFF
--- a/.github/workflows/auto-approve-releases.yml
+++ b/.github/workflows/auto-approve-releases.yml
@@ -10,8 +10,8 @@ jobs:
   auto-approve:
     if: |
       github.actor == 'Automator77' &&
-      github.event.label.name == 'automated pr'
-
+      github.event.label.name == 'automated pr' &&
+      github.repository == 'project-chip/matter.js'  
     runs-on: ubuntu-latest
     steps:
       - uses: hmarr/auto-approve-action@v3

--- a/.github/workflows/chip-tool-tests.yml
+++ b/.github/workflows/chip-tool-tests.yml
@@ -19,6 +19,7 @@ concurrency:
 jobs:
   # Find out what is needed to be done by this test workflow
   chip-tests-needed:
+    if: github.repository == 'project-chip/matter.js'  
     runs-on: ubuntu-latest
     outputs:
       chip-changes: ${{ steps.changes.outputs.src }}
@@ -73,6 +74,7 @@ jobs:
 
   # If we need to do anything make sure that chip binaries are build and environment can be set up
   prepare-chip-build:
+    if: github.repository == 'project-chip/matter.js' 
     needs: [chip-tests-needed]
     if: ${{ needs.chip-tests-needed.outputs.chip-tool-rebuild == 'true' || needs.chip-tests-needed.outputs.chip-tests-required == 'true' || needs.chip-tests-needed.outputs.chip-changes == 'true' || needs.chip-tests-needed.outputs.chip-long-tests-required == 'true' }}
     runs-on: ubuntu-latest
@@ -88,6 +90,7 @@ jobs:
 
   # Execute the normal tests
   chip-tests:
+    if: github.repository == 'project-chip/matter.js' 
     needs: [prepare-chip-build]
     if: ${{ needs.chip-tests-needed.outputs.chip-tool-rebuild == 'true' || needs.chip-tests-needed.outputs.chip-tests-required == 'true' || needs.chip-tests-needed.outputs.chip-changes == 'true' || needs.chip-tests-needed.outputs.chip-long-tests-required == 'true' }}
     runs-on: ubuntu-latest
@@ -109,6 +112,7 @@ jobs:
 
   # Execute the long running tests (if needed)
   chip-tests-long:
+    if: github.repository == 'project-chip/matter.js' 
     needs: [prepare-chip-build]
     if: ${{ needs.chip-tests-needed.outputs.chip-long-tests-required == 'true' }}
     runs-on: ubuntu-latest

--- a/.github/workflows/chip-tool-tests.yml
+++ b/.github/workflows/chip-tool-tests.yml
@@ -74,9 +74,8 @@ jobs:
 
   # If we need to do anything make sure that chip binaries are build and environment can be set up
   prepare-chip-build:
-    if: github.repository == 'project-chip/matter.js' 
     needs: [chip-tests-needed]
-    if: ${{ needs.chip-tests-needed.outputs.chip-tool-rebuild == 'true' || needs.chip-tests-needed.outputs.chip-tests-required == 'true' || needs.chip-tests-needed.outputs.chip-changes == 'true' || needs.chip-tests-needed.outputs.chip-long-tests-required == 'true' }}
+    if: ${{ github.repository == 'project-chip/matter.js' && (needs.chip-tests-needed.outputs.chip-tool-rebuild == 'true' || needs.chip-tests-needed.outputs.chip-tests-required == 'true' || needs.chip-tests-needed.outputs.chip-changes == 'true' || needs.chip-tests-needed.outputs.chip-long-tests-required == 'true') }}
     runs-on: ubuntu-latest
     steps:
       - name: Check out matter.js
@@ -90,9 +89,8 @@ jobs:
 
   # Execute the normal tests
   chip-tests:
-    if: github.repository == 'project-chip/matter.js' 
     needs: [prepare-chip-build]
-    if: ${{ needs.chip-tests-needed.outputs.chip-tool-rebuild == 'true' || needs.chip-tests-needed.outputs.chip-tests-required == 'true' || needs.chip-tests-needed.outputs.chip-changes == 'true' || needs.chip-tests-needed.outputs.chip-long-tests-required == 'true' }}
+    if: ${{ github.repository == 'project-chip/matter.js' && (needs.chip-tests-needed.outputs.chip-tool-rebuild == 'true' || needs.chip-tests-needed.outputs.chip-tests-required == 'true' || needs.chip-tests-needed.outputs.chip-changes == 'true' || needs.chip-tests-needed.outputs.chip-long-tests-required == 'true') }}
     runs-on: ubuntu-latest
     steps:
       - name: Check out matter.js
@@ -112,9 +110,8 @@ jobs:
 
   # Execute the long running tests (if needed)
   chip-tests-long:
-    if: github.repository == 'project-chip/matter.js' 
     needs: [prepare-chip-build]
-    if: ${{ needs.chip-tests-needed.outputs.chip-long-tests-required == 'true' }}
+    if: ${{ github.repository == 'project-chip/matter.js' && needs.chip-tests-needed.outputs.chip-long-tests-required == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Check out matter.js

--- a/.github/workflows/nightly-dev-release.yml
+++ b/.github/workflows/nightly-dev-release.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   publish-config:
+    if: github.repository == 'project-chip/matter.js'  
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/official-release.yml
+++ b/.github/workflows/official-release.yml
@@ -16,6 +16,7 @@ on:
 
 jobs:
   publish-config:
+    if: github.repository == 'project-chip/matter.js' 
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -13,6 +13,7 @@ concurrency:
 
 jobs:
   check-and-lint:
+    if: github.repository == 'project-chip/matter.js' 
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -22,6 +23,7 @@ jobs:
       - run: npm run lint
 
   build-non-linux:
+    if: github.repository == 'project-chip/matter.js' 
     needs: [ check-and-lint ]
     runs-on: ${{ matrix.os }}
     strategy:
@@ -37,6 +39,7 @@ jobs:
           os: ${{ matrix.os }}
 
   test:
+    if: github.repository == 'project-chip/matter.js' 
     needs: [ check-and-lint ]
     runs-on: ubuntu-latest
     strategy:
@@ -56,7 +59,8 @@ jobs:
   auto-merge:
     if: |
       always() &&
-      github.event_name == 'pull_request'
+      github.event_name == 'pull_request' &&
+      github.repository == 'project-chip/matter.js'
     needs: [ test, build-non-linux, check-and-lint ]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
There are a couple of github actions that run on a nightly cron but if you have a fork of the repo these will likely fail.
This checks that the repo is project-chip/matter.js when then run and if not they will be skipped