### PR TITLE
Fix a couple of bugs in Model and codegen

### DIFF
--- a/codegen/src/generate-model.ts
+++ b/codegen/src/generate-model.ts
@@ -8,7 +8,7 @@
 
 import { ChipMatter, LocalMatter, SpecMatter } from "@project-chip/matter.js-intermediate-models";
 import { Logger } from "@project-chip/matter.js/log";
-import { AnyElement, ElementTag, MatterElement, MatterModel, MergeModels } from "@project-chip/matter.js/model";
+import { AnyElement, ElementTag, MatterElement, MatterModel, MergedModel } from "@project-chip/matter.js/model";
 import { generateElement } from "./mom/common/generate-element.js";
 import { TsFile } from "./util/TsFile.js";
 import { clean } from "./util/file.js";
@@ -50,7 +50,7 @@ export async function main() {
     }
 
     const matter = new MatterModel(
-        MergeModels({ spec: SpecMatter, chip: ChipMatter, local: LocalMatter }) as MatterElement,
+        MergedModel({ spec: SpecMatter, chip: ChipMatter, local: LocalMatter }) as MatterElement,
     );
 
     const validationResult = finalizeModel(matter);

--- a/codegen/src/mom/spec/translate-device.ts
+++ b/codegen/src/mom/spec/translate-device.ts
@@ -20,8 +20,8 @@ const ActualClusterNames = {
     NodeOperationalCredentials: "OperationalCredentials",
 };
 
-// The specification references to clusters are not entirely formal.  This
-// translator converts colloquial names to the actual cluster name
+// The specification references to clusters are not entirely formal.  This translator converts colloquial names to the
+// actual cluster name
 const ClusterName = (el: HTMLElement) => {
     const name = Identifier(el);
     return (ActualClusterNames as any)[name] ?? name;
@@ -188,9 +188,8 @@ function addClusters(device: DeviceTypeElement, deviceRef: DeviceReference) {
         conformance: Optional(Str),
     });
 
-    // CSA seems to mix in Zigbee just for old time's sake.  They reference
-    // clusters that aren't even in the Matter cluster spec.  Filter these
-    // out
+    // CSA seems to mix in Zigbee just for old time's sake.  They reference clusters that aren't even in the Matter
+    // cluster spec.  Filter these out
     clusterRecords = clusterRecords.filter(c => c.conformance !== "[Zigbee]");
 
     const clusters = translateRecordsToMatter("clusters", clusterRecords, RequirementElement);

--- a/codegen/src/util/TsFile.ts
+++ b/codegen/src/util/TsFile.ts
@@ -231,6 +231,9 @@ export class Block extends Entry {
 
         if (this.suffix) {
             parts.push(`${linePrefix}${this.suffix}`);
+            if (this.prefix && parts.length === 2) {
+                return parts.join("");
+            }
         }
         return parts.join("\n");
     }

