### PR TITLE
Enhance Hight level APIs CLusterClient/ClusterServer and Devices

### DIFF
--- a/packages/matter-node.js/test/IntegrationTest.ts
+++ b/packages/matter-node.js/test/IntegrationTest.ts
@@ -980,8 +980,8 @@ describe("Integration Test", () => {
             }>();
             callback = (value: DecodedEventData<any>) => updateResolver({ value, time: Time.nowMs() });
 
-            await MockTime.advance(2 * 1000);
-            basicInformationServer.setReachableAttribute(false);
+            await MockTime.advance(200);
+            commissioningServer.setReachability(false);
             await MockTime.advance(100);
             await MockTime.advance(1);
 
@@ -990,13 +990,13 @@ describe("Integration Test", () => {
                 value: {
                     eventNumber: 3,
                     priority: 1,
-                    epochTimestamp: BigInt(startTime + 2 * 1000), // Triggered directly
+                    epochTimestamp: BigInt(startTime + 200), // Triggered directly
                     data: {
                         reachableNewValue: false,
                     },
                     path: undefined,
                 },
-                time: startTime + 2 * 1000 + 101,
+                time: startTime + 200 + 101,
             });
 
             // Await update Report on value change
@@ -1011,13 +1011,13 @@ describe("Integration Test", () => {
                 value: {
                     eventNumber: 3,
                     priority: 1,
-                    epochTimestamp: BigInt(startTime + 2 * 1000), // Triggered directly
+                    epochTimestamp: BigInt(startTime + 200), // Triggered directly
                     data: {
                         reachableNewValue: false,
                     },
                     path: undefined,
                 },
-                time: startTime + 2 * 1000 + 101,
+                time: startTime + 200 + 101,
             });
         });
     });

--- a/packages/matter.js/src/CommissioningServer.ts
+++ b/packages/matter.js/src/CommissioningServer.ts
@@ -880,6 +880,23 @@ export class CommissioningServer extends MatterNode {
         this.commandHandler.removeHandler(command, handler);
     }
 
+    /**
+     * Set the reachability of the commissioning server aka "the main matter device". This call only has effect when
+     * the reachability flag was set in the BasicInformationCluster or in the BasicInformation data in the constructor!
+     *
+     * @param reachable true if reachable, false otherwise
+     */
+    setReachability(reachable: boolean) {
+        const basicInformationCluster = this.getRootClusterServer(BasicInformationCluster);
+        if (basicInformationCluster === undefined) {
+            throw new ImplementationError("BasicInformationCluster needs to be set!");
+        }
+        if (basicInformationCluster.attributes.reachable !== undefined) {
+            basicInformationCluster.setReachableAttribute(reachable);
+        }
+    }
+
+    /** Starts the Matter device and advertises it. */
     async start() {
         if (this.delayedAnnouncement !== true) {
             return this.advertise();

--- a/packages/matter.js/src/cluster/client/AttributeClient.ts
+++ b/packages/matter.js/src/cluster/client/AttributeClient.ts
@@ -27,10 +27,10 @@ export function createAttributeClient<T>(
     present = false,
 ): AttributeClient<T> {
     if (attribute.unknown) {
-        return new UnknownPresentAttributeClient(attribute, name, endpointId, clusterId, interactionClient);
+        return new UnknownSupportedAttributeClient(attribute, name, endpointId, clusterId, interactionClient);
     }
     if (present) {
-        return new PresentAttributeClient(attribute, name, endpointId, clusterId, interactionClient);
+        return new SupportedAttributeClient(attribute, name, endpointId, clusterId, interactionClient);
     }
     return new AttributeClient(attribute, name, endpointId, clusterId, interactionClient);
 }
@@ -177,12 +177,12 @@ export class AttributeClient<T> {
 }
 
 /**
- * Special AttributeClient class to allow identifying attributes that are present because reported by the Devices.
+ * Special AttributeClient class to allow identifying attributes that are supported because reported by the Devices.
  */
-export class PresentAttributeClient<T> extends AttributeClient<T> {}
+export class SupportedAttributeClient<T> extends AttributeClient<T> {}
 
 /**
- * Special AttributeClient class to allow identifying attributes that are present because reported by the Devices,
+ * Special AttributeClient class to allow identifying attributes that are supported because reported by the Devices,
  * but the contained attribute is unknown.
  */
-export class UnknownPresentAttributeClient extends PresentAttributeClient<any> {}
+export class UnknownSupportedAttributeClient extends SupportedAttributeClient<any> {}

--- a/packages/matter.js/src/cluster/client/ClusterClient.ts
+++ b/packages/matter.js/src/cluster/client/ClusterClient.ts
@@ -52,7 +52,7 @@ export function ClusterClient<F extends BitSchema, A extends Attributes, C exten
             endpointId,
             clusterId,
             interactionClient,
-            globalAttributeValues?.attributeList ? globalAttributeValues?.attributeList.includes(attribute.id) : false,
+            !!globalAttributeValues?.attributeList?.includes(attribute.id),
         );
         attributeToId[attribute.id] = attributeName;
         const capitalizedAttributeName = capitalize(attributeName);
@@ -103,7 +103,7 @@ export function ClusterClient<F extends BitSchema, A extends Attributes, C exten
             endpointId,
             clusterId,
             interactionClient,
-            globalAttributeValues?.eventList ? globalAttributeValues?.eventList.includes(event.id) : false,
+            !!globalAttributeValues?.eventList?.includes(event.id),
         );
         eventToId[event.id] = eventName;
         const capitalizedEventName = capitalize(eventName);
