### PR TITLE
Fix TemperatureMeasurement definition (again)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,15 @@ The main work (all changes without a GitHub username in brackets in the below li
 	## __WORK IN PROGRESS__
 -->
 
+## __WORK IN PROGRESS__
+* Matter-Core functionality:
+  * Corrected default values for TemperatureMeasurement Cluster
+  * Handled Message extensions and Secured extensions in matter messages correctly (means they are ignored for now but read from the data stream)
+  * Handles too huge UDP messages correctly by dropping such messages
+
 ## 0.7.1 (2023-11-24)
 * Matter-Core functionality:
-  * Optimized Exchange deletion and change a throw to log when a already deleted Exchange should be deleted again 
+  * Optimized Exchange deletion and change a throw to log when a already deleted Exchange should be deleted again
 * matter.js API:
   * Added some convenient methods on PairedNode instance to access Clusters on Devices and also the RootEndpoint (if needed)
   * Added method to cancel a running discovery process for commissionable devices

--- a/models/src/local/TemperatureMeasurementOverrides.ts
+++ b/models/src/local/TemperatureMeasurementOverrides.ts
@@ -21,7 +21,7 @@ LocalMatter.children.push({
             tag: "attribute",
             id: 0x1,
             name: "MinMeasuredValue",
-            default: 32766,
+            default: -27315,
             constraint: "-27315 to MaxMeasuredValue-1",
         },
         {

--- a/models/src/local/TemperatureMeasurementOverrides.ts
+++ b/models/src/local/TemperatureMeasurementOverrides.ts
@@ -15,7 +15,7 @@ LocalMatter.children.push({
             tag: "attribute",
             id: 0x0,
             name: "MeasuredValue",
-            constraint: "-27315 to MaxMeasuredValue-1",
+            constraint: "MinMeasuredValue to MaxMeasuredValue",
         },
         {
             tag: "attribute",

--- a/packages/matter.js/src/cluster/definitions/TemperatureMeasurementCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/TemperatureMeasurementCluster.ts
@@ -47,7 +47,7 @@ export namespace TemperatureMeasurement {
              *
              * @see {@link MatterApplicationClusterSpecificationV1_1} § 2.3.4.2
              */
-            minMeasuredValue: Attribute(0x1, TlvNullable(TlvInt16.bound({ min: -27315 })), { default: 32766 }),
+            minMeasuredValue: Attribute(0x1, TlvNullable(TlvInt16.bound({ min: -27315 })), { default: -27315 }),
 
             /**
              * The MaxMeasuredValue attribute indicates the maximum value of MeasuredValue that is capable of being

--- a/packages/matter.js/src/model/standard/elements/TemperatureMeasurement.ts
+++ b/packages/matter.js/src/model/standard/elements/TemperatureMeasurement.ts
@@ -20,7 +20,7 @@ Matter.children.push({
 
         {
             tag: "attribute", name: "MeasuredValue", id: 0x0, type: "int16", access: "R V", conformance: "M",
-            constraint: "MinMeasuredValue to MaxMeasuredValue", quality: "X P",
+            constraint: "-27315 to MaxMeasuredValue1", quality: "X P",
 
             details: "Represents the temperature in degrees Celsius as follows:" +
                 "\n" +
@@ -34,7 +34,7 @@ Matter.children.push({
 
         {
             tag: "attribute", name: "MinMeasuredValue", id: 0x1, type: "int16", access: "R V", conformance: "M",
-            constraint: "-27315 to MaxMeasuredValue1", default: 32768, quality: "X",
+            constraint: "-27315 to MaxMeasuredValue1", default: -27315, quality: "X",
             details: "The MinMeasuredValue attribute indicates the minimum value of MeasuredValue that is capable of " +
                 "being measured. See Measured Value for more details." +
                 "\n" +
@@ -44,7 +44,7 @@ Matter.children.push({
 
         {
             tag: "attribute", name: "MaxMeasuredValue", id: 0x2, type: "int16", access: "R V", conformance: "M",
-            constraint: "MinMeasuredValue1 to 32767", default: 32768, quality: "X",
+            constraint: "MinMeasuredValue1 to 32767", default: 32767, quality: "X",
             details: "The MaxMeasuredValue attribute indicates the maximum value of MeasuredValue that is capable of " +
                 "being measured. See Measured Value for more details." +
                 "\n" +

--- a/packages/matter.js/src/model/standard/elements/TemperatureMeasurement.ts
+++ b/packages/matter.js/src/model/standard/elements/TemperatureMeasurement.ts
@@ -20,7 +20,7 @@ Matter.children.push({
 
         {
             tag: "attribute", name: "MeasuredValue", id: 0x0, type: "int16", access: "R V", conformance: "M",
-            constraint: "-27315 to MaxMeasuredValue1", quality: "X P",
+            constraint: "MinMeasuredValue to MaxMeasuredValue", quality: "X P",
 
             details: "Represents the temperature in degrees Celsius as follows:" +
                 "\n" +


### PR DESCRIPTION
I think for min the real min makes more sense as default...

Followup from #555 and fixes #553