### PR TITLE
Add FactoryReset method for CommissioningServer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The main work (all changes without a GitHub username in brackets in the below li
   * Feature: Generalized Discovery logic and allow discoveries via different methods (BLE+IP) in parallel
   * Feature: Added functionality to clear session contexts including data in sub-contexts or not
 * matter.js API:
+  * Breaking: Rename resetStorage() on CommissioningServer to factoryReset() and add logic to restart the device if currently running
   * Breaking: Restructure the CommissioningController to allow pairing with multiple nodes
     * Adjusts some property and structure namings to be more consistent
     * Introducing class PairedNode with the High level API for a paired Node

--- a/packages/matter.js/src/MatterServer.ts
+++ b/packages/matter.js/src/MatterServer.ts
@@ -125,7 +125,7 @@ export class MatterServer {
 
         if (destroyStorage) {
             // Destroy storage
-            commissioningServer.resetStorage();
+            await commissioningServer.factoryReset();
         }
     }
 


### PR DESCRIPTION
This PR adds a factoryReset() method to the commissioningServer which is used internally when the last fabric is removed and can also called by a developer. The method detects if the device is currently running and stops it and restarts afterwards automatically if it was running. Else just the session is cleared.

This method is tested by IntegrationTest