@@ -245,6 +245,42 @@ export function ClusterClient<F extends BitSchema, A extends Attributes, C exten
             } else {
                 logger.warn("Event not found", eventName, "in list", Object.keys(events));
             }
+        },
+
+        isAttributeSupported: (attributeId: AttributeId) => {
+            return !!globalAttributeValues?.attributeList?.includes(attributeId);
+        },
+
+        isAttributeSupportedByName: (attributeName: string) => {
+            const attribute = (attributes as any)[attributeName];
+            if (attribute === undefined) {
+                return false;
+            }
+            return !!globalAttributeValues?.attributeList?.includes(attribute.id);
+        },
+
+        isEventSupported: (eventId: EventId) => {
+            return !!globalAttributeValues?.eventList?.includes(eventId);
+        },
+
+        isEventSupportedByName: (eventName: string) => {
+            const event = (events as any)[eventName];
+            if (event === undefined) {
+                return false;
+            }
+            return !!globalAttributeValues?.eventList?.includes(event.id);
+        },
+
+        isCommandSupported: (commandId: CommandId) => {
+            return !!globalAttributeValues?.acceptedCommandList?.includes(commandId);
+        },
+
+        isCommandSupportedByName: (commandName: string) => {
+            const command = commandDef[commandName];
+            if (command === undefined) {
+                return false;
+            }
+            return !!globalAttributeValues?.acceptedCommandList?.includes(command.requestId);
         },
     };
 

--- a/packages/matter.js/src/cluster/client/ClusterClientTypes.ts
+++ b/packages/matter.js/src/cluster/client/ClusterClientTypes.ts
@@ -5,6 +5,7 @@
  */
 import { AttributeId } from "../../datatype/AttributeId.js";
 import { ClusterId } from "../../datatype/ClusterId.js";
+import { CommandId } from "../../datatype/CommandId.js";
 import { EndpointNumber } from "../../datatype/EndpointNumber.js";
 import { EventId } from "../../datatype/EventId.js";
 import { DecodedEventData } from "../../protocol/interaction/EventDataDecoder.js";
@@ -216,6 +217,24 @@ export type ClusterClientObj<F extends BitSchema, A extends Attributes, C extend
         eventFilters?: TypeFromSchema<typeof TlvEventFilter>[];
         dataVersionFilters?: { endpointId: EndpointNumber; clusterId: ClusterId; dataVersion: number }[];
     }) => Promise<void>;
+
+    /** Returns if a given Attribute Id is present and supported at the connected cluster server. */
+    isAttributeSupported: (attributeId: AttributeId) => boolean;
+
+    /** Returns if a given Attribute with provided name is present and supported at the connected cluster server. */
+    isAttributeSupportedByName: (attributeName: string) => boolean;
+
+    /** Returns if a given Event Id is present and supported at the connected cluster server. */
+    isEventSupported: (eventId: EventId) => boolean;
+
+    /** Returns if a given Event with provided name is present and supported at the connected cluster server. */
+    isEventSupportedByName: (eventName: string) => boolean;
+
+    /** Returns if a given Command Id is present and supported at the connected cluster server. */
+    isCommandSupported: (commandId: CommandId) => boolean;
+
+    /** Returns if a given Command with provided name is present and supported at the connected cluster server. */
+    isCommandSupportedByName: (commandName: string) => boolean;
 } & ClientAttributeGetters<A> &
     ClientGlobalAttributeGetters<F> &
     ClientAttributeSetters<A> &

