### PR TITLE
A wrong operator, in the right place?

### DIFF
--- a/packages/matter.js/src/mdns/MdnsServer.ts
+++ b/packages/matter.js/src/mdns/MdnsServer.ts
@@ -92,7 +92,7 @@ export class MdnsServer {
         const message = DnsCodec.decode(messageBytes);
         if (message === undefined) return; // The message cannot be parsed
         const { transactionId, messageType, queries, answers: knownAnswers } = message;
-        if (messageType !== DnsMessageType.Query && messageType !== DnsMessageType.TruncatedQuery) return;
+        if (messageType !== DnsMessageType.Query || messageType !== DnsMessageType.TruncatedQuery) return;
         if (queries.length === 0) return; // No queries to answer, can happen in a TruncatedQuery, let's ignore for now
         for (const portRecords of records.values()) {
             let answers = queries.flatMap(query => this.queryRecords(query, portRecords));


### PR DESCRIPTION
I think there is an issue with this, how can one message type be both at the same time?