--- a/models/src/local/ColorControlOverrides.ts
+++ b/models/src/local/ColorControlOverrides.ts
@@ -31,8 +31,8 @@ LocalMatter.children.push({
         { tag: "attribute", id: 0x29, name: "Primary6Y", conformance: "NumberOfPrimaries > 5" },
         { tag: "attribute", id: 0x2a, name: "Primary6Intensity", conformance: "NumberOfPrimaries > 5" },
 
-        // Spec defines conformance on these as "CT | ColorTemperatureMireds" which doesn't
-        // make sense because conformance on ColorTemperatureMireds is "CT"
+        // Spec defines conformance on these as "CT | ColorTemperatureMireds" which doesn't make sense because
+        // conformance on ColorTemperatureMireds is "CT"
         {
             tag: "attribute",
             id: 0x400d,
@@ -48,5 +48,7 @@ LocalMatter.children.push({
 
         // Spec states the values of this bitmap are the same as the feature map
         { tag: "attribute", id: 0x400a, name: "ColorCapabilities", type: "FeatureMap" },
+
+        // The spec defines "direction"
     ],
 });

--- a/packages/matter.js/src/endpoint/definitions/device/ColorDimmerSwitchDevice.ts
+++ b/packages/matter.js/src/endpoint/definitions/device/ColorDimmerSwitchDevice.ts
@@ -6,6 +6,7 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
+import { IdentifyServer as BaseIdentifyServer } from "../../../behavior/definitions/identify/IdentifyServer.js";
 import { IdentifyBehavior as BaseIdentifyBehavior } from "../../../behavior/definitions/identify/IdentifyBehavior.js";
 import { OnOffBehavior as BaseOnOffBehavior } from "../../../behavior/definitions/on-off/OnOffBehavior.js";
 import {
@@ -30,6 +31,13 @@ import { MatterDeviceLibrarySpecificationV1_1 } from "../../../spec/Specificatio
 export interface ColorDimmerSwitchDevice extends Identity<typeof ColorDimmerSwitchDeviceDefinition> {}
 
 export namespace ColorDimmerSwitchRequirements {
+    /**
+     * The {@link Identify} cluster is required by the Matter specification
+     *
+     * We provide this alias for convenience.
+     */
+    export const IdentifyServer = BaseIdentifyServer;
+
     /**
      * The {@link Identify} cluster is required by the Matter specification
      *
@@ -73,6 +81,11 @@ export namespace ColorDimmerSwitchRequirements {
     export const ScenesBehavior = BaseScenesBehavior;
 
     /**
+     * An implementation for each server cluster supported by the endpoint per the Matter specification.
+     */
+    export const server = { mandatory: { Identify: IdentifyServer } };
+
+    /**
      * A definition for each client cluster supported by the endpoint per the Matter specification.
      */
     export const client = {
@@ -92,7 +105,7 @@ export const ColorDimmerSwitchDeviceDefinition = MutableEndpoint({
     deviceType: 0x105,
     deviceRevision: 2,
     requirements: ColorDimmerSwitchRequirements,
-    behaviors: SupportedBehaviors()
+    behaviors: SupportedBehaviors(ColorDimmerSwitchRequirements.server.mandatory.Identify)
 });
 
 export const ColorDimmerSwitchDevice: ColorDimmerSwitchDevice = ColorDimmerSwitchDeviceDefinition;

--- a/packages/matter.js/src/endpoint/definitions/device/ControlBridgeDevice.ts
+++ b/packages/matter.js/src/endpoint/definitions/device/ControlBridgeDevice.ts
@@ -6,6 +6,7 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
+import { IdentifyServer as BaseIdentifyServer } from "../../../behavior/definitions/identify/IdentifyServer.js";
 import { IdentifyBehavior as BaseIdentifyBehavior } from "../../../behavior/definitions/identify/IdentifyBehavior.js";
 import { GroupsBehavior as BaseGroupsBehavior } from "../../../behavior/definitions/groups/GroupsBehavior.js";
 import { ScenesBehavior as BaseScenesBehavior } from "../../../behavior/definitions/scenes/ScenesBehavior.js";
@@ -37,6 +38,13 @@ import { MatterDeviceLibrarySpecificationV1_1 } from "../../../spec/Specificatio
 export interface ControlBridgeDevice extends Identity<typeof ControlBridgeDeviceDefinition> {}
 
 export namespace ControlBridgeRequirements {
+    /**
+     * The {@link Identify} cluster is required by the Matter specification
+     *
+     * We provide this alias for convenience.
+     */
+    export const IdentifyServer = BaseIdentifyServer;
+
     /**
      * The {@link Identify} cluster is required by the Matter specification
      *
@@ -94,6 +102,11 @@ export namespace ControlBridgeRequirements {
     export const OccupancySensingBehavior = BaseOccupancySensingBehavior;
 
     /**
+     * An implementation for each server cluster supported by the endpoint per the Matter specification.
+     */
+    export const server = { mandatory: { Identify: IdentifyServer } };
+
+    /**
      * A definition for each client cluster supported by the endpoint per the Matter specification.
      */
     export const client = {
@@ -118,7 +131,7 @@ export const ControlBridgeDeviceDefinition = MutableEndpoint({
     deviceType: 0x840,
     deviceRevision: 2,
     requirements: ControlBridgeRequirements,
-    behaviors: SupportedBehaviors()
+    behaviors: SupportedBehaviors(ControlBridgeRequirements.server.mandatory.Identify)
 });
 
 export const ControlBridgeDevice: ControlBridgeDevice = ControlBridgeDeviceDefinition;

--- a/packages/matter.js/src/endpoint/definitions/device/DimmerSwitchDevice.ts
+++ b/packages/matter.js/src/endpoint/definitions/device/DimmerSwitchDevice.ts
@@ -6,6 +6,7 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
+import { IdentifyServer as BaseIdentifyServer } from "../../../behavior/definitions/identify/IdentifyServer.js";
 import { IdentifyBehavior as BaseIdentifyBehavior } from "../../../behavior/definitions/identify/IdentifyBehavior.js";
 import { OnOffBehavior as BaseOnOffBehavior } from "../../../behavior/definitions/on-off/OnOffBehavior.js";
 import {
@@ -27,6 +28,13 @@ import { MatterDeviceLibrarySpecificationV1_1 } from "../../../spec/Specificatio
 export interface DimmerSwitchDevice extends Identity<typeof DimmerSwitchDeviceDefinition> {}
 
 export namespace DimmerSwitchRequirements {
+    /**
+     * The {@link Identify} cluster is required by the Matter specification
+     *
+     * We provide this alias for convenience.
+     */
+    export const IdentifyServer = BaseIdentifyServer;
+
     /**
      * The {@link Identify} cluster is required by the Matter specification
      *
@@ -63,6 +71,11 @@ export namespace DimmerSwitchRequirements {
     export const ScenesBehavior = BaseScenesBehavior;
 
     /**
+     * An implementation for each server cluster supported by the endpoint per the Matter specification.
+     */
+    export const server = { mandatory: { Identify: IdentifyServer } };
+
+    /**
      * A definition for each client cluster supported by the endpoint per the Matter specification.
      */
     export const client = {
@@ -76,7 +89,7 @@ export const DimmerSwitchDeviceDefinition = MutableEndpoint({
     deviceType: 0x104,
     deviceRevision: 2,
     requirements: DimmerSwitchRequirements,
-    behaviors: SupportedBehaviors()
+    behaviors: SupportedBehaviors(DimmerSwitchRequirements.server.mandatory.Identify)
 });
 
 export const DimmerSwitchDevice: DimmerSwitchDevice = DimmerSwitchDeviceDefinition;

--- a/packages/matter.js/src/endpoint/definitions/device/DoorLockControllerDevice.ts
+++ b/packages/matter.js/src/endpoint/definitions/device/DoorLockControllerDevice.ts
@@ -6,6 +6,7 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
+import { IdentifyServer as BaseIdentifyServer } from "../../../behavior/definitions/identify/IdentifyServer.js";
 import { TimeSyncServer as BaseTimeSyncServer } from "../../../behavior/definitions/time-sync/TimeSyncServer.js";
 import { DoorLockBehavior as BaseDoorLockBehavior } from "../../../behavior/definitions/door-lock/DoorLockBehavior.js";
 import { IdentifyBehavior as BaseIdentifyBehavior } from "../../../behavior/definitions/identify/IdentifyBehavior.js";
@@ -24,6 +25,13 @@ import { MatterDeviceLibrarySpecificationV1_1 } from "../../../spec/Specificatio
 export interface DoorLockControllerDevice extends Identity<typeof DoorLockControllerDeviceDefinition> {}
 
 export namespace DoorLockControllerRequirements {
+    /**
+     * The {@link Identify} cluster is optional per the Matter specification
+     *
+     * We provide this alias for convenience.
+     */
+    export const IdentifyServer = BaseIdentifyServer;
+
     /**
      * The {@link TimeSync} cluster is optional per the Matter specification
      *
@@ -62,7 +70,7 @@ export namespace DoorLockControllerRequirements {
     /**
      * An implementation for each server cluster supported by the endpoint per the Matter specification.
      */
-    export const server = { optional: { TimeSync: TimeSyncServer }, mandatory: {} };
+    export const server = { optional: { Identify: IdentifyServer, TimeSync: TimeSyncServer }, mandatory: {} };
 
     /**
      * A definition for each client cluster supported by the endpoint per the Matter specification.

--- a/packages/matter.js/src/endpoint/definitions/device/OnOffLightSwitchDevice.ts
+++ b/packages/matter.js/src/endpoint/definitions/device/OnOffLightSwitchDevice.ts
@@ -6,6 +6,7 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
+import { IdentifyServer as BaseIdentifyServer } from "../../../behavior/definitions/identify/IdentifyServer.js";
 import { IdentifyBehavior as BaseIdentifyBehavior } from "../../../behavior/definitions/identify/IdentifyBehavior.js";
 import { OnOffBehavior as BaseOnOffBehavior } from "../../../behavior/definitions/on-off/OnOffBehavior.js";
 import { GroupsBehavior as BaseGroupsBehavior } from "../../../behavior/definitions/groups/GroupsBehavior.js";
@@ -24,6 +25,13 @@ import { MatterDeviceLibrarySpecificationV1_1 } from "../../../spec/Specificatio
 export interface OnOffLightSwitchDevice extends Identity<typeof OnOffLightSwitchDeviceDefinition> {}
 
 export namespace OnOffLightSwitchRequirements {
+    /**
+     * The {@link Identify} cluster is required by the Matter specification
+     *
+     * We provide this alias for convenience.
+     */
+    export const IdentifyServer = BaseIdentifyServer;
+
     /**
      * The {@link Identify} cluster is required by the Matter specification
      *
@@ -53,6 +61,11 @@ export namespace OnOffLightSwitchRequirements {
     export const ScenesBehavior = BaseScenesBehavior;
 
     /**
+     * An implementation for each server cluster supported by the endpoint per the Matter specification.
+     */
+    export const server = { mandatory: { Identify: IdentifyServer } };
+
+    /**
      * A definition for each client cluster supported by the endpoint per the Matter specification.
      */
     export const client = {
@@ -66,7 +79,7 @@ export const OnOffLightSwitchDeviceDefinition = MutableEndpoint({
     deviceType: 0x103,
     deviceRevision: 2,
     requirements: OnOffLightSwitchRequirements,
-    behaviors: SupportedBehaviors()
+    behaviors: SupportedBehaviors(OnOffLightSwitchRequirements.server.mandatory.Identify)
 });
 
 export const OnOffLightSwitchDevice: OnOffLightSwitchDevice = OnOffLightSwitchDeviceDefinition;

--- a/packages/matter.js/src/endpoint/definitions/device/OnOffSensorDevice.ts
+++ b/packages/matter.js/src/endpoint/definitions/device/OnOffSensorDevice.ts
@@ -6,6 +6,7 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
+import { IdentifyServer as BaseIdentifyServer } from "../../../behavior/definitions/identify/IdentifyServer.js";
 import { IdentifyBehavior as BaseIdentifyBehavior } from "../../../behavior/definitions/identify/IdentifyBehavior.js";
 import { OnOffBehavior as BaseOnOffBehavior } from "../../../behavior/definitions/on-off/OnOffBehavior.js";
 import { GroupsBehavior as BaseGroupsBehavior } from "../../../behavior/definitions/groups/GroupsBehavior.js";
@@ -30,6 +31,13 @@ import { MatterDeviceLibrarySpecificationV1_1 } from "../../../spec/Specificatio
 export interface OnOffSensorDevice extends Identity<typeof OnOffSensorDeviceDefinition> {}
 
 export namespace OnOffSensorRequirements {
+    /**
+     * The {@link Identify} cluster is required by the Matter specification
+     *
+     * We provide this alias for convenience.
+     */
+    export const IdentifyServer = BaseIdentifyServer;
+
     /**
      * The {@link Identify} cluster is required by the Matter specification
      *
@@ -73,6 +81,11 @@ export namespace OnOffSensorRequirements {
     export const ColorControlBehavior = BaseColorControlBehavior;
 
     /**
+     * An implementation for each server cluster supported by the endpoint per the Matter specification.
+     */
+    export const server = { mandatory: { Identify: IdentifyServer } };
+
+    /**
      * A definition for each client cluster supported by the endpoint per the Matter specification.
      */
     export const client = {
@@ -92,7 +105,7 @@ export const OnOffSensorDeviceDefinition = MutableEndpoint({
     deviceType: 0x850,
     deviceRevision: 2,
     requirements: OnOffSensorRequirements,
-    behaviors: SupportedBehaviors()
+    behaviors: SupportedBehaviors(OnOffSensorRequirements.server.mandatory.Identify)
 });
 
 export const OnOffSensorDevice: OnOffSensorDevice = OnOffSensorDeviceDefinition;

--- a/packages/matter.js/src/endpoint/definitions/device/PumpControllerDevice.ts
+++ b/packages/matter.js/src/endpoint/definitions/device/PumpControllerDevice.ts
@@ -6,6 +6,7 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
+import { IdentifyServer as BaseIdentifyServer } from "../../../behavior/definitions/identify/IdentifyServer.js";
 import { BindingBehavior as BaseBindingBehavior } from "../../../behavior/definitions/binding/BindingBehavior.js";
 import { OnOffBehavior as BaseOnOffBehavior } from "../../../behavior/definitions/on-off/OnOffBehavior.js";
 import {
@@ -39,6 +40,13 @@ import { MatterDeviceLibrarySpecificationV1_1 } from "../../../spec/Specificatio
 export interface PumpControllerDevice extends Identity<typeof PumpControllerDeviceDefinition> {}
 
 export namespace PumpControllerRequirements {
+    /**
+     * The {@link Identify} cluster is required by the Matter specification
+     *
+     * We provide this alias for convenience.
+     */
+    export const IdentifyServer = BaseIdentifyServer;
+
     /**
      * The {@link Binding} cluster is required by the Matter specification
      *
@@ -110,6 +118,11 @@ export namespace PumpControllerRequirements {
     export const FlowMeasurementBehavior = BaseFlowMeasurementBehavior;
 
     /**
+     * An implementation for each server cluster supported by the endpoint per the Matter specification.
+     */
+    export const server = { mandatory: { Identify: IdentifyServer } };
+
+    /**
      * A definition for each client cluster supported by the endpoint per the Matter specification.
      */
     export const client = {
@@ -136,7 +149,7 @@ export const PumpControllerDeviceDefinition = MutableEndpoint({
     deviceType: 0x304,
     deviceRevision: 2,
     requirements: PumpControllerRequirements,
-    behaviors: SupportedBehaviors()
+    behaviors: SupportedBehaviors(PumpControllerRequirements.server.mandatory.Identify)
 });
 
 export const PumpControllerDevice: PumpControllerDevice = PumpControllerDeviceDefinition;

--- a/packages/matter.js/src/endpoint/definitions/device/PumpDevice.ts
+++ b/packages/matter.js/src/endpoint/definitions/device/PumpDevice.ts
@@ -17,6 +17,15 @@ import {
 import { ScenesServer as BaseScenesServer } from "../../../behavior/definitions/scenes/ScenesServer.js";
 import { GroupsServer as BaseGroupsServer } from "../../../behavior/definitions/groups/GroupsServer.js";
 import {
+    TemperatureMeasurementServer as BaseTemperatureMeasurementServer
+} from "../../../behavior/definitions/temperature-measurement/TemperatureMeasurementServer.js";
+import {
+    PressureMeasurementServer as BasePressureMeasurementServer
+} from "../../../behavior/definitions/pressure-measurement/PressureMeasurementServer.js";
+import {
+    FlowMeasurementServer as BaseFlowMeasurementServer
+} from "../../../behavior/definitions/flow-measurement/FlowMeasurementServer.js";
+import {
     TemperatureMeasurementBehavior as BaseTemperatureMeasurementBehavior
 } from "../../../behavior/definitions/temperature-measurement/TemperatureMeasurementBehavior.js";
 import {
@@ -92,6 +101,27 @@ export namespace PumpRequirements {
      *
      * We provide this alias for convenience.
      */
+    export const TemperatureMeasurementServer = BaseTemperatureMeasurementServer;
+
+    /**
+     * The {@link PressureMeasurement} cluster is optional per the Matter specification
+     *
+     * We provide this alias for convenience.
+     */
+    export const PressureMeasurementServer = BasePressureMeasurementServer;
+
+    /**
+     * The {@link FlowMeasurement} cluster is optional per the Matter specification
+     *
+     * We provide this alias for convenience.
+     */
+    export const FlowMeasurementServer = BaseFlowMeasurementServer;
+
+    /**
+     * The {@link TemperatureMeasurement} cluster is optional per the Matter specification
+     *
+     * We provide this alias for convenience.
+     */
     export const TemperatureMeasurementBehavior = BaseTemperatureMeasurementBehavior;
 
     /**
@@ -124,7 +154,15 @@ export namespace PumpRequirements {
             PumpConfigurationAndControl: PumpConfigurationAndControlServer,
             Identify: IdentifyServer
         },
-        optional: { LevelControl: LevelControlServer, Scenes: ScenesServer, Groups: GroupsServer }
+
+        optional: {
+            LevelControl: LevelControlServer,
+            Scenes: ScenesServer,
+            Groups: GroupsServer,
+            TemperatureMeasurement: TemperatureMeasurementServer,
+            PressureMeasurement: PressureMeasurementServer,
+            FlowMeasurement: FlowMeasurementServer
+        }
     };
 
     /**

--- a/packages/matter.js/src/endpoint/definitions/device/ThermostatDevice.ts
+++ b/packages/matter.js/src/endpoint/definitions/device/ThermostatDevice.ts
@@ -13,6 +13,7 @@ import { ScenesServer as BaseScenesServer } from "../../../behavior/definitions/
 import {
     ThermostatUserInterfaceConfigurationServer as BaseThermostatUserInterfaceConfigurationServer
 } from "../../../behavior/definitions/thermostat-user-interface-configuration/ThermostatUserInterfaceConfigurationServer.js";
+import { TimeSyncServer as BaseTimeSyncServer } from "../../../behavior/definitions/time-sync/TimeSyncServer.js";
 import {
     RelativeHumidityMeasurementBehavior as BaseRelativeHumidityMeasurementBehavior
 } from "../../../behavior/definitions/relative-humidity-measurement/RelativeHumidityMeasurementBehavior.js";
@@ -81,6 +82,13 @@ export namespace ThermostatRequirements {
     export const ThermostatUserInterfaceConfigurationServer = BaseThermostatUserInterfaceConfigurationServer;
 
     /**
+     * The {@link TimeSync} cluster is optional per the Matter specification
+     *
+     * We provide this alias for convenience.
+     */
+    export const TimeSyncServer = BaseTimeSyncServer;
+
+    /**
      * The {@link RelativeHumidityMeasurement} cluster is optional per the Matter specification
      *
      * We provide this alias for convenience.
@@ -120,10 +128,12 @@ export namespace ThermostatRequirements {
      */
     export const server = {
         mandatory: { Identify: IdentifyServer, Thermostat: ThermostatServer },
+
         optional: {
             Groups: GroupsServer,
             Scenes: ScenesServer,
-            ThermostatUserInterfaceConfiguration: ThermostatUserInterfaceConfigurationServer
+            ThermostatUserInterfaceConfiguration: ThermostatUserInterfaceConfigurationServer,
+            TimeSync: TimeSyncServer
         }
     };
 

--- a/packages/matter.js/src/endpoint/definitions/device/WindowCoveringControllerDevice.ts
+++ b/packages/matter.js/src/endpoint/definitions/device/WindowCoveringControllerDevice.ts
@@ -6,6 +6,7 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
+import { IdentifyServer as BaseIdentifyServer } from "../../../behavior/definitions/identify/IdentifyServer.js";
 import {
     WindowCoveringBehavior as BaseWindowCoveringBehavior
 } from "../../../behavior/definitions/window-covering/WindowCoveringBehavior.js";
@@ -25,6 +26,13 @@ import { MatterDeviceLibrarySpecificationV1_1 } from "../../../spec/Specificatio
 export interface WindowCoveringControllerDevice extends Identity<typeof WindowCoveringControllerDeviceDefinition> {}
 
 export namespace WindowCoveringControllerRequirements {
+    /**
+     * The {@link Identify} cluster is optional per the Matter specification
+     *
+     * We provide this alias for convenience.
+     */
+    export const IdentifyServer = BaseIdentifyServer;
+
     /**
      * The {@link WindowCovering} cluster is required by the Matter specification
      *
@@ -52,6 +60,11 @@ export namespace WindowCoveringControllerRequirements {
      * We provide this alias for convenience.
      */
     export const ScenesBehavior = BaseScenesBehavior;
+
+    /**
+     * An implementation for each server cluster supported by the endpoint per the Matter specification.
+     */
+    export const server = { optional: { Identify: IdentifyServer }, mandatory: {} };
 
     /**
      * A definition for each client cluster supported by the endpoint per the Matter specification.

--- a/packages/matter.js/src/model/logic/ModelVariantTraversal.ts
+++ b/packages/matter.js/src/model/logic/ModelVariantTraversal.ts
@@ -14,9 +14,8 @@ import { ModelTraversal } from "./ModelTraversal.js";
 const logger = Logger.get("ModelVariantTraversal");
 
 /**
- * This is a map of equivalent models keyed by "source name".  The source
- * name is a string that identifies the source of the variant, such as "chip",
- * "spec" or "local".
+ * This is a map of equivalent models keyed by "source name".  The source name is a string that identifies the source of
+ * the variant, such as "chip", "spec" or "local".
  */
 export type VariantMap = { [sourceName: string]: Model };
 
@@ -35,8 +34,7 @@ export interface VariantDetail {
     tag: ElementTag;
 
     /**
-     * The highest priority ID across all variants, if any variant has an
-     * ID.
+     * The highest priority ID across all variants, if any variant has an ID.
      */
     id?: number;
 
@@ -60,15 +58,13 @@ export abstract class ModelVariantTraversal<S = void> {
     private modelTraversal = new ModelTraversal();
 
     /**
-     * Create a new visitor.  Must list the valid names of sources.  The order
-     * of this list implies the priority used for choosing a name when multiple
-     * model variants have different names.
+     * Create a new visitor.  Must list the valid names of sources.  The order of this list implies the priority used
+     * for choosing a name when multiple model variants have different names.
      */
     constructor(private sourceNames: string[]) {}
 
     /**
-     * Initiate traversal.  The class is stateful so this call should not be
-     * invoked while traversal is ongoing.
+     * Initiate traversal.  The class is stateful so this call should not be invoked while traversal is ongoing.
      */
     traverse(variants: TraverseMap): S {
         // Ensure it's clear this class is stateful
@@ -99,9 +95,8 @@ export abstract class ModelVariantTraversal<S = void> {
     }
 
     /**
-     * This is the primary callback.  It is invoked for every set of variants
-     * during traversal.  It may optionally return state that is returned
-     * from traverse().
+     * This is the primary callback.  It is invoked for every set of variants during traversal.  It may optionally
+     * return state that is returned from traverse().
      *
      * @param variants the set of equivalent models
      * @param recurse call this function to recurse into variant children
@@ -109,8 +104,8 @@ export abstract class ModelVariantTraversal<S = void> {
     protected abstract visit(variants: VariantDetail, recurse: () => S[]): S;
 
     /**
-     * Get the canonical name for a model.  Within cluster scope alternate
-     * names may be selected, otherwise the name of the model is returned.
+     * Get the canonical name for a model.  Within cluster scope alternate names may be selected, otherwise the name of
+     * the model is returned.
      */
     protected getCanonicalName(model: Model) {
         if (this.clusterState) {
@@ -139,8 +134,8 @@ export abstract class ModelVariantTraversal<S = void> {
      * This is the function that actually recurses during the visit.
      */
     private visitVariants(variants: VariantDetail): S {
-        // Note that the only role ModelTraversal plays here is to protect
-        // against loops.  We do the actual traversal ourselves
+        // Note that the only role ModelTraversal plays here is to protect against loops.  We do the actual traversal
+        // ourselves
         const state = this.modelTraversal.operation(() => {
             return this.visit(variants, () => {
                 const enteredCluster = this.enterCluster(variants);
@@ -221,19 +216,23 @@ export abstract class ModelVariantTraversal<S = void> {
                 const mapping =
                     mappings[child.tag] || (mappings[child.tag] = { slots: [], idToSlot: {}, nameToSlot: {} });
 
-                const childId = child.key;
-                const childName = this.getCanonicalName(child);
+                const idKey = child.key;
+                let nameKey = this.getCanonicalName(child);
+
+                if (child.discriminator !== undefined) {
+                    nameKey = `${nameKey}␜${child.discriminator}`;
+                }
 
                 let slot;
 
                 // Find existing slot by ID
-                if (childId !== undefined) {
-                    slot = mapping.idToSlot[childId];
+                if (idKey !== undefined) {
+                    slot = mapping.idToSlot[idKey];
                 }
 
                 // Find existing slot by name
                 if (slot === undefined) {
-                    slot = mapping.nameToSlot[childName];
+                    slot = mapping.nameToSlot[nameKey];
                 }
 
                 // Create a new slot if necessary
@@ -243,15 +242,15 @@ export abstract class ModelVariantTraversal<S = void> {
                 }
 
                 // Map the child's ID to the slot
-                if (childId !== undefined) {
-                    if (mapping.idToSlot[childId] === undefined) {
-                        mapping.idToSlot[childId] = slot;
+                if (idKey !== undefined) {
+                    if (mapping.idToSlot[idKey] === undefined) {
+                        mapping.idToSlot[idKey] = slot;
                     }
                 }
 
                 // Map the child's name to the slot
-                if (mapping.nameToSlot[childName] === undefined) {
-                    mapping.nameToSlot[childName] = slot;
+                if (mapping.nameToSlot[nameKey] === undefined) {
+                    mapping.nameToSlot[nameKey] = slot;
                 }
 
                 // Update the slot
@@ -316,20 +315,19 @@ type ClusterState = {
 };
 
 /**
- * We go to a whole lot of work to choose proper datatype names.  This is to
- * reduce the number of manual overrides we need to correct dirty data.
+ * We go to a whole lot of work to choose proper datatype names.  This is to reduce the number of manual overrides we
+ * need to correct dirty data.
  *
- * This may seem like an unreasonable amount of logic but with evolving
- * specifications and 3k+ named elements (and counting) it seems worthwhile.
+ * This may seem like an unreasonable amount of logic but with evolving specifications and 3k+ named elements (and
+ * counting) it seems worthwhile.
  *
- * ModelVariantTraversal calls this function each time it enters a cluster.
- * Thus we are only dealing with names scoped to a single cluster
+ * ModelVariantTraversal calls this function each time it enters a cluster. Thus we are only dealing with names scoped
+ * to a single cluster
  */
 function computeCanonicalNames(sourceNames: string[], variants: VariantDetail) {
-    // First, infer name equivalence of datatypes based on usage.  There is no
-    // ID on datatypes.  This is a reliable alternative.  We perform this
-    // iteratively as new mappings could appear from subfields of previously-
-    // unknown equivalent datatypes
+    // First, infer name equivalence of datatypes based on usage.  There is no ID on datatypes.  This is a reliable
+    // alternative.  We perform this iteratively as new mappings could appear from subfields of previously- unknown
+    // equivalent datatypes
     const datatypeNameMap = new Map<Model, string>();
     let numberOfMappings;
 
@@ -338,20 +336,20 @@ function computeCanonicalNames(sourceNames: string[], variants: VariantDetail) {
         inferEquivalentDatatypes(sourceNames, variants, datatypeNameMap);
     } while (numberOfMappings != datatypeNameMap.size);
 
-    // Now that we generally what what equals what, go through the names and
-    // choose the name for the final model
+    // Now that we generally what what equals what, go through the names and choose the name for the final model
     const canonicalNames = chooseCanonicalNames(sourceNames, variants, datatypeNameMap);
 
     return canonicalNames;
 }
 
 /**
- * Populate the canonical datatype name lookup for a specific cluster.  This is
- * pretty ugly but in pseudo code:
+ * Populate the canonical datatype name lookup for a specific cluster.  This is pretty ugly but in pseudo code:
  *
- * for each datatype that has a base type:
- *     find the name referenced by the variant of highest priority
- *     add a mapping from the referenced name to the name we found
+ * For each datatype that has a base type:
+ *
+ *  - Find the name referenced by the variant of highest priority
+ *
+ *  - Add a mapping from the referenced name to the name we found
  */
 function inferEquivalentDatatypes(sourceNames: string[], variants: VariantDetail, datatypeNameMap: NameMapping) {
     type ModelNameMapping = {
@@ -389,10 +387,8 @@ function inferEquivalentDatatypes(sourceNames: string[], variants: VariantDetail
                 // Find existing entry
                 const existingEntry = nameVariants.get(base);
 
-                // Replace existing entry if this is a higher priority.
-                // Otherwise the types should in theory be equivalent.  If
-                // they're not it's a definition bug that will need to be
-                // corrected manually
+                // Replace existing entry if this is a higher priority. Otherwise the types should in theory be
+                // equivalent.  If they're not it's a definition bug that will need to be corrected manually
                 if (existingEntry) {
                     if (existingEntry.priority > mapEntry.priority) {
                         nameVariants.set(base, mapEntry);
@@ -410,9 +406,8 @@ function inferEquivalentDatatypes(sourceNames: string[], variants: VariantDetail
         }
 
         override enterCluster() {
-            // Do not call base logic because it is uses inferCanonicalNames,
-            // but do install existing mappings that may be present from
-            // previous iterations of this function
+            // Do not call base logic because it is uses inferCanonicalNames, but do install existing mappings that may
+            // be present from previous iterations of this function
             if (variants.tag === ElementTag.Cluster) {
                 this.clusterState = { canonicalNames: datatypeNameMap };
                 return true;
@@ -431,8 +426,7 @@ function inferEquivalentDatatypes(sourceNames: string[], variants: VariantDetail
 }
 
 /**
- * Heuristically select the best name for each element.  Priority does affect
- * this selection but it's not absolute
+ * Heuristically select the best name for each element.  Priority does affect this selection but it's not absolute
  */
 function chooseCanonicalNames(
     sourceNames: string[],
@@ -449,8 +443,8 @@ function chooseCanonicalNames(
             for (let i = 0; i < sourceNames.length; i++) {
                 const name = variants.map[sourceNames[i]]?.name;
 
-                // We give absolute priority to the highest priority element.
-                // This is presumably an editorial decision made by a human
+                // We give absolute priority to the highest priority element. This is presumably an editorial decision
+                // made by a human
                 if (!i && name !== undefined) {
                     break;
                 }
@@ -461,19 +455,15 @@ function chooseCanonicalNames(
                     continue;
                 }
 
-                // Prefer the shortest available name.  CHIP tends to add
-                // non-standard prefixes because they have a global namespace.
-                // When we scrape the spec we sometimes pick up extraneous
-                // garbage
+                // Prefer the shortest available name.  CHIP tends to add non-standard prefixes because they have a
+                // global namespace. When we scrape the spec we sometimes pick up extraneous garbage
                 if (name?.length < canonicalName?.length) {
                     canonicalName = name;
                     continue;
                 }
 
-                // If two names are equivalent except for case, prefer the one
-                // with more capital letters.  This corrects for case issues
-                // that can arise from automatic camelization in our spec
-                // scraper
+                // If two names are equivalent except for case, prefer the one with more capital letters.  This corrects
+                // for case issues that can arise from automatic camelization in our spec scraper
                 if (canonicalName?.toLowerCase() === name?.toLowerCase()) {
                     if (canonicalName === name) {
                         continue;
@@ -486,14 +476,12 @@ function chooseCanonicalNames(
                 }
             }
 
-            // We should have found a name but if not, fall back to the name
-            // chosen previously
+            // We should have found a name but if not, fall back to the name chosen previously
             if (!canonicalName) {
                 canonicalName = variants.name;
             }
 
-            // Now install a mapping for any losing variants to the preferred
-            // name
+            // Now install a mapping for any losing variants to the preferred name
             for (const sourceName in variants.map) {
                 const variant = variants.map[sourceName];
                 if (variant.name !== canonicalName) {
@@ -505,8 +493,8 @@ function chooseCanonicalNames(
         }
 
         override enterCluster(variants: VariantDetail) {
-            // Disable default logic, just ensure our datatype names are always
-            // installed so datatypes match up correctly
+            // Disable default logic, just ensure our datatype names are always installed so datatypes match up
+            // correctly
             if (variants.tag === ElementTag.Cluster) {
                 this.clusterState = { canonicalNames: datatypeNameMap };
                 return true;

--- a/packages/matter.js/src/model/logic/index.ts
+++ b/packages/matter.js/src/model/logic/index.ts
@@ -6,7 +6,7 @@
 
 export * from "./ClusterVariance.js";
 export * from "./DefaultValue.js";
-export * from "./MergeModels.js";
+export * from "./MergedModel.js";
 export * from "./ModelVariantTraversal.js";
 export * from "./ValidateModel.js";
 export * from "./cluster-variance/FeatureBitmap.js";

--- a/packages/matter.js/src/model/models/CommandModel.ts
+++ b/packages/matter.js/src/model/models/CommandModel.ts
@@ -29,11 +29,20 @@ export class CommandModel extends ValueModel implements CommandElement {
     }
 
     /**
-     * Commands may re-use the ID for request and response so identification
-     * requires the ID in conjunction with the direction.
+     * Commands may re-use the ID for request and response so identification requires the ID in conjunction with the
+     * direction.
      */
-    override get key() {
-        return `${super.key}:${this.direction}`;
+    override get discriminator() {
+        // If direction is not present, rely on naming convention for discrimination.  This allows overrides to omit
+        // the direction without voiding matching
+        if (this.direction === undefined) {
+            if (this.name.endsWith("Response")) {
+                return CommandElement.Direction.Response;
+            }
+            return CommandElement.Direction.Request;
+        }
+
+        return this.direction;
     }
 
     constructor(definition: CommandElement.Properties) {

--- a/packages/matter.js/src/model/models/RequirementModel.ts
+++ b/packages/matter.js/src/model/models/RequirementModel.ts
@@ -21,8 +21,8 @@ export class RequirementModel extends Model implements RequirementElement {
     element!: RequirementElement.ElementType;
     default?: any;
 
-    override get key() {
-        return `${this.id ?? this.name}:${this.element}`;
+    override get discriminator() {
+        return this.element;
     }
 
     override get children(): Children<RequirementModel | FieldModel, RequirementElement | FieldElement> {

--- a/packages/matter.js/src/model/standard/elements/ColorDimmerSwitchDT.ts
+++ b/packages/matter.js/src/model/standard/elements/ColorDimmerSwitchDT.ts
@@ -21,6 +21,11 @@ Matter.children.push(DeviceType({
             children: [Requirement({ name: "DeviceTypeList", default: [ { deviceType: 261, revision: 2 } ], element: "attribute" })]
         }),
         Requirement({
+            name: "Identify", id: 0x3, conformance: "M", element: "serverCluster",
+            xref: { document: "device", section: "6.3.4" },
+            children: [Requirement({ name: "QUERY", conformance: "!Matter", element: "feature" })]
+        }),
+        Requirement({
             name: "Identify", id: 0x3, conformance: "M", element: "clientCluster",
             xref: { document: "device", section: "6.3.4" },
             children: [Requirement({ name: "QUERY", conformance: "!Matter", element: "feature" })]

--- a/packages/matter.js/src/model/standard/elements/ControlBridgeDT.ts
+++ b/packages/matter.js/src/model/standard/elements/ControlBridgeDT.ts
@@ -23,6 +23,11 @@ Matter.children.push(DeviceType({
             children: [Requirement({ name: "DeviceTypeList", default: [ { deviceType: 2112, revision: 2 } ], element: "attribute" })]
         }),
         Requirement({
+            name: "Identify", id: 0x3, conformance: "M", element: "serverCluster",
+            xref: { document: "device", section: "6.4.4" },
+            children: [Requirement({ name: "QUERY", conformance: "!Matter", element: "feature" })]
+        }),
+        Requirement({
             name: "Identify", id: 0x3, conformance: "M", element: "clientCluster",
             xref: { document: "device", section: "6.4.4" },
             children: [Requirement({ name: "QUERY", conformance: "!Matter", element: "feature" })]

--- a/packages/matter.js/src/model/standard/elements/DimmerSwitchDT.ts
+++ b/packages/matter.js/src/model/standard/elements/DimmerSwitchDT.ts
@@ -22,6 +22,11 @@ Matter.children.push(DeviceType({
             children: [Requirement({ name: "DeviceTypeList", default: [ { deviceType: 260, revision: 2 } ], element: "attribute" })]
         }),
         Requirement({
+            name: "Identify", id: 0x3, conformance: "M", element: "serverCluster",
+            xref: { document: "device", section: "6.2.4" },
+            children: [Requirement({ name: "QUERY", conformance: "!Matter", element: "feature" })]
+        }),
+        Requirement({
             name: "Identify", id: 0x3, conformance: "M", element: "clientCluster",
             xref: { document: "device", section: "6.2.4" },
             children: [Requirement({ name: "QUERY", conformance: "!Matter", element: "feature" })]

--- a/packages/matter.js/src/model/standard/elements/DoorLockControllerDT.ts
+++ b/packages/matter.js/src/model/standard/elements/DoorLockControllerDT.ts
@@ -23,6 +23,11 @@ Matter.children.push(DeviceType({
         }),
 
         Requirement({
+            name: "Identify", id: 0x3, conformance: "[EZ, Target]", element: "serverCluster",
+            xref: { document: "device", section: "8.2.3" },
+            children: [Requirement({ name: "QUERY", conformance: "!Matter", element: "feature" })]
+        }),
+        Requirement({
             name: "Identify", id: 0x3, conformance: "[EZ, Initiator]", element: "clientCluster",
             xref: { document: "device", section: "8.2.3" },
             children: [Requirement({ name: "QUERY", conformance: "!Matter", element: "feature" })]

--- a/packages/matter.js/src/model/standard/elements/OnOffLightSwitchDT.ts
+++ b/packages/matter.js/src/model/standard/elements/OnOffLightSwitchDT.ts
@@ -21,6 +21,11 @@ Matter.children.push(DeviceType({
             children: [Requirement({ name: "DeviceTypeList", default: [ { deviceType: 259, revision: 2 } ], element: "attribute" })]
         }),
         Requirement({
+            name: "Identify", id: 0x3, conformance: "M", element: "serverCluster",
+            xref: { document: "device", section: "6.1.4" },
+            children: [Requirement({ name: "QUERY", conformance: "!Matter", element: "feature" })]
+        }),
+        Requirement({
             name: "Identify", id: 0x3, conformance: "M", element: "clientCluster",
             xref: { document: "device", section: "6.1.4" },
             children: [Requirement({ name: "QUERY", conformance: "!Matter", element: "feature" })]

--- a/packages/matter.js/src/model/standard/elements/OnOffSensorDT.ts
+++ b/packages/matter.js/src/model/standard/elements/OnOffSensorDT.ts
@@ -21,6 +21,11 @@ Matter.children.push(DeviceType({
             children: [Requirement({ name: "DeviceTypeList", default: [ { deviceType: 2128, revision: 2 } ], element: "attribute" })]
         }),
         Requirement({
+            name: "Identify", id: 0x3, conformance: "M", element: "serverCluster",
+            xref: { document: "device", section: "7.8.4" },
+            children: [Requirement({ name: "QUERY", conformance: "!Matter", element: "feature" })]
+        }),
+        Requirement({
             name: "Identify", id: 0x3, conformance: "M", element: "clientCluster",
             xref: { document: "device", section: "7.8.4" },
             children: [Requirement({ name: "QUERY", conformance: "!Matter", element: "feature" })]

--- a/packages/matter.js/src/model/standard/elements/PumpControllerDT.ts
+++ b/packages/matter.js/src/model/standard/elements/PumpControllerDT.ts
@@ -32,6 +32,11 @@ Matter.children.push(DeviceType({
             xref: { document: "device", section: "6.5.3" }
         }),
         Requirement({
+            name: "Identify", id: 0x3, conformance: "M", element: "serverCluster",
+            xref: { document: "device", section: "6.5.3" },
+            children: [Requirement({ name: "QUERY", conformance: "!Matter", element: "feature" })]
+        }),
+        Requirement({
             name: "Identify", id: 0x3, conformance: "O", element: "clientCluster",
             xref: { document: "device", section: "6.5.3" },
             children: [Requirement({ name: "QUERY", conformance: "!Matter", element: "feature" })]

--- a/packages/matter.js/src/model/standard/elements/PumpDT.ts
+++ b/packages/matter.js/src/model/standard/elements/PumpDT.ts
@@ -46,6 +46,18 @@ Matter.children.push(DeviceType({
             xref: { document: "device", section: "5.3.4" }
         }),
         Requirement({
+            name: "TemperatureMeasurement", id: 0x402, conformance: "O", element: "serverCluster",
+            xref: { document: "device", section: "5.3.4" }
+        }),
+        Requirement({
+            name: "PressureMeasurement", id: 0x403, conformance: "O", element: "serverCluster",
+            xref: { document: "device", section: "5.3.4" }
+        }),
+        Requirement({
+            name: "FlowMeasurement", id: 0x404, conformance: "O", element: "serverCluster",
+            xref: { document: "device", section: "5.3.4" }
+        }),
+        Requirement({
             name: "TemperatureMeasurement", id: 0x402, conformance: "O", element: "clientCluster",
             xref: { document: "device", section: "5.3.4" }
         }),

--- a/packages/matter.js/src/model/standard/elements/ThermostatDT.ts
+++ b/packages/matter.js/src/model/standard/elements/ThermostatDT.ts
@@ -58,6 +58,10 @@ Matter.children.push(DeviceType({
             xref: { document: "device", section: "9.2.4" }
         }),
         Requirement({
+            name: "TimeSync", id: 0x38, conformance: "P, O", element: "serverCluster",
+            xref: { document: "device", section: "9.2.4" }
+        }),
+        Requirement({
             name: "TimeSync", id: 0x38, conformance: "P, O", element: "clientCluster",
             xref: { document: "device", section: "9.2.4" }
         }),

--- a/packages/matter.js/src/model/standard/elements/WindowCoveringControllerDT.ts
+++ b/packages/matter.js/src/model/standard/elements/WindowCoveringControllerDT.ts
@@ -20,6 +20,11 @@ Matter.children.push(DeviceType({
             children: [Requirement({ name: "DeviceTypeList", default: [ { deviceType: 515, revision: 2 } ], element: "attribute" })]
         }),
         Requirement({
+            name: "Identify", id: 0x3, conformance: "O", element: "serverCluster",
+            xref: { document: "device", section: "8.4.4" },
+            children: [Requirement({ name: "QUERY", conformance: "!Matter", element: "feature" })]
+        }),
+        Requirement({
             name: "Identify", id: 0x3, conformance: "O", element: "clientCluster",
             xref: { document: "device", section: "8.4.4" },
             children: [Requirement({ name: "QUERY", conformance: "!Matter", element: "feature" })]

--- a/packages/matter.js/test/model/logic/MergeModelsTest.ts
+++ b/packages/matter.js/test/model/logic/MergeModelsTest.ts
@@ -5,7 +5,7 @@
  */
 
 import { ClusterElement, ClusterModel, MatterElement, MatterModel } from "../../../src/model/index.js";
-import { MergeModels } from "../../../src/model/logic/index.js";
+import { MergedModel } from "../../../src/model/logic/index.js";
 
 // Utility function to perform merge.  Type resolution works differently
 // without the global types in MatterModel so we fake that up even though we're
@@ -14,7 +14,7 @@ function merge({ spec, chip }: { spec: MatterElement.Child; chip: MatterElement.
     const specMatter = new MatterModel({ name: "Spec", children: [spec] });
     const chipMatter = new MatterModel({ name: "Chip", children: [chip] });
 
-    return MergeModels({
+    return MergedModel({
         spec: specMatter.children[specMatter.children.length - 1],
         chip: chipMatter.children[chipMatter.children.length - 1],
     });

--- a/packages/matter.js/test/model/models/ModelTest.ts
+++ b/packages/matter.js/test/model/models/ModelTest.ts
@@ -80,6 +80,35 @@ describe("Model", () => {
             expect(parent2.children[0].name).equal("Bar1");
             expect(parent2.children[1].name).equal("Bar2");
         });
+
+        it("splices correctly", () => {
+            const parent = new ClusterModel({ name: "Foo" });
+
+            parent.children = [
+                { tag: "datatype", name: "Bar1" },
+                { tag: "datatype", name: "Bar2" },
+                { tag: "datatype", name: "Bar3" },
+            ];
+
+            const removed = parent.children.splice(
+                1,
+                1,
+                { tag: "datatype", name: "Bar4" },
+                { tag: "datatype", name: "Bar5" },
+            );
+
+            expect(removed.length === 1);
+            expect(removed[0].name === "Bar2");
+            expect(removed[0].parent === undefined);
+
+            expect(parent.children.length === 4);
+            expect(parent.children.map(({ name, parent }) => ({ name, parent: parent?.name }))).deep.equals([
+                { name: "Bar1", parent: "Foo" },
+                { name: "Bar4", parent: "Foo" },
+                { name: "Bar5", parent: "Foo" },
+                { name: "Bar3", parent: "Foo" },
+            ]);
+        });
     });
 
     describe("all", () => {


### PR DESCRIPTION
- Child removal had a bug where parent field would be cleared in elements following a splice position
- Model merge would incorrectly merged two children with the same name but no ID even if other fields should discirminate
- Rename "MergeModels" to "MergedModel" since it used type-like rather than function-like naming
- Tweaked codegen of empty blocks to match Prettier configuration
- Reformatted comments in the files I touched

Fixes #752