### PR TITLE
Add Deployment Automation account to approver list

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -85,6 +85,7 @@ groups:
             users:
               - lauckhart
               - Apollon77
+              - Automator77
               - mfucci
               - Wes
             teams:


### PR DESCRIPTION
The Deploy and Nightly Deploy mechanism uses the user "Automator77" (my personal automation account). He also needs to be allowed to approve