### PR TITLE
Protocol handler refactoring

### DIFF
--- a/packages/matter.js/src/MatterDevice.ts
+++ b/packages/matter.js/src/MatterDevice.ts
@@ -108,6 +108,10 @@ export class MatterDevice {
         return this;
     }
 
+    hasProtocolHandler(protocolId: number) {
+        return this.exchangeManager.hasProtocolHandler(protocolId);
+    }
+
     addProtocolHandler(protocol: ProtocolHandler<MatterDevice>) {
         this.exchangeManager.addProtocolHandler(protocol);
         return this;

--- a/packages/matter.js/src/protocol/ExchangeManager.ts
+++ b/packages/matter.js/src/protocol/ExchangeManager.ts
@@ -6,7 +6,7 @@
 
 import { Message, MessageCodec, SessionType } from "../codec/MessageCodec.js";
 import { Channel } from "../common/Channel.js";
-import { MatterFlowError, NotImplementedError } from "../common/MatterError.js";
+import { ImplementationError, MatterFlowError, NotImplementedError } from "../common/MatterError.js";
 import { Listener, TransportInterface } from "../common/TransportInterface.js";
 import { Crypto } from "../crypto/Crypto.js";
 import { NodeId } from "../datatype/NodeId.js";

--- a/packages/matter.js/src/protocol/ExchangeManager.ts
+++ b/packages/matter.js/src/protocol/ExchangeManager.ts
@@ -98,6 +98,9 @@ export class ExchangeManager<ContextT> {
     }
 
     async close() {
+        for (const protocol of this.protocols.values()) {
+            await protocol.close();
+        }
         for (const netListener of this.transportListeners) {
             await netListener.close();
         }

--- a/packages/matter.js/src/protocol/ExchangeManager.ts
+++ b/packages/matter.js/src/protocol/ExchangeManager.ts
@@ -67,7 +67,18 @@ export class ExchangeManager<ContextT> {
         );
     }
 
+    hasProtocolHandler(protocolId: number) {
+        return this.protocols.has(protocolId);
+    }
+
+    getProtocolHandler(protocolId: number) {
+        return this.protocols.get(protocolId);
+    }
+
     addProtocolHandler(protocol: ProtocolHandler<ContextT>) {
+        if (this.hasProtocolHandler(protocol.getId())) {
+            throw new ImplementationError(`Handler for protocol ${protocol.getId()} already registered.`);
+        }
         this.protocols.set(protocol.getId(), protocol);
     }
 
@@ -160,6 +171,14 @@ export class ExchangeProvider {
         private channel: MessageChannel<MatterController>,
         private readonly reconnectChannelFunc?: () => Promise<MessageChannel<MatterController>>,
     ) {}
+
+    hasProtocolHandler(protocolId: number) {
+        return this.exchangeManager.hasProtocolHandler(protocolId);
+    }
+
+    getProtocolHandler(protocolId: number) {
+        return this.exchangeManager.getProtocolHandler(protocolId);
+    }
 
     addProtocolHandler(handler: ProtocolHandler<MatterController>) {
         this.exchangeManager.addProtocolHandler(handler);

--- a/packages/matter.js/src/protocol/ProtocolHandler.ts
+++ b/packages/matter.js/src/protocol/ProtocolHandler.ts
@@ -10,4 +10,5 @@ import { MessageExchange } from "./MessageExchange.js";
 export interface ProtocolHandler<ContextT> {
     getId(): number;
     onNewExchange(exchange: MessageExchange<ContextT>, message: Message): Promise<void>;
+    close(): Promise<void>;
 }

--- a/packages/matter.js/src/protocol/interaction/InteractionClient.ts
+++ b/packages/matter.js/src/protocol/interaction/InteractionClient.ts
@@ -115,6 +115,12 @@ export class SubscriptionClient implements ProtocolHandler<MatterController> {
         }
         listener(dataReport);
     }
+
+    async close() {
+        this.subscriptionListeners.clear();
+        this.subscriptionUpdateTimers.forEach(timer => timer.stop());
+        this.subscriptionUpdateTimers.clear();
+    }
 }
 
 export class InteractionClient {

--- a/packages/matter.js/src/protocol/interaction/InteractionClient.ts
+++ b/packages/matter.js/src/protocol/interaction/InteractionClient.ts
@@ -61,13 +61,30 @@ export interface AttributeStatus {
 }
 
 export class SubscriptionClient implements ProtocolHandler<MatterController> {
-    constructor(
-        private readonly subscriptionListeners: Map<number, (dataReport: DataReport) => void>,
-        private readonly subscriptionUpdateTimers = new Map<number, Timer>(),
-    ) {}
+    private readonly subscriptionListeners = new Map<number, (dataReport: DataReport) => void>();
+    private readonly subscriptionUpdateTimers = new Map<number, Timer>();
+
+    constructor() {}
 
     getId() {
         return INTERACTION_PROTOCOL_ID;
+    }
+
+    registerSubscriptionListener(subscriptionId: number, listener: (dataReport: DataReport) => void) {
+        this.subscriptionListeners.set(subscriptionId, listener);
+    }
+
+    removeSubscriptionListener(subscriptionId: number) {
+        this.subscriptionListeners.delete(subscriptionId);
+    }
+
+    registerSubscriptionUpdateTimer(subscriptionId: number, timer: Timer) {
+        this.subscriptionUpdateTimers.set(subscriptionId, timer);
+    }
+
+    removeSubscriptionUpdateTimer(subscriptionId: number) {
+        this.subscriptionUpdateTimers.get(subscriptionId)?.stop();
+        this.subscriptionUpdateTimers.delete(subscriptionId);
     }
 
     async onNewExchange(exchange: MessageExchange<MatterController>) {
@@ -84,9 +101,8 @@ export class SubscriptionClient implements ProtocolHandler<MatterController> {
             await messenger.sendStatus(StatusCode.InvalidSubscription);
             logger.info(`Received data for unknown subscription ID ${subscriptionId}. Cancel this subscription.`);
             if (timer !== undefined) {
-                // Should not happen but let's make sure to cleanup
-                timer.stop();
-                this.subscriptionUpdateTimers.delete(subscriptionId);
+                // Should not happen but let's make sure to clean up
+                this.removeSubscriptionUpdateTimer(subscriptionId);
             }
             await messenger.close();
             return;
@@ -102,20 +118,39 @@ export class SubscriptionClient implements ProtocolHandler<MatterController> {
 }
 
 export class InteractionClient {
-    private readonly subscriptionListeners = new Map<number, (dataReport: DataReport) => void>();
-    private readonly subscriptionUpdateTimers = new Map<number, Timer>();
     // TODO Add storage for these data to be able to optimize follow up subscriptions by only request updated data
     private readonly subscribedLocalValues = new Map<string, any>();
     private readonly subscribedClusterDataVersions = new Map<string, number>();
+    private readonly ownSubscriptionIds = new Set<number>();
+    private readonly subscriptionClient: SubscriptionClient;
 
     constructor(
         private readonly exchangeProvider: ExchangeProvider,
         readonly nodeId: NodeId,
     ) {
-        // TODO: Right now we potentially add multiple handlers for the same protocol, We need to fix this
-        this.exchangeProvider.addProtocolHandler(
-            new SubscriptionClient(this.subscriptionListeners, this.subscriptionUpdateTimers),
-        );
+        if (this.exchangeProvider.hasProtocolHandler(INTERACTION_PROTOCOL_ID)) {
+            const client = this.exchangeProvider.getProtocolHandler(INTERACTION_PROTOCOL_ID);
+            if (!(client instanceof SubscriptionClient)) {
+                throw new ImplementationError(
+                    `Unexpected protocol handler ${INTERACTION_PROTOCOL_ID} for InteractionClient already registered`,
+                );
+            }
+            this.subscriptionClient = client;
+        } else {
+            this.subscriptionClient = new SubscriptionClient();
+            this.exchangeProvider.addProtocolHandler(this.subscriptionClient);
+        }
+    }
+
+    registerSubscriptionListener(subscriptionId: number, listener: (dataReport: DataReport) => void) {
+        this.ownSubscriptionIds.add(subscriptionId);
+        this.subscriptionClient.registerSubscriptionListener(subscriptionId, listener);
+    }
+
+    removeSubscription(subscriptionId: number) {
+        this.ownSubscriptionIds.delete(subscriptionId);
+        this.subscriptionClient.removeSubscriptionListener(subscriptionId);
+        this.subscriptionClient.removeSubscriptionUpdateTimer(subscriptionId);
     }
 
     async getAllAttributes(
@@ -530,7 +565,7 @@ export class InteractionClient {
                 this.subscribedClusterDataVersions.set(clusterPathToId({ endpointId, clusterId }), version);
                 listener?.(value, version);
             };
-            this.subscriptionListeners.set(subscriptionId, subscriptionListener);
+            this.registerSubscriptionListener(subscriptionId, subscriptionListener);
             if (updateTimeoutHandler !== undefined) {
                 this.registerSubscriptionUpdateTimer(subscriptionId, maxInterval, updateTimeoutHandler);
             }
@@ -601,7 +636,7 @@ export class InteractionClient {
 
                 events.forEach(event => listener?.(event));
             };
-            this.subscriptionListeners.set(subscriptionId, subscriptionListener);
+            this.registerSubscriptionListener(subscriptionId, subscriptionListener);
             if (updateTimeoutHandler !== undefined) {
                 this.registerSubscriptionUpdateTimer(subscriptionId, maxInterval, updateTimeoutHandler);
             }
@@ -717,10 +752,6 @@ export class InteractionClient {
                 `Subscription successfully initialized with ID ${subscriptionId} and maxInterval ${maxInterval}s.`,
             );
 
-            if (updateTimeoutHandler !== undefined) {
-                this.registerSubscriptionUpdateTimer(subscriptionId, maxInterval, updateTimeoutHandler);
-            }
-
             const subscriptionListener = (dataReport: {
                 attributeReports?: DecodedAttributeReportValue<any>[];
                 eventReports?: DecodedEventReportValue<any>[];
@@ -767,7 +798,7 @@ export class InteractionClient {
                     });
                 }
             };
-            this.subscriptionListeners.set(subscriptionId, dataReport => {
+            this.registerSubscriptionListener(subscriptionId, dataReport => {
                 subscriptionListener({
                     attributeReports:
                         dataReport.attributeReports !== undefined
@@ -779,6 +810,10 @@ export class InteractionClient {
                             : undefined,
                 });
             });
+
+            if (updateTimeoutHandler !== undefined) {
+                this.registerSubscriptionUpdateTimer(subscriptionId, maxInterval, updateTimeoutHandler);
+            }
 
             const seedReport = {
                 attributeReports:
@@ -961,23 +996,27 @@ export class InteractionClient {
         maxInterval: number,
         updateTimeoutHandler: TimerCallback,
     ) {
+        if (!this.ownSubscriptionIds.has(subscriptionId)) {
+            throw new MatterFlowError(
+                `Cannot register update timer for subscription ${subscriptionId} because it is not owned by this client.`,
+            );
+        }
         maxInterval += 5; // Add 5 seconds to the maxInterval to allow at least one full resubmission cycle before assuming the subscription is lost
         const timer = Time.getTimer(maxInterval * 1000, () => {
             logger.info(`Subscription ${subscriptionId} timed out ...`);
-            this.subscriptionUpdateTimers.delete(subscriptionId);
-            this.subscriptionListeners.delete(subscriptionId);
+            this.removeSubscription(subscriptionId);
             // We remove all data because we don't know which data is still valid, so we better read from remote if needed
             this.subscribedLocalValues.clear();
             this.subscribedClusterDataVersions.clear();
             updateTimeoutHandler();
         }).start();
-        this.subscriptionUpdateTimers.set(subscriptionId, timer);
+        this.subscriptionClient.registerSubscriptionUpdateTimer(subscriptionId, timer);
     }
 
     close() {
-        this.subscriptionUpdateTimers.forEach(timer => timer.stop());
-        this.subscriptionUpdateTimers.clear();
-        this.subscriptionListeners.clear();
+        for (const subscriptionId of this.ownSubscriptionIds) {
+            this.removeSubscription(subscriptionId);
+        }
         this.subscribedLocalValues.clear();
         this.subscribedClusterDataVersions.clear();
     }

--- a/packages/matter.js/src/protocol/interaction/InteractionClient.ts
+++ b/packages/matter.js/src/protocol/interaction/InteractionClient.ts
@@ -138,7 +138,7 @@ export class InteractionClient {
             const client = this.exchangeProvider.getProtocolHandler(INTERACTION_PROTOCOL_ID);
             if (!(client instanceof SubscriptionClient)) {
                 throw new ImplementationError(
-                    `Unexpected protocol handler ${INTERACTION_PROTOCOL_ID} for InteractionClient already registered`,
+                    `Already existing protocol handler ${INTERACTION_PROTOCOL_ID} is not a SubscriptionClient.`,
                 );
             }
             this.subscriptionClient = client;

--- a/packages/matter.js/src/protocol/securechannel/SecureChannelProtocol.ts
+++ b/packages/matter.js/src/protocol/securechannel/SecureChannelProtocol.ts
@@ -118,4 +118,8 @@ export class SecureChannelProtocol implements ProtocolHandler<MatterDevice> {
     static isStandaloneAck(protocolId: number, messageType: number) {
         return protocolId === SECURE_CHANNEL_PROTOCOL_ID && messageType === MessageType.StandaloneAck;
     }
+
+    async close() {
+        // Nothing to do
+    }
 }

--- a/packages/matter.js/src/session/case/CaseServer.ts
+++ b/packages/matter.js/src/session/case/CaseServer.ts
@@ -208,4 +208,8 @@ export class CaseServer implements ProtocolHandler<MatterDevice> {
             server.saveResumptionRecord(resumptionRecord);
         }
     }
+
+    async close() {
+        // Nothing to do
+    }
 }

--- a/packages/matter.js/src/session/pase/PaseServer.ts
+++ b/packages/matter.js/src/session/pase/PaseServer.ts
@@ -155,4 +155,8 @@ export class PaseServer implements ProtocolHandler<MatterDevice> {
         }
         await messenger.close();
     }
+
+    async close() {
+        // Nothing to do
+    }
 }


### PR DESCRIPTION
This PR makes sure that Protocol handler can not get added twice and mainly clean up the Subscription handler for InterationClients by reusing formerly created Subscription Protocol handlers and adding support to cleanly handle multiple InteractionClients.
Additonally it adds cleanup for protocol handlers on close.