### PR TITLE
Scanner, Discovery and Controller enhancements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The main work (all changes without a GitHub username in brackets in the below li
   * Feature: Added generation method for random passcodes to PaseClient
   * Feature: Generalized Discovery logic and allow discoveries via different methods (BLE+IP) in parallel
   * Feature: Added functionality to clear session contexts including data in sub-contexts or not
+  * Feature: Enhance discovery methods to allow continuous discovery for operational devices
 * matter.js API:
   * Breaking: Rename resetStorage() on CommissioningServer to factoryReset() and add logic to restart the device if currently running
   * Breaking: Restructure the CommissioningController to allow pairing with multiple nodes
@@ -33,6 +34,8 @@ The main work (all changes without a GitHub username in brackets in the below li
     * Introducing class PairedNode with the High level API for a paired Node
     * Restructured CommissioningController to handle multiple nodes and offer new high level API
     * Changed name of the unique storage id for servers or controllers added to MatterServer to "uniqueStorageKey"
+    * Adjusted subscription callbacks to also provide the nodeId of the affected device reporting the changes to allow callbacks to be used generically when connecting to all nodes
+    * Introduces a node state information callback to inform about the connection status but also when the node structure changed (for bridges) or such.
   * Feature: Makes Port for CommissioningServer optional and add automatic port handling in MatterServer
   * Feature: Allows removal of Controller or Server instances from Matter server, optionally with deleting the storage
   * Enhance: Makes passcode and discriminator for CommissioningServer optional and randomly generate them if not provided 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     * Changed name of the unique storage id for servers or controllers added to MatterServer to "uniqueStorageKey"
     * Adjusted subscription callbacks to also provide the nodeId of the affected device reporting the changes to allow callbacks to be used generically when connecting to all nodes
     * Introduces a node state information callback to inform about the connection status but also when the node structure changed (for bridges) or such.
+  * Feature: Enhanced CommissioningServer API and CommissioningController for improved practical usage
   * Feature: Makes Port for CommissioningServer optional and add automatic port handling in MatterServer
   * Feature: Allows removal of Controller or Server instances from Matter server, optionally with deleting the storage
   * Enhance: Makes passcode and discriminator for CommissioningServer optional and randomly generate them if not provided 

--- a/packages/matter-node-ble.js/src/ble/BleScanner.ts
+++ b/packages/matter-node-ble.js/src/ble/BleScanner.ts
@@ -34,7 +34,11 @@ type CommissionableDeviceData = CommissionableDevice & {
 export class BleScanner implements Scanner {
     private readonly recordWaiters = new Map<
         string,
-        { resolver: () => void; timer: Timer; resolveOnUpdatedRecords: boolean }
+        {
+            resolver: () => void;
+            timer: Timer;
+            resolveOnUpdatedRecords: boolean;
+        }
     >();
     private readonly discoveredMatterDevices = new Map<string, DiscoveredBleDevice>();
 
@@ -65,7 +69,7 @@ export class BleScanner implements Scanner {
                 resolveOnUpdatedRecords ? "" : " (not resolving on updated records)"
             }`,
         );
-        return { promise };
+        await promise;
     }
 
     /**
@@ -221,11 +225,9 @@ export class BleScanner implements Scanner {
         let storedRecords = this.getCommissionableDevices(identifier);
         if (storedRecords.length === 0) {
             const queryKey = this.buildCommissionableQueryIdentifier(identifier);
-            const { promise } = await this.registerWaiterPromise(queryKey, timeoutSeconds);
 
             await this.nobleClient.startScanning();
-
-            await promise;
+            await this.registerWaiterPromise(queryKey, timeoutSeconds);
 
             storedRecords = this.getCommissionableDevices(identifier);
             await this.nobleClient.stopScanning();
@@ -257,8 +259,7 @@ export class BleScanner implements Scanner {
             if (remainingTime <= 0) {
                 break;
             }
-            const { promise } = await this.registerWaiterPromise(queryKey, remainingTime, false);
-            await promise;
+            await this.registerWaiterPromise(queryKey, remainingTime, false);
         }
         await this.nobleClient.stopScanning();
         return this.getCommissionableDevices(identifier).map(({ deviceData }) => deviceData);

--- a/packages/matter-node-shell.js/src/MatterNode.ts
+++ b/packages/matter-node-shell.js/src/MatterNode.ts
@@ -3,6 +3,7 @@
  * Copyright 2022-2023 Project CHIP Authors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // Include this first to auto-register Crypto, Network and Time Node.js implementations
 import { CommissioningController, MatterServer } from "@project-chip/matter-node.js";
 
@@ -23,7 +24,7 @@ export class MatterNode {
     private storageContext?: StorageContext;
 
     commissioningController?: CommissioningController;
-    private matterDevice?: MatterServer;
+    private matterController?: MatterServer;
 
     constructor(private nodeNum: number) {}
 
@@ -54,7 +55,7 @@ export class MatterNode {
     }
 
     async close() {
-        await this.matterDevice?.close();
+        await this.matterController?.close();
         this.closeStorage();
     }
 
@@ -69,7 +70,7 @@ export class MatterNode {
         if (this.storageManager === undefined) {
             throw new Error("StorageManager not initialized"); // Should never happen
         }
-        if (this.matterDevice !== undefined) {
+        if (this.matterController !== undefined) {
             return;
         }
         logger.info(`matter.js shell controller started for node ${this.nodeNum}`);
@@ -87,11 +88,11 @@ export class MatterNode {
          * are called.
          */
 
-        this.matterDevice = new MatterServer(this.storageManager);
+        this.matterController = new MatterServer(this.storageManager);
         this.commissioningController = new CommissioningController({
             autoConnect: false,
         });
-        this.matterDevice.addCommissioningController(this.commissioningController);
+        this.matterController.addCommissioningController(this.commissioningController);
 
         /**
          * Start the Matter Server
@@ -100,7 +101,7 @@ export class MatterNode {
          * CommissioningServer node then this command also starts the announcement of the device into the network.
          */
 
-        await this.matterDevice.start();
+        await this.matterController.start();
     }
 
     async connectAndGetNodes(nodeIdStr?: string) {

--- a/packages/matter-node-shell.js/src/MatterNode.ts
+++ b/packages/matter-node-shell.js/src/MatterNode.ts
@@ -1,5 +1,7 @@
 /**
- * Import needed modules from @project-chip/matter-node.js
+ * @license
+ * Copyright 2022-2023 Project CHIP Authors
+ * SPDX-License-Identifier: Apache-2.0
  */
 // Include this first to auto-register Crypto, Network and Time Node.js implementations
 import { CommissioningController, MatterServer } from "@project-chip/matter-node.js";

--- a/packages/matter-node-shell.js/src/app.ts
+++ b/packages/matter-node-shell.js/src/app.ts
@@ -75,7 +75,7 @@ async function main() {
 
                 const { nodeNum, ble, nodeType, resetStorage } = argv;
 
-                const theNode = new MatterNode(nodeNum);
+                theNode = new MatterNode(nodeNum);
                 await theNode.initialize(resetStorage);
                 const theShell = new Shell(theNode, PROMPT);
 

--- a/packages/matter-node-shell.js/src/app.ts
+++ b/packages/matter-node-shell.js/src/app.ts
@@ -1,17 +1,7 @@
 /**
- * Copyright 2022 Project CHIP Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * @license
+ * Copyright 2022-2023 Project CHIP Authors
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import { BleNode } from "@project-chip/matter-node-ble.js/ble";

--- a/packages/matter-node-shell.js/src/shell/Shell.ts
+++ b/packages/matter-node-shell.js/src/shell/Shell.ts
@@ -1,17 +1,7 @@
 /**
- * Copyright 2022 Project CHIP Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * @license
+ * Copyright 2022-2023 Project CHIP Authors
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import { MatterError } from "@project-chip/matter-node.js/common";

--- a/packages/matter-node-shell.js/src/shell/Shell.ts
+++ b/packages/matter-node-shell.js/src/shell/Shell.ts
@@ -46,7 +46,6 @@ export class Shell {
      *
      * @param {MatterNode} theNode MatterNode object to use for all commands.
      * @param {string} prompt Prompt string to use for each command line.
-     * @param {Array} commandList Array of JSON commands dispatch structures.
      */
     constructor(
         public theNode: MatterNode,

--- a/packages/matter-node-shell.js/src/shell/Shell.ts
+++ b/packages/matter-node-shell.js/src/shell/Shell.ts
@@ -12,6 +12,7 @@ import { MatterNode } from "../MatterNode.js";
 import { exit } from "../app";
 import cmdCommission from "./cmd_commission.js";
 import cmdConfig from "./cmd_config.js";
+import cmdDiscover from "./cmd_discover.js";
 import cmdIdentify from "./cmd_identify.js";
 import cmdLock from "./cmd_lock.js";
 import cmdNodes from "./cmd_nodes.js";
@@ -92,6 +93,7 @@ export class Shell {
                     cmdOnOff(this.theNode),
                     cmdSubscribe(this.theNode),
                     cmdIdentify(this.theNode),
+                    cmdDiscover(this.theNode),
                     exitCommand(),
                 ])
                 .command({

--- a/packages/matter-node-shell.js/src/shell/Shell.ts
+++ b/packages/matter-node-shell.js/src/shell/Shell.ts
@@ -68,8 +68,12 @@ export class Shell {
                 });
             })
             .on("close", () => {
-                process.stdout.write("goodbye\n");
-                process.exit(0);
+                exit()
+                    .then(() => process.exit(0))
+                    .catch(e => {
+                        process.stderr.write(`Close error: ${e}\n`);
+                        process.exit(1);
+                    });
             });
 
         this.readline.prompt();
@@ -116,6 +120,8 @@ export class Shell {
                 if (argv.unhandled) {
                     process.stderr.write(`Unknown command: ${line}\n`);
                     yargsInstance.showHelp();
+                } else {
+                    console.log("Done.");
                 }
             } catch (error) {
                 process.stderr.write(`Error happened during command: ${error}\n`);

--- a/packages/matter-node-shell.js/src/shell/cmd_commission.ts
+++ b/packages/matter-node-shell.js/src/shell/cmd_commission.ts
@@ -44,7 +44,14 @@ export default function commands(theNode: MatterNode) {
                                         });
                                 },
                                 async argv => {
-                                    const { pairingCode, nodeId: nodeIdStr, ipPort, ip, ble = false } = argv;
+                                    const {
+                                        pairingCode,
+                                        nodeId: nodeIdStr,
+                                        ipPort,
+                                        ip,
+                                        ble = false,
+                                        instanceId,
+                                    } = argv;
                                     let { setupPinCode, discriminator, shortDiscriminator } = argv;
 
                                     if (typeof pairingCode === "string") {
@@ -70,7 +77,9 @@ export default function commands(theNode: MatterNode) {
                                                     ? { ip, port: ipPort, type: "udp" }
                                                     : undefined,
                                             identifierData:
-                                                discriminator !== undefined
+                                                instanceId !== undefined
+                                                    ? { instanceId }
+                                                    : discriminator !== undefined
                                                     ? { longDiscriminator: discriminator }
                                                     : shortDiscriminator !== undefined
                                                     ? { shortDiscriminator }
@@ -147,6 +156,11 @@ export default function commands(theNode: MatterNode) {
                                     describe: "setup pin code",
                                     default: 20202021,
                                     type: "number",
+                                },
+                                instanceId: {
+                                    alias: "i",
+                                    describe: "instance id",
+                                    type: "string",
                                 },
                                 discriminator: {
                                     alias: "d",

--- a/packages/matter-node-shell.js/src/shell/cmd_commission.ts
+++ b/packages/matter-node-shell.js/src/shell/cmd_commission.ts
@@ -1,17 +1,7 @@
 /**
- * Copyright 2022 Project CHIP Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * @license
+ * Copyright 2022-2023 Project CHIP Authors
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import { NodeCommissioningOptions } from "@project-chip/matter-node.js";

--- a/packages/matter-node-shell.js/src/shell/cmd_commission.ts
+++ b/packages/matter-node-shell.js/src/shell/cmd_commission.ts
@@ -7,6 +7,8 @@
 import { NodeCommissioningOptions } from "@project-chip/matter-node.js";
 import { BasicInformationCluster, DescriptorCluster, GeneralCommissioning } from "@project-chip/matter-node.js/cluster";
 import { NodeId } from "@project-chip/matter-node.js/datatype";
+import { NodeStateInformation } from "@project-chip/matter-node.js/device";
+import { Logger } from "@project-chip/matter-node.js/log";
 import { ManualPairingCodeCodec, QrCode } from "@project-chip/matter-node.js/schema";
 import type { Argv } from "yargs";
 import { MatterNode } from "../MatterNode";
@@ -90,6 +92,53 @@ export default function commands(theNode: MatterNode) {
                                             },
                                         },
                                         passcode: setupPinCode,
+                                        attributeChangedCallback: (
+                                            peerNodeId,
+                                            { path: { nodeId, clusterId, endpointId, attributeName }, value },
+                                        ) =>
+                                            console.log(
+                                                `attributeChangedCallback ${peerNodeId} Attribute ${nodeId}/${endpointId}/${clusterId}/${attributeName} changed to ${Logger.toJSON(
+                                                    value,
+                                                )}`,
+                                            ),
+                                        eventTriggeredCallback: (
+                                            peerNodeId,
+                                            { path: { nodeId, clusterId, endpointId, eventName }, events },
+                                        ) =>
+                                            console.log(
+                                                `eventTriggeredCallback ${peerNodeId} Event ${nodeId}/${endpointId}/${clusterId}/${eventName} triggered with ${Logger.toJSON(
+                                                    events,
+                                                )}`,
+                                            ),
+                                        stateInformationCallback: (peerNodeId, info) => {
+                                            switch (info) {
+                                                case NodeStateInformation.Connected:
+                                                    console.log(
+                                                        `stateInformationCallback: Node ${peerNodeId} connected`,
+                                                    );
+                                                    break;
+                                                case NodeStateInformation.Disconnected:
+                                                    console.log(
+                                                        `stateInformationCallback: Node ${peerNodeId} disconnected`,
+                                                    );
+                                                    break;
+                                                case NodeStateInformation.Reconnecting:
+                                                    console.log(
+                                                        `stateInformationCallback: Node ${peerNodeId} reconnecting`,
+                                                    );
+                                                    break;
+                                                case NodeStateInformation.WaitingForDeviceDiscovery:
+                                                    console.log(
+                                                        `stateInformationCallback: Node ${peerNodeId} waiting that device gets discovered again`,
+                                                    );
+                                                    break;
+                                                case NodeStateInformation.StructureChanged:
+                                                    console.log(
+                                                        `stateInformationCallback: Node ${peerNodeId} structure changed`,
+                                                    );
+                                                    break;
+                                            }
+                                        },
                                     } as NodeCommissioningOptions;
 
                                     options.commissioning = {
@@ -98,7 +147,7 @@ export default function commands(theNode: MatterNode) {
                                         regulatoryCountryCode: "XX",
                                     };
 
-                                    console.log(JSON.stringify(options));
+                                    console.log(Logger.toJSON(options));
 
                                     if (theNode.Store.has("WiFiSsid") && theNode.Store.has("WiFiPassword")) {
                                         options.commissioning.wifiNetwork = {

--- a/packages/matter-node-shell.js/src/shell/cmd_commission.ts
+++ b/packages/matter-node-shell.js/src/shell/cmd_commission.ts
@@ -7,11 +7,11 @@
 import { NodeCommissioningOptions } from "@project-chip/matter-node.js";
 import { BasicInformationCluster, DescriptorCluster, GeneralCommissioning } from "@project-chip/matter-node.js/cluster";
 import { NodeId } from "@project-chip/matter-node.js/datatype";
-import { NodeStateInformation } from "@project-chip/matter-node.js/device";
 import { Logger } from "@project-chip/matter-node.js/log";
 import { ManualPairingCodeCodec, QrCode } from "@project-chip/matter-node.js/schema";
 import type { Argv } from "yargs";
 import { MatterNode } from "../MatterNode";
+import { createDiagnosticCallbacks } from "./cmd_nodes";
 
 export default function commands(theNode: MatterNode) {
     return {
@@ -92,53 +92,7 @@ export default function commands(theNode: MatterNode) {
                                             },
                                         },
                                         passcode: setupPinCode,
-                                        attributeChangedCallback: (
-                                            peerNodeId,
-                                            { path: { nodeId, clusterId, endpointId, attributeName }, value },
-                                        ) =>
-                                            console.log(
-                                                `attributeChangedCallback ${peerNodeId} Attribute ${nodeId}/${endpointId}/${clusterId}/${attributeName} changed to ${Logger.toJSON(
-                                                    value,
-                                                )}`,
-                                            ),
-                                        eventTriggeredCallback: (
-                                            peerNodeId,
-                                            { path: { nodeId, clusterId, endpointId, eventName }, events },
-                                        ) =>
-                                            console.log(
-                                                `eventTriggeredCallback ${peerNodeId} Event ${nodeId}/${endpointId}/${clusterId}/${eventName} triggered with ${Logger.toJSON(
-                                                    events,
-                                                )}`,
-                                            ),
-                                        stateInformationCallback: (peerNodeId, info) => {
-                                            switch (info) {
-                                                case NodeStateInformation.Connected:
-                                                    console.log(
-                                                        `stateInformationCallback: Node ${peerNodeId} connected`,
-                                                    );
-                                                    break;
-                                                case NodeStateInformation.Disconnected:
-                                                    console.log(
-                                                        `stateInformationCallback: Node ${peerNodeId} disconnected`,
-                                                    );
-                                                    break;
-                                                case NodeStateInformation.Reconnecting:
-                                                    console.log(
-                                                        `stateInformationCallback: Node ${peerNodeId} reconnecting`,
-                                                    );
-                                                    break;
-                                                case NodeStateInformation.WaitingForDeviceDiscovery:
-                                                    console.log(
-                                                        `stateInformationCallback: Node ${peerNodeId} waiting that device gets discovered again`,
-                                                    );
-                                                    break;
-                                                case NodeStateInformation.StructureChanged:
-                                                    console.log(
-                                                        `stateInformationCallback: Node ${peerNodeId} structure changed`,
-                                                    );
-                                                    break;
-                                            }
-                                        },
+                                        ...createDiagnosticCallbacks(),
                                     } as NodeCommissioningOptions;
 
                                     options.commissioning = {

--- a/packages/matter-node-shell.js/src/shell/cmd_commission.ts
+++ b/packages/matter-node-shell.js/src/shell/cmd_commission.ts
@@ -287,6 +287,23 @@ export default function commands(theNode: MatterNode) {
                         );
                         console.log(`Manual pairing code: ${manualPairingCode}`);
                     },
+                )
+                .command(
+                    "unpair <node-id>",
+                    "Unpair/Decommission a node",
+                    yargs => {
+                        return yargs.positional("node-id", {
+                            describe: "node id",
+                            type: "string",
+                            demandOption: true,
+                        });
+                    },
+                    async argv => {
+                        await theNode.start();
+                        const { nodeId } = argv;
+                        const node = (await theNode.connectAndGetNodes(nodeId))[0];
+                        await node.decommission();
+                    },
                 ),
         handler: async (argv: any) => {
             argv.unhandled = true;

--- a/packages/matter-node-shell.js/src/shell/cmd_config.ts
+++ b/packages/matter-node-shell.js/src/shell/cmd_config.ts
@@ -1,17 +1,7 @@
 /**
- * Copyright 2022 Project CHIP Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * @license
+ * Copyright 2022-2023 Project CHIP Authors
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import { Logger } from "@project-chip/matter-node.js/log";

--- a/packages/matter-node-shell.js/src/shell/cmd_discover.ts
+++ b/packages/matter-node-shell.js/src/shell/cmd_discover.ts
@@ -1,0 +1,127 @@
+/**
+ * @license
+ * Copyright 2022-2023 Project CHIP Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { VendorId } from "@project-chip/matter-node.js/datatype";
+import { Logger } from "@project-chip/matter-node.js/log";
+import { ManualPairingCodeCodec } from "@project-chip/matter-node.js/schema";
+import { CommissionableDeviceIdentifiers } from "@project-chip/matter.js/common";
+import type { Argv } from "yargs";
+import { MatterNode } from "../MatterNode";
+
+export default function commands(theNode: MatterNode) {
+    return {
+        command: "discover",
+        describe: "Handle device discovery",
+        builder: (yargs: Argv) =>
+            yargs
+                // Pair
+                .command(
+                    "commissionable [timeout-seconds]",
+                    "Discover commissionable devices",
+                    () => {
+                        return yargs
+                            .positional("timeout-seconds", {
+                                describe: "Discovery timeout in seconds",
+                                default: 900,
+                                type: "number",
+                            })
+                            .options({
+                                pairingCode: {
+                                    describe: "pairing code",
+                                    default: undefined,
+                                    type: "string",
+                                },
+                                discriminator: {
+                                    alias: "d",
+                                    description: "Long discriminator",
+                                    default: undefined,
+                                    type: "number",
+                                },
+                                shortDiscriminator: {
+                                    alias: "s",
+                                    description: "Short discriminator",
+                                    default: undefined,
+                                    type: "number",
+                                },
+                                vendorId: {
+                                    alias: "v",
+                                    description: "Vendor ID",
+                                    default: undefined,
+                                    type: "number",
+                                },
+                                productId: {
+                                    alias: "p",
+                                    description: "Product ID",
+                                    default: undefined,
+                                    type: "number",
+                                },
+                                deviceType: {
+                                    alias: "t",
+                                    description: "Device Type",
+                                    default: undefined,
+                                    type: "number",
+                                },
+                                ble: {
+                                    alias: "b",
+                                    description: "Also discover over BLE",
+                                    default: false,
+                                    type: "boolean",
+                                },
+                            });
+                    },
+                    async argv => {
+                        const { ble = false, pairingCode, vendorId, productId, deviceType, timeoutSeconds } = argv;
+                        let { discriminator, shortDiscriminator } = argv;
+
+                        if (typeof pairingCode === "string") {
+                            const { shortDiscriminator: pairingCodeShortDiscriminator } =
+                                ManualPairingCodeCodec.decode(pairingCode);
+                            shortDiscriminator = pairingCodeShortDiscriminator;
+                            discriminator = undefined;
+                        }
+
+                        await theNode.start();
+                        if (theNode.commissioningController === undefined) {
+                            throw new Error("CommissioningController not initialized");
+                        }
+
+                        const identifierData: CommissionableDeviceIdentifiers =
+                            discriminator !== undefined
+                                ? { longDiscriminator: discriminator }
+                                : shortDiscriminator !== undefined
+                                ? { shortDiscriminator }
+                                : vendorId !== undefined
+                                ? { vendorId: VendorId(vendorId) }
+                                : productId !== undefined
+                                ? { productId }
+                                : deviceType !== undefined
+                                ? { deviceType }
+                                : {};
+
+                        console.log(
+                            `Discover devices with identifier ${Logger.toJSON(
+                                identifierData,
+                            )} for ${timeoutSeconds} seconds.`,
+                        );
+
+                        const results = await theNode.commissioningController.discoverCommissionableDevices(
+                            identifierData,
+                            {
+                                ble,
+                                onIpNetwork: true,
+                            },
+                            device => console.log(`Discovered device ${Logger.toJSON(device)}`),
+                            timeoutSeconds,
+                        );
+
+                        console.log(`Discovered ${results.length} devices`, results);
+                    },
+                ),
+        handler: async (argv: any) => {
+            argv.unhandled = true;
+        },
+    };
+}

--- a/packages/matter-node-shell.js/src/shell/cmd_identify.ts
+++ b/packages/matter-node-shell.js/src/shell/cmd_identify.ts
@@ -1,17 +1,7 @@
 /**
- * Copyright 2022 Project CHIP Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * @license
+ * Copyright 2022-2023 Project CHIP Authors
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import { IdentifyCluster } from "@project-chip/matter-node.js/cluster";

--- a/packages/matter-node-shell.js/src/shell/cmd_lock.ts
+++ b/packages/matter-node-shell.js/src/shell/cmd_lock.ts
@@ -1,17 +1,7 @@
 /**
- * Copyright 2022 Project CHIP Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * @license
+ * Copyright 2022-2023 Project CHIP Authors
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import type { Argv } from "yargs";

--- a/packages/matter-node-shell.js/src/shell/cmd_nodes.ts
+++ b/packages/matter-node-shell.js/src/shell/cmd_nodes.ts
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { NodeId } from "@project-chip/matter-node.js/datatype";
+import { NodeStateInformation } from "@project-chip/matter-node.js/device";
+import { Logger } from "@project-chip/matter-node.js/log";
 import type { Argv } from "yargs";
 import { MatterNode } from "../MatterNode";
 
@@ -62,7 +65,135 @@ export default function commands(theNode: MatterNode) {
                         const node = (await theNode.connectAndGetNodes(nodeId))[0];
 
                         console.log("Logging structure of Node ", node.nodeId.toString());
-                        node.logStructure();
+                        node.logStructure({});
+                    },
+                )
+                .command(
+                    "connect <node-id> [min-subscription-interval] [max-subscription-interval]",
+                    "Connects to one or all cmmissioned nodes",
+                    yargs => {
+                        return yargs
+                            .positional("node-id", {
+                                describe: "node id to connect. Use 'all' to connect to all nodes.",
+                                default: undefined,
+                                type: "string",
+                                demandOption: true,
+                            })
+                            .positional("min-subscription-interval", {
+                                describe:
+                                    "Minimum subscription interval in seconds. If set then the node is subscribed to all attributes and events.",
+                                type: "number",
+                            })
+                            .positional("max-subscription-interval", {
+                                describe:
+                                    "Maximum subscription interval in seconds. If minimum interval is set and this not this is set to 30 seconds.",
+                                type: "number",
+                            });
+                    },
+                    async argv => {
+                        const { nodeId: nodeIdStr, maxSubscriptionInterval, minSubscriptionInterval } = argv;
+                        await theNode.start();
+                        if (theNode.commissioningController === undefined) {
+                            throw new Error("CommissioningController not initialized");
+                        }
+                        let nodeIds = theNode.commissioningController.getCommissionedNodes();
+                        if (nodeIdStr !== "all") {
+                            const cmdNodeId = NodeId(BigInt(nodeIdStr));
+                            nodeIds = nodeIds.filter(nodeId => nodeId === cmdNodeId);
+                            if (!nodeIds.length) {
+                                throw new Error(`Node ${nodeIdStr} not commissioned`);
+                            }
+                        }
+
+                        const autoSubscribe = minSubscriptionInterval !== undefined;
+
+                        for (const nodeIdToProcess of nodeIds) {
+                            await theNode.commissioningController.connectNode(nodeIdToProcess, {
+                                autoSubscribe,
+                                subscribeMinIntervalFloorSeconds: autoSubscribe ? minSubscriptionInterval : undefined,
+                                subscribeMaxIntervalCeilingSeconds: autoSubscribe
+                                    ? maxSubscriptionInterval ?? 30
+                                    : undefined,
+                                attributeChangedCallback: (
+                                    peerNodeId,
+                                    { path: { nodeId, clusterId, endpointId, attributeName }, value },
+                                ) =>
+                                    console.log(
+                                        `attributeChangedCallback ${peerNodeId}: Attribute ${nodeId}/${endpointId}/${clusterId}/${attributeName} changed to ${Logger.toJSON(
+                                            value,
+                                        )}`,
+                                    ),
+                                eventTriggeredCallback: (
+                                    peerNodeId,
+                                    { path: { nodeId, clusterId, endpointId, eventName }, events },
+                                ) =>
+                                    console.log(
+                                        `eventTriggeredCallback ${peerNodeId}: Event ${nodeId}/${endpointId}/${clusterId}/${eventName} triggered with ${Logger.toJSON(
+                                            events,
+                                        )}`,
+                                    ),
+                                stateInformationCallback: (peerNodeId, info) => {
+                                    switch (info) {
+                                        case NodeStateInformation.Connected:
+                                            console.log(`stateInformationCallback Node ${peerNodeId} connected`);
+                                            break;
+                                        case NodeStateInformation.Disconnected:
+                                            console.log(`stateInformationCallback Node ${peerNodeId} disconnected`);
+                                            break;
+                                        case NodeStateInformation.Reconnecting:
+                                            console.log(`stateInformationCallback Node ${peerNodeId} reconnecting`);
+                                            break;
+                                        case NodeStateInformation.WaitingForDeviceDiscovery:
+                                            console.log(
+                                                `stateInformationCallback Node ${peerNodeId} waiting that device gets discovered again`,
+                                            );
+                                            break;
+                                        case NodeStateInformation.StructureChanged:
+                                            console.log(
+                                                `stateInformationCallback Node ${peerNodeId} structure changed`,
+                                            );
+                                            break;
+                                    }
+                                },
+                            });
+                        }
+                    },
+                )
+                .command(
+                    "disconnect <node-id>",
+                    "Disconnects from one or all nodes",
+                    yargs => {
+                        return yargs.positional("node-id", {
+                            describe: "node id to disconnect. Use 'all' to disconnect from all nodes.",
+                            default: undefined,
+                            type: "string",
+                            demandOption: true,
+                        });
+                    },
+                    async argv => {
+                        const { nodeId: nodeIdStr } = argv;
+                        if (theNode.commissioningController === undefined) {
+                            console.log("Controller not initialized, nothing to disconnect.");
+                            return;
+                        }
+
+                        let nodeIds = theNode.commissioningController.getCommissionedNodes();
+                        if (nodeIdStr !== "all") {
+                            const cmdNodeId = NodeId(BigInt(nodeIdStr));
+                            nodeIds = nodeIds.filter(nodeId => nodeId === cmdNodeId);
+                            if (!nodeIds.length) {
+                                throw new Error(`Node ${nodeIdStr} not commissioned`);
+                            }
+                        }
+
+                        for (const nodeIdToProcess of nodeIds) {
+                            const node = theNode.commissioningController.getConnectedNode(nodeIdToProcess);
+                            if (node === undefined) {
+                                console.log(`Node ${nodeIdToProcess} not connected`);
+                                continue;
+                            }
+                            await node.disconnect();
+                        }
                     },
                 ),
         handler: async (argv: any) => {

--- a/packages/matter-node-shell.js/src/shell/cmd_nodes.ts
+++ b/packages/matter-node-shell.js/src/shell/cmd_nodes.ts
@@ -1,17 +1,7 @@
 /**
- * Copyright 2022 Project CHIP Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * @license
+ * Copyright 2022-2023 Project CHIP Authors
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import type { Argv } from "yargs";

--- a/packages/matter-node-shell.js/src/shell/cmd_onoff.ts
+++ b/packages/matter-node-shell.js/src/shell/cmd_onoff.ts
@@ -1,17 +1,7 @@
 /**
- * Copyright 2022 Project CHIP Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * @license
+ * Copyright 2022-2023 Project CHIP Authors
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import { OnOffCluster } from "@project-chip/matter-node.js/cluster";

--- a/packages/matter-node-shell.js/src/shell/cmd_session.ts
+++ b/packages/matter-node-shell.js/src/shell/cmd_session.ts
@@ -1,17 +1,7 @@
 /**
- * Copyright 2022 Project CHIP Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * @license
+ * Copyright 2022-2023 Project CHIP Authors
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import { MatterNode } from "../MatterNode";

--- a/packages/matter-node-shell.js/src/shell/cmd_subscribe.ts
+++ b/packages/matter-node-shell.js/src/shell/cmd_subscribe.ts
@@ -35,13 +35,13 @@ export default function commands(theNode: MatterNode) {
                                 value,
                             }) =>
                                 console.log(
-                                    `Attribute ${nodeId}/${endpointId}/${clusterId}/${attributeName} changed to ${Logger.toJSON(
+                                    `${nodeId}: Attribute ${nodeId}/${endpointId}/${clusterId}/${attributeName} changed to ${Logger.toJSON(
                                         value,
                                     )}`,
                                 ),
                             eventTriggeredCallback: ({ path: { nodeId, clusterId, endpointId, eventName }, events }) =>
                                 console.log(
-                                    `Event ${nodeId}/${endpointId}/${clusterId}/${eventName} triggered with ${Logger.toJSON(
+                                    `${nodeId} Event ${nodeId}/${endpointId}/${clusterId}/${eventName} triggered with ${Logger.toJSON(
                                         events,
                                     )}`,
                                 ),

--- a/packages/matter-node-shell.js/src/shell/cmd_subscribe.ts
+++ b/packages/matter-node-shell.js/src/shell/cmd_subscribe.ts
@@ -1,17 +1,7 @@
 /**
- * Copyright 2022 Project CHIP Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * @license
+ * Copyright 2022-2023 Project CHIP Authors
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import { Logger } from "@project-chip/matter-node.js/log";

--- a/packages/matter-node.js/test/IntegrationTest.ts
+++ b/packages/matter-node.js/test/IntegrationTest.ts
@@ -1074,7 +1074,7 @@ describe("Integration Test", () => {
         it("Check callback info", async () => {
             assert.equal(commissioningChangedCallsServer.length, 1);
             assert.ok(sessionChangedCallsServer.length >= 6); // not 100% accurate because of MockTime and not 100% finished responses and stuff like that
-            assert.equal(sessionChangedCallsServer[4].fabricIndex, FabricIndex(1));
+            assert.equal(sessionChangedCallsServer[sessionChangedCallsServer.length - 1].fabricIndex, FabricIndex(1));
             const sessionInfo = commissioningServer.getActiveSessionInformation();
             assert.equal(sessionInfo.length, 1);
             assert.ok(sessionInfo[0].fabric);
@@ -1445,7 +1445,7 @@ describe("Integration Test", () => {
 
             assert.equal(commissioningChangedCallsServer.length, 2);
             assert.ok(sessionChangedCallsServer.length >= 7);
-            assert.equal(sessionChangedCallsServer[7].fabricIndex, FabricIndex(2));
+            assert.equal(sessionChangedCallsServer[sessionChangedCallsServer.length - 1].fabricIndex, FabricIndex(2));
             const sessionInfo = commissioningServer.getActiveSessionInformation();
             assert.equal(sessionInfo.length, 2);
             assert.ok(sessionInfo[1].fabric);

--- a/packages/matter-node.js/test/IntegrationTest.ts
+++ b/packages/matter-node.js/test/IntegrationTest.ts
@@ -32,7 +32,7 @@ import {
     NodeId,
     VendorId,
 } from "@project-chip/matter.js/datatype";
-import { OnOffLightDevice } from "@project-chip/matter.js/device";
+import { NodeStateInformation, OnOffLightDevice } from "@project-chip/matter.js/device";
 import { FabricJsonObject } from "@project-chip/matter.js/fabric";
 import { DecodedEventData, InteractionClientMessenger } from "@project-chip/matter.js/interaction";
 import { MdnsBroadcaster, MdnsScanner } from "@project-chip/matter.js/mdns";
@@ -87,6 +87,21 @@ describe("Integration Test", () => {
     const commissioningChangedCallsServer2 = new Array<{ fabricIndex: FabricIndex; time: number }>();
     const sessionChangedCallsServer = new Array<{ fabricIndex: FabricIndex; time: number }>();
     const sessionChangedCallsServer2 = new Array<{ fabricIndex: FabricIndex; time: number }>();
+    const nodeStateChangesController1Node1 = new Array<{
+        nodeId: NodeId;
+        nodeState: NodeStateInformation;
+        time: number;
+    }>();
+    const nodeStateChangesController1Node2 = new Array<{
+        nodeId: NodeId;
+        nodeState: NodeStateInformation;
+        time: number;
+    }>();
+    const nodeStateChangesController2Node1 = new Array<{
+        nodeId: NodeId;
+        nodeState: NodeStateInformation;
+        time: number;
+    }>();
 
     before(async () => {
         MockTime.reset(TIME_START);
@@ -267,6 +282,8 @@ describe("Integration Test", () => {
                     regulatoryCountryCode: "DE",
                 },
                 passcode: setupPin,
+                stateInformationCallback: (nodeId: NodeId, nodeState: NodeStateInformation) =>
+                    nodeStateChangesController1Node1.push({ nodeId, nodeState, time: MockTime.nowMs() }),
             });
 
             Time.get = () => mockTimeInstance;
@@ -285,6 +302,10 @@ describe("Integration Test", () => {
             assert.ok(sessionInfo[0].fabric);
             assert.equal(sessionInfo[0].fabric.fabricIndex, FabricIndex(1));
             assert.equal(sessionInfo[0].nodeId, node.nodeId);
+
+            assert.deepEqual(nodeStateChangesController1Node1.length, 1);
+            assert.equal(nodeStateChangesController1Node1[0].nodeId, node.nodeId);
+            assert.equal(nodeStateChangesController1Node1[0].nodeState, NodeStateInformation.Connected);
         });
 
         it("We can connect to the new commissioned device", async () => {
@@ -300,6 +321,8 @@ describe("Integration Test", () => {
             assert.ok(sessionInfo[0].fabric);
             assert.equal(sessionInfo[0].fabric.fabricIndex, FabricIndex(1));
             assert.equal(sessionInfo[0].numberOfActiveSubscriptions, 0);
+
+            assert.deepEqual(nodeStateChangesController1Node1.length, 1); // no new entry, stay connected
         });
 
         it("Subscribe to all Attributes and bind updates to them", async () => {
@@ -1244,6 +1267,8 @@ describe("Integration Test", () => {
                     regulatoryCountryCode: "DE",
                 },
                 passcode: setupPin2,
+                stateInformationCallback: (nodeId: NodeId, nodeState: NodeStateInformation) =>
+                    nodeStateChangesController1Node2.push({ nodeId, nodeState, time: MockTime.nowMs() }),
             });
 
             Time.get = () => mockTimeInstance;
@@ -1257,6 +1282,10 @@ describe("Integration Test", () => {
             assert.equal(sessionInfo.length, 1);
             assert.ok(sessionInfo[0].fabric);
             assert.equal(sessionInfo[0].numberOfActiveSubscriptions, 0);
+
+            assert.equal(nodeStateChangesController1Node2.length, 1);
+            assert.equal(nodeStateChangesController1Node2[0].nodeId, node.nodeId);
+            assert.equal(nodeStateChangesController1Node2[0].nodeState, NodeStateInformation.Connected);
         });
 
         it("We can connect to the new commissioned device", async () => {
@@ -1271,6 +1300,8 @@ describe("Integration Test", () => {
             assert.equal(sessionInfo.length, 1);
             assert.ok(sessionInfo[0].fabric);
             assert.equal(sessionInfo[0].numberOfActiveSubscriptions, 0);
+
+            assert.equal(nodeStateChangesController1Node2[0].nodeState, NodeStateInformation.Connected);
         });
 
         it("Subscribe to all Attributes and bind updates to them for second device", async () => {
@@ -1440,6 +1471,8 @@ describe("Integration Test", () => {
                             regulatoryCountryCode: "DE",
                         },
                         passcode,
+                        stateInformationCallback: (nodeId: NodeId, nodeState: NodeStateInformation) =>
+                            nodeStateChangesController2Node1.push({ nodeId, nodeState, time: MockTime.nowMs() }),
                     }),
             );
 
@@ -1451,6 +1484,9 @@ describe("Integration Test", () => {
             assert.ok(sessionInfo[1].fabric);
             assert.equal(sessionInfo[1].numberOfActiveSubscriptions, 0);
             assert.equal(commissioningChangedCallsServer2.length, 1);
+
+            assert.equal(nodeStateChangesController2Node1.length, 1);
+            assert.equal(nodeStateChangesController2Node1[0].nodeState, NodeStateInformation.Connected);
         }).timeout(10_000);
 
         it("verify that the server storage got updated", async () => {
@@ -1561,6 +1597,9 @@ describe("Integration Test", () => {
             assert.equal(commissioningChangedCallsServer.length, 3);
             assert.equal(commissioningChangedCallsServer[2].fabricIndex, FabricIndex(1));
             assert.equal(commissioningChangedCallsServer2.length, 1);
+
+            assert.equal(nodeStateChangesController1Node1.length, 2);
+            assert.equal(nodeStateChangesController1Node1[1].nodeState, NodeStateInformation.Disconnected);
         });
 
         it("read and remove second node by removing fabric from device unplanned and doing factory reset", async () => {
@@ -1606,6 +1645,10 @@ describe("Integration Test", () => {
             assert.equal(commissioningController.getCommissionedNodes().length, 0);
             assert.equal(commissioningChangedCallsServer2.length, 2);
             assert.equal(commissioningChangedCallsServer2[1].fabricIndex, FabricIndex(1));
+
+            assert.equal(nodeStateChangesController1Node2.length, 3);
+            assert.equal(nodeStateChangesController1Node2[1].nodeState, NodeStateInformation.Reconnecting);
+            assert.equal(nodeStateChangesController1Node2[2].nodeState, NodeStateInformation.Disconnected);
         }).timeout(30_000);
 
         it("controller storage is updated for removed nodes", async () => {

--- a/packages/matter.js/src/CommissioningController.ts
+++ b/packages/matter.js/src/CommissioningController.ts
@@ -180,6 +180,7 @@ export class CommissioningController extends MatterNode {
         const nodeId = await controller.commission(nodeOptions);
 
         return this.connectNode(nodeId, {
+            ...nodeOptions,
             autoSubscribe: nodeOptions.autoSubscribe ?? this.options.autoSubscribe,
             subscribeMinIntervalFloorSeconds:
                 nodeOptions.subscribeMinIntervalFloorSeconds ?? this.options.subscribeMinIntervalFloorSeconds,

--- a/packages/matter.js/src/CommissioningController.ts
+++ b/packages/matter.js/src/CommissioningController.ts
@@ -83,6 +83,12 @@ export type NodeCommissioningOptions = CommissioningControllerNodeOptions & {
         identifierData: CommissionableDeviceIdentifiers;
 
         /**
+         * Commissionable device object returned by a discovery run.
+         * If this property is provided then identifierData and knownAddress are ignored.
+         */
+        commissionableDevice?: CommissionableDevice;
+
+        /**
          * Discovery capabilities to use for discovery. These are included in the QR code normally and defined if BLE
          * is supported for initial commissioning.
          */

--- a/packages/matter.js/src/CommissioningController.ts
+++ b/packages/matter.js/src/CommissioningController.ts
@@ -75,19 +75,23 @@ export type NodeCommissioningOptions = CommissioningControllerNodeOptions & {
     commissioning?: CommissioningOptions;
 
     /** Discovery related options. */
-    discovery: {
-        /**
-         * Device identifiers (Short or Long Discriminator, Product/Vendor-Ids, Device-type or a pre-discovered
-         * instance Id, or "nothing" to discover all commissionable matter devices) to use for discovery.
-         */
-        identifierData: CommissionableDeviceIdentifiers;
-
-        /**
-         * Commissionable device object returned by a discovery run.
-         * If this property is provided then identifierData and knownAddress are ignored.
-         */
-        commissionableDevice?: CommissionableDevice;
-
+    discovery: (
+        | {
+              /**
+               * Device identifiers (Short or Long Discriminator, Product/Vendor-Ids, Device-type or a pre-discovered
+               * instance Id, or "nothing" to discover all commissionable matter devices) to use for discovery.
+               * If the property commissionableDevice is provided this property is ignored.
+               */
+              identifierData: CommissionableDeviceIdentifiers;
+          }
+        | {
+              /**
+               * Commissionable device object returned by a discovery run.
+               * If this property is provided then identifierData and knownAddress are ignored.
+               */
+              commissionableDevice: CommissionableDevice;
+          }
+    ) & {
         /**
          * Discovery capabilities to use for discovery. These are included in the QR code normally and defined if BLE
          * is supported for initial commissioning.
@@ -248,7 +252,7 @@ export class CommissioningController extends MatterNode {
 
         const existingNode = this.connectedNodes.get(nodeId);
         if (existingNode !== undefined) {
-            if (!existingNode.isConnencted) {
+            if (!existingNode.isConnected) {
                 await existingNode.reconnect();
             }
             return existingNode;

--- a/packages/matter.js/src/MatterController.ts
+++ b/packages/matter.js/src/MatterController.ts
@@ -638,7 +638,7 @@ export class MatterController {
         return new InteractionClient(
             new ExchangeProvider(this.exchangeManager, channel, async () => {
                 await this.channelManager.removeChannel(this.fabric, peerNodeId);
-                await this.resume(peerNodeId);
+                await this.resume(peerNodeId, 60); // Channel reconnection only waits limited time
                 return this.channelManager.getChannel(this.fabric, peerNodeId);
             }),
             peerNodeId,

--- a/packages/matter.js/src/MatterController.ts
+++ b/packages/matter.js/src/MatterController.ts
@@ -312,6 +312,11 @@ export class MatterController {
         return await this.commissionDevice(paseSecureChannel, commissioningOptions);
     }
 
+    async disconnect(nodeId: NodeId) {
+        await this.sessionManager.removeAllSessionsForNode(nodeId, true);
+        await this.channelManager.removeChannel(this.fabric, nodeId);
+    }
+
     async removeNode(nodeId: NodeId) {
         logger.info(`Removing commissioned node ${nodeId} from controller.`);
         await this.sessionManager.removeAllSessionsForNode(nodeId);

--- a/packages/matter.js/src/cluster/server/AdministratorCommissioningServer.ts
+++ b/packages/matter.js/src/cluster/server/AdministratorCommissioningServer.ts
@@ -155,7 +155,7 @@ class AdministratorCommissioningManager {
     /** This method is used to close a commissioning window. */
     async closeCommissioningWindow(session: Session<MatterDevice>) {
         this.endCommissioning();
-        session.getContext().endCommissioning();
+        await session.getContext().endCommissioning();
     }
 
     /** This method is used to revoke a commissioning window. */

--- a/packages/matter.js/src/cluster/server/AdministratorCommissioningServer.ts
+++ b/packages/matter.js/src/cluster/server/AdministratorCommissioningServer.ts
@@ -51,8 +51,9 @@ class AdministratorCommissioningManager {
             throw new InternalError("Commissioning window already initialized.");
         }
         logger.debug(`Commissioning window timer started for ${commissioningTimeout} seconds for ${session.name}.`);
-        this.commissioningWindowTimeout = Time.getTimer(commissioningTimeout * 1000, () =>
-            this.closeCommissioningWindow(session),
+        this.commissioningWindowTimeout = Time.getTimer(
+            commissioningTimeout * 1000,
+            async () => await this.closeCommissioningWindow(session),
         ).start();
 
         this.adminFabricIndexAttribute.setLocal(session.getAssociatedFabric().fabricIndex);
@@ -154,7 +155,7 @@ class AdministratorCommissioningManager {
     /** This method is used to close a commissioning window. */
     async closeCommissioningWindow(session: Session<MatterDevice>) {
         this.endCommissioning();
-        await session.getContext().endCommissioning();
+        session.getContext().endCommissioning();
     }
 
     /** This method is used to revoke a commissioning window. */

--- a/packages/matter.js/src/common/Scanner.ts
+++ b/packages/matter.js/src/common/Scanner.ts
@@ -14,6 +14,8 @@ import { ServerAddress, ServerAddressIp } from "./ServerAddress.js";
  * The properties are named identical as in the Matter specification.
  */
 export type CommissionableDevice = {
+    deviceIdentifier: string;
+
     /** The device's addresses IP/port pairs */
     addresses: ServerAddress[];
 

--- a/packages/matter.js/src/common/Scanner.ts
+++ b/packages/matter.js/src/common/Scanner.ts
@@ -92,7 +92,12 @@ export interface Scanner {
      * Send DNS-SD queries to discover the current addresses of an operational paired device by its operational ID
      * and return them.
      */
-    findOperationalDevice(fabric: Fabric, nodeId: NodeId, timeoutSeconds?: number): Promise<ServerAddressIp[]>;
+    findOperationalDevice(
+        fabric: Fabric,
+        nodeId: NodeId,
+        timeoutSeconds?: number,
+        ignoreExistingRecords?: boolean,
+    ): Promise<ServerAddressIp[]>;
 
     /**
      * Return already discovered addresses of an operational paired device and return them. Does not send out new
@@ -101,16 +106,34 @@ export interface Scanner {
     getDiscoveredOperationalDevices(fabric: Fabric, nodeId: NodeId): ServerAddressIp[];
 
     /**
-     * Send DNS-SD queries to discover commissionable devices by an provided identifier (e.g. discriminator,
-     * vendorId, etc.) and return them.
+     * Send DNS-SD queries to discover commissionable devices by a provided identifier (e.g. discriminator,
+     * vendorId, etc.) and returns as soon as minimum one was found or the timeout is over.
      */
     findCommissionableDevices(
         identifier: CommissionableDeviceIdentifiers,
+        timeoutSeconds?: number,
+        ignoreExistingRecords?: boolean,
+    ): Promise<CommissionableDevice[]>;
+
+    /**
+     * Send DNS-SD queries to discover commissionable devices by a provided identifier (e.g. discriminator,
+     * vendorId, etc.) and returns after the timeout is over. For each new discovered device the provided callback is
+     * called when it is discovered.
+     */
+    findCommissionableDevicesContinuously(
+        identifier: CommissionableDeviceIdentifiers,
+        callback: (device: CommissionableDevice) => void,
         timeoutSeconds?: number,
     ): Promise<CommissionableDevice[]>;
 
     /** Return already discovered commissionable devices and return them. Does not send out new DNS-SD queries. */
     getDiscoveredCommissionableDevices(identifier: CommissionableDeviceIdentifiers): CommissionableDevice[];
+
+    /**
+     * Cancel a running discovery of commissionable devices. The waiter promises are resolved as if the timeout would
+     * be over.
+     */
+    cancelCommissionableDeviceDiscovery(identifier: CommissionableDeviceIdentifiers): void;
 
     /** Close the scanner server and free resources. */
     close(): void;

--- a/packages/matter.js/src/device/PairedNode.ts
+++ b/packages/matter.js/src/device/PairedNode.ts
@@ -51,7 +51,7 @@ import { PaseClient } from "../session/pase/PaseClient.js";
 import { Time } from "../time/Time.js";
 import { DeviceTypeDefinition, DeviceTypes, UnknownDeviceType, getDeviceTypeDefinitionByCode } from "./DeviceTypes.js";
 import { Endpoint } from "./Endpoint.js";
-import { logEndpoint } from "./EndpointStructureLogger.js";
+import { EndpointLoggingOptions, logEndpoint } from "./EndpointStructureLogger.js";
 
 const logger = Logger.get("PairedNode");
 
@@ -252,13 +252,13 @@ export class PairedNode {
     }
 
     /** Method to log the structure of this node with all endpoint and clusters. */
-    logStructure() {
+    logStructure(options?: EndpointLoggingOptions) {
         const rootEndpoint = this.endpoints.get(EndpointNumber(0));
         if (rootEndpoint === undefined) {
             logger.info(`Node ${this.nodeId} has not yet been initialized!`);
             return;
         }
-        logEndpoint(rootEndpoint);
+        logEndpoint(rootEndpoint, options);
     }
 
     /**

--- a/packages/matter.js/src/device/PairedNode.ts
+++ b/packages/matter.js/src/device/PairedNode.ts
@@ -222,8 +222,8 @@ export class PairedNode {
         if (autoSubscribe !== false) {
             const initialSubscriptionData = await this.subscribeAllAttributesAndEvents({
                 ignoreInitialTriggers: true,
-                attributeChangedCallback,
-                eventTriggeredCallback,
+                attributeChangedCallback: data => attributeChangedCallback?.(this.nodeId, data),
+                eventTriggeredCallback: data => eventTriggeredCallback?.(this.nodeId, data),
             }); // Ignore Triggers from Subscribing during initialization
 
             if (initialSubscriptionData.attributeReports === undefined) {

--- a/packages/matter.js/src/mdns/MdnsScanner.ts
+++ b/packages/matter.js/src/mdns/MdnsScanner.ts
@@ -541,15 +541,20 @@ export class MdnsScanner implements Scanner {
         this.handleCommissionableRecords(answers, this.getActiveQueryEarlierAnswers(), netInterface);
     }
 
-    private handleIpRecords(answers: DnsRecord<any>[], target: string, netInterface: string) {
+    private handleIpRecords(
+        answers: DnsRecord<any>[],
+        target: string,
+        netInterface: string,
+    ): { value: string; ttl: number }[] {
         const ipRecords = answers.filter(
             ({ name, recordType }) =>
                 ((recordType === DnsRecordType.A && this.enableIpv4) || recordType === DnsRecordType.AAAA) &&
                 name === target,
         );
-        return (ipRecords as DnsRecord<string>[]).map(({ value }) =>
-            value.startsWith("fe80::") ? `${value}%${netInterface}` : value,
-        );
+        return (ipRecords as DnsRecord<string>[]).map(({ value, ttl }) => ({
+            value: value.startsWith("fe80::") ? `${value}%${netInterface}` : value,
+            ttl,
+        }));
     }
 
     private handleOperationalSrvRecord(

--- a/packages/matter.js/src/mdns/MdnsScanner.ts
+++ b/packages/matter.js/src/mdns/MdnsScanner.ts
@@ -290,6 +290,11 @@ export class MdnsScanner implements Scanner {
         this.recordWaiters.delete(queryId);
     }
 
+    /** Returns weather a waiter promise is registered for a specific queryId. */
+    private hasWaiter(queryId: string) {
+        return this.recordWaiters.has(queryId);
+    }
+
     private createOperationalMatterQName(operationalId: ByteArray, nodeId: NodeId) {
         const operationalIdString = operationalId.toHex().toUpperCase();
         return getDeviceMatterQname(operationalIdString, NodeId.toHexString(nodeId));
@@ -327,6 +332,16 @@ export class MdnsScanner implements Scanner {
             this.removeQuery(deviceMatterQname);
         }
         return storedRecords;
+    }
+
+    cancelOperationalDeviceDiscovery(fabric: Fabric, nodeId: NodeId) {
+        const deviceMatterQname = this.createOperationalMatterQName(fabric.operationalId, nodeId);
+        this.finishWaiter(deviceMatterQname, true);
+    }
+
+    cancelCommissionableDeviceDiscovery(identifier: CommissionableDeviceIdentifiers) {
+        const queryId = this.buildCommissionableQueryIdentifier(identifier);
+        this.finishWaiter(queryId, true);
     }
 
     getDiscoveredOperationalDevices({ operationalId }: Fabric, nodeId: NodeId) {

--- a/packages/matter.js/src/util/Cache.ts
+++ b/packages/matter.js/src/util/Cache.ts
@@ -9,6 +9,7 @@
 import { Time, Timer } from "../time/Time.js";
 
 export class Cache<T> {
+    private readonly knownKeys = new Set<string>();
     private readonly values = new Map<string, T>();
     private readonly timestamps = new Map<string, number>();
     private readonly periodicTimer: Timer;
@@ -27,13 +28,14 @@ export class Cache<T> {
         if (value === undefined) {
             value = this.generator(...params);
             this.values.set(key, value);
+            this.knownKeys.add(key);
         }
         this.timestamps.set(key, Time.nowMs());
         return value;
     }
 
     keys() {
-        return Array.from(this.values.keys());
+        return Array.from(this.knownKeys.values());
     }
 
     private async deleteEntry(key: string) {
@@ -55,6 +57,7 @@ export class Cache<T> {
 
     async close() {
         await this.clear();
+        this.knownKeys.clear();
         this.periodicTimer.stop();
     }
 

--- a/packages/matter.js/src/util/Promises.ts
+++ b/packages/matter.js/src/util/Promises.ts
@@ -34,3 +34,30 @@ export function createPromise<T>(): {
         rejecter,
     };
 }
+
+/**
+ * Use all promises or promise returning methods and return the first resolved promise or reject when all promises
+ * rejected
+ */
+export function anyPromise<T>(promises: ((() => Promise<T>) | Promise<T>)[]): Promise<T> {
+    return new Promise((resolve, reject) => {
+        let numberRejected = 0;
+        let wasResolved = false;
+        for (const entry of promises) {
+            const promise = typeof entry === "function" ? entry() : entry;
+            promise
+                .then(value => {
+                    if (!wasResolved) {
+                        wasResolved = true;
+                        resolve(value);
+                    }
+                })
+                .catch(reason => {
+                    numberRejected++;
+                    if (!wasResolved && numberRejected === promises.length) {
+                        reject(reason);
+                    }
+                });
+        }
+    });
+}


### PR DESCRIPTION
This PRS combines the following changes
* MDNS Scanner respecs now also record expiries and removes records from the own cache
* MDNS scanner allows to scan continuously (to get a trigger when a node comes back online)
* MDNS scanner allows to continue a scan and ignore alteady discovered entries
* Controller now allows to scan for BLE and IP in parallel
* Controller now allows to scan for commissionable devices for a defined timeframe but get callbacks on discovery of a new entry. This is usefull for UIs
* Controller now allows to use a discovered device (aka object returned by discovery process) als for commissioning whcih will use the just discovered addresses before rediscovering
* PairedNode maintains a connection state of the node (connected, disconncted, reconnecting, wait-for-device-discovery)
* PairedNode also reacts now to bridge structure changes, updates it's structure and notifies the developer about it
* Shell got enhanced by several new commands and options

* Addresses https://github.com/orgs/project-chip/projects/11/views/1?pane=issue&itemId=36546943
* Addresses https://github.com/orgs/project-chip/projects/11/views/1?pane=issue&itemId=40550305
* Addresses https://github.com/orgs/project-chip/projects/11/views/1?pane=issue&itemId=36541600
* Addresses https://github.com/orgs/project-chip/projects/11/views/1?pane=issue&itemId=36165544