### PR TITLE
Make NetworkCommissioningCluster optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The main work (all changes without a GitHub username in brackets in the below li
   * Fix: Enhanced handling for fabric scoped command invokes to match with specification
   * Fix: Enhanced handling for fabric sensitive attribute reads to match with specification
 * matter.js API:
+  * Fix (potentially Breaking): Remove NetworkCommissioningCluster (Ethernet) from default added clusters in CommissioningServer because we formally have an out-of-band network connection, re-add manually if needed!
   * Enhancement: Allowed to pass connect options when connecting a node for Controller
   * Enhancement: Stored Discovery and Basic information data for commissioned nodes and allow API access for easy determination of devices without need to connect to them
   * Enhancement: Improved OnOff/Dimmable Lighting devices and add Startup handling to match specification
@@ -39,6 +40,7 @@ The main work (all changes without a GitHub username in brackets in the below li
   * Enhancement: Enhanced CLI arguments parser to allow "--name" additionally to "-name"
   * Fix: Adjusted the Group limits in GroupKeyManagement cluster to 1 because we do not support groups yet
   * Fix: (Luligu) Corrected the Device type for bridged nodes with Power source information
+  * Fix: Adjusted Commissioning logic for Controller to accept devices without network commissioning cluster by assuming out-of-band IP connection 
 * matter.js shell:
   * Feature: Added support for Debug logging into a Logfile additionally to e.g. Info logging in console
   * Enhancement: Adjusted logic to output detailed node information on nodes command

--- a/packages/matter.js/src/CommissioningServer.ts
+++ b/packages/matter.js/src/CommissioningServer.ts
@@ -23,10 +23,6 @@ import {
 } from "./cluster/definitions/GeneralCommissioningCluster.js";
 import { GeneralDiagnostics, GeneralDiagnosticsCluster } from "./cluster/definitions/GeneralDiagnosticsCluster.js";
 import { GroupKeyManagementCluster } from "./cluster/definitions/GroupKeyManagementCluster.js";
-import {
-    NetworkCommissioning,
-    NetworkCommissioningCluster,
-} from "./cluster/definitions/NetworkCommissioningCluster.js";
 import { OperationalCredentialsCluster } from "./cluster/definitions/OperationalCredentialsCluster.js";
 import { AdministratorCommissioningHandler } from "./cluster/server/AdministratorCommissioningServer.js";
 import { ClusterServer } from "./cluster/server/ClusterServer.js";
@@ -357,23 +353,6 @@ export class CommissioningServer extends MatterNode {
                     allowCountryCodeChange: generalCommissioning?.allowCountryCodeChange ?? true,
                     countryCodeWhitelist: generalCommissioning?.countryCodeWhitelist ?? undefined,
                 }),
-            ),
-        );
-
-        const networkId = new ByteArray(32);
-        // TODO Get the defaults from the cluster meta details
-        this.rootEndpoint.addClusterServer(
-            ClusterServer(
-                NetworkCommissioningCluster.with("EthernetNetworkInterface"),
-                {
-                    maxNetworks: 1,
-                    interfaceEnabled: true,
-                    lastConnectErrorValue: 0,
-                    lastNetworkId: networkId,
-                    lastNetworkingStatus: NetworkCommissioning.NetworkCommissioningStatus.Success,
-                    networks: [{ networkId: networkId, connected: true }],
-                },
-                {}, // Ethernet is not requiring any methods
             ),
         );
 

--- a/packages/matter.js/src/common/FailSafeManager.ts
+++ b/packages/matter.js/src/common/FailSafeManager.ts
@@ -5,13 +5,10 @@ import { NodeId } from "../datatype/NodeId.js";
 import { VendorId } from "../datatype/VendorId.js";
 import { Endpoint } from "../device/Endpoint.js";
 import { Fabric, FabricBuilder } from "../fabric/Fabric.js";
-import { Logger } from "../log/Logger.js";
 import { Time, Timer } from "../time/Time.js";
 import { TypeFromSchema } from "../tlv/TlvSchema.js";
 import { ByteArray } from "../util/ByteArray.js";
 import { MatterFlowError } from "./MatterError.js";
-
-const logger = Logger.get("FailSafeManager");
 
 export class MatterFabricConflictError extends MatterFlowError {}
 
@@ -64,10 +61,6 @@ export class FailSafeManager {
             const networkCluster = endpoint.getClusterServer(NetworkCommissioning.Cluster);
             if (networkCluster !== undefined) {
                 networkCluster.setNetworksAttribute(networkState);
-            } else {
-                logger.warn(
-                    `NetworkCluster not found for endpoint ${endpointId}, but expected. Can not restore network data!`,
-                );
             }
             this.storedNetworkClusterState.delete(endpointId);
         }


### PR DESCRIPTION
This PR removes the Network commissioning cluster (Ethernet) from being added by default to the CommissioningServers, because we do not manage networks for now, so we by definition have a "Out of band" network config which is custom and so the cluster is not needed.

If needed and you have details like a real ID for a network interface and such then add it manually.

Additionally, we also remove the expectation that a network commisioning cluster is required in some places nd adjust the controller commissioner to also accept devices without network commissioning cluster