### PR TITLE
Adjust endpoint state type to read-only

### DIFF
--- a/packages/matter.js/src/behavior/definitions/general-commissioning/ServerNodeFailsafeContext.ts
+++ b/packages/matter.js/src/behavior/definitions/general-commissioning/ServerNodeFailsafeContext.ts
@@ -9,6 +9,7 @@ import { Lifecycle } from "../../../common/Lifecycle.js";
 import { Endpoint } from "../../../endpoint/Endpoint.js";
 import { Fabric } from "../../../fabric/Fabric.js";
 import { Node } from "../../../node/Node.js";
+import { Immutable } from "../../../util/Type.js";
 import { NetworkCommissioningBehavior } from "../network-commissioning/NetworkCommissioningBehavior.js";
 
 /**
@@ -17,7 +18,7 @@ import { NetworkCommissioningBehavior } from "../network-commissioning/NetworkCo
 export class ServerNodeFailsafeContext extends FailsafeContext {
     #node: Node;
     #storedState?: {
-        networks: Map<Endpoint, NetworkCommissioningBehavior.State["networks"]>;
+        networks: Map<Endpoint, Immutable<NetworkCommissioningBehavior.State["networks"]>>;
         /*
 
         When Fabrics are no longer managed centrally in FabricManager we need this. Maybe we change to this later,
@@ -82,7 +83,7 @@ export class ServerNodeFailsafeContext extends FailsafeContext {
             await this.#node.visit(async endpoint => {
                 const networks = this.#storedState?.networks.get(endpoint);
                 if (networks) {
-                    context.agentFor(endpoint).get(NetworkCommissioningBehavior).state.networks = networks;
+                    context.agentFor(endpoint).get(NetworkCommissioningBehavior).state.networks = [...networks];
                 }
             });
         });

--- a/packages/matter.js/src/endpoint/Endpoint.ts
+++ b/packages/matter.js/src/endpoint/Endpoint.ts
@@ -19,6 +19,7 @@ import type { Node } from "../node/Node.js";
 import { IdentityService } from "../node/server/IdentityService.js";
 import { AsyncConstruction } from "../util/AsyncConstruction.js";
 import { MaybePromise } from "../util/Promises.js";
+import { Immutable } from "../util/Type.js";
 import { Agent } from "./Agent.js";
 import { DataModelPath } from "./DataModelPath.js";
 import { RootEndpoint } from "./definitions/system/RootEndpoint.js";
@@ -50,7 +51,7 @@ export class Endpoint<T extends EndpointType = EndpointType.Empty> {
     #lifecycle: EndpointLifecycle;
     #parts?: Parts;
     #construction: AsyncConstruction<Endpoint<T>>;
-    #stateView = {} as SupportedBehaviors.StateOf<T["behaviors"]>;
+    #stateView = {} as Immutable<SupportedBehaviors.StateOf<T["behaviors"]>>;
     #eventsView = {} as SupportedBehaviors.EventsOf<T["behaviors"]>;
     #activity?: NodeActivity;
 
@@ -144,7 +145,7 @@ export class Endpoint<T extends EndpointType = EndpointType.Empty> {
         if (!this.behaviors.has(type)) {
             throw new ImplementationError(`Behavior ${type.id} is not supported by this endpoint`);
         }
-        return this.#stateView[type.id] as Behavior.StateOf<T>;
+        return (this.#stateView as Record<string, unknown>)[type.id] as Immutable<Behavior.StateOf<T>>;
     }
 
     /**

--- a/packages/matter.js/src/endpoint/properties/Behaviors.ts
+++ b/packages/matter.js/src/endpoint/properties/Behaviors.ts
@@ -496,7 +496,7 @@ export class Behaviors {
             },
 
             set() {
-                throw new ReadOnlyError();
+                throw new ReadOnlyError('The "state" property is read-only; you must use set() to modify state');
             },
 
             enumerable: true,
@@ -505,10 +505,6 @@ export class Behaviors {
         Object.defineProperty(this.#endpoint.events, type.id, {
             get: () => {
                 return this.#backingFor("events", type).events;
-            },
-
-            set() {
-                throw new ReadOnlyError();
             },
 
             enumerable: true,

--- a/packages/matter.js/src/util/Type.ts
+++ b/packages/matter.js/src/util/Type.ts
@@ -69,12 +69,20 @@ export type Branded<T, B> = T & Brand<B>;
 
 /**
  * Make a type immutable.
+ *
+ * TODO - might need to extend depending type (e.g. doesn't handle Maps, Sets or Promises yet)
+ *
+ * Good reference implementation here:
+ *
+ *     https://github.com/ts-essentials/ts-essentials/blob/master/lib/deep-readonly/index.ts
  */
 export type Immutable<T> = T extends (...args: any[]) => any
     ? T
-    : T extends object
-      ? { readonly [K in keyof T]: Immutable<T[K]> }
-      : T;
+    : T extends number // Necessary for our "branded" IDs
+      ? T
+      : T extends object
+        ? { readonly [K in keyof T]: Immutable<T[K]> }
+        : T;
 
 /**
  * Convert a union to an interface.


### PR DESCRIPTION
Should help make it more clear that endpoint state must be modified using set().  Also added runtime error for non-TS usage.