### PR TITLE
WIP: Make examples ESM and add ESM to node-ble

### DIFF
--- a/packages/matter-node-ble.js/package.json
+++ b/packages/matter-node-ble.js/package.json
@@ -49,13 +49,25 @@
         "LICENSE",
         "README.md"
     ],
+    "type": "module",
     "main": "dist/cjs/ble/export.js",
     "types": "dist/cjs/ble/export.d.ts",
     "exports": {
         "./package.json": "./package.json",
         "./*": {
-            "types": "./dist/cjs/*/export.d.ts",
-            "default": "./dist/cjs/*/export.js"
+            "import": {
+                "types": "./dist/esm/*/export.d.ts",
+                "default": "./dist/esm/*/export.js"
+            },
+            "require": {
+                "types": "./dist/cjs/*/export.d.ts",
+                "default": "./dist/cjs/*/export.js"
+            }
+        },
+        "./require": {
+            "types": "./require/require.d.ts",
+            "import": "./require/require.mjs",
+            "require": "./require/require.cjs"
         }
     },
     "typesVersions": {

--- a/packages/matter-node-ble.js/require/package.json
+++ b/packages/matter-node-ble.js/require/package.json
@@ -1,0 +1,4 @@
+{
+    "main": "./require.cjs",
+    "module": "./require.mjs"
+}

--- a/packages/matter-node-ble.js/require/require.cjs
+++ b/packages/matter-node-ble.js/require/require.cjs
@@ -1,0 +1,1 @@
+exports.require = require;

--- a/packages/matter-node-ble.js/require/require.d.ts
+++ b/packages/matter-node-ble.js/require/require.d.ts
@@ -1,0 +1,1 @@
+export declare const require: NodeRequire;

--- a/packages/matter-node-ble.js/require/require.mjs
+++ b/packages/matter-node-ble.js/require/require.mjs
@@ -1,0 +1,3 @@
+import { createRequire } from "module";
+
+export const require = createRequire(import.meta.url);

--- a/packages/matter-node-ble.js/src/ble/BleBroadcaster.ts
+++ b/packages/matter-node-ble.js/src/ble/BleBroadcaster.ts
@@ -13,7 +13,7 @@ import {
 import { VendorId } from "@project-chip/matter.js/datatype";
 import { Logger } from "@project-chip/matter.js/log";
 import { ByteArray } from "@project-chip/matter.js/util";
-import { BlenoBleServer } from "./BlenoBleServer";
+import { BlenoBleServer } from "./BlenoBleServer.js";
 
 const logger = Logger.get("BleBroadcaster");
 

--- a/packages/matter-node-ble.js/src/ble/BleNode.ts
+++ b/packages/matter-node-ble.js/src/ble/BleNode.ts
@@ -8,12 +8,12 @@ import { Ble } from "@project-chip/matter.js/ble";
 import { InstanceBroadcaster, Scanner, TransportInterface } from "@project-chip/matter.js/common";
 import { NetInterface } from "@project-chip/matter.js/net";
 import { ByteArray } from "@project-chip/matter.js/util";
-import { BleBroadcaster } from "./BleBroadcaster";
-import { BlePeripheralInterface } from "./BlePeripheralInterface";
-import { BleScanner } from "./BleScanner";
-import { BlenoBleServer } from "./BlenoBleServer";
-import { NobleBleCentralInterface } from "./NobleBleChannel";
-import { NobleBleClient } from "./NobleBleClient";
+import { BleBroadcaster } from "./BleBroadcaster.js";
+import { BlePeripheralInterface } from "./BlePeripheralInterface.js";
+import { BleScanner } from "./BleScanner.js";
+import { BlenoBleServer } from "./BlenoBleServer.js";
+import { NobleBleCentralInterface } from "./NobleBleChannel.js";
+import { NobleBleClient } from "./NobleBleClient.js";
 
 export type BleOptions = {
     hciId?: number;

--- a/packages/matter-node-ble.js/src/ble/BlePeripheralInterface.ts
+++ b/packages/matter-node-ble.js/src/ble/BlePeripheralInterface.ts
@@ -6,7 +6,7 @@
 
 import { Channel, Listener, TransportInterface } from "@project-chip/matter.js/common";
 import { ByteArray } from "@project-chip/matter.js/util";
-import { BlenoBleServer } from "./BlenoBleServer";
+import { BlenoBleServer } from "./BlenoBleServer.js";
 
 export class BlePeripheralInterface implements TransportInterface {
     constructor(private readonly blenoServer: BlenoBleServer) {}

--- a/packages/matter-node-ble.js/src/ble/BleScanner.ts
+++ b/packages/matter-node-ble.js/src/ble/BleScanner.ts
@@ -17,7 +17,7 @@ import { VendorId } from "@project-chip/matter.js/datatype";
 import { Logger } from "@project-chip/matter.js/log";
 import { Time, Timer } from "@project-chip/matter.js/time";
 import { ByteArray, createPromise } from "@project-chip/matter.js/util";
-import { NobleBleClient } from "./NobleBleClient";
+import { NobleBleClient } from "./NobleBleClient.js";
 
 const logger = Logger.get("BleScanner");
 

--- a/packages/matter-node-ble.js/src/ble/BlenoBleServer.ts
+++ b/packages/matter-node-ble.js/src/ble/BlenoBleServer.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { require } from "@project-chip/matter-node-ble.js/require";
 import {
     BLE_MATTER_C1_CHARACTERISTIC_UUID,
     BLE_MATTER_C2_CHARACTERISTIC_UUID,
@@ -18,7 +19,7 @@ import { Channel, InternalError } from "@project-chip/matter.js/common";
 import { Logger } from "@project-chip/matter.js/log";
 import { Time } from "@project-chip/matter.js/time";
 import { ByteArray, createPromise } from "@project-chip/matter.js/util";
-import { BleOptions } from "./BleNode";
+import { BleOptions } from "./BleNode.js";
 
 const logger = Logger.get("BlenoBleServer");
 let Bleno: typeof import("@abandonware/bleno");

--- a/packages/matter-node-ble.js/src/ble/NobleBleChannel.ts
+++ b/packages/matter-node-ble.js/src/ble/NobleBleChannel.ts
@@ -25,7 +25,7 @@ import { Logger } from "@project-chip/matter.js/log";
 import { NetInterface } from "@project-chip/matter.js/net";
 import { Time } from "@project-chip/matter.js/time";
 import { ByteArray, createPromise } from "@project-chip/matter.js/util";
-import { BleScanner } from "./BleScanner";
+import { BleScanner } from "./BleScanner.js";
 
 const logger = Logger.get("BleChannel");
 

--- a/packages/matter-node-ble.js/src/ble/NobleBleClient.ts
+++ b/packages/matter-node-ble.js/src/ble/NobleBleClient.ts
@@ -5,10 +5,11 @@
  */
 
 import type { Peripheral } from "@abandonware/noble";
+import { require } from "@project-chip/matter-node-ble.js/require";
 import { BLE_MATTER_SERVICE_UUID } from "@project-chip/matter.js/ble";
 import { Logger } from "@project-chip/matter.js/log";
 import { ByteArray } from "@project-chip/matter.js/util";
-import { BleOptions } from "./BleNode";
+import { BleOptions } from "./BleNode.js";
 
 const logger = Logger.get("NobleBleClient");
 let noble: typeof import("@abandonware/noble");

--- a/packages/matter-node-ble.js/src/ble/export.ts
+++ b/packages/matter-node-ble.js/src/ble/export.ts
@@ -5,5 +5,5 @@
  */
 
 export * from "./BleBroadcaster.js";
-export * from "./BleNode";
-export * from "./BleScanner";
+export * from "./BleNode.js";
+export * from "./BleScanner.js";

--- a/packages/matter-node-ble.js/src/tsconfig.json
+++ b/packages/matter-node-ble.js/src/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "extends": "../../../tools/tsconfig.base.json",
     "compilerOptions": {
-        "outDir": "../dist/cjs",
+        "outDir": "../dist/esm",
         "types": ["node"]
     },
     "references": [{ "path": "../../matter.js/src" }],

--- a/packages/matter-node.js-examples/package.json
+++ b/packages/matter-node.js-examples/package.json
@@ -60,6 +60,7 @@
         "LICENSE",
         "README.md"
     ],
+    "type": "module",
     "publishConfig": {
         "access": "public"
     }

--- a/packages/matter-node.js-examples/src/tsconfig.json
+++ b/packages/matter-node.js-examples/src/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "extends": "../../../tools/tsconfig.base.json",
     "compilerOptions": {
-        "outDir": "../dist/cjs",
+        "outDir": "../dist/esm",
         "types": ["node"]
     },
     "references": [{ "path": "../../matter-node.js/src" }, { "path": "../../matter-node-ble.js/src" }]


### PR DESCRIPTION
- Changed package.json `type` for both `matter-node-ble.js` and `matter-node.js-examples` to `"module"`.
- Added missing `.js` file extension for `matter-node-ble.js`.
- Added `require` that works in both CJS and ESM using Node.js `package.json`. **Other better ways?**