### PR TITLE
Handle Message extensions and Secured extensions correctly

### DIFF
--- a/packages/matter-node.js/test/session/SecureSessionTest.ts
+++ b/packages/matter-node.js/test/session/SecureSessionTest.ts
@@ -34,6 +34,7 @@ const MESSAGE: Message = {
         exchangeId: 0x048d,
         protocolId: 0x0001,
         ackedMessageId: 0x00531422,
+        hasSecuredExtension: false,
     },
     payload: ByteArray.fromHex(
         "1536011535012600799ac60c37012402002403312404031824021418181535012600b771f32f3701240200240328240404182502018018181535012600b771f32f3701240200240328240402182502f1ff18181535012600ddad82d637012402002403302404031824020218181535012600ddad82d637012402002403302404021824020018181535012600ddad82d6370124020024033024040118350224003c1818181535012600ddad82d637012402002403302404001824020018181535012600799ac60c37012402002403312504fcff18240201181818290424ff0118",
@@ -62,7 +63,8 @@ describe("SecureSession", () => {
         it("decrypts a message", () => {
             const packet = MessageCodec.decodePacket(MESSAGE_ENCRYPTED);
 
-            const result = secureSession.decode(packet);
+            const aad = MESSAGE_ENCRYPTED.slice(0, MESSAGE_ENCRYPTED.length - packet.applicationPayload.length);
+            const result = secureSession.decode(packet, aad);
 
             assert.equal(result.payload.toHex(), DECRYPTED_BYTES.toHex());
         });
@@ -72,7 +74,7 @@ describe("SecureSession", () => {
         it("encrypts a message", () => {
             const result = secureSession.encode(MESSAGE);
 
-            assert.deepEqual(result.bytes.toHex(), ENCRYPTED_BYTES.toHex());
+            assert.deepEqual(result.applicationPayload.toHex(), ENCRYPTED_BYTES.toHex());
         });
     });
 });

--- a/packages/matter.js/src/codec/MessageCodec.ts
+++ b/packages/matter.js/src/codec/MessageCodec.ts
@@ -127,7 +127,7 @@ export class MessageCodec {
 
     static encodePayload({ packetHeader, payloadHeader, payload, securityExtension }: Message): Packet {
         if (securityExtension !== undefined || payloadHeader.hasSecuredExtension) {
-            throw new NotImplementedError(`Security extensions not supported.`);
+            throw new NotImplementedError(`Security extensions not supported when encoding a payload.`);
         }
 
         return {
@@ -138,7 +138,7 @@ export class MessageCodec {
 
     static encodePacket({ header, applicationPayload, messageExtension }: Packet): ByteArray {
         if (messageExtension !== undefined || header.hasMessageExtensions) {
-            throw new NotImplementedError(`Message extensions not supported.`);
+            throw new NotImplementedError(`Message extensions not supported when encoding a packet.`);
         }
         return ByteArray.concat(this.encodePacketHeader(header), applicationPayload);
     }

--- a/packages/matter.js/src/protocol/ExchangeManager.ts
+++ b/packages/matter.js/src/protocol/ExchangeManager.ts
@@ -133,7 +133,7 @@ export class ExchangeManager<ContextT> {
         const session = this.sessionManager.getSession(packet.header.sessionId);
         if (session === undefined) throw new MatterFlowError(`Cannot find a session for ID ${packet.header.sessionId}`);
 
-        const aad = messageBytes.slice(messageBytes.length - packet.applicationPayload.length);
+        const aad = messageBytes.slice(0, messageBytes.length - packet.applicationPayload.length); // Header+Extensions
         const message = session.decode(packet, aad);
         const exchangeIndex = message.payloadHeader.isInitiatorMessage
             ? message.payloadHeader.exchangeId

--- a/packages/matter.js/src/protocol/ExchangeManager.ts
+++ b/packages/matter.js/src/protocol/ExchangeManager.ts
@@ -133,7 +133,8 @@ export class ExchangeManager<ContextT> {
         const session = this.sessionManager.getSession(packet.header.sessionId);
         if (session === undefined) throw new MatterFlowError(`Cannot find a session for ID ${packet.header.sessionId}`);
 
-        const message = session.decode(packet);
+        const aad = messageBytes.slice(messageBytes.length - packet.applicationPayload.length);
+        const message = session.decode(packet, aad);
         const exchangeIndex = message.payloadHeader.isInitiatorMessage
             ? message.payloadHeader.exchangeId
             : message.payloadHeader.exchangeId | 0x10000;

--- a/packages/matter.js/src/protocol/MessageExchange.ts
+++ b/packages/matter.js/src/protocol/MessageExchange.ts
@@ -238,6 +238,7 @@ export class MessageExchange<ContextT> {
                 isInitiatorMessage: this.isInitiator,
                 requiresAck: requiresAck ?? messageType !== MessageType.StandaloneAck,
                 ackedMessageId: this.receivedMessageToAck?.packetHeader.messageId,
+                hasSecuredExtension: false,
             },
             payload,
         };

--- a/packages/matter.js/src/session/SecureSession.ts
+++ b/packages/matter.js/src/session/SecureSession.ts
@@ -6,7 +6,7 @@
 
 import { Message, MessageCodec, Packet } from "../codec/MessageCodec.js";
 import { MatterFlowError } from "../common/MatterError.js";
-import { Crypto } from "../crypto/Crypto.js";
+import { CRYPTO_SYMMETRIC_KEY_LENGTH, Crypto } from "../crypto/Crypto.js";
 import { NodeId } from "../datatype/NodeId.js";
 import { Fabric } from "../fabric/Fabric.js";
 import { Logger } from "../log/Logger.js";
@@ -84,7 +84,7 @@ export class SecureSession<T> implements Session<T> {
             sharedSecret,
             salt,
             isResumption ? SESSION_RESUMPTION_KEYS_INFO : SESSION_KEYS_INFO,
-            16 * 3,
+            CRYPTO_SYMMETRIC_KEY_LENGTH * 3,
         );
         const decryptKey = isInitiator ? keys.slice(16, 32) : keys.slice(0, 16);
         const encryptKey = isInitiator ? keys.slice(0, 16) : keys.slice(16, 32);
@@ -193,24 +193,32 @@ export class SecureSession<T> implements Session<T> {
         return Time.nowMs() - this.activeTimestamp < SLEEPY_ACTIVE_THRESHOLD_MS;
     }
 
-    decode({ header, bytes }: Packet): Message {
-        const headerBytes = MessageCodec.encodePacketHeader(header);
-        const securityFlags = headerBytes[3];
+    decode({ header, applicationPayload, messageExtension }: Packet, aad: ByteArray): Message {
+        if (header.hasMessageExtensions) {
+            logger.info(`Message extensions are not supported. Ignoring ${messageExtension?.toHex()}`);
+        }
+        const securityFlags = aad[3];
         const nonce = this.generateNonce(securityFlags, header.messageId, this.peerNodeId);
-        return MessageCodec.decodePayload({
+        const message = MessageCodec.decodePayload({
             header,
-            bytes: Crypto.decrypt(this.decryptKey, bytes, nonce, headerBytes),
+            applicationPayload: Crypto.decrypt(this.decryptKey, applicationPayload, nonce, aad),
         });
+
+        if (message.payloadHeader.hasSecuredExtension) {
+            logger.info(`Secured extensions are not supported. Ignoring ${message.securityExtension?.toHex()}`);
+        }
+
+        return message;
     }
 
     encode(message: Message): Packet {
         message.packetHeader.sessionId = this.peerSessionId;
-        const { header, bytes } = MessageCodec.encodePayload(message);
+        const { header, applicationPayload } = MessageCodec.encodePayload(message);
         const headerBytes = MessageCodec.encodePacketHeader(message.packetHeader);
         const securityFlags = headerBytes[3];
         const sessionNodeId = this.isPase() ? UNDEFINED_NODE_ID : this.fabric?.nodeId ?? UNDEFINED_NODE_ID;
         const nonce = this.generateNonce(securityFlags, header.messageId, sessionNodeId);
-        return { header, bytes: Crypto.encrypt(this.encryptKey, bytes, nonce, headerBytes) };
+        return { header, applicationPayload: Crypto.encrypt(this.encryptKey, applicationPayload, nonce, headerBytes) };
     }
 
     getAttestationChallengeKey(): ByteArray {

--- a/packages/matter.js/src/session/Session.ts
+++ b/packages/matter.js/src/session/Session.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Message, Packet } from "../codec/MessageCodec.js";
+import { DecodedMessage, DecodedPacket, Message, Packet } from "../codec/MessageCodec.js";
 import { NodeId } from "../datatype/NodeId.js";
 import { Fabric } from "../fabric/Fabric.js";
 import { ByteArray } from "../util/ByteArray.js";
@@ -34,7 +34,7 @@ export interface Session<T> {
 
     isSecure(): boolean;
     isPase(): boolean;
-    decode(packet: Packet, aad?: ByteArray): Message;
+    decode(packet: DecodedPacket, aad?: ByteArray): DecodedMessage;
     encode(message: Message): Packet;
     getMrpParameters(): MrpParameters;
     getContext(): T;

--- a/packages/matter.js/src/session/Session.ts
+++ b/packages/matter.js/src/session/Session.ts
@@ -7,6 +7,7 @@
 import { Message, Packet } from "../codec/MessageCodec.js";
 import { NodeId } from "../datatype/NodeId.js";
 import { Fabric } from "../fabric/Fabric.js";
+import { ByteArray } from "../util/ByteArray.js";
 
 export const DEFAULT_IDLE_RETRANSMISSION_TIMEOUT_MS = 5000;
 export const DEFAULT_ACTIVE_RETRANSMISSION_TIMEOUT_MS = 300;
@@ -33,7 +34,7 @@ export interface Session<T> {
 
     isSecure(): boolean;
     isPase(): boolean;
-    decode(packet: Packet): Message;
+    decode(packet: Packet, aad?: ByteArray): Message;
     encode(message: Message): Packet;
     getMrpParameters(): MrpParameters;
     getContext(): T;

--- a/packages/matter.js/src/session/UnsecureSession.ts
+++ b/packages/matter.js/src/session/UnsecureSession.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Message, MessageCodec, Packet } from "../codec/MessageCodec.js";
+import { DecodedMessage, DecodedPacket, Message, MessageCodec, Packet } from "../codec/MessageCodec.js";
 import { InternalError, MatterFlowError } from "../common/MatterError.js";
 import { NodeId } from "../datatype/NodeId.js";
 import { Fabric } from "../fabric/Fabric.js";
@@ -40,7 +40,7 @@ export class UnsecureSession<T> implements Session<T> {
         return true;
     }
 
-    decode(packet: Packet): Message {
+    decode(packet: DecodedPacket): DecodedMessage {
         return MessageCodec.decodePayload(packet);
     }
 

--- a/packages/matter.js/test/codec/MessageTest.ts
+++ b/packages/matter.js/test/codec/MessageTest.ts
@@ -143,7 +143,7 @@ describe("MessageCodec", () => {
                     ...DECODED,
                     securityExtension: ByteArray.fromHex("0102030405060708090a0b0c0d0e0f10"),
                 }),
-            ).throws("Security extensions not supported.");
+            ).throws("Security extensions not supported when encoding a payload.");
         });
 
         it("throws when encoding a message with securityExtensions flag", () => {
@@ -152,7 +152,9 @@ describe("MessageCodec", () => {
             } as Message;
             decoded.payloadHeader = { ...decoded.payloadHeader }; // make copy to not change original value
             decoded.payloadHeader.hasSecuredExtension = true;
-            expect(() => MessageCodec.encodePayload(decoded)).throws("Security extensions not supported.");
+            expect(() => MessageCodec.encodePayload(decoded)).throws(
+                "Security extensions not supported when encoding a payload.",
+            );
         });
 
         it("throws when encoding a message with messageExtension data", () => {
@@ -161,7 +163,7 @@ describe("MessageCodec", () => {
                     ...MessageCodec.encodePayload(DECODED),
                     messageExtension: ByteArray.fromHex("0102030405060708090a0b0c0d0e0f10"),
                 }),
-            ).throws("Message extensions not supported.");
+            ).throws("Message extensions not supported when encoding a packet.");
         });
 
         it("throws when encoding a message with messageExtension flag", () => {
@@ -171,7 +173,9 @@ describe("MessageCodec", () => {
             payload.header = { ...payload.header }; // make copy to not change original value
             payload.header.hasMessageExtensions = true;
 
-            expect(() => MessageCodec.encodePacket(payload)).throws("Message extensions not supported.");
+            expect(() => MessageCodec.encodePacket(payload)).throws(
+                "Message extensions not supported when encoding a packet.",
+            );
         });
     });
 });

--- a/packages/matter.js/test/codec/MessageTest.ts
+++ b/packages/matter.js/test/codec/MessageTest.ts
@@ -31,6 +31,7 @@ const DECODED = {
         messageType: 0x20,
         requiresAck: true,
         ackedMessageId: undefined,
+        hasSecuredExtension: false,
     },
     payload: ByteArray.fromHex(
         "153001204715a406c6b0496ad52039e347db8528cb69a1cb2fce6f2318552ae65e103aca250233dc240300280435052501881325022c011818",
@@ -60,6 +61,7 @@ const DECODED_2 = {
         messageType: 0x21,
         requiresAck: true,
         ackedMessageId: 401755914,
+        hasSecuredExtension: false,
     },
     payload: ByteArray.fromHex(
         "153001204715a406c6b0496ad52039e347db8528cb69a1cb2fce6f2318552ae65e103aca3002201783302d95a4a9fb0decb8fdd6564b90a957681459aeee069961bea61d7b247125039d8935042501e80330022099f813dd41bd081a1c63e811828f0662594bca89cd9d4ed26f7427fdb2a027361835052501881325022c011818",


### PR DESCRIPTION
In fact this means that they need to be read, but ignored.

This PR implements the following:
* When decoding the two extension types are detected and read from the message in order to get the payload correctly. No exceptions are thrown anymore when decoding and the extension data are provided as data. An info message is logged if they are present to make this transparent.
* When encoding we throw an exception when any extensions are declared or data provided because we do not support this right now - to be added when we need such extensions.
* On message decoding we now use the securityflags from the original message and not encode a full header again just to (hopefully) get the same securityflags again. Should perform a bit better. Also logic got added to correctly handle the "additional authenticated data" while decoding also in case message extensions are present.


Ideally review in full and not "by commit" because of some changes" ... should be easier