--- a/packages/matter.js/src/cluster/client/EventClient.ts
+++ b/packages/matter.js/src/cluster/client/EventClient.ts
@@ -23,10 +23,10 @@ export function createEventClient<T>(
     present = false,
 ): EventClient<T> {
     if (event.unknown) {
-        return new UnknownPresentEventClient(event, name, endpointId, clusterId, interactionClient);
+        return new UnknownSupportedEventClient(event, name, endpointId, clusterId, interactionClient);
     }
     if (present) {
-        return new PresentEventClient(event, name, endpointId, clusterId, interactionClient);
+        return new SupportedEventClient(event, name, endpointId, clusterId, interactionClient);
     }
     return new EventClient(event, name, endpointId, clusterId, interactionClient);
 }
@@ -100,12 +100,12 @@ export class EventClient<T> {
 }
 
 /**
- * Special EventClient class to allow identifying events that are present because reported by the Devices.
+ * Special EventClient class to allow identifying events that are supported because reported by the Devices.
  */
-export class PresentEventClient<T> extends EventClient<T> {}
+export class SupportedEventClient<T> extends EventClient<T> {}
 
 /**
- * Special EventClient class to allow identifying events that are present because reported by the Devices,
+ * Special EventClient class to allow identifying events that are supported because reported by the Devices,
  * but the contained event is unknown.
  */
-export class UnknownPresentEventClient extends EventClient<any> {}
+export class UnknownSupportedEventClient extends EventClient<any> {}

--- a/packages/matter.js/src/cluster/server/ClusterServer.ts
+++ b/packages/matter.js/src/cluster/server/ClusterServer.ts
@@ -197,6 +197,30 @@ export function ClusterServer<
             }
             return true;
         },
