### PR TITLE
Fix interrupt handling and polyfill Symbol.dispose

### DIFF
--- a/packages/matter-node.js/src/environment/ProcessManager.ts
+++ b/packages/matter-node.js/src/environment/ProcessManager.ts
@@ -85,7 +85,8 @@ export class ProcessManager implements Destructable {
         }
     };
 
-    protected interruptHandler = () => {
+    protected interruptHandler = (signal: string) => {
+        process.off(signal, this.interruptHandler);
         this.runtime.cancel();
     };
 

--- a/packages/matter.js-tools/src/running/cli.ts
+++ b/packages/matter.js-tools/src/running/cli.ts
@@ -71,12 +71,9 @@ export async function main(argv = process.argv) {
     } else {
         // Our behavior in response to SIGINT should mirror the child process's.  So ignore the signal locally, only
         // quitting once the child process does
-        ignoreSigint();
+        process.on("SIGINT", () => {});
+        process.on("SIGTERM", () => {});
 
         process.exitCode = await executeNode(script, argv);
-    }
-
-    function ignoreSigint() {
-        process.on("SIGINT", ignoreSigint);
     }
 }

--- a/packages/matter.js/src/behavior/Behavior.ts
+++ b/packages/matter.js/src/behavior/Behavior.ts
@@ -7,6 +7,7 @@
 import type { ClusterType } from "../cluster/ClusterType.js";
 import { ImplementationError, NotImplementedError } from "../common/MatterError.js";
 import { Agent, INSTALL_BEHAVIOR } from "../endpoint/Agent.js";
+import "../polyfills/disposable.js";
 import { assertSecureSession } from "../session/SecureSession.js";
 import { GeneratedClass } from "../util/GeneratedClass.js";
 import { EventEmitter, Observable } from "../util/Observable.js";

