### PR TITLE
Only run auto-Release when labeled as needed

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   check-and-lint:
-    if: github.repository == 'project-chip/matter.js' 
+    if: github.repository == 'project-chip/matter.js' && contains(github.event.pull_request.labels.*.name, 'automated pr')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -23,7 +23,7 @@ jobs:
       - run: npm run lint
 
   build-non-linux:
-    if: github.repository == 'project-chip/matter.js' 
+    if: github.repository == 'project-chip/matter.js' && contains(github.event.pull_request.labels.*.name, 'automated pr')
     needs: [ check-and-lint ]
     runs-on: ${{ matrix.os }}
     strategy:
@@ -39,7 +39,7 @@ jobs:
           os: ${{ matrix.os }}
 
   test:
-    if: github.repository == 'project-chip/matter.js' 
+    if: github.repository == 'project-chip/matter.js' && contains(github.event.pull_request.labels.*.name, 'automated pr')
     needs: [ check-and-lint ]
     runs-on: ubuntu-latest
     strategy:
@@ -60,7 +60,8 @@ jobs:
     if: |
       always() &&
       github.event_name == 'pull_request' &&
-      github.repository == 'project-chip/matter.js'
+      github.repository == 'project-chip/matter.js' &&
+      contains(github.event.pull_request.labels.*.name, 'automated pr')
     needs: [ test, build-non-linux, check-and-lint ]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
The "Automatic Labeled Release action" is running too often right now while we have more labels from pullapprove and such. So limit it's run a bit