### PR TITLE
Reactivate macos testing by downgrading python in github runner

### DIFF
--- a/.github/workflows/build-test.js.yml
+++ b/.github/workflows/build-test.js.yml
@@ -39,11 +39,15 @@ jobs:
     strategy:
       matrix:
         node-version: [ 16.x, 18.x, 20.x ]
-        # os: [ macos-latest, windows-2019 ]
-        os: [ windows-2019 ]
+        os: [ macos-latest, windows-2019 ]
     steps:
       - uses: actions/checkout@v4
         if: ${{ needs.check-and-lint.outputs.package-changes == 'true' }}
+      - uses: actions/setup-python@v4
+        if: ${{ needs.check-and-lint.outputs.package-changes == 'true' }}
+        # needed as long as we test Node.js 16 and npm <10.2.2 is used for Node.js 18/20
+        with:
+          python-version: '3.11'
       - name: Build on ${{ matrix.os }}
         if: ${{ needs.check-and-lint.outputs.package-changes == 'true' }}
         uses: ./.github/actions/prepare-env

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -29,10 +29,13 @@ jobs:
     strategy:
       matrix:
         node-version: [ 16.x, 18.x, 20.x ]
-        # os: [ macos-latest, windows-2019 ]
-        os: [ windows-2019 ]
+        os: [ macos-latest, windows-2019 ]
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        # needed as long as we test Node.js 16 and npm <10.2.2 is used for Node.js 18/20
+        with:
+          python-version: '3.11'
       - name: Build on ${{ matrix.os }}
         uses: ./.github/actions/prepare-env
         with:


### PR DESCRIPTION
We can downgrade to Python 3.11