### PR TITLE
Use Netinterface limitation also for scanner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,11 +33,14 @@ The main work (all changes without a GitHub username in brackets in the below li
     * Introducing class PairedNode with the High level API for a paired Node
     * Restructured CommissioningController to handle multiple nodes and offer new high level API
     * Changed name of the unique storage id for servers or controllers added to MatterServer to "uniqueStorageKey"
+  * Breaking: option "mdnsAnnounceInterface" was deprecated and replaced by "mdnsInterface" and now used to limit announcements and scanning to a specific interface
   * Feature: Makes Port for CommissioningServer optional and add automatic port handling in MatterServer
   * Feature: Allows removal of Controller or Server instances from Matter server, optionally with deleting the storage
   * Enhance: Makes passcode and discriminator for CommissioningServer optional and randomly generate them if not provided 
 * matter-node-shell.js
   * Feature: Completely refactored and enhances shell to support commissioning, identify and many more new commands. See Readme, try it
+* matter-node.js-examples
+  * Breaking: Rename parameter -announceinterface to -netinterface and use for announcements and scanning
 
 ## 0.6.0 (2023-10-08)
 * Matter-Core functionality:

--- a/packages/matter-node-shell.js/src/MatterNode.ts
+++ b/packages/matter-node-shell.js/src/MatterNode.ts
@@ -23,7 +23,10 @@ export class MatterNode {
     commissioningController?: CommissioningController;
     private matterDevice?: MatterServer;
 
-    constructor(private nodeNum: number) {}
+    constructor(
+        private readonly nodeNum: number,
+        private readonly netInterface?: string,
+    ) {}
 
     async initialize(resetStorage: boolean) {
         /**
@@ -85,7 +88,7 @@ export class MatterNode {
          * are called.
          */
 
-        this.matterDevice = new MatterServer(this.storageManager);
+        this.matterDevice = new MatterServer(this.storageManager, { mdnsInterface: this.netInterface });
         this.commissioningController = new CommissioningController({
             autoConnect: false,
         });

--- a/packages/matter-node-shell.js/src/app.ts
+++ b/packages/matter-node-shell.js/src/app.ts
@@ -73,20 +73,25 @@ async function main() {
                             description: "Enable BLE support",
                             type: "boolean",
                         },
-                        "reset-storage": {
-                            description: "Reset storage of this node",
+                        "factory-reset": {
+                            description: "Factory-Reset storage of this node",
                             default: false,
                             type: "boolean",
+                        },
+                        "net-interface": {
+                            description: "Network interface to use for MDNS announcements and scanning",
+                            type: "string",
+                            default: undefined,
                         },
                     });
             },
             async argv => {
                 if (argv.help) return;
 
-                const { nodeNum, ble, nodeType, resetStorage } = argv;
+                const { nodeNum, ble, nodeType, factoryReset, netInterface } = argv;
 
-                const theNode = new MatterNode(nodeNum);
-                await theNode.initialize(resetStorage);
+                const theNode = new MatterNode(nodeNum, netInterface);
+                await theNode.initialize(factoryReset);
                 const theShell = new Shell(theNode, PROMPT);
 
                 if (ble) {

--- a/packages/matter-node.js-examples/README.md
+++ b/packages/matter-node.js-examples/README.md
@@ -95,7 +95,7 @@ The following parameters are available:
 * -productid: the product ID as number to use for pairing (default: 32768 (0x8000))
 * -uniqueid: a unique ID for this device to be used in naming and to store structure information (default: ms time now)
 * -type: the device type to use for pairing (default: light, alternative value is "socket")
-* -announceinterface: limit mdns announcements to the provided network interface, e.g. "en0" (default: all interfaces available)
+* -netinterface: limit mdns announcements and scanning to the provided network interface, e.g. "en0" (default: all interfaces available)
 * -ble: enable BLE support (default: false) If this is enabled the device will announce itself _only_ via BLE if not commissioned and also presents a "Wifi only" device for commissioning to show this feature!
 * -ble-hci-id: Optionally, HCI ID to use (Linux only, default 0)
 * -port: the port to listen on for the device (default: 5540)

--- a/packages/matter-node.js-examples/src/examples/BridgedDevicesNode.ts
+++ b/packages/matter-node.js-examples/src/examples/BridgedDevicesNode.ts
@@ -107,7 +107,7 @@ class BridgedDevice {
         const productName = `node-matter OnOff-Bridge`;
         const productId = getIntParameter("productid") ?? deviceStorage.get("productid", 0x8000);
 
-        const netAnnounceInterface = getParameter("announceinterface");
+        const netInterface = getParameter("netinterface");
         const port = getIntParameter("port") ?? 5540;
 
         const uniqueId = getIntParameter("uniqueid") ?? deviceStorage.get("uniqueid", Time.nowMs());
@@ -131,7 +131,7 @@ class BridgedDevice {
          * are called.
          */
 
-        this.matterServer = new MatterServer(storageManager, { mdnsAnnounceInterface: netAnnounceInterface });
+        this.matterServer = new MatterServer(storageManager, { mdnsInterface: netInterface });
 
         const commissioningServer = new CommissioningServer({
             port,

--- a/packages/matter-node.js-examples/src/examples/ComposedDeviceNode.ts
+++ b/packages/matter-node.js-examples/src/examples/ComposedDeviceNode.ts
@@ -114,7 +114,7 @@ class ComposedDevice {
         const productName = `node-matter OnOff-Bridge`;
         const productId = getIntParameter("productid") ?? deviceStorage.get("productid", 0x8000);
 
-        const netAnnounceInterface = getParameter("announceinterface");
+        const netInterface = getParameter("netinterface");
         const port = getIntParameter("port") ?? 5540;
 
         const uniqueId = getIntParameter("uniqueid") ?? deviceStorage.get("uniqueid", Time.nowMs());
@@ -139,7 +139,7 @@ class ComposedDevice {
          * are called.
          */
 
-        this.matterServer = new MatterServer(storageManager, { mdnsAnnounceInterface: netAnnounceInterface });
+        this.matterServer = new MatterServer(storageManager, { mdnsInterface: netInterface });
 
         const commissioningServer = new CommissioningServer({
             port,

--- a/packages/matter-node.js-examples/src/examples/DeviceNode.ts
+++ b/packages/matter-node.js-examples/src/examples/DeviceNode.ts
@@ -124,7 +124,7 @@ class Device {
         const productName = `node-matter OnOff ${isSocket ? "Socket" : "Light"}`;
         const productId = getIntParameter("productid") ?? deviceStorage.get("productid", 0x8000);
 
-        const netAnnounceInterface = getParameter("announceinterface");
+        const netInterface = getParameter("netinterface");
         const port = getIntParameter("port") ?? 5540;
 
         const uniqueId = getIntParameter("uniqueid") ?? deviceStorage.get("uniqueid", Time.nowMs());
@@ -168,7 +168,7 @@ class Device {
          * are called.
          */
 
-        this.matterServer = new MatterServer(storageManager, { mdnsAnnounceInterface: netAnnounceInterface });
+        this.matterServer = new MatterServer(storageManager, { mdnsInterface: netInterface });
 
         const commissioningServer = new CommissioningServer({
             port,

--- a/packages/matter-node.js-examples/src/examples/MultiDeviceNode.ts
+++ b/packages/matter-node.js-examples/src/examples/MultiDeviceNode.ts
@@ -96,7 +96,7 @@ class Device {
          * and easy reuse. When you also do that be careful to not overlap with Matter-Server own contexts
          * (so maybe better not ;-)).
          */
-        const netAnnounceInterface = getParameter("announceinterface");
+        const netInterface = getParameter("netinterface");
 
         const deviceStorage = storageManager.createContext("Device");
 
@@ -113,7 +113,7 @@ class Device {
          * are called.
          */
 
-        this.matterServer = new MatterServer(storageManager, { mdnsAnnounceInterface: netAnnounceInterface });
+        this.matterServer = new MatterServer(storageManager, { mdnsInterface: netInterface });
 
         /**
          * Create Device instance and add needed Listener

--- a/packages/matter.js/src/MatterServer.ts
+++ b/packages/matter.js/src/MatterServer.ts
@@ -34,8 +34,16 @@ export type MatterServerOptions = {
 
     /**
      * Interface to use for MDNS announcements. If not provided announcements will be sent from all network interfaces
+     * TODO: Remove in later versions then 0.7
+     * @deprecated
      */
     mdnsAnnounceInterface?: string;
+
+    /**
+     * Interface to use for MDNS announcements and scanning. If not provided announcements/scanning will be done on all
+     * network interfaces
+     */
+    mdnsInterface?: string;
 };
 
 /**
@@ -180,11 +188,14 @@ export class MatterServer {
         if (this.mdnsBroadcaster === undefined) {
             this.mdnsBroadcaster = await MdnsBroadcaster.create({
                 enableIpv4: !this.ipv4Disabled,
-                multicastInterface: this.options?.mdnsAnnounceInterface,
+                multicastInterface: this.options?.mdnsInterface ?? this.options?.mdnsAnnounceInterface,
             });
         }
         if (this.mdnsScanner === undefined) {
-            this.mdnsScanner = await MdnsScanner.create({ enableIpv4: !this.ipv4Disabled });
+            this.mdnsScanner = await MdnsScanner.create({
+                enableIpv4: !this.ipv4Disabled,
+                netInterface: this.options?.mdnsInterface,
+            });
         }
         // TODO the mdns classes will later be in this class and assigned differently!!
         for (const node of this.nodes) {


### PR DESCRIPTION
This PR is deprcates  mdnsAnnounceInterface option for MatterServer and replace by a generic mdnsInterface which is used by Scanner and Broadcaster. Examples are also adjusted and the Shell also got an option to provide a netInterface parameter