### PR TITLE
MessageExchange and Channel optimizations

### DIFF
--- a/packages/matter.js/src/MatterController.ts
+++ b/packages/matter.js/src/MatterController.ts
@@ -281,7 +281,7 @@ export class MatterController {
         logger.info(`Removing commissioned node ${nodeId} from controller.`);
         await this.sessionManager.removeAllSessionsForNode(nodeId);
         this.sessionManager.removeResumptionRecord(nodeId);
-        this.channelManager.removeChannel(this.fabric, nodeId);
+        await this.channelManager.removeChannel(this.fabric, nodeId);
         this.commissionedNodes.delete(nodeId);
         this.storeCommisionedNodes();
     }

--- a/packages/matter.js/src/MatterController.ts
+++ b/packages/matter.js/src/MatterController.ts
@@ -497,7 +497,7 @@ export class MatterController {
             }, // Convert error
         );
         const channel = new MessageChannel(operationalChannel, operationalSecureSession);
-        this.channelManager.setChannel(this.fabric, peerNodeId, channel);
+        await this.channelManager.setChannel(this.fabric, peerNodeId, channel);
         return channel;
     }
 
@@ -548,8 +548,8 @@ export class MatterController {
         }
         return new InteractionClient(
             new ExchangeProvider(this.exchangeManager, channel, async () => {
-                this.channelManager.removeChannel(this.fabric, peerNodeId);
                 await this.resume(peerNodeId);
+                await this.channelManager.removeChannel(this.fabric, peerNodeId);
                 return this.channelManager.getChannel(this.fabric, peerNodeId);
             }),
             peerNodeId,

--- a/packages/matter.js/src/MatterController.ts
+++ b/packages/matter.js/src/MatterController.ts
@@ -548,8 +548,8 @@ export class MatterController {
         }
         return new InteractionClient(
             new ExchangeProvider(this.exchangeManager, channel, async () => {
-                await this.resume(peerNodeId);
                 await this.channelManager.removeChannel(this.fabric, peerNodeId);
+                await this.resume(peerNodeId);
                 return this.channelManager.getChannel(this.fabric, peerNodeId);
             }),
             peerNodeId,

--- a/packages/matter.js/src/protocol/ChannelManager.ts
+++ b/packages/matter.js/src/protocol/ChannelManager.ts
@@ -8,10 +8,13 @@ import { Channel } from "../common/Channel.js";
 import { MatterError } from "../common/MatterError.js";
 import { NodeId } from "../datatype/NodeId.js";
 import { Fabric } from "../fabric/Fabric.js";
+import { Logger } from "../log/Logger.js";
 import { SecureSession } from "../session/SecureSession.js";
 import { Session } from "../session/Session.js";
 import { ByteArray } from "../util/ByteArray.js";
 import { MessageChannel } from "./ExchangeManager.js";
+
+const logger = Logger.get("ChannelManager");
 
 export class NoChannelError extends MatterError {}
 
@@ -23,8 +26,20 @@ export class ChannelManager {
         return `${fabric.fabricId}/${nodeId}`;
     }
 
-    setChannel(fabric: Fabric, nodeId: NodeId, channel: MessageChannel<any>) {
-        this.channels.set(this.getChannelKey(fabric, nodeId), channel);
+    async setChannel(fabric: Fabric, nodeId: NodeId, channel: MessageChannel<any>) {
+        const channelKey = this.getChannelKey(fabric, nodeId);
+        const currentChannel = this.channels.get(channelKey);
+        if (currentChannel !== undefined) {
+            const { session } = currentChannel;
+            if (session.getId() !== channel.session.getId()) {
+                logger.debug(
+                    `Existing channel for fabricIndex ${fabric.fabricIndex} and node ${nodeId} with session ${session.name} gets replaced. Consider former session already inactive and so close it.`,
+                );
+                await session.destroy(false);
+            }
+            await currentChannel.close();
+        }
+        this.channels.set(channelKey, channel);
     }
 
     getChannel(fabric: Fabric, nodeId: NodeId) {
@@ -41,34 +56,53 @@ export class ChannelManager {
             if (fabric === undefined) {
                 return this.paseChannels.get(session);
             }
-            return this.getChannel(fabric, nodeId);
+            const channel = this.getChannel(fabric, nodeId);
+            if (channel.session.getId() !== session.getId()) {
+                return undefined;
+            }
+            return channel;
         }
         return this.paseChannels.get(session);
     }
 
-    removeChannel(fabric: Fabric, nodeId: NodeId) {
-        this.channels.delete(this.getChannelKey(fabric, nodeId));
+    async removeChannel(fabric: Fabric, nodeId: NodeId) {
+        const channelKey = this.getChannelKey(fabric, nodeId);
+        const channel = this.channels.get(channelKey);
+        if (channel !== undefined) {
+            await channel.close();
+            this.channels.delete(channelKey);
+        }
     }
 
-    getOrCreateChannel(byteArrayChannel: Channel<ByteArray>, session: Session<any>) {
+    private getOrCreateAsPaseChannel(byteArrayChannel: Channel<ByteArray>, session: Session<any>) {
+        const msgChannel = new MessageChannel(
+            byteArrayChannel,
+            session,
+            async () => void this.paseChannels.delete(session),
+        );
+        this.paseChannels.set(session, msgChannel);
+        return msgChannel;
+    }
+
+    async getOrCreateChannel(byteArrayChannel: Channel<ByteArray>, session: Session<any>) {
         if (!session.isSecure()) {
-            const msgChannel = new MessageChannel(byteArrayChannel, session, () => this.paseChannels.delete(session));
-            this.paseChannels.set(session, msgChannel);
-            return msgChannel;
+            return this.getOrCreateAsPaseChannel(byteArrayChannel, session);
         }
         const secureSession = session as SecureSession<any>;
         const fabric = secureSession.getFabric();
         const nodeId = secureSession.getPeerNodeId();
         if (fabric === undefined) {
-            const msgChannel = new MessageChannel(byteArrayChannel, session, () => this.paseChannels.delete(session));
-            this.paseChannels.set(session, msgChannel);
-            return msgChannel;
+            return this.getOrCreateAsPaseChannel(byteArrayChannel, session);
         }
 
         let result = this.channels.get(this.getChannelKey(fabric, nodeId));
         if (result === undefined || result.session.getId() !== session.getId()) {
-            result = new MessageChannel(byteArrayChannel, session, () => this.removeChannel(fabric, nodeId));
-            this.setChannel(fabric, nodeId, result);
+            result = new MessageChannel(
+                byteArrayChannel,
+                session,
+                async () => await this.removeChannel(fabric, nodeId),
+            );
+            await this.setChannel(fabric, nodeId, result);
         }
         return result;
     }

--- a/packages/matter.js/src/protocol/ExchangeManager.ts
+++ b/packages/matter.js/src/protocol/ExchangeManager.ts
@@ -143,7 +143,7 @@ export class ExchangeManager<ContextT> {
                 );
             }
             const exchange = MessageExchange.fromInitialMessage(
-                this.channelManager.getOrCreateChannel(channel, session),
+                await this.channelManager.getOrCreateChannel(channel, session),
                 this.messageCounter,
                 message,
                 async () => await this.deleteExchange(exchangeIndex),

--- a/packages/matter.js/src/protocol/MessageExchange.ts
+++ b/packages/matter.js/src/protocol/MessageExchange.ts
@@ -345,7 +345,7 @@ export class MessageExchange<ContextT> {
     }
 
     async destroy() {
-        if (this.receivedMessageToAck !== undefined) {
+        if (this.closeTimer === undefined && this.receivedMessageToAck !== undefined) {
             try {
                 await this.send(MessageType.StandaloneAck, new ByteArray(0));
             } catch (error) {
@@ -394,6 +394,7 @@ export class MessageExchange<ContextT> {
     }
 
     async close() {
+        if (this.closeTimer !== undefined) return; // close was already called
         if (this.receivedMessageToAck !== undefined) {
             try {
                 await this.send(MessageType.StandaloneAck, new ByteArray(0));

--- a/packages/matter.js/src/protocol/interaction/InteractionMessenger.ts
+++ b/packages/matter.js/src/protocol/interaction/InteractionMessenger.ts
@@ -7,7 +7,13 @@
 import { MatterController } from "../../MatterController.js";
 import { MatterDevice } from "../../MatterDevice.js";
 import { Message, SessionType } from "../../codec/MessageCodec.js";
-import { MatterError, MatterFlowError, NotImplementedError, UnexpectedDataError } from "../../common/MatterError.js";
+import {
+    ImplementationError,
+    MatterError,
+    MatterFlowError,
+    NotImplementedError,
+    UnexpectedDataError,
+} from "../../common/MatterError.js";
 import { tryCatchAsync } from "../../common/TryCatchHandler.js";
 import { Logger } from "../../log/Logger.js";
 import { ExchangeProvider } from "../../protocol/ExchangeManager.js";
@@ -376,6 +382,9 @@ export class InteractionClientMessenger extends IncomingInteractionClientMesseng
 
     /** Implements a send method with an automatic reconnection mechanism */
     override async send(messageType: number, payload: ByteArray, options?: ExchangeSendOptions) {
+        if (this.exchange.channel.closed) {
+            throw new ImplementationError("The exchange channel is closed. Please connect the device first.");
+        }
         try {
             return await this.exchange.send(messageType, payload, options);
         } catch (error) {


### PR DESCRIPTION
This PR cleans up some cases where ...
* Message Channels could be overridden and so potentially missing cleanup
* reduce some duplicate code
* make sure MessageExchanges are not starting multiple close timers
* Make sure to not send traffic on closed exchange channels

These changes are covered by existing tests, especially Intergation and chip test