--- a/packages/matter.js/src/behavior/cluster/ClusterBehaviorUtil.ts
+++ b/packages/matter.js/src/behavior/cluster/ClusterBehaviorUtil.ts
@@ -41,8 +41,15 @@ export function createType<const C extends ClusterType>(cluster: C, base: Behavi
 
     schema = syncFeatures(schema, cluster);
 
+    let name;
+    if (base.name.startsWith(cluster.name)) {
+        name = base.name;
+    } else {
+        name = `${cluster.name}Behavior`;
+    }
+
     return GeneratedClass({
-        name: `${cluster.name}Behavior`,
+        name,
         base,
 
         // These are really read-only but installing as getters on the prototype prevents us from overriding using

--- a/packages/matter.js/src/behavior/cluster/ClusterBehaviorUtil.ts
+++ b/packages/matter.js/src/behavior/cluster/ClusterBehaviorUtil.ts
@@ -9,7 +9,7 @@ import { ClusterType } from "../../cluster/ClusterType.js";
 import { ImplementationError } from "../../common/MatterError.js";
 import { AttributeModel, ClusterModel, ElementTag, FeatureSet, Matter, Metatype } from "../../model/index.js";
 import { GeneratedClass } from "../../util/GeneratedClass.js";
-import { EventEmitter, Observable } from "../../util/Observable.js";
+import { Observable } from "../../util/Observable.js";
 import { camelize } from "../../util/String.js";
 import { Behavior } from "../Behavior.js";
 import { DerivedState } from "../state/StateType.js";
@@ -58,7 +58,7 @@ export function createType<const C extends ClusterType>(cluster: C, base: Behavi
         staticProperties: {
             State: createDerivedState(cluster, schema, base, namesUsed),
 
-            Events: createBaseEvents(cluster, namesUsed),
+            Events: createDerivedEvents(cluster, base, namesUsed),
         },
 
         staticDescriptors: {
@@ -162,21 +162,33 @@ function isGlobal(attribute: ClusterType.Attribute) {
 /**
  * Extend events with additional implementations.
  */
-function createBaseEvents(cluster: ClusterType, stateNames: Set<string>) {
+function createDerivedEvents(cluster: ClusterType, base: Behavior.Type, stateNames: Set<string>) {
     const names = new Set<string>();
 
+    const baseInstance = new base.Events() as unknown as Record<string, unknown>;
+
+    // Add mandatory events that are not present in the base class
+    const applicableClusterEvents = new Set();
     for (const name in cluster.events) {
-        if (!cluster.events[name].optional) {
+        applicableClusterEvents.add(name);
+        if (!cluster.events[name].optional && baseInstance[name] === undefined) {
             names.add(name);
         }
     }
-    for (const name of stateNames) {
-        names.add(`${name}$Change`);
+
+    // Add events for mandatory attributes that are not present in the base class
+    for (const attrName of stateNames) {
+        const name = `${attrName}$Change`;
+        if (baseInstance[name] === undefined) {
+            names.add(name);
+        }
     }
+
+    // TODO - if necessary, mask out (set to undefined) events present in base cluster but not derived cluster
 
     return GeneratedClass({
         name: `${cluster.name}$Events`,
-        base: EventEmitter,
+        base: base.Events,
 
         initialize() {
             for (const name of names) {

--- a/packages/matter.js/src/environment/Environment.ts
+++ b/packages/matter.js/src/environment/Environment.ts
@@ -7,6 +7,7 @@
 import { UnsupportedDependencyError } from "../common/Lifecycle.js";
 import { DiagnosticSource } from "../log/DiagnosticSource.js";
 import { Logger } from "../log/Logger.js";
+import "../polyfills/disposable.js";
 import { Time } from "../time/Time.js";
 import { Observable } from "../util/Observable.js";
 import { Environmental } from "./Environmental.js";

--- a/packages/matter.js/src/polyfills/disposable.ts
+++ b/packages/matter.js/src/polyfills/disposable.ts
@@ -17,7 +17,7 @@ if (typeof Symbol.dispose !== "symbol") {
 }
 
 if (typeof Symbol.asyncDispose !== "symbol") {
-    (Symbol as { asyncDispose: Symbol }).asyncDispose = Symbol("asyncDispose");
+    (Symbol as { asyncDispose: symbol }).asyncDispose = Symbol("asyncDispose");
     if (typeof Symbol.asyncDispose !== "symbol") {
         throw new Error("Symbol.asyncDispose is undefined and polyfill installation failed");
     }

--- a/packages/matter.js/src/polyfills/disposable.ts
+++ b/packages/matter.js/src/polyfills/disposable.ts
@@ -1,0 +1,24 @@
+/**
+ * @license
+ * Copyright 2022-2024 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// See https://github.com/tc39/proposal-explicit-resource-management
+//
+// We downlevel support for "using foo = ..." using esbuild but downleveling does not include a polyfill so we patch in
+// standin symbols here
+
+if (typeof Symbol.dispose !== "symbol") {
+    (Symbol as { dispose: symbol }).dispose = Symbol("dispose");
+    if (typeof Symbol.dispose !== "symbol") {
+        throw new Error("Symbol.dispose is undefined and polyfill installation failed");
+    }
+}
+
+if (typeof Symbol.asyncDispose !== "symbol") {
+    (Symbol as { asyncDispose: Symbol }).asyncDispose = Symbol("asyncDispose");
+    if (typeof Symbol.asyncDispose !== "symbol") {
+        throw new Error("Symbol.asyncDispose is undefined and polyfill installation failed");
+    }
+}

--- a/packages/matter.js/test/behavior/cluster/ClusterBehaviorTest.ts
+++ b/packages/matter.js/test/behavior/cluster/ClusterBehaviorTest.ts
@@ -26,6 +26,15 @@ import { MaybePromise } from "../../../src/util/Promises.js";
 import { MockEndpoint } from "../../endpoint/mock-endpoint.js";
 import { My, MyBehavior, MyCluster } from "./cluster-behavior-test-util.js";
 
+class MyEventedBehavior extends MyBehavior {
+    declare events: MyEventedBehavior.Events;
+}
+namespace MyEventedBehavior {
+    export class Events extends MyBehavior.Events {
+        somethingHappened = new Observable<[]>();
+    }
+}
+
 describe("ClusterBehavior", () => {
     type Match<Input, Type> = Input extends Type ? true : false;
 
@@ -187,6 +196,15 @@ describe("ClusterBehavior", () => {
             const AlteredBehavior = MyBehavior.alter({});
             AlteredBehavior.id satisfies "myCluster";
             expect(AlteredBehavior.id).equals("myCluster");
+        });
+
+        it("extends correct event class", () => {
+            const base = new MyEventedBehavior.Events();
+            expect(typeof base.somethingHappened?.on).equals("function");
+
+            const Altered = MyEventedBehavior.alter({});
+            const altered = new Altered.Events();
+            expect(typeof altered.somethingHappened?.on).equals("function");
         });
     });
 


### PR DESCRIPTION
- Interrupt handling previously must've been installed using "once" but is no longer doing so, so adjust accordingly
- Symbol.dispose and Symbol.asyncDispose require polyfill for node <= 18 and browsers too I believe