### PR TITLE
Prevent async reaction to sync observables

### DIFF
--- a/packages/matter.js/src/behavior/Reactor.ts
+++ b/packages/matter.js/src/behavior/Reactor.ts
@@ -5,14 +5,14 @@
  */
 
 import type { Endpoint } from "../endpoint/Endpoint.js";
-import type { Observable } from "../util/Observable.js";
+import type { Observable, Observer } from "../util/Observable.js";
 import { MaybePromise } from "../util/Promises.js";
 import type { Behavior } from "./Behavior.js";
 import { Resource } from "./state/transaction/Resource.js";
 
 /**
- * A reactor is an {@link Observable} observer managed by a {@link Behavior}.  You install reactors using
- * {@link Behavior.reactTo} on the behavior that receives the event.
+ * A reactor is an {@link Observer} managed by a {@link Behavior}.  You install reactors using {@link Behavior.reactTo}
+ * on the behavior that receives the event.
  *
  * A reactor is similar to a normal handler installed with {@link Observable.on}.  It provides several benefits over
  * installing an observer directly:

--- a/packages/matter.js/src/behavior/definitions/operational-credentials/OperationalCredentialsServer.ts
+++ b/packages/matter.js/src/behavior/definitions/operational-credentials/OperationalCredentialsServer.ts
@@ -54,7 +54,7 @@ export class OperationalCredentialsServer extends OperationalCredentialsBehavior
         }
         this.state.commissionedFabrics = this.state.fabrics.length;
 
-        this.reactTo((this.endpoint as Node).lifecycle.online, this.#nodeOnline);
+        this.reactTo((this.endpoint as Node).lifecycle.online, this.#nodeOnline, { offline: true });
     }
 
     override attestationRequest({ attestationNonce }: AttestationRequest) {

--- a/packages/matter.js/src/behavior/internal/Reactors.ts
+++ b/packages/matter.js/src/behavior/internal/Reactors.ts
@@ -259,11 +259,14 @@ class ReactorBacking<T extends any[], R> {
         // offline option.  Can probably enforce that with types but right now we just throw an error at runtime
         if (context) {
             const result = this.#reactWithContext(context, this.#owner.backing, args);
+
             if (MaybePromise.is(result) && !this.#observable.isAsync) {
                 throw new ImplementationError(
                     `${this} returned a Promise but the observable is synchronous; you must set the "offline" option so this reactor runs with a dedicated transaction`,
                 );
             }
+
+            return result;
         }
 
         // Otherwise run in independent context and errors do not interfere with emitter

--- a/packages/matter.js/src/behavior/internal/Reactors.ts
+++ b/packages/matter.js/src/behavior/internal/Reactors.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { InternalError } from "../../common/MatterError.js";
+import { ImplementationError, InternalError } from "../../common/MatterError.js";
 import { Endpoint } from "../../endpoint/Endpoint.js";
 import { Logger } from "../../log/Logger.js";
 import type { Observable, Observer } from "../../util/Observable.js";
@@ -256,9 +256,14 @@ class ReactorBacking<T extends any[], R> {
         // If the emitter's context is available, execute in that
         //
         // TODO - if emitter doesn't await promise, things will probably go wrong so async reactors need to use the
-        // offline option.  Can probably enforce that with types
+        // offline option.  Can probably enforce that with types but right now we just throw an error at runtime
         if (context) {
-            return this.#reactWithContext(context, this.#owner.backing, args);
+            const result = this.#reactWithContext(context, this.#owner.backing, args);
+            if (MaybePromise.is(result) && !this.#observable.isAsync) {
+                throw new ImplementationError(
+                    `${this} returned a Promise but the observable is synchronous; you must set the "offline" option so this reactor runs with a dedicated transaction`,
+                );
+            }
         }
 
         // Otherwise run in independent context and errors do not interfere with emitter

--- a/packages/matter.js/test/behavior/internal/ReactorsTest.ts
+++ b/packages/matter.js/test/behavior/internal/ReactorsTest.ts
@@ -248,59 +248,84 @@ describe("Reactors", () => {
         const endpoint = new MockEndpoint();
         const context = MockContext(false);
 
-        let reacted = false;
+        let reacted = 0;
+
+        let reactionText: string | undefined;
+        let offline: boolean | undefined;
+        let reactionContext: ActionContext | undefined;
+        let reactionThis: Behavior | undefined;
 
         endpoint.reactTo(endpoint.event, function (this: Behavior, text: string) {
-            reacted = true;
+            reacted++;
 
-            expect(text).equals("foo");
-            expect(this.context.offline).false;
-            expect(this.context).equals(context);
-            expect(this).equals(context.agentFor({} as any).get({} as Behavior.Type));
+            reactionText = text;
+            offline = this.context.offline;
+            reactionContext = this.context;
+            reactionThis = this;
         });
 
         void endpoint.emit("foo", context);
 
-        expect(reacted).true;
+        expect(reactionText).equals("foo");
+        expect(offline).false;
+        expect(reactionContext).equals(context);
+        expect(reactionThis).equals(context.agentFor({} as any).get({} as Behavior.Type));
+
+        expect(reacted).equals(1);
     });
 
     it("reacts with offline agent when agent is unavailable", async () => {
         const endpoint = new MockEndpoint();
 
-        let reacted = false;
+        let reacted = 0;
+
+        let reactionText: string | undefined;
+        let offline: boolean | undefined;
 
         endpoint.reactTo(endpoint.event, function (this: Behavior, text: string) {
-            reacted = true;
+            reacted++;
 
-            expect(text).equals("foo");
-            expect(this.context.offline).true;
+            reactionText = text;
+            offline = this.context.offline;
         });
 
         void endpoint.emit("foo");
 
-        expect(reacted).true;
+        expect(reactionText).equals("foo");
+        expect(offline).equals(true);
+
+        expect(reacted).equals(1);
     });
 
     it("reacts with offline agent in offline mode", async () => {
         const endpoint = new MockEndpoint();
         const context = MockContext(false);
 
-        let reacted = false;
+        let reacted = 0;
+
+        let reactionText: string | undefined;
+        let offline: boolean | undefined;
+        let reactionContext: ActionContext | undefined;
 
         endpoint.reactTo(
             endpoint.event,
             function (this: Behavior, text: string) {
-                reacted = true;
+                reacted++;
 
-                expect(text).equals("foo");
-                expect(this.context.offline).true;
-                expect(this.context).not.equals(context);
+                reactionText = text;
+                offline = this.context.offline;
+                reactionContext = this.context;
             },
             { offline: true },
         );
 
         void endpoint.emit("foo", context);
 
-        expect(reacted).true;
+        expect(reactionText).equals("foo");
+        expect(offline).equals(true);
+        expect(reactionContext).not.undefined;
+        expect(reactionContext).not.equals(context);
+
+        expect(reacted).equals(1);
     });
 });


### PR DESCRIPTION
Previously there was a "TODO" that warned it might be bad if this happened.  Turned out it was.  This adds a runtime error to prevent this.  Could also probably prevent via types but will be a bit of a PITA so will wait to see if it's a significant issue.

Fixes #745