### PR TITLE
Correctly set Group key limits for now

### DIFF
--- a/packages/matter.js/src/CommissioningServer.ts
+++ b/packages/matter.js/src/CommissioningServer.ts
@@ -403,8 +403,8 @@ export class CommissioningServer extends MatterNode {
                 {
                     groupKeyMap: [],
                     groupTable: [],
-                    maxGroupsPerFabric: 254,
-                    maxGroupKeysPerFabric: 254,
+                    maxGroupsPerFabric: 1,
+                    maxGroupKeysPerFabric: 1,
                 },
                 GroupKeyManagementClusterHandler(),
             ),


### PR DESCRIPTION
Because we do not support Groups for now we should just set the limits correctly to 1 (IPK).