### PR TITLE
Add convenience infos for node implementors

### DIFF
--- a/docs/MIGRATION_GUIDE_08.md
+++ b/docs/MIGRATION_GUIDE_08.md
@@ -302,7 +302,7 @@ These events will not trigger if the node gets added to another controller. If y
  * This event is triggered when a fabric is added, removed or updated on the device. Use this if more granular
  * information is needed.
  */
-server.events.commissioning.commissionedFabricsChanged.on((fabricIndex, fabricAction) => {
+server.events.commissioning.fabricsChanged.on((fabricIndex, fabricAction) => {
     let action = "";
     switch (fabricAction) {
         case FabricAction.Added:
@@ -316,7 +316,7 @@ server.events.commissioning.commissionedFabricsChanged.on((fabricIndex, fabricAc
             break;
     }
     console.log(`Commissioned Fabrics changed event (${action}) for ${fabricIndex} triggered`);
-    console.log(server.state.operationalCredentials.fabrics);
+    console.log(server.state.commissioning.fabrics[fabricIndex]);
 });
 ```
 

--- a/packages/matter-node.js-examples/src/examples/DeviceNodeFull.ts
+++ b/packages/matter-node.js-examples/src/examples/DeviceNodeFull.ts
@@ -323,7 +323,7 @@ server.lifecycle.offline.on(() => console.log("Server is offline"));
  * This event is triggered when a fabric is added, removed or updated on the device. Use this if more granular
  * information is needed.
  */
-server.events.commissioning.commissionedFabricsChanged.on((fabricIndex, fabricAction) => {
+server.events.commissioning.fabricsChanged.on((fabricIndex, fabricAction) => {
     let action = "";
     switch (fabricAction) {
         case FabricAction.Added:
@@ -337,7 +337,7 @@ server.events.commissioning.commissionedFabricsChanged.on((fabricIndex, fabricAc
             break;
     }
     console.log(`Commissioned Fabrics changed event (${action}) for ${fabricIndex} triggered`);
-    console.log(server.state.operationalCredentials.fabrics);
+    console.log(server.state.commissioning.fabrics[fabricIndex]);
 });
 
 /**

--- a/packages/matter.js/src/behavior/system/commissioning/CommissioningBehavior.ts
+++ b/packages/matter.js/src/behavior/system/commissioning/CommissioningBehavior.ts
@@ -100,11 +100,11 @@ export class CommissioningBehavior extends Behavior {
         const fabrics = this.endpoint.env.get(FabricManager).getFabrics();
         const commissioned = !!fabrics.length;
         if (fabricAction === FabricAction.Removed) {
-            delete this.state.commissionedFabrics[fabricIndex];
+            delete this.state.fabrics[fabricIndex];
         } else {
             const fabric = fabrics.find(fabric => fabric.fabricIndex === fabricIndex);
             if (fabric !== undefined) {
-                this.state.commissionedFabrics[fabricIndex] = {
+                this.state.fabrics[fabricIndex] = {
                     fabricIndex: fabric.fabricIndex,
                     fabricId: fabric.fabricId,
                     nodeId: fabric.nodeId,
@@ -130,7 +130,7 @@ export class CommissioningBehavior extends Behavior {
             }
         }
 
-        this.events.commissionedFabricsChanged.emit(fabricIndex, fabricAction);
+        this.events.fabricsChanged.emit(fabricIndex, fabricAction);
     }
 
     #monitorFailsafe(failsafe: FailsafeContext) {
@@ -231,14 +231,12 @@ export class CommissioningBehavior extends Behavior {
         if (!this.agent.get(OperationalCredentialsBehavior).state.commissionedFabrics) {
             this.initiateCommissioning();
         } else {
-            const commissionedFabrics: Record<FabricIndex, ExposedFabricInformation> = {};
+            const fabrics: Record<FabricIndex, ExposedFabricInformation> = {};
             this.endpoint.env
                 .get(FabricManager)
                 .getFabrics()
-                .forEach(
-                    ({ fabricIndex, externalInformation }) => (commissionedFabrics[fabricIndex] = externalInformation),
-                );
-            this.state.commissionedFabrics = commissionedFabrics;
+                .forEach(({ fabricIndex, externalInformation }) => (fabrics[fabricIndex] = externalInformation));
+            this.state.fabrics = fabrics;
         }
     }
 
@@ -260,7 +258,7 @@ export namespace CommissioningBehavior {
 
     export class State implements CommissioningOptions {
         commissioned = false;
-        commissionedFabrics: Record<FabricIndex, ExposedFabricInformation> = {};
+        fabrics: Record<FabricIndex, ExposedFabricInformation> = {};
         passcode = -1;
         discriminator = -1;
         flowType = CommissioningFlowType.Standard;
@@ -279,6 +277,6 @@ export namespace CommissioningBehavior {
     export class Events extends EventEmitter {
         commissioned = Observable<[session: ActionContext]>();
         decommissioned = Observable<[session: ActionContext]>();
-        commissionedFabricsChanged = Observable<[fabricIndex: FabricIndex, action: FabricAction]>();
+        fabricsChanged = Observable<[fabricIndex: FabricIndex, action: FabricAction]>();
     }
 }

--- a/packages/matter.js/src/node/ServerNode.ts
+++ b/packages/matter.js/src/node/ServerNode.ts
@@ -189,6 +189,10 @@ export class ServerNode<T extends ServerNode.RootEndpoint = ServerNode.RootEndpo
         await this.#mutex;
     }
 
+    advertiseNow() {
+        this.act(agent => agent.get(NetworkServer).advertiseNow());
+    }
+
     protected override async initialize(agent: Agent.Instance<T>) {
         // Load the environment with node-specific services
         const serverStore = await ServerStore.create(this.env, this.id);

--- a/packages/matter.js/src/node/ServerNode.ts
+++ b/packages/matter.js/src/node/ServerNode.ts
@@ -189,8 +189,8 @@ export class ServerNode<T extends ServerNode.RootEndpoint = ServerNode.RootEndpo
         await this.#mutex;
     }
 
-    advertiseNow() {
-        this.act(agent => agent.get(NetworkServer).advertiseNow());
+    async advertiseNow() {
+        await this.act(agent => agent.get(NetworkServer).advertiseNow());
     }
 
     protected override async initialize(agent: Agent.Instance<T>) {


### PR DESCRIPTION
This PR adds:
* Allows to announce a Node als later as convenience method on SeverNode
* Add a "exposed Fabric Infos" object on CommissioningBehaviorfor access like we had in old API