+
+        isAttributeSupported: (attributeId: AttributeId) => {
+            return (attributes as any).attributeList.getLocal().includes(attributeId);
+        },
+
+        isAttributeSupportedByName: (attributeName: string) => {
+            return (attributesInitialValues as any)[attributeName] !== undefined;
+        },
+
+        isEventSupported: (eventId: EventId) => {
+            return (attributes as any).eventList.getLocal().includes(eventId);
+        },
+
+        isEventSupportedByName: (eventName: string) => {
+            return (supportedEvents as any)[eventName] === true;
+        },
+
+        isCommandSupported: (commandId: CommandId) => {
+            return (attributes as any).acceptedCommandList.getLocal().includes(commandId);
+        },
+
+        isCommandSupportedByName: (commandName: string) => {
+            return (commands as any)[commandName] !== undefined;
+        },
     };
 
     const attributeStorageListener = (attributeName: string, value: any) => {

--- a/packages/matter.js/src/cluster/server/ClusterServerTypes.ts
+++ b/packages/matter.js/src/cluster/server/ClusterServerTypes.ts
@@ -5,7 +5,10 @@
  */
 
 import { Message } from "../../codec/MessageCodec.js";
+import { AttributeId } from "../../datatype/AttributeId.js";
 import { ClusterId } from "../../datatype/ClusterId.js";
+import { CommandId } from "../../datatype/CommandId.js";
+import { EventId } from "../../datatype/EventId.js";
 import { Endpoint } from "../../device/Endpoint.js";
 import { Fabric } from "../../fabric/Fabric.js";
 import { MatterDevice } from "../../MatterDevice.js";
@@ -288,6 +291,24 @@ export type ClusterServerObj<A extends Attributes, E extends Events> = {
      * @readonly
      */
     readonly attributes: AttributeServers<A>;
+
+    /** Returns if a given Attribute Id is defined and supported by this cluster server. */
+    isAttributeSupported: (attributeId: AttributeId) => boolean;
+
+    /** Returns if a given Attribute for provided name is defined and supported by this cluster server. */
+    isAttributeSupportedByName: (attributeName: string) => boolean;
+
+    /** Returns if a given Event is defined and supported by this cluster server. */
+    isEventSupported: (eventId: EventId) => boolean;
+
+    /** Returns if a given Event for provided name is defined and supported by this cluster server. */
+    isEventSupportedByName: (eventName: string) => boolean;
+
+    /** Returns if a given Command is defined and supported by this cluster server. */
+    isCommandSupported: (commandId: CommandId) => boolean;
+
+    /** Returns if a given Command for provided name is defined and supported by this cluster server. */
+    isCommandSupportedByName: (commandName: string) => boolean;
 } & ServerAttributeGetters<A> &
     ServerAttributeSetters<A> &
     ServerAttributeSubscribers<A> &

--- a/packages/matter.js/src/device/ComposedDevice.ts
+++ b/packages/matter.js/src/device/ComposedDevice.ts
@@ -3,6 +3,8 @@
  * Copyright 2022 The matter.js Authors
  * SPDX-License-Identifier: Apache-2.0
  */
+import { BridgedDeviceBasicInformationCluster } from "../cluster/definitions/index.js";
+import { ImplementationError } from "../common/MatterError.js";
 import { Device } from "./Device.js";
 import { DeviceTypeDefinition } from "./DeviceTypes.js";
 import { Endpoint, EndpointOptions } from "./Endpoint.js";
@@ -49,5 +51,20 @@ export class ComposedDevice extends Endpoint {
         //      somehow match with the device types of the composed device?!
         //      For now we do not check this
         return;
+    }
+
+    /**
+     * Set the reachability of the Composed device exposed via the bridge.
+     *
+     * @param reachable true if reachable, false otherwise
+     */
+    setBridgedDeviceReachability(reachable: boolean) {
+        const bridgedBasicInformationCluster = this.getClusterServer(BridgedDeviceBasicInformationCluster);
+        if (bridgedBasicInformationCluster === undefined) {
+            throw new ImplementationError(
+                "The reachability flag can only be set for bridged devices this way. To set the reachability flag for a non-bridged device or for the bridget itself please set it on the CommissioningServer!",
+            );
+        }
+        bridgedBasicInformationCluster.setReachableAttribute(reachable);
     }
 }

--- a/packages/matter.js/src/device/Device.ts
+++ b/packages/matter.js/src/device/Device.ts
@@ -4,9 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ClusterClientObj, isClusterClient } from "../cluster/client/ClusterClientTypes.js";
 import { Attributes, Cluster, Commands, Events } from "../cluster/Cluster.js";
+import { ClusterClientObj, isClusterClient } from "../cluster/client/ClusterClientTypes.js";
 import { Binding } from "../cluster/definitions/BindingCluster.js";
+import { BridgedDeviceBasicInformationCluster } from "../cluster/definitions/BridgedDeviceBasicInformationCluster.js";
 import { ClusterServer } from "../cluster/server/ClusterServer.js";
 import { ClusterServerHandlers, ClusterServerObj, isClusterServer } from "../cluster/server/ClusterServerTypes.js";
 import { ImplementationError, NotImplementedError } from "../common/MatterError.js";
@@ -284,5 +285,21 @@ export class Device extends Endpoint {
                 this.addClusterClient(clusterClient);
             }
         }
+    }
+
+    /**
+     * Set the reachability of the device exposed via the bridge. If this is a device inside  a composed device the
+     * reachability needs to be set there.
+     *
+     * @param reachable true if reachable, false otherwise
+     */
+    setBridgedDeviceReachability(reachable: boolean) {
+        const bridgedBasicInformationCluster = this.getClusterServer(BridgedDeviceBasicInformationCluster);
+        if (bridgedBasicInformationCluster === undefined) {
+            throw new ImplementationError(
+                "The reachability flag can only be set for bridged devices this way. To set the reachability flag for a non-bridged device or for the bridget itself please set it on the CommissioningServer!",
+            );
+        }
+        bridgedBasicInformationCluster.setReachableAttribute(reachable);
     }
 }

--- a/packages/matter.js/src/device/EndpointStructureLogger.ts
+++ b/packages/matter.js/src/device/EndpointStructureLogger.ts
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { PresentAttributeClient, UnknownPresentAttributeClient } from "../cluster/client/AttributeClient.js";
+import { SupportedAttributeClient, UnknownSupportedAttributeClient } from "../cluster/client/AttributeClient.js";
 import { ClusterClientObj } from "../cluster/client/ClusterClientTypes.js";
-import { PresentEventClient, UnknownPresentEventClient } from "../cluster/client/EventClient.js";
+import { SupportedEventClient, UnknownSupportedEventClient } from "../cluster/client/EventClient.js";
 import { GlobalAttributes } from "../cluster/Cluster.js";
 import { AnyAttributeServer, FabricScopeError } from "../cluster/server/AttributeServer.js";
 import { asClusterServerInternal, ClusterServerObj } from "../cluster/server/ClusterServerTypes.js";
@@ -26,7 +26,7 @@ type EndpointLoggingOptions = {
     logChildEndpoints?: boolean;
     logClusterGlobalAttributes?: boolean;
     logClusterAttributes?: boolean;
-    logNotPresentClusterAttributes?: boolean;
+    logNotSupportedClusterAttributes?: boolean;
     logClusterCommands?: boolean;
     logClusterEvents?: boolean;
     logNotPresentClusterEvents?: boolean;
@@ -190,12 +190,12 @@ function logClusterClient(
                     if (attributeName in globalAttributes) continue;
                     const attribute = clusterClient.attributes[attributeName];
                     if (attribute === undefined) continue;
-                    const present = attribute instanceof PresentAttributeClient;
-                    if (!present && options.logNotPresentClusterAttributes === true) continue;
-                    const unknown = attribute instanceof UnknownPresentAttributeClient;
+                    const supported = attribute instanceof SupportedAttributeClient;
+                    if (!supported && options.logNotSupportedClusterAttributes === false) continue;
+                    const unknown = attribute instanceof UnknownSupportedAttributeClient;
 
                     let info = "";
-                    if (!present) info += " (Not Present)";
+                    if (!supported) info += " (Not Supported)";
                     if (unknown) info += " (Unknown)";
 
                     logger.info(`"${attribute.name}" (${toHexString(attribute.id)})${info}`);
@@ -220,12 +220,12 @@ function logClusterClient(
                 for (const eventName in clusterClient.events) {
                     const event = clusterClient.events[eventName];
                     if (event === undefined) continue;
-                    const present = event instanceof PresentEventClient;
-                    if (!present && options.logNotPresentClusterEvents === true) continue;
-                    const unknown = event instanceof UnknownPresentEventClient;
+                    const supported = event instanceof SupportedEventClient;
+                    if (!supported && options.logNotSupportedClusterEvents === false) continue;
+                    const unknown = event instanceof UnknownSupportedEventClient;
 
                     let info = "";
-                    if (!present) info += " (Not Present)";
+                    if (!supported) info += " (Not Supported)";
                     if (unknown) info += " (Unknown)";
 
                     logger.info(`"${event.name}" (${toHexString(event.id)})${info}`);

--- a/packages/matter.js/test/cluster/ClusterClientTest.ts
+++ b/packages/matter.js/test/cluster/ClusterClientTest.ts
@@ -1,0 +1,91 @@
+/**
+ * @license
+ * Copyright 2022-2023 Project CHIP Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+    AttributeClient,
+    SupportedAttributeClient,
+    UnknownSupportedAttributeClient,
+} from "../../src/cluster/client/AttributeClient.js";
+import { ClusterClient } from "../../src/cluster/client/ClusterClient.js";
+import { EventClient, SupportedEventClient } from "../../src/cluster/client/EventClient.js";
+import { BasicInformationCluster } from "../../src/cluster/definitions/BasicInformationCluster.js";
+import { Identify, IdentifyCluster } from "../../src/cluster/definitions/IdentifyCluster.js";
+import { AttributeId } from "../../src/datatype/AttributeId.js";
+import { EndpointNumber } from "../../src/datatype/EndpointNumber.js";
+import { InteractionClient } from "../../src/protocol/interaction/InteractionClient.js";
+
+describe("ClusterClient structure", () => {
+    it("correct attribute clients are used and exposed", () => {
+        const basicClusterClient = ClusterClient(BasicInformationCluster, EndpointNumber(0), {} as InteractionClient, {
+            attributeList: [
+                BasicInformationCluster.attributes.vendorName.id,
+                BasicInformationCluster.attributes.productName.id,
+                BasicInformationCluster.attributes.nodeLabel.id,
+                BasicInformationCluster.attributes.reachable.id,
+                AttributeId(0x1000),
+            ],
+        });
+
+        expect(basicClusterClient.isAttributeSupported(BasicInformationCluster.attributes.vendorName.id)).equal(true);
+        expect(basicClusterClient.isAttributeSupportedByName("vendorName")).equal(true);
+        expect(basicClusterClient.attributes.vendorName instanceof SupportedAttributeClient).equal(true);
+
+        expect(basicClusterClient.isAttributeSupported(BasicInformationCluster.attributes.productName.id)).equal(true);
+        expect(basicClusterClient.isAttributeSupportedByName("productName")).equal(true);
+        expect(basicClusterClient.attributes.productName instanceof SupportedAttributeClient).equal(true);
+
+        expect(basicClusterClient.isAttributeSupported(BasicInformationCluster.attributes.nodeLabel.id)).equal(true);
+        expect(basicClusterClient.isAttributeSupportedByName("nodeLabel")).equal(true);
+        expect(basicClusterClient.attributes.nodeLabel instanceof SupportedAttributeClient).equal(true);
+
+        expect(basicClusterClient.isAttributeSupported(BasicInformationCluster.attributes.reachable.id)).equal(true);
+        expect(basicClusterClient.isAttributeSupportedByName("reachable")).equal(true);
+        expect(basicClusterClient.attributes.reachable instanceof SupportedAttributeClient).equal(true);
+
+        expect(basicClusterClient.isAttributeSupported(BasicInformationCluster.attributes.serialNumber.id)).equal(
+            false,
+        );
+        expect(basicClusterClient.isAttributeSupportedByName("serialNumber")).equal(false);
+        expect(basicClusterClient.attributes.serialNumber instanceof SupportedAttributeClient).equal(false);
+        expect(basicClusterClient.attributes.serialNumber instanceof AttributeClient).equal(true);
+
+        expect(basicClusterClient.isAttributeSupported(AttributeId(0x1000))).equal(true);
+        expect(basicClusterClient.isAttributeSupportedByName("unknownAttribute_0x1000")).equal(true);
+        expect(
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore
+            basicClusterClient.attributes["unknownAttribute_0x1000"] instanceof UnknownSupportedAttributeClient,
+        ).equal(true);
+    });
+
+    it("correct event clients are used and exposed", () => {
+        const basicClusterClient = ClusterClient(BasicInformationCluster, EndpointNumber(0), {} as InteractionClient, {
+            eventList: [BasicInformationCluster.events.reachableChanged.id],
+        });
+
+        expect(basicClusterClient.isEventSupported(BasicInformationCluster.events.reachableChanged.id)).equal(true);
+        expect(basicClusterClient.isEventSupportedByName("reachableChanged")).equal(true);
+        expect(basicClusterClient.events.reachableChanged instanceof SupportedEventClient).equal(true);
+
+        expect(basicClusterClient.isEventSupported(BasicInformationCluster.events.shutDown.id)).equal(false);
+        expect(basicClusterClient.isEventSupportedByName("shutDown")).equal(false);
+        expect(basicClusterClient.events.shutDown instanceof SupportedEventClient).equal(false);
+        expect(basicClusterClient.events.shutDown instanceof EventClient).equal(true);
+    });
+
+    it("correct command clients are used and exposed", () => {
+        const identifyClient = ClusterClient(IdentifyCluster, EndpointNumber(0), {} as InteractionClient, {
+            acceptedCommandList: [IdentifyCluster.commands.identify.requestId],
+        });
+
+        expect(identifyClient.isCommandSupported(IdentifyCluster.commands.identify.requestId)).equal(true);
+        expect(identifyClient.isCommandSupportedByName("identify")).equal(true);
+        expect(typeof identifyClient.commands.identify).equal("function");
+
+        expect(identifyClient.isCommandSupported(Identify.Complete.commands.identifyQuery.requestId)).equal(false);
+        expect(identifyClient.isCommandSupportedByName("identifyQuery")).equal(false);
+    });
+});

--- a/packages/matter.js/test/cluster/ClusterServerTest.ts
+++ b/packages/matter.js/test/cluster/ClusterServerTest.ts
@@ -92,7 +92,7 @@ describe("ClusterServer structure", () => {
             expect(basic2.subscribeSoftwareVersionAttribute).undefined;
         });
 
-        it("Normal Attribute has set and get", async () => {
+        it("Normal Attribute have set and get", async () => {
             const basic = ClusterServer(
                 BasicInformationCluster,
                 {
@@ -749,6 +749,71 @@ describe("ClusterServer structure", () => {
                         'xxxx-xx-xx xx:xx:xx.xxx WARN ClusterServer Command "WindowCovering/goToLiftPercentage" is REQUIRED by supportedFeatures: {"lift":true,"positionAwareLift":true} but is not set!',
                 },
             ]);
+        });
+    });
+
+    describe("check supported methods on server", () => {
+        it("attributes and events returned correctly", async () => {
+            const basic = ClusterServer(
+                BasicInformationCluster,
+                {
+                    dataModelRevision: 1,
+                    vendorName: "test",
+                    vendorId: VendorId(0),
+                    productName: "test",
+                    productId: 1,
+                    nodeLabel: "",
+                    location: "DE",
+                    hardwareVersion: 1,
+                    hardwareVersionString: "1",
+                    softwareVersion: 1,
+                    softwareVersionString: "1",
+                    capabilityMinima: {
+                        caseSessionsPerFabric: 3,
+                        subscriptionsPerFabric: 3,
+                    },
+                },
+                {},
+                {
+                    startUp: true,
+                },
+            );
+
+            expect(basic.isAttributeSupported(BasicInformationCluster.attributes.vendorName.id)).equal(true);
+            expect(basic.isAttributeSupportedByName("vendorName")).equal(true);
+            expect(basic.isAttributeSupported(BasicInformationCluster.attributes.softwareVersionString.id)).equal(true);
+            expect(basic.isAttributeSupportedByName("softwareVersionString")).equal(true);
+            expect(basic.isAttributeSupported(BasicInformationCluster.attributes.reachable.id)).equal(false);
+            expect(basic.isAttributeSupportedByName("reachable")).equal(false);
+
+            expect(basic.isEventSupported(BasicInformationCluster.events.startUp.id)).equal(true);
+            expect(basic.isEventSupportedByName("startUp")).equal(true);
+            expect(basic.isEventSupported(BasicInformationCluster.events.reachableChanged.id)).equal(false);
+            expect(basic.isEventSupportedByName("reachableChanged")).equal(false);
+        });
+
+        it("Commands returned correctly", async () => {
+            const identifyServer = ClusterServer(
+                IdentifyCluster,
+                {
+                    identifyTime: 100,
+                    identifyType: Identify.IdentifyType.None,
+                },
+                {
+                    identify: async () => {
+                        /* dummy */
+                    },
+                },
+            );
+
+            expect(identifyServer.isAttributeSupported(IdentifyCluster.attributes.identifyTime.id)).equal(true);
+            expect(identifyServer.isAttributeSupportedByName("identifyType")).equal(true);
+            expect(identifyServer.isAttributeSupported(IdentifyCluster.attributes.identifyType.id)).equal(true);
+            expect(identifyServer.isAttributeSupportedByName("identifyTime")).equal(true);
+            expect(identifyServer.isCommandSupported(IdentifyCluster.commands.identify.requestId)).equal(true);
+            expect(identifyServer.isCommandSupportedByName("identify")).equal(true);
+            expect(identifyServer.isCommandSupported(Identify.Complete.commands.identifyQuery.requestId)).equal(false);
+            expect(identifyServer.isCommandSupportedByName("identifyQuery")).equal(false);
         });
     });
 });


### PR DESCRIPTION
This PR adds the following:
* Introduce some convenience methods to easiely chaeck if an Attribute, Event or command is supported/defined by a clusterServer or also ClusterClient. This is more convenient to use instead of knowing internal structures and ow to use them.
* Add "setReachability" methods for the "main matter device" (aka the CommissioningServer) and also for Bridged Devices to allow setting reachablity more convenient then by searching for the BasicInformationCluster and such
* I decided for the ClusterClient and EndpointLogger to change wording from "present" to "supported" because this can be used generically in Client and Server and should be understandable better then the "present" we had so far.
* Additionally one test case got change a bit in timing