### PR TITLE
MatterServer node start optimizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,8 @@ The main work (all changes without a GitHub username in brackets in the below li
     * Changed name of the unique storage id for servers or controllers added to MatterServer to "uniqueStorageKey"
     * Adjusted subscription callbacks to also provide the nodeId of the affected device reporting the changes to allow callbacks to be used generically when connecting to all nodes
     * Introduces a node state information callback to inform about the connection status but also when the node structure changed (for bridges) or such.
-  * Breaking: option "mdnsAnnounceInterface" was deprecated and replaced by "mdnsInterface" and now used to limit announcements and scanning to a specific interface
+  * Breaking: Deprecated the option "mdnsAnnounceInterface" and replaced by "mdnsInterface" and now used to limit announcements and scanning to a specific interface
+  * Breaking: Makes sure that also nodes added to a MatterServer after it was started are also started to behave the same. "add" methods are now async. 
   * Feature: Enhanced CommissioningServer API and CommissioningController for improved practical usage
   * Feature: Makes Port for CommissioningServer optional and add automatic port handling in MatterServer
   * Feature: Allows removal of Controller or Server instances from Matter server, optionally with deleting the storage

--- a/chip-testing/src/DeviceTestInstance.ts
+++ b/chip-testing/src/DeviceTestInstance.ts
@@ -24,7 +24,7 @@ export abstract class DeviceTestInstance {
             await this.storageManager.initialize(); // hacky but works
             this.matterServer = new MatterServer(this.storageManager);
 
-            this.matterServer.addCommissioningServer(await this.setupCommissioningServer());
+            await this.matterServer.addCommissioningServer(await this.setupCommissioningServer());
         } catch (error) {
             // Catch and log error, else the test framework hides issues here
             console.log(error);

--- a/packages/matter-node-shell.js/src/MatterNode.ts
+++ b/packages/matter-node-shell.js/src/MatterNode.ts
@@ -95,7 +95,7 @@ export class MatterNode {
         this.commissioningController = new CommissioningController({
             autoConnect: false,
         });
-        this.matterController.addCommissioningController(this.commissioningController);
+        await this.matterController.addCommissioningController(this.commissioningController);
 
         /**
          * Start the Matter Server

--- a/packages/matter-node.js-examples/src/examples/BridgedDevicesNode.ts
+++ b/packages/matter-node.js-examples/src/examples/BridgedDevicesNode.ts
@@ -188,7 +188,7 @@ class BridgedDevice {
 
         commissioningServer.addDevice(aggregator);
 
-        this.matterServer.addCommissioningServer(commissioningServer);
+        await this.matterServer.addCommissioningServer(commissioningServer);
 
         /**
          * Start the Matter Server

--- a/packages/matter-node.js-examples/src/examples/ComposedDeviceNode.ts
+++ b/packages/matter-node.js-examples/src/examples/ComposedDeviceNode.ts
@@ -186,7 +186,7 @@ class ComposedDevice {
             commissioningServer.addDevice(onOffDevice);
         }
 
-        this.matterServer.addCommissioningServer(commissioningServer);
+        await this.matterServer.addCommissioningServer(commissioningServer);
 
         /**
          * Start the Matter Server

--- a/packages/matter-node.js-examples/src/examples/ControllerNode.ts
+++ b/packages/matter-node.js-examples/src/examples/ControllerNode.ts
@@ -180,7 +180,7 @@ class ControllerNode {
         const commissioningController = new CommissioningController({
             autoConnect: false,
         });
-        matterServer.addCommissioningController(commissioningController);
+        await matterServer.addCommissioningController(commissioningController);
 
         /**
          * Start the Matter Server

--- a/packages/matter-node.js-examples/src/examples/DeviceNode.ts
+++ b/packages/matter-node.js-examples/src/examples/DeviceNode.ts
@@ -226,7 +226,7 @@ class Device {
 
         commissioningServer.addDevice(onOffDevice);
 
-        this.matterServer.addCommissioningServer(commissioningServer);
+        await this.matterServer.addCommissioningServer(commissioningServer);
 
         /**
          * Start the Matter Server

--- a/packages/matter-node.js-examples/src/examples/MultiDeviceNode.ts
+++ b/packages/matter-node.js-examples/src/examples/MultiDeviceNode.ts
@@ -192,7 +192,7 @@ class Device {
             onOffDevice.addOnOffListener(on => commandExecutor(on ? `on${i}` : `off${i}`)?.());
             commissioningServer.addDevice(onOffDevice);
 
-            this.matterServer.addCommissioningServer(commissioningServer);
+            await this.matterServer.addCommissioningServer(commissioningServer);
 
             commissioningServers.push(commissioningServer);
         }

--- a/packages/matter-node.js/test/IntegrationTest.ts
+++ b/packages/matter-node.js/test/IntegrationTest.ts
@@ -117,7 +117,7 @@ describe("Integration Test", () => {
             autoConnect: false,
             autoSubscribe: false,
         });
-        matterClient.addCommissioningController(commissioningController);
+        await matterClient.addCommissioningController(commissioningController);
 
         Network.get = () => serverNetwork;
 
@@ -210,7 +210,7 @@ describe("Integration Test", () => {
             ),
         );
 
-        matterServer.addCommissioningServer(commissioningServer);
+        await matterServer.addCommissioningServer(commissioningServer);
         assert.equal(commissioningServer.getPort(), matterPort);
 
         // override the mdns scanner to avoid the client to try to resolve the server's address
@@ -1237,7 +1237,7 @@ describe("Integration Test", () => {
             onOffLightDeviceServer = new OnOffLightDevice();
             commissioningServer2.addDevice(onOffLightDeviceServer);
 
-            matterServer.addCommissioningServer(commissioningServer2, { uniqueStorageKey: "second" });
+            await matterServer.addCommissioningServer(commissioningServer2, { uniqueStorageKey: "second" });
             assert.equal(commissioningServer2.getPort(), matterPort2);
 
             commissioningServer2.setMdnsScanner(serverMdnsScanner);
@@ -1453,7 +1453,9 @@ describe("Integration Test", () => {
                 adminFabricIndex: FabricIndex(1001),
                 adminVendorId: VendorId(0x1234),
             });
-            matterClient.addCommissioningController(commissioningController2, { uniqueStorageKey: "another-second" });
+            await matterClient.addCommissioningController(commissioningController2, {
+                uniqueStorageKey: "another-second",
+            });
             commissioningController2.setMdnsScanner(clientMdnsScanner);
 
             Network.get = () => serverNetwork;

--- a/packages/matter.js/src/CommissioningServer.ts
+++ b/packages/matter.js/src/CommissioningServer.ts
@@ -210,6 +210,7 @@ type CommissioningServerCommands = {
  * host
  */
 export class CommissioningServer extends MatterNode {
+    private ipv4Disabled?: boolean;
     private port?: number;
     private readonly passcode: number;
     private readonly discriminator: number;
@@ -925,8 +926,21 @@ export class CommissioningServer extends MatterNode {
         }
     }
 
+    /** used internally by MatterServer to initialize the state of the device. */
+    initialize(ipv4Disabled: boolean) {
+        if (this.ipv4Disabled !== undefined && this.ipv4Disabled !== ipv4Disabled) {
+            throw new ImplementationError(
+                "Changing the IPv4 disabled flag after starting the device is not supported.",
+            );
+        }
+        this.ipv4Disabled = ipv4Disabled;
+    }
+
     /** Starts the Matter device and advertises it. */
     async start() {
+        if (this.ipv4Disabled === undefined) {
+            throw new ImplementationError("Add the device to the MatterServer first.");
+        }
         if (this.delayedAnnouncement !== true) {
             return this.advertise();
         }

--- a/packages/matter.js/src/MatterNode.ts
+++ b/packages/matter.js/src/MatterNode.ts
@@ -11,11 +11,11 @@ import { MdnsScanner } from "./mdns/MdnsScanner.js";
  * Abstract base class that represents a node in the matter ecosystem.
  */
 export abstract class MatterNode {
-    ipv4Disabled: boolean = false;
-
     abstract close(): Promise<void>;
 
     abstract getPort(): number | undefined;
+
+    abstract initialize(ipv4Disabled: boolean): void;
 
     abstract start(): Promise<void>;
 


### PR DESCRIPTION
This PR optimized the start handling in MatterServer. it mainly makes siure that nodes get also started when added to the MatterServer after this one itself was initially started (and so started all previously added nodes). With this it behaves the same for a developer irrelevant when he adds a node