### PR TITLE
Adjust WC cluster to match Matter SDK rather then spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ The main work (all changes without a GitHub username in brackets in the below li
 	## __WORK IN PROGRESS__
 -->
 
+## __WORK IN PROGRESS__
+* Matter-Core functionality:
+  * Fix: Adjust commands GoToLiftPercentage and GoToTiltPercentage to match with Matter SDK and work around specification issue
+
+
 ## 0.7.4 (2023-12-31)
 * Matter-Core functionality:
   * Enhancement: Refactor Core Session management to match specification

--- a/models/src/local/WindowCoveringOverrides.ts
+++ b/models/src/local/WindowCoveringOverrides.ts
@@ -107,5 +107,37 @@ LocalMatter.children.push({
                 },
             ],
         },
+
+        {
+            tag: "command",
+            name: "GoToLiftPercentage",
+            id: 0x5,
+
+            children: [
+                {
+                    tag: "datatype",
+                    name: "LiftPercent100thsValue",
+                    id: 0x0,
+                    type: "percent100ths",
+                    conformance: "M",
+                    constraint: "desc",
+                },
+            ],
+        },
+        {
+            tag: "command",
+            name: "GoToTiltPercentage",
+            id: 0x8,
+            children: [
+                {
+                    tag: "datatype",
+                    name: "TiltPercent100thsValue",
+                    id: 0x0,
+                    type: "percent100ths",
+                    conformance: "M",
+                    constraint: "desc",
+                },
+            ],
+        },
     ],
 });

--- a/packages/matter.js/src/cluster/definitions/WindowCoveringCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/WindowCoveringCluster.ts
@@ -26,10 +26,10 @@ import {
     OptionalFixedAttribute,
     OptionalCommand
 } from "../../cluster/Cluster.js";
-import { TlvEnum, TlvUInt8, TlvBitmap, TlvUInt16, TlvPercent, TlvPercent100ths } from "../../tlv/TlvNumber.js";
+import { TlvEnum, TlvUInt8, TlvBitmap, TlvUInt16, TlvPercent100ths, TlvPercent } from "../../tlv/TlvNumber.js";
 import { TlvNoArguments } from "../../tlv/TlvNoArguments.js";
 import { TlvNullable } from "../../tlv/TlvNullable.js";
-import { TlvObject, TlvOptionalField, TlvField } from "../../tlv/TlvObject.js";
+import { TlvObject, TlvField } from "../../tlv/TlvObject.js";
 
 export namespace WindowCovering {
     /**
@@ -288,20 +288,14 @@ export namespace WindowCovering {
      *
      * @see {@link MatterApplicationClusterSpecificationV1_1} § 5.3.6.5
      */
-    export const TlvGoToLiftPercentageRequest = TlvObject({
-        liftPercentageValue: TlvOptionalField(0, TlvPercent),
-        liftPercent100thsValue: TlvOptionalField(1, TlvPercent100ths)
-    });
+    export const TlvGoToLiftPercentageRequest = TlvObject({ liftPercent100thsValue: TlvField(0, TlvPercent100ths) });
 
     /**
      * Input to the WindowCovering goToTiltPercentage command
      *
      * @see {@link MatterApplicationClusterSpecificationV1_1} § 5.3.6.7
      */
-    export const TlvGoToTiltPercentageRequest = TlvObject({
-        tiltPercentageValue: TlvOptionalField(0, TlvPercent),
-        tiltPercent100thsValue: TlvOptionalField(1, TlvPercent100ths)
-    });
+    export const TlvGoToTiltPercentageRequest = TlvObject({ tiltPercent100thsValue: TlvField(0, TlvPercent100ths) });
 
     /**
      * Input to the WindowCovering goToLiftValue command

--- a/packages/matter.js/src/model/standard/elements/WindowCovering.ts
+++ b/packages/matter.js/src/model/standard/elements/WindowCovering.ts
@@ -538,17 +538,10 @@ Matter.children.push({
                 "status SHOULD be returned.",
 
             xref: { document: "cluster", section: "5.3.6.5" },
-
-            children: [
-                {
-                    tag: "datatype", name: "LiftPercentageValue", id: 0x0, type: "percent", conformance: "O.a",
-                    constraint: "desc"
-                },
-                {
-                    tag: "datatype", name: "LiftPercent100thsValue", id: 0x1, type: "percent100ths", conformance: "O.a",
-                    constraint: "desc"
-                }
-            ]
+            children: [{
+                tag: "datatype", name: "LiftPercent100thsValue", id: 0x0, type: "percent100ths", conformance: "M",
+                constraint: "desc"
+            }]
         },
 
         {
@@ -590,17 +583,10 @@ Matter.children.push({
                 "status SHOULD be returned.",
 
             xref: { document: "cluster", section: "5.3.6.7" },
-
-            children: [
-                {
-                    tag: "datatype", name: "TiltPercentageValue", id: 0x0, type: "percent", conformance: "O.a",
-                    constraint: "desc"
-                },
-                {
-                    tag: "datatype", name: "TiltPercent100thsValue", id: 0x1, type: "percent100ths", conformance: "O.a",
-                    constraint: "desc"
-                }
-            ]
+            children: [{
+                tag: "datatype", name: "TiltPercent100thsValue", id: 0x0, type: "percent100ths", conformance: "M",
+                constraint: "desc"
+            }]
         },
 
         {


### PR DESCRIPTION
As discussed in Discord and in reference to https://github.com/project-chip/connectedhomeip/blob/master/src/app/zap-templates/zcl/data-model/chip/window-covering.xml#L110-L113 we adjust the WC cluster to match with Mater SDK rather then specification.

Override and changelog was manually adjusted. Other two files are generated