### PR TITLE
Add correct approval user for deployment actions

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -86,6 +86,7 @@ groups:
               - lauckhart
               - Apollon77
               - Automator77
+              - github-actions
               - mfucci
               - Wes
             teams:


### PR DESCRIPTION
The approver for nightlies/official release actions is "github-actions" ... so add him too. see https://github.com/project-chip/matter.js/pull/442