### PR TITLE
Fix TemperatureMeasurement definition

### DIFF
--- a/models/src/local/TemperatureMeasurementOverrides.ts
+++ b/models/src/local/TemperatureMeasurementOverrides.ts
@@ -1,0 +1,35 @@
+/**
+ * @license
+ * Copyright 2022-2023 Project CHIP Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { LocalMatter } from "../local.js";
+
+LocalMatter.children.push({
+    tag: "cluster",
+    name: "TemperatureMeasurement",
+
+    children: [
+        {
+            tag: "attribute",
+            id: 0x0,
+            name: "MeasuredValue",
+            constraint: "-27315 to MaxMeasuredValue-1",
+        },
+        {
+            tag: "attribute",
+            id: 0x1,
+            name: "MinMeasuredValue",
+            default: 32766,
+            constraint: "-27315 to MaxMeasuredValue-1",
+        },
+        {
+            tag: "attribute",
+            id: 0x2,
+            name: "MaxMeasuredValue",
+            default: 32767,
+            constraint: "MinMeasuredValue+1 to 32767",
+        },
+    ],
+});

--- a/models/src/local/index.ts
+++ b/models/src/local/index.ts
@@ -24,5 +24,6 @@ import "./ModeSelectOverrides.js";
 import "./OperationalCredentialsOverrides.js";
 import "./PumpConfigurationAndControlOverrides.js";
 import "./ScenesOverrides.js";
+import "./TemperatureMeasurementOverrides.js";
 import "./UserLabelOverrides.js";
 import "./WindowCoveringOverrides.js";

--- a/packages/matter.js/src/cluster/definitions/TemperatureMeasurementCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/TemperatureMeasurementCluster.ts
@@ -47,7 +47,7 @@ export namespace TemperatureMeasurement {
              *
              * @see {@link MatterApplicationClusterSpecificationV1_1} § 2.3.4.2
              */
-            minMeasuredValue: Attribute(0x1, TlvNullable(TlvInt16.bound({ min: -27315 })), { default: 32768 }),
+            minMeasuredValue: Attribute(0x1, TlvNullable(TlvInt16.bound({ min: -27315 })), { default: 32766 }),
 
             /**
              * The MaxMeasuredValue attribute indicates the maximum value of MeasuredValue that is capable of being
@@ -57,7 +57,7 @@ export namespace TemperatureMeasurement {
              *
              * @see {@link MatterApplicationClusterSpecificationV1_1} § 2.3.4.3
              */
-            maxMeasuredValue: Attribute(0x2, TlvNullable(TlvInt16), { default: 32768 }),
+            maxMeasuredValue: Attribute(0x2, TlvNullable(TlvInt16), { default: 32767 }),
 
             /**
              * See Measured Value.


### PR DESCRIPTION
This PR adds a manual override for invalid default values from chip repo (see https://github.com/project-chip/connectedhomeip/issues/30775)

fixes #553 

@lauckhart I needed to also include attribute 0x00 and also the contrains for the other two because else the minimum values were missing after generation with the override