### PR TITLE
Change NetworkServer address configuration

### DIFF
--- a/packages/matter-node.js-examples/src/examples/DeviceNodeFull.ts
+++ b/packages/matter-node.js-examples/src/examples/DeviceNodeFull.ts
@@ -41,7 +41,7 @@ import { Endpoint, EndpointServer } from "@project-chip/matter.js/endpoint";
 import { RootRequirements } from "@project-chip/matter.js/endpoint/definitions";
 import { Environment, StorageService } from "@project-chip/matter.js/environment";
 import { FabricAction } from "@project-chip/matter.js/fabric";
-import { Level, Logger, levelFromString } from "@project-chip/matter.js/log";
+import { Logger, levelFromString } from "@project-chip/matter.js/log";
 import { ServerNode } from "@project-chip/matter.js/node";
 import { QrCode } from "@project-chip/matter.js/schema";
 import { Time } from "@project-chip/matter.js/time";
@@ -103,7 +103,7 @@ function executeCommand(scriptParamName: string) {
 const logFile = environment.vars.string("logfile.filename");
 if (logFile !== undefined) {
     Logger.addLogger("filelogger", await createFileLogger(logFile), {
-        defaultLogLevel: levelFromString(environment.vars.string("logfile.loglevel")) ?? Level.DEBUG,
+        defaultLogLevel: levelFromString(environment.vars.string("logfile.loglevel", "debug")),
     });
 }
 

--- a/packages/matter-node.js-examples/src/examples/cluster/DummyThreadNetworkCommissioningServer.ts
+++ b/packages/matter-node.js-examples/src/examples/cluster/DummyThreadNetworkCommissioningServer.ts
@@ -43,7 +43,7 @@ export class DummyThreadNetworkCommissioningServer extends NetworkCommissioningB
         const threadScanResults = [
             {
                 panId: this.endpoint.env.vars.number("ble.thread.panId"),
-                extendedPanId: BigInt(this.endpoint.env.vars.string("ble.thread.extendedPanId")),
+                extendedPanId: this.endpoint.env.vars.bigint("ble.thread.extendedPanId"),
                 networkName: this.endpoint.env.vars.string("ble.thread.networkName"),
                 channel: this.endpoint.env.vars.number("ble.thread.channel"),
                 version: 130,

--- a/packages/matter-node.js/src/net/UdpChannelNode.ts
+++ b/packages/matter-node.js/src/net/UdpChannelNode.ts
@@ -47,10 +47,14 @@ export class UdpChannelNode implements UdpChannel {
         listeningAddress,
         netInterface,
         membershipAddresses,
+        reuseAddress,
     }: UdpChannelOptions) {
-        const socketOptions: dgram.SocketOptions = { type, reuseAddr: true };
+        const socketOptions: dgram.SocketOptions = { type: type === "udp" ? "udp6" : type };
         if (type === "udp6") {
             socketOptions.ipv6Only = true;
+        }
+        if (reuseAddress) {
+            socketOptions.reuseAddr = true;
         }
         const socket = await createDgramSocket(listeningAddress, listeningPort, socketOptions);
         socket.setBroadcast(true);

--- a/packages/matter.js/src/behavior/system/network/NetworkRuntime.ts
+++ b/packages/matter.js/src/behavior/system/network/NetworkRuntime.ts
@@ -62,8 +62,6 @@ export abstract class NetworkRuntime {
         }
     }
 
-    abstract operationalPort: number;
-
     protected abstract start(): Promise<void>;
 
     protected abstract stop(): Promise<void>;

--- a/packages/matter.js/src/net/UdpChannel.ts
+++ b/packages/matter.js/src/net/UdpChannel.ts
@@ -8,10 +8,32 @@ import { Listener } from "../common/TransportInterface.js";
 import { ByteArray } from "../util/ByteArray.js";
 
 export interface UdpChannelOptions {
+    /**
+     * UDP channel type.  "udp4" and "udp6" mean IPv4 and IPv6 respectively.  "udp" is dual-mode IPv4/IPv6.
+     * {@link listeningAddress} in this case must be undefined or "::".
+     */
+    type: "udp" | "udp4" | "udp6";
+
+    /**
+     * The port to listen on.  undefined or 0 directs the operating system to select an open port.
+     */
     listeningPort?: number;
-    type: "udp4" | "udp6";
+
+    /**
+     * The address to listen on, either a hostname or IP address in correct format based on {@link type}.
+     */
     listeningAddress?: string;
+
+    /**
+     * If true the socket is opened non-exclusively.
+     */
+    reuseAddress?: boolean;
+
+    /**
+     * The network interface, required for multicast.
+     */
     netInterface?: string;
+
     membershipAddresses?: string[];
 }
 

--- a/packages/matter.js/src/net/UdpInterface.ts
+++ b/packages/matter.js/src/net/UdpInterface.ts
@@ -13,7 +13,13 @@ import { Network, NetworkError } from "./Network.js";
 import { UdpChannel } from "./UdpChannel.js";
 
 export class UdpInterface implements NetInterface {
-    static async create(network: Network, type: "udp4" | "udp6", port?: number, host?: string, netInterface?: string) {
+    static async create(
+        network: Network,
+        type: "udp" | "udp4" | "udp6",
+        port?: number,
+        host?: string,
+        netInterface?: string,
+    ) {
         return new UdpInterface(
             await network.createUdpChannel({ listeningPort: port, type, netInterface, listeningAddress: host }),
         );

--- a/packages/matter.js/src/net/fake/UdpChannelFake.ts
+++ b/packages/matter.js/src/net/fake/UdpChannelFake.ts
@@ -35,7 +35,7 @@ export class UdpChannelFake implements UdpChannel {
         private readonly listeningAddress: string | undefined,
         listeningPort?: number,
     ) {
-        this.listeningPort = listeningPort ?? 1024 + Math.floor(Math.random() * 64511); // Random port 1024-65535
+        this.listeningPort = listeningPort ? listeningPort : 1024 + Math.floor(Math.random() * 64511); // Random port 1024-65535
     }
 
     onData(listener: (netInterface: string, peerAddress: string, peerPort: number, data: ByteArray) => void) {


### PR DESCRIPTION
Now takes addresses as a list of listening address instead of one each of IPv4, IPv6 and BLE.  Adds support for dual-mode (IPv4 + IPv6) sockets.

Adds one dual-mode UDP listener on all addresses if none is configured.  Adds one BLE listener if BLE is supported and "ble" option is not set to false.

Throws an error if there are multiple BLE addresses or the HCI address is specified in the listener list (these require lower-level changes I did not make yet).

I want to make similar changes for Mdns at some point but figured I'd see how these go over first.

Includes some additional convenience methods for variable access.