### PR TITLE
Upgrade Interaction protocol revision to 11 (Matter 1.2) - Redone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The main work (all changes without a GitHub username in brackets in the below li
 * Matter-Core functionality:
   * Enhancement: Refactor Core Session management to match specification
   * Enhancement: Refactor message duplication detection and handling to match specification
+  * Feature: Upgrade Interaction protocol revision to 11 (Matter 1.2) and adjust event error handling in DataReports
 
 ## 0.7.3 (2023-12-18)
 * Matter-Core functionality:

--- a/packages/matter-node.js/test/IntegrationTest.ts
+++ b/packages/matter-node.js/test/IntegrationTest.ts
@@ -35,7 +35,11 @@ import {
 } from "@project-chip/matter.js/datatype";
 import { NodeStateInformation, OnOffLightDevice } from "@project-chip/matter.js/device";
 import { Fabric, FabricBuilder, FabricJsonObject } from "@project-chip/matter.js/fabric";
-import { DecodedEventData, InteractionClientMessenger } from "@project-chip/matter.js/interaction";
+import {
+    DecodedEventData,
+    INTERACTION_MODEL_REVISION,
+    InteractionClientMessenger,
+} from "@project-chip/matter.js/interaction";
 import { MdnsBroadcaster, MdnsScanner } from "@project-chip/matter.js/mdns";
 import { Network, NetworkFake } from "@project-chip/matter.js/net";
 import { ManualPairingCodeCodec } from "@project-chip/matter.js/schema";
@@ -505,6 +509,7 @@ describe("Integration Test", () => {
             const nodeId = commissioningController.getCommissionedNodes()[0];
             const node = commissioningController.getConnectedNode(nodeId);
             assert.ok(node);
+
             const response = await (
                 await node.getInteractionClient()
             ).getMultipleAttributes({

--- a/packages/matter-node.js/test/IntegrationTest.ts
+++ b/packages/matter-node.js/test/IntegrationTest.ts
@@ -82,6 +82,7 @@ describe("Integration Test", () => {
     let matterServer: MatterServer;
     let matterClient: MatterServer;
     let commissioningController: CommissioningController;
+    let commissioningController2: CommissioningController;
     let commissioningServer: CommissioningServer;
     let commissioningServer2: CommissioningServer;
     let onOffLightDeviceServer: OnOffLightDevice;
@@ -643,10 +644,15 @@ describe("Integration Test", () => {
                         eventId: GeneralDiagnostics.Cluster.events.bootReason.id,
                     }, // 0/GeneralDiagnosticsCluster/bootReason
                     { endpointId: EndpointNumber(2) }, // 2 / * /* - will be discarded in results!
+                    {
+                        endpointId: EndpointNumber(100),
+                        clusterId: GeneralDiagnostics.Cluster.id,
+                        eventId: GeneralDiagnostics.Cluster.events.bootReason.id,
+                    }, // invalid endpoint
                 ],
             });
 
-            assert.equal(response.length, 2);
+            assert.equal(response.length, 2); // Error one is not returned currently
             assert.equal(
                 response.filter(
                     ({ path: { endpointId, clusterId } }) =>
@@ -1464,7 +1470,7 @@ describe("Integration Test", () => {
         it("connect this device to a new controller", async () => {
             Network.get = () => clientNetwork;
 
-            const commissioningController2 = new CommissioningController({
+            commissioningController2 = new CommissioningController({
                 listeningAddressIpv6: CLIENT_IPv6,
                 autoConnect: false,
                 autoSubscribe: false,
@@ -1588,6 +1594,90 @@ describe("Integration Test", () => {
 
         after(() => {
             Time.get = () => mockTimeInstance;
+        });
+    });
+
+    describe("Do some interactions with the second controller", () => {
+        it("read events", async () => {
+            const nodeId = commissioningController2.getCommissionedNodes()[0];
+            const node = commissioningController2.getConnectedNode(nodeId);
+            assert.ok(node);
+
+            let checked = false;
+            MockTime.interceptOnce(InteractionClientMessenger.prototype, "sendReadRequest", async ({ resolve }) => {
+                assert.ok(resolve);
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-ignore
+                assert.equal(resolve.interactionModelRevision, INTERACTION_MODEL_REVISION);
+                checked = true;
+            });
+
+            const response = await (
+                await node.getInteractionClient()
+            ).getMultipleEvents({
+                events: [
+                    { clusterId: BasicInformation.Cluster.id }, // * /BasicInformationCluster/ *
+                    {
+                        endpointId: EndpointNumber(0),
+                        clusterId: GeneralDiagnostics.Cluster.id,
+                        eventId: GeneralDiagnostics.Cluster.events.bootReason.id,
+                    }, // 0/GeneralDiagnosticsCluster/bootReason
+                    { endpointId: EndpointNumber(2) }, // 2 / * /* - will be discarded in results!
+                    {
+                        endpointId: EndpointNumber(100),
+                        clusterId: GeneralDiagnostics.Cluster.id,
+                        eventId: GeneralDiagnostics.Cluster.events.bootReason.id,
+                    }, // invalid endpoint
+                ],
+            });
+
+            assert.equal(checked, true);
+
+            assert.equal(response.length, 3); // Error one is not returned currently
+            assert.equal(
+                response.filter(
+                    ({ path: { endpointId, clusterId } }) =>
+                        endpointId === 0 && clusterId === BasicInformation.Cluster.id,
+                ).length,
+                2,
+            );
+
+            const startUpEventData = response.find(
+                ({ path: { endpointId, clusterId, eventId } }) =>
+                    endpointId === 0 &&
+                    clusterId === BasicInformation.Cluster.id &&
+                    eventId === BasicInformation.Cluster.events.startUp.id,
+            );
+
+            assert.deepEqual(startUpEventData?.events, [
+                {
+                    eventNumber: 1,
+                    epochTimestamp: TIME_START,
+                    priority: BasicInformation.Cluster.events.startUp.priority,
+                    data: {
+                        softwareVersion: 1,
+                    },
+                    path: undefined,
+                },
+            ]);
+
+            const bootReasonEventData = response.find(
+                ({ path: { endpointId, clusterId, eventId } }) =>
+                    endpointId === 0 &&
+                    clusterId === GeneralDiagnostics.Cluster.id &&
+                    eventId === GeneralDiagnostics.Cluster.events.bootReason.id,
+            );
+            assert.deepEqual(bootReasonEventData?.events, [
+                {
+                    eventNumber: 2,
+                    epochTimestamp: TIME_START,
+                    priority: BasicInformation.Cluster.events.startUp.priority,
+                    data: {
+                        bootReason: GeneralDiagnostics.BootReason.Unspecified,
+                    },
+                    path: undefined,
+                },
+            ]);
         });
     });
 

--- a/packages/matter-node.js/test/interaction/InteractionProtocolTest.ts
+++ b/packages/matter-node.js/test/interaction/InteractionProtocolTest.ts
@@ -11,6 +11,7 @@ import {
     AccessControlCluster,
     AccessLevel,
     AdministratorCommissioning,
+    BasicInformation,
     BasicInformationCluster,
     ClusterServer,
     ClusterServerObjForCluster,
@@ -87,6 +88,12 @@ const READ_REQUEST: ReadRequest = {
         { endpointId: undefined, clusterId: ClusterId(0x99), attributeId: AttributeId(3) }, // ignore
         { endpointId: EndpointNumber(0), clusterId: ClusterId(0x1d), attributeId: AttributeId(1) },
     ],
+    eventRequests: [
+        { endpointId: EndpointNumber(0), clusterId: ClusterId(0x28), eventId: EventId(0) }, // existing event
+        { endpointId: EndpointNumber(0), clusterId: ClusterId(0x28), eventId: EventId(400) }, // unsupported event
+        { endpointId: EndpointNumber(0), clusterId: ClusterId(0x99), eventId: EventId(4) }, // unsupported cluster
+        { endpointId: EndpointNumber(1), clusterId: ClusterId(0x28), eventId: EventId(1) }, // unsupported endpoint
+    ],
 };
 
 const READ_REQUEST_WITH_UNUSED_FILTER: ReadRequest = {
@@ -103,6 +110,13 @@ const READ_REQUEST_WITH_UNUSED_FILTER: ReadRequest = {
         { endpointId: EndpointNumber(0), clusterId: ClusterId(0x1d), attributeId: AttributeId(1) },
     ],
     dataVersionFilters: [{ path: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x28) }, dataVersion: 1 }],
+    eventRequests: [
+        { endpointId: EndpointNumber(0), clusterId: ClusterId(0x28), eventId: EventId(0) }, // existing event
+        { endpointId: EndpointNumber(0), clusterId: ClusterId(0x28), eventId: EventId(400) }, // unsupported event
+        { endpointId: EndpointNumber(0), clusterId: ClusterId(0x99), eventId: EventId(4) }, // unsupported cluster
+        { endpointId: EndpointNumber(1), clusterId: ClusterId(0x28), eventId: EventId(1) }, // unsupported endpoint
+    ],
+    eventFilters: [{ eventMin: 1 }],
 };
 
 const READ_REQUEST_WITH_FILTER: ReadRequest = {
@@ -119,12 +133,18 @@ const READ_REQUEST_WITH_FILTER: ReadRequest = {
         { endpointId: EndpointNumber(0), clusterId: ClusterId(0x1d), attributeId: AttributeId(1) },
     ],
     dataVersionFilters: [{ path: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x28) }, dataVersion: 0 }],
+    eventRequests: [
+        { endpointId: EndpointNumber(0), clusterId: ClusterId(0x28), eventId: EventId(0) }, // existing event
+        { endpointId: EndpointNumber(0), clusterId: ClusterId(0x28), eventId: EventId(400) }, // unsupported event
+        { endpointId: EndpointNumber(0), clusterId: ClusterId(0x99), eventId: EventId(4) }, // unsupported cluster
+        { endpointId: EndpointNumber(1), clusterId: ClusterId(0x28), eventId: EventId(1) }, // unsupported endpoint
+    ],
+    eventFilters: [{ eventMin: 2 }],
 };
 
 const READ_RESPONSE: DataReportPayload = {
     interactionModelRevision: INTERACTION_MODEL_REVISION,
     suppressResponse: false,
-    eventReportsPayload: undefined,
     attributeReportsPayload: [
         {
             attributeData: {
@@ -181,12 +201,65 @@ const READ_RESPONSE: DataReportPayload = {
             },
         },
     ],
+    eventReportsPayload: [
+        {
+            eventData: {
+                path: {
+                    endpointId: EndpointNumber(0),
+                    clusterId: ClusterId(0x28),
+                    eventId: EventId(0),
+                    isUrgent: undefined,
+                },
+                schema: BasicInformation.TlvStartUpEvent,
+                payload: {
+                    softwareVersion: 1,
+                },
+                eventNumber: 1,
+                priority: 2,
+                epochTimestamp: 0,
+            },
+        },
+        {
+            eventData: {
+                path: {
+                    endpointId: EndpointNumber(0),
+                    clusterId: ClusterId(0x28),
+                    eventId: EventId(0),
+                    isUrgent: undefined,
+                },
+                schema: BasicInformation.TlvStartUpEvent,
+                payload: {
+                    softwareVersion: 2,
+                },
+                eventNumber: 2,
+                priority: 2,
+                epochTimestamp: 0,
+            },
+        },
+        {
+            eventStatus: {
+                path: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x28), eventId: EventId(400) },
+                status: { status: 199 },
+            },
+        },
+        {
+            eventStatus: {
+                path: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x99), eventId: EventId(4) },
+                status: { status: 195 },
+            },
+        },
+        {
+            eventStatus: {
+                path: { endpointId: EndpointNumber(1), clusterId: ClusterId(0x28), eventId: EventId(1) },
+                status: { status: 127 },
+            },
+        },
+    ],
 };
 
 const READ_RESPONSE_WITH_FILTER: DataReportPayload = {
     interactionModelRevision: INTERACTION_MODEL_REVISION,
     suppressResponse: false,
-    eventReportsPayload: undefined,
     attributeReportsPayload: [
         {
             attributeStatus: {
@@ -216,6 +289,43 @@ const READ_RESPONSE_WITH_FILTER: DataReportPayload = {
                 schema: TlvArray(TlvClusterId),
                 payload: [ClusterId(29), ClusterId(40)],
                 dataVersion: 0,
+            },
+        },
+    ],
+    eventReportsPayload: [
+        {
+            eventData: {
+                path: {
+                    endpointId: EndpointNumber(0),
+                    clusterId: ClusterId(0x28),
+                    eventId: EventId(0),
+                    isUrgent: undefined,
+                },
+                schema: BasicInformation.TlvStartUpEvent,
+                payload: {
+                    softwareVersion: 2,
+                },
+                eventNumber: 2,
+                priority: 2,
+                epochTimestamp: 0,
+            },
+        },
+        {
+            eventStatus: {
+                path: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x28), eventId: EventId(400) },
+                status: { status: 199 },
+            },
+        },
+        {
+            eventStatus: {
+                path: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x99), eventId: EventId(4) },
+                status: { status: 195 },
+            },
+        },
+        {
+            eventStatus: {
+                path: { endpointId: EndpointNumber(1), clusterId: ClusterId(0x28), eventId: EventId(1) },
+                status: { status: 127 },
             },
         },
     ],
@@ -765,6 +875,7 @@ describe("InteractionProtocol", () => {
         Crypto.get().getRandomData = (length: number) => {
             return new Uint8Array(length);
         };
+        MockTime.reset();
     });
 
     after(() => {
@@ -812,8 +923,13 @@ describe("InteractionProtocol", () => {
         });
 
         it("replies with attribute values", async () => {
-            endpoint.addClusterServer(basicInfoClusterServer());
+            const basicInfoServer = basicInfoClusterServer();
+
+            endpoint.addClusterServer(basicInfoServer);
             interactionProtocol.setRootEndpoint(endpoint);
+
+            basicInfoServer.triggerStartUpEvent({ softwareVersion: 1 });
+            basicInfoServer.triggerStartUpEvent({ softwareVersion: 2 });
 
             const result = interactionProtocol.handleReadRequest(await getDummyMessageExchange(), READ_REQUEST);
 
@@ -821,8 +937,13 @@ describe("InteractionProtocol", () => {
         });
 
         it("replies with attribute values using (unused) version filter", async () => {
-            endpoint.addClusterServer(basicInfoClusterServer());
+            const basicInfoServer = basicInfoClusterServer();
+
+            endpoint.addClusterServer(basicInfoServer);
             interactionProtocol.setRootEndpoint(endpoint);
+
+            basicInfoServer.triggerStartUpEvent({ softwareVersion: 1 });
+            basicInfoServer.triggerStartUpEvent({ softwareVersion: 2 });
 
             const result = interactionProtocol.handleReadRequest(
                 await getDummyMessageExchange(),
@@ -833,8 +954,13 @@ describe("InteractionProtocol", () => {
         });
 
         it("replies with attribute values with active version filter", async () => {
-            endpoint.addClusterServer(basicInfoClusterServer());
+            const basicInfoServer = basicInfoClusterServer();
+
+            endpoint.addClusterServer(basicInfoServer);
             interactionProtocol.setRootEndpoint(endpoint);
+
+            basicInfoServer.triggerStartUpEvent({ softwareVersion: 1 });
+            basicInfoServer.triggerStartUpEvent({ softwareVersion: 2 });
 
             const result = interactionProtocol.handleReadRequest(
                 await getDummyMessageExchange(),

--- a/packages/matter-node.js/test/interaction/InteractionProtocolTest.ts
+++ b/packages/matter-node.js/test/interaction/InteractionProtocolTest.ts
@@ -38,6 +38,7 @@ import { DeviceClasses, DeviceTypeDefinition, Endpoint } from "@project-chip/mat
 import { Fabric } from "@project-chip/matter.js/fabric";
 import {
     DataReportPayload,
+    INTERACTION_MODEL_REVISION,
     InteractionServer,
     InteractionServerMessenger,
     InvokeRequest,
@@ -74,7 +75,7 @@ const DummyTestDevice = DeviceTypeDefinition({
 });
 
 const READ_REQUEST: ReadRequest = {
-    interactionModelRevision: 10,
+    interactionModelRevision: INTERACTION_MODEL_REVISION,
     isFabricFiltered: true,
     attributeRequests: [
         { endpointId: EndpointNumber(0), clusterId: ClusterId(0x28), attributeId: AttributeId(2) },
@@ -89,7 +90,7 @@ const READ_REQUEST: ReadRequest = {
 };
 
 const READ_REQUEST_WITH_UNUSED_FILTER: ReadRequest = {
-    interactionModelRevision: 10,
+    interactionModelRevision: INTERACTION_MODEL_REVISION,
     isFabricFiltered: true,
     attributeRequests: [
         { endpointId: EndpointNumber(0), clusterId: ClusterId(0x28), attributeId: AttributeId(2) },
@@ -105,7 +106,7 @@ const READ_REQUEST_WITH_UNUSED_FILTER: ReadRequest = {
 };
 
 const READ_REQUEST_WITH_FILTER: ReadRequest = {
-    interactionModelRevision: 10,
+    interactionModelRevision: INTERACTION_MODEL_REVISION,
     isFabricFiltered: true,
     attributeRequests: [
         { endpointId: EndpointNumber(0), clusterId: ClusterId(0x28), attributeId: AttributeId(2) },
@@ -121,7 +122,7 @@ const READ_REQUEST_WITH_FILTER: ReadRequest = {
 };
 
 const READ_RESPONSE: DataReportPayload = {
-    interactionModelRevision: 10,
+    interactionModelRevision: INTERACTION_MODEL_REVISION,
     suppressResponse: false,
     eventReportsPayload: undefined,
     attributeReportsPayload: [
@@ -183,7 +184,7 @@ const READ_RESPONSE: DataReportPayload = {
 };
 
 const READ_RESPONSE_WITH_FILTER: DataReportPayload = {
-    interactionModelRevision: 10,
+    interactionModelRevision: INTERACTION_MODEL_REVISION,
     suppressResponse: false,
     eventReportsPayload: undefined,
     attributeReportsPayload: [
@@ -221,7 +222,7 @@ const READ_RESPONSE_WITH_FILTER: DataReportPayload = {
 };
 
 const INVALID_SUBSCRIBE_REQUEST: SubscribeRequest = {
-    interactionModelRevision: 10,
+    interactionModelRevision: INTERACTION_MODEL_REVISION,
     isFabricFiltered: true,
     attributeRequests: [
         { endpointId: EndpointNumber(0), clusterId: ClusterId(0x99), attributeId: AttributeId(2) },
@@ -237,7 +238,7 @@ const INVALID_SUBSCRIBE_REQUEST: SubscribeRequest = {
 };
 
 const WRITE_REQUEST: WriteRequest = {
-    interactionModelRevision: 10,
+    interactionModelRevision: INTERACTION_MODEL_REVISION,
     suppressResponse: false,
     timedRequest: false,
     writeRequests: [
@@ -274,7 +275,7 @@ const WRITE_REQUEST: WriteRequest = {
 };
 
 const WRITE_RESPONSE: WriteResponse = {
-    interactionModelRevision: 10,
+    interactionModelRevision: INTERACTION_MODEL_REVISION,
     writeResponses: [
         {
             path: { attributeId: AttributeId(100), clusterId: ClusterId(40), endpointId: EndpointNumber(0) },
@@ -304,7 +305,7 @@ const WRITE_RESPONSE: WriteResponse = {
 };
 
 const WRITE_REQUEST_TIMED_REQUIRED: WriteRequest = {
-    interactionModelRevision: 10,
+    interactionModelRevision: INTERACTION_MODEL_REVISION,
     suppressResponse: false,
     timedRequest: false,
     writeRequests: [
@@ -318,7 +319,7 @@ const WRITE_REQUEST_TIMED_REQUIRED: WriteRequest = {
 };
 
 const WRITE_RESPONSE_TIMED_REQUIRED: WriteResponse = {
-    interactionModelRevision: 10,
+    interactionModelRevision: INTERACTION_MODEL_REVISION,
     writeResponses: [
         {
             path: { attributeId: AttributeId(5), clusterId: ClusterId(40), endpointId: EndpointNumber(0) },
@@ -328,7 +329,7 @@ const WRITE_RESPONSE_TIMED_REQUIRED: WriteResponse = {
 };
 
 const WRITE_RESPONSE_TIMED_ERROR: WriteResponse = {
-    interactionModelRevision: 10,
+    interactionModelRevision: INTERACTION_MODEL_REVISION,
     writeResponses: [
         {
             path: { attributeId: AttributeId(5), clusterId: ClusterId(40), endpointId: EndpointNumber(0) },
@@ -338,7 +339,7 @@ const WRITE_RESPONSE_TIMED_ERROR: WriteResponse = {
 };
 
 const MASS_WRITE_REQUEST: WriteRequest = {
-    interactionModelRevision: 10,
+    interactionModelRevision: INTERACTION_MODEL_REVISION,
     suppressResponse: false,
     timedRequest: false,
     writeRequests: [
@@ -362,7 +363,7 @@ const MASS_WRITE_REQUEST: WriteRequest = {
 };
 
 const MASS_WRITE_RESPONSE: WriteResponse = {
-    interactionModelRevision: 10,
+    interactionModelRevision: INTERACTION_MODEL_REVISION,
     writeResponses: [
         {
             path: { attributeId: AttributeId(5), clusterId: ClusterId(40), endpointId: EndpointNumber(0) },
@@ -388,7 +389,7 @@ const TlvAclTestSchema = TlvObject({
 });
 
 const CHUNKED_ARRAY_WRITE_REQUEST: WriteRequest = {
-    interactionModelRevision: 10,
+    interactionModelRevision: INTERACTION_MODEL_REVISION,
     suppressResponse: false,
     timedRequest: false,
     writeRequests: [
@@ -449,7 +450,7 @@ const CHUNKED_ARRAY_WRITE_REQUEST: WriteRequest = {
 };
 
 const CHUNKED_ARRAY_WRITE_RESPONSE: WriteResponse = {
-    interactionModelRevision: 10,
+    interactionModelRevision: INTERACTION_MODEL_REVISION,
     writeResponses: [
         {
             path: { attributeId: AttributeId(0), clusterId: ClusterId(31), endpointId: EndpointNumber(0) },
@@ -459,7 +460,7 @@ const CHUNKED_ARRAY_WRITE_RESPONSE: WriteResponse = {
 };
 
 const INVOKE_COMMAND_REQUEST_WITH_EMPTY_ARGS: InvokeRequest = {
-    interactionModelRevision: 10,
+    interactionModelRevision: INTERACTION_MODEL_REVISION,
     suppressResponse: false,
     timedRequest: false,
     invokeRequests: [
@@ -475,7 +476,7 @@ const INVOKE_COMMAND_REQUEST_WITH_EMPTY_ARGS: InvokeRequest = {
 };
 
 const INVOKE_COMMAND_REQUEST_TIMED_REQUIRED: InvokeRequest = {
-    interactionModelRevision: 10,
+    interactionModelRevision: INTERACTION_MODEL_REVISION,
     suppressResponse: false,
     timedRequest: false,
     invokeRequests: [
@@ -491,7 +492,7 @@ const INVOKE_COMMAND_REQUEST_TIMED_REQUIRED: InvokeRequest = {
 };
 
 const INVOKE_COMMAND_RESPONSE_TIMED_REQUIRED: InvokeResponse = {
-    interactionModelRevision: 10,
+    interactionModelRevision: INTERACTION_MODEL_REVISION,
     suppressResponse: false,
     invokeResponses: [
         {
@@ -504,7 +505,7 @@ const INVOKE_COMMAND_RESPONSE_TIMED_REQUIRED: InvokeResponse = {
 };
 
 const INVOKE_COMMAND_RESPONSE_TIMED_REQUIRED_SUCCESS: InvokeResponse = {
-    interactionModelRevision: 10,
+    interactionModelRevision: INTERACTION_MODEL_REVISION,
     suppressResponse: false,
     invokeResponses: [
         {
@@ -517,7 +518,7 @@ const INVOKE_COMMAND_RESPONSE_TIMED_REQUIRED_SUCCESS: InvokeResponse = {
 };
 
 const INVOKE_COMMAND_REQUEST_WITH_NO_ARGS: InvokeRequest = {
-    interactionModelRevision: 10,
+    interactionModelRevision: INTERACTION_MODEL_REVISION,
     suppressResponse: false,
     timedRequest: false,
     invokeRequests: [
@@ -528,7 +529,7 @@ const INVOKE_COMMAND_REQUEST_WITH_NO_ARGS: InvokeRequest = {
 };
 
 const INVOKE_COMMAND_REQUEST_MULTI: InvokeRequest = {
-    interactionModelRevision: 10,
+    interactionModelRevision: INTERACTION_MODEL_REVISION,
     suppressResponse: false,
     timedRequest: false,
     invokeRequests: [
@@ -554,7 +555,7 @@ const INVOKE_COMMAND_REQUEST_MULTI: InvokeRequest = {
 };
 
 const INVOKE_COMMAND_REQUEST_INVALID: InvokeRequest = {
-    interactionModelRevision: 10,
+    interactionModelRevision: INTERACTION_MODEL_REVISION,
     suppressResponse: false,
     timedRequest: false,
     invokeRequests: [
@@ -565,7 +566,7 @@ const INVOKE_COMMAND_REQUEST_INVALID: InvokeRequest = {
 };
 
 const INVOKE_COMMAND_REQUEST_VALIDATION_ERROR: InvokeRequest = {
-    interactionModelRevision: 10,
+    interactionModelRevision: INTERACTION_MODEL_REVISION,
     suppressResponse: false,
     timedRequest: false,
     invokeRequests: [
@@ -576,7 +577,7 @@ const INVOKE_COMMAND_REQUEST_VALIDATION_ERROR: InvokeRequest = {
 };
 
 const INVOKE_COMMAND_REQUEST_VALIDATION_ERROR_DATA: InvokeRequest = {
-    interactionModelRevision: 10,
+    interactionModelRevision: INTERACTION_MODEL_REVISION,
     suppressResponse: false,
     timedRequest: false,
     invokeRequests: [
@@ -592,7 +593,7 @@ const INVOKE_COMMAND_REQUEST_VALIDATION_ERROR_DATA: InvokeRequest = {
 };
 
 const INVOKE_COMMAND_RESPONSE: InvokeResponse = {
-    interactionModelRevision: 10,
+    interactionModelRevision: INTERACTION_MODEL_REVISION,
     suppressResponse: false,
     invokeResponses: [
         {
@@ -605,7 +606,7 @@ const INVOKE_COMMAND_RESPONSE: InvokeResponse = {
 };
 
 const INVOKE_COMMAND_RESPONSE_BUSY: InvokeResponse = {
-    interactionModelRevision: 10,
+    interactionModelRevision: INTERACTION_MODEL_REVISION,
     suppressResponse: false,
     invokeResponses: [
         {
@@ -618,7 +619,7 @@ const INVOKE_COMMAND_RESPONSE_BUSY: InvokeResponse = {
 };
 
 const INVOKE_COMMAND_RESPONSE_VALIDATION_ERROR: InvokeResponse = {
-    interactionModelRevision: 10,
+    interactionModelRevision: INTERACTION_MODEL_REVISION,
     suppressResponse: false,
     invokeResponses: [
         {
@@ -631,7 +632,7 @@ const INVOKE_COMMAND_RESPONSE_VALIDATION_ERROR: InvokeResponse = {
 };
 
 const INVOKE_COMMAND_RESPONSE_VALIDATION_ERROR_DATA: InvokeResponse = {
-    interactionModelRevision: 10,
+    interactionModelRevision: INTERACTION_MODEL_REVISION,
     suppressResponse: false,
     invokeResponses: [
         {
@@ -644,7 +645,7 @@ const INVOKE_COMMAND_RESPONSE_VALIDATION_ERROR_DATA: InvokeResponse = {
 };
 
 const INVOKE_COMMAND_RESPONSE_INVALID: InvokeResponse = {
-    interactionModelRevision: 10,
+    interactionModelRevision: INTERACTION_MODEL_REVISION,
     suppressResponse: false,
     invokeResponses: [
         {
@@ -657,7 +658,7 @@ const INVOKE_COMMAND_RESPONSE_INVALID: InvokeResponse = {
 };
 
 const INVOKE_COMMAND_RESPONSE_MULTI: InvokeResponse = {
-    interactionModelRevision: 10,
+    interactionModelRevision: INTERACTION_MODEL_REVISION,
     suppressResponse: false,
     invokeResponses: [
         {
@@ -895,14 +896,14 @@ describe("InteractionProtocol", () => {
                 await getDummyMessageExchange(),
                 INVALID_SUBSCRIBE_REQUEST,
                 {
-                    sendStatus: code => {
+                    sendStatus: (code: StatusCode) => {
                         statusSent = code;
                     },
 
                     close: async () => {
                         closed = true;
                     },
-                } as InteractionServerMessenger,
+                } as unknown as InteractionServerMessenger,
             );
             assert.equal(statusSent, 128);
             assert.equal(closed, true);

--- a/packages/matter.js-tools/src/testing/mocks/time.ts
+++ b/packages/matter.js-tools/src/testing/mocks/time.ts
@@ -133,7 +133,7 @@ export class MockTime {
      * Unhooks after completion.
      *
      * Handles both synchronous and asynchronous methods.  The interceptor
-     * should match the asynchronous of the intercepted method.
+     * should match the async-ness of the intercepted method.
      *
      * The interceptor can optionally access and/or replace the resolve/reject
      * value.

--- a/packages/matter.js-tools/src/testing/mocks/time.ts
+++ b/packages/matter.js-tools/src/testing/mocks/time.ts
@@ -133,7 +133,7 @@ export class MockTime {
      * Unhooks after completion.
      *
      * Handles both synchronous and asynchronous methods.  The interceptor
-     * should match the asyncnous of the intercepted method.
+     * should match the asynchronous of the intercepted method.
      *
      * The interceptor can optionally access and/or replace the resolve/reject
      * value.

--- a/packages/matter.js/src/protocol/interaction/EventHandler.ts
+++ b/packages/matter.js/src/protocol/interaction/EventHandler.ts
@@ -58,10 +58,11 @@ export class EventHandler {
     }
 
     getEvents(eventPath: TypeFromSchema<typeof TlvEventPath>, filters?: TypeFromSchema<typeof TlvEventFilter>[]) {
-        const eventFilter = filters
-            ? (event: EventStorageData<any>) =>
-                  filters.some(filter => filter.eventMin !== undefined && event.eventNumber >= filter.eventMin)
-            : () => true; // TODO also add Node Id check
+        const eventFilter =
+            filters !== undefined && filters.length > 0
+                ? (event: EventStorageData<any>) =>
+                      filters.some(filter => filter.eventMin !== undefined && event.eventNumber >= filter.eventMin)
+                : () => true; // TODO also add Node Id check
         const events = new Array<EventStorageData<any>>();
         const { endpointId, clusterId, eventId } = eventPath;
         for (const priority of [EventPriority.Critical, EventPriority.Info, EventPriority.Debug]) {

--- a/packages/matter.js/src/protocol/interaction/InteractionEndpointStructure.ts
+++ b/packages/matter.js/src/protocol/interaction/InteractionEndpointStructure.ts
@@ -30,6 +30,7 @@ import {
     eventPathToId,
     genericElementPathToId,
 } from "./InteractionServer.js";
+import { StatusCode, StatusResponseError } from "./StatusCode.js";
 
 export class InteractionEndpointStructure {
     endpoints = new Map<EndpointNumber, Endpoint>();
@@ -201,12 +202,34 @@ export class InteractionEndpointStructure {
         return !!this.getAttribute(endpointId, clusterId, attributeId);
     }
 
+    validateConcreteAttributePath(endpointId: EndpointNumber, clusterId: ClusterId, attributeId: AttributeId) {
+        if (!this.hasEndpoint(endpointId)) {
+            throw new StatusResponseError(`Endpoint ${endpointId} does not exist.`, StatusCode.UnsupportedEndpoint);
+        }
+        if (!this.hasClusterServer(endpointId, clusterId)) {
+            throw new StatusResponseError(`Cluster ${clusterId} does not exist.`, StatusCode.UnsupportedCluster);
+        }
+        if (this.hasAttribute(endpointId, clusterId, attributeId)) return true;
+        throw new StatusResponseError(`Attribute ${attributeId} does not exist`, StatusCode.UnsupportedAttribute);
+    }
+
     getEvent(endpointId: EndpointNumber, clusterId: ClusterId, eventId: EventId): EventServer<any> | undefined {
         return this.events.get(eventPathToId({ endpointId, clusterId, eventId }));
     }
 
     hasEvent(endpointId: EndpointNumber, clusterId: ClusterId, eventId: EventId): boolean {
         return !!this.getEvent(endpointId, clusterId, eventId);
+    }
+
+    validateConcreteEventPath(endpointId: EndpointNumber, clusterId: ClusterId, eventId: EventId) {
+        if (!this.hasEndpoint(endpointId)) {
+            throw new StatusResponseError(`Endpoint ${endpointId} does not exist.`, StatusCode.UnsupportedEndpoint);
+        }
+        if (!this.hasClusterServer(endpointId, clusterId)) {
+            throw new StatusResponseError(`Cluster ${clusterId} does not exist.`, StatusCode.UnsupportedCluster);
+        }
+        if (this.hasEvent(endpointId, clusterId, eventId)) return true;
+        throw new StatusResponseError(`Event ${eventId} does not exist`, StatusCode.UnsupportedEvent);
     }
 
     getCommand(
@@ -219,6 +242,17 @@ export class InteractionEndpointStructure {
 
     hasCommand(endpointId: EndpointNumber, clusterId: ClusterId, commandId: CommandId): boolean {
         return !!this.getCommand(endpointId, clusterId, commandId);
+    }
+
+    validateConcreteCommandPath(endpointId: EndpointNumber, clusterId: ClusterId, commandId: CommandId) {
+        if (!this.hasEndpoint(endpointId)) {
+            throw new StatusResponseError(`Endpoint ${endpointId} does not exist.`, StatusCode.UnsupportedEndpoint);
+        }
+        if (!this.hasClusterServer(endpointId, clusterId)) {
+            throw new StatusResponseError(`Cluster ${clusterId} does not exist.`, StatusCode.UnsupportedCluster);
+        }
+        if (this.hasCommand(endpointId, clusterId, commandId)) return true;
+        throw new StatusResponseError(`Command ${commandId} does not exist`, StatusCode.UnsupportedCommand);
     }
 
     getAttributes(filters: TypeFromSchema<typeof TlvAttributePath>[], onlyWritable = false): AttributeWithPath[] {

--- a/packages/matter.js/src/protocol/interaction/InteractionEndpointStructure.ts
+++ b/packages/matter.js/src/protocol/interaction/InteractionEndpointStructure.ts
@@ -203,6 +203,7 @@ export class InteractionEndpointStructure {
     }
 
     validateConcreteAttributePath(endpointId: EndpointNumber, clusterId: ClusterId, attributeId: AttributeId) {
+        // TODO: Also hande the InvalidAction cases depending on the action for the check
         if (!this.hasEndpoint(endpointId)) {
             throw new StatusResponseError(`Endpoint ${endpointId} does not exist.`, StatusCode.UnsupportedEndpoint);
         }
@@ -222,6 +223,7 @@ export class InteractionEndpointStructure {
     }
 
     validateConcreteEventPath(endpointId: EndpointNumber, clusterId: ClusterId, eventId: EventId) {
+        // TODO: Also hande the InvalidAction cases depending on the action for the check
         if (!this.hasEndpoint(endpointId)) {
             throw new StatusResponseError(`Endpoint ${endpointId} does not exist.`, StatusCode.UnsupportedEndpoint);
         }
@@ -245,6 +247,7 @@ export class InteractionEndpointStructure {
     }
 
     validateConcreteCommandPath(endpointId: EndpointNumber, clusterId: ClusterId, commandId: CommandId) {
+        // TODO: Also hande the InvalidAction cases
         if (!this.hasEndpoint(endpointId)) {
             throw new StatusResponseError(`Endpoint ${endpointId} does not exist.`, StatusCode.UnsupportedEndpoint);
         }

--- a/packages/matter.js/src/protocol/interaction/InteractionServer.ts
+++ b/packages/matter.js/src/protocol/interaction/InteractionServer.ts
@@ -58,7 +58,7 @@ import { StatusCode, StatusResponseError } from "./StatusCode.js";
 import { SubscriptionHandler } from "./SubscriptionHandler.js";
 
 export const INTERACTION_PROTOCOL_ID = 0x0001;
-export const INTERACTION_MODEL_REVISION = 10;
+export const INTERACTION_MODEL_REVISION = 11;
 
 const logger = Logger.get("InteractionServer");
 


### PR DESCRIPTION
This PR is implementing the following:
* Based on discovered information the event error handling in DataReports (Read and Subscription) was adjusted (https://github.com/orgs/project-chip/projects/11/views/1?pane=issue&itemId=43796949)
* Refactor and centralized ConcretePath checks.
* Interaction protocol version is increased to 11
* Some tests are enhanced and asjusted accordingly

This is a recreated simplified version of #491 and replaces this.