### PR TITLE
Optimized Commissioning error handling

### DIFF
--- a/packages/matter.js/src/MatterController.ts
+++ b/packages/matter.js/src/MatterController.ts
@@ -451,7 +451,15 @@ export class MatterController {
             },
         );
 
-        await commissioningManager.executeCommissioning();
+        try {
+            await commissioningManager.executeCommissioning();
+        } catch (error) {
+            if (this.commissionedNodes.has(peerNodeId)) {
+                // We might have added data for an operational address that we need to cleanup
+                this.commissionedNodes.delete(peerNodeId);
+            }
+            throw error;
+        }
 
         this.controllerStorage.set("fabric", this.fabric.toStorageObject());
 


### PR DESCRIPTION
... by catching also StatusResponseErrors and convert to Commissioning Errors. Additionally, for cases where errors happen after an operational connection was done, make sure to clean up internal entries.