### PR TITLE
Update Events in subscriptions

### DIFF
--- a/packages/matter-node-ble.js/src/ble/BleScanner.ts
+++ b/packages/matter-node-ble.js/src/ble/BleScanner.ts
@@ -106,7 +106,7 @@ export class BleScanner implements Scanner {
                 CM: 1, // Can be no other mode,
                 addresses: [{ type: "ble", peripheralAddress: peripheral.address }],
             };
-            logger.debug(`Discovered device ${peripheral.address} data: ${JSON.stringify(commissionableDevice)}`);
+            logger.debug(`Discovered device ${peripheral.address} data: ${Logger.toJSON(commissionableDevice)}`);
 
             const deviceExisting = this.discoveredMatterDevices.has(peripheral.address);
 

--- a/packages/matter-node.js-examples/src/examples/ControllerNode.ts
+++ b/packages/matter-node.js-examples/src/examples/ControllerNode.ts
@@ -184,7 +184,7 @@ class ControllerNode {
                 },
                 passcode: setupPin,
             } as NodeCommissioningOptions;
-            logger.info(`Commissioning ... ${JSON.stringify(options)}`);
+            logger.info(`Commissioning ... ${Logger.toJSON(options)}`);
             const nodeId = await commissioningController.commissionNode(options);
 
             console.log(`Commissioning successfully done with nodeId ${nodeId}`);

--- a/packages/matter-node.js-examples/src/examples/ControllerNodeLegacy.ts
+++ b/packages/matter-node.js-examples/src/examples/ControllerNodeLegacy.ts
@@ -211,7 +211,7 @@ class ControllerNode {
                 },
                 passcode: setupPin,
             } as NodeCommissioningOptions;
-            logger.info(`Commissioning ... ${JSON.stringify(options)}`);
+            logger.info(`Commissioning ... ${Logger.toJSON(options)}`);
             const nodeId = await commissioningController.commissionNode(options);
 
             console.log(`Commissioning successfully done with nodeId ${nodeId}`);

--- a/packages/matter-node.js/test/IntegrationTest.ts
+++ b/packages/matter-node.js/test/IntegrationTest.ts
@@ -26,6 +26,7 @@ import {
     ClusterId,
     DeviceTypeId,
     EndpointNumber,
+    EventNumber,
     FabricId,
     FabricIndex,
     GroupId,
@@ -653,7 +654,7 @@ describe("Integration Test", () => {
 
             assert.deepEqual(startUpEventData?.events, [
                 {
-                    eventNumber: 1,
+                    eventNumber: EventNumber(1),
                     epochTimestamp: TIME_START,
                     priority: BasicInformation.Cluster.events.startUp.priority,
                     data: {
@@ -671,7 +672,7 @@ describe("Integration Test", () => {
             );
             assert.deepEqual(bootReasonEventData?.events, [
                 {
-                    eventNumber: 2,
+                    eventNumber: EventNumber(2),
                     epochTimestamp: TIME_START,
                     priority: BasicInformation.Cluster.events.startUp.priority,
                     data: {
@@ -1039,7 +1040,7 @@ describe("Integration Test", () => {
 
             assert.deepEqual(firstReport, {
                 value: {
-                    eventNumber: 1,
+                    eventNumber: EventNumber(1),
                     priority: 2,
                     epochTimestamp: BigInt(TIME_START), // Triggered directly
                     data: {
@@ -1086,7 +1087,7 @@ describe("Integration Test", () => {
             const updateReport = await updatePromise;
             assert.deepEqual(updateReport, {
                 value: {
-                    eventNumber: 3,
+                    eventNumber: EventNumber(3),
                     priority: 1,
                     epochTimestamp: BigInt(startTime + 200), // Triggered directly
                     data: {
@@ -1107,7 +1108,7 @@ describe("Integration Test", () => {
             const updateReport2 = await updatePromise2;
             assert.deepEqual(updateReport2, {
                 value: {
-                    eventNumber: 3,
+                    eventNumber: EventNumber(3),
                     priority: 1,
                     epochTimestamp: BigInt(startTime + 200), // Triggered directly
                     data: {

--- a/packages/matter-node.js/test/interaction/InteractionProtocolTest.ts
+++ b/packages/matter-node.js/test/interaction/InteractionProtocolTest.ts
@@ -28,6 +28,7 @@ import {
     CommandId,
     EndpointNumber,
     EventId,
+    EventNumber,
     FabricId,
     FabricIndex,
     NodeId,
@@ -217,7 +218,7 @@ const READ_RESPONSE: DataReportPayload = {
                 payload: {
                     softwareVersion: 1,
                 },
-                eventNumber: 1,
+                eventNumber: EventNumber(1),
                 priority: 2,
                 epochTimestamp: 0,
             },
@@ -234,7 +235,7 @@ const READ_RESPONSE: DataReportPayload = {
                 payload: {
                     softwareVersion: 2,
                 },
-                eventNumber: 2,
+                eventNumber: EventNumber(2),
                 priority: 2,
                 epochTimestamp: 0,
             },
@@ -308,7 +309,7 @@ const READ_RESPONSE_WITH_FILTER: DataReportPayload = {
                 payload: {
                     softwareVersion: 2,
                 },
-                eventNumber: 2,
+                eventNumber: EventNumber(2),
                 priority: 2,
                 epochTimestamp: 0,
             },

--- a/packages/matter.js/src/MatterController.ts
+++ b/packages/matter.js/src/MatterController.ts
@@ -296,7 +296,7 @@ export class MatterController {
         logger.info(
             `Commissioning device with identifier ${Logger.toJSON(identifierData)} and ${
                 scannersToUse.length
-            } scanners and knownAddress ${JSON.stringify(knownAddress)}`,
+            } scanners and knownAddress ${Logger.toJSON(knownAddress)}`,
         );
 
         // If we have a known address we try this first before we discover the device

--- a/packages/matter.js/src/cluster/client/EventClient.ts
+++ b/packages/matter.js/src/cluster/client/EventClient.ts
@@ -7,6 +7,7 @@
 import { ClusterId } from "../../datatype/ClusterId.js";
 import { EndpointNumber } from "../../datatype/EndpointNumber.js";
 import { EventId } from "../../datatype/EventId.js";
+import { EventNumber } from "../../datatype/EventNumber.js";
 import { DecodedEventData } from "../../protocol/interaction/EventDataDecoder.js";
 import { InteractionClient } from "../../protocol/interaction/InteractionClient.js";
 import { Event } from "../Cluster.js";
@@ -49,7 +50,7 @@ export class EventClient<T> {
     }
 
     async get(
-        minimumEventNumber?: number | bigint,
+        minimumEventNumber?: EventNumber,
         isFabricFiltered?: boolean,
     ): Promise<DecodedEventData<T>[] | undefined> {
         return await this.interactionClient.getEvent({
@@ -65,7 +66,7 @@ export class EventClient<T> {
         minIntervalFloorSeconds: number,
         maxIntervalCeilingSeconds: number,
         isUrgent = true,
-        minimumEventNumber?: number | bigint,
+        minimumEventNumber?: EventNumber,
         isFabricFiltered?: boolean,
     ) {
         return await this.interactionClient.subscribeEvent({

--- a/packages/matter.js/src/cluster/server/ClusterServer.ts
+++ b/packages/matter.js/src/cluster/server/ClusterServer.ts
@@ -256,7 +256,7 @@ export function ClusterServer<
                     logger.warn(
                         `InitialAttributeValue for "${
                             clusterDef.name
-                        }/${attributeName}" is REQUIRED by supportedFeatures: ${JSON.stringify(
+                        }/${attributeName}" is REQUIRED by supportedFeatures: ${Logger.toJSON(
                             supportedFeatures,
                         )} but is not set!`,
                     );
@@ -270,7 +270,7 @@ export function ClusterServer<
                     logger.debug(
                         `InitialAttributeValue for "${
                             clusterDef.name
-                        }/${attributeName}" is optional by supportedFeatures: ${JSON.stringify(
+                        }/${attributeName}" is optional by supportedFeatures: ${Logger.toJSON(
                             supportedFeatures,
                         )} and is not set!`,
                     );
@@ -282,7 +282,7 @@ export function ClusterServer<
                 logger.warn(
                     `InitialAttributeValue for "${
                         clusterDef.name
-                    }/${attributeName}" is provided but it's neither optional or mandatory for supportedFeatures: ${JSON.stringify(
+                    }/${attributeName}" is provided but it's neither optional or mandatory for supportedFeatures: ${Logger.toJSON(
                         supportedFeatures,
                     )} but is set!`,
                 );
@@ -391,7 +391,7 @@ export function ClusterServer<
                 const conditionMatched = isConditionMatching(mandatoryIf, supportedFeatures);
                 if (conditionMatched && handler === undefined) {
                     logger.warn(
-                        `Command "${clusterDef.name}/${name}" is REQUIRED by supportedFeatures: ${JSON.stringify(
+                        `Command "${clusterDef.name}/${name}" is REQUIRED by supportedFeatures: ${Logger.toJSON(
                             supportedFeatures,
                         )} but is not set!`,
                     );
@@ -403,7 +403,7 @@ export function ClusterServer<
                 const conditionMatched = isConditionMatching(optionalIf, supportedFeatures);
                 if (conditionMatched && handler === undefined) {
                     logger.debug(
-                        `Command "${clusterDef.name}/${name}" is optional by supportedFeatures: ${JSON.stringify(
+                        `Command "${clusterDef.name}/${name}" is optional by supportedFeatures: ${Logger.toJSON(
                             supportedFeatures,
                         )} and is not set!`,
                     );
@@ -415,7 +415,7 @@ export function ClusterServer<
                 logger.warn(
                     `Command "${
                         clusterDef.name
-                    }/${name}" is provided but it's neither optional nor mandatory for supportedFeatures: ${JSON.stringify(
+                    }/${name}" is provided but it's neither optional nor mandatory for supportedFeatures: ${Logger.toJSON(
                         supportedFeatures,
                     )} but is set!`,
                 );
@@ -467,7 +467,7 @@ export function ClusterServer<
                 const conditionMatched = isConditionMatching(mandatoryIf, supportedFeatures);
                 if (conditionMatched && (supportedEvents as any)[eventName] === undefined) {
                     logger.warn(
-                        `Event "${clusterDef.name}/${eventName}" is REQUIRED by supportedFeatures: ${JSON.stringify(
+                        `Event "${clusterDef.name}/${eventName}" is REQUIRED by supportedFeatures: ${Logger.toJSON(
                             supportedFeatures,
                         )} but is not set!`,
                     );
@@ -479,7 +479,7 @@ export function ClusterServer<
                 const conditionMatched = isConditionMatching(optionalIf, supportedFeatures);
                 if (conditionMatched && (supportedEvents as any)[eventName] === undefined) {
                     logger.debug(
-                        `Event "${clusterDef.name}/${eventName}" is optional by supportedFeatures: ${JSON.stringify(
+                        `Event "${clusterDef.name}/${eventName}" is optional by supportedFeatures: ${Logger.toJSON(
                             supportedFeatures,
                         )} and is not set!`,
                     );
@@ -491,7 +491,7 @@ export function ClusterServer<
                 logger.warn(
                     `Event "${
                         clusterDef.name
-                    }/${eventName}" is provided but it's neither optional or mandatory for supportedFeatures: ${JSON.stringify(
+                    }/${eventName}" is provided but it's neither optional or mandatory for supportedFeatures: ${Logger.toJSON(
                         supportedFeatures,
                     )} but is set!`,
                 );

--- a/packages/matter.js/src/datatype/EventNumber.ts
+++ b/packages/matter.js/src/datatype/EventNumber.ts
@@ -14,15 +14,15 @@ import { Branded } from "../util/Type.js";
  *
  * @see {@link MatterSpecification.v11.Core} § 7.14.2.1
  */
-export type EventNumber = Branded<number | bigint, "EventNumber">;
+export type EventNumber = Branded<bigint, "EventNumber">;
 
 export function EventNumber(id: number | bigint): EventNumber {
-    return id as EventNumber;
+    return BigInt(id) as EventNumber;
 }
 
 /** TLV schema for a data version. */
 export const TlvEventNumber = new TlvWrapper<EventNumber, number | bigint>(
     TlvUInt64,
-    dataVersion => dataVersion,
+    eventNumber => eventNumber,
     value => EventNumber(value),
 );

--- a/packages/matter.js/src/device/PairedNode.ts
+++ b/packages/matter.js/src/device/PairedNode.ts
@@ -462,7 +462,7 @@ export class PairedNode {
             }),
         );
 
-        logger.debug(`Node ${this.nodeId}: Endpoint usages`, JSON.stringify(endpointUsages));
+        logger.debug(`Node ${this.nodeId}: Endpoint usages`, Logger.toJSON(endpointUsages));
 
         while (true) {
             // get all endpoints with only one usage
@@ -473,7 +473,7 @@ export class PairedNode {
                 break;
             }
 
-            logger.debug(`Node ${this.nodeId}: Processing Endpoint ${JSON.stringify(singleUsageEndpoints)}`);
+            logger.debug(`Node ${this.nodeId}: Processing Endpoint ${Logger.toJSON(singleUsageEndpoints)}`);
 
             const idsToCleanup: { [key: EndpointNumber]: boolean } = {};
             singleUsageEndpoints.forEach(([childId, usages]) => {
@@ -495,7 +495,7 @@ export class PairedNode {
                 delete endpointUsages[EndpointNumber(parseInt(childId))];
                 idsToCleanup[usages[0]] = true;
             });
-            logger.debug(`Node ${this.nodeId}: Endpoint data Cleanup`, JSON.stringify(idsToCleanup));
+            logger.debug(`Node ${this.nodeId}: Endpoint data Cleanup`, Logger.toJSON(idsToCleanup));
             Object.keys(idsToCleanup).forEach(idToCleanup => {
                 Object.keys(endpointUsages).forEach(id => {
                     const usageId = EndpointNumber(parseInt(id));

--- a/packages/matter.js/src/mdns/MdnsScanner.ts
+++ b/packages/matter.js/src/mdns/MdnsScanner.ts
@@ -171,7 +171,7 @@ export class MdnsScanner implements Scanner {
                     if (dnsMessageDataToSend.answers.length === 0) {
                         // The first answer is already too big, log at least a warning
                         logger.warn(
-                            `MDNS Query with ${JSON.stringify(
+                            `MDNS Query with ${Logger.toJSON(
                                 queries,
                             )} is too big to fit into a single MDNS message. Send anyway, but please report!`,
                         );
@@ -220,7 +220,7 @@ export class MdnsScanner implements Scanner {
             answers = [...activeExistingQuery.answers, ...answers];
         }
         this.activeAnnounceQueries.set(queryId, { queries, answers });
-        logger.debug(`Set ${queries.length} query records for query ${queryId}: ${JSON.stringify(queries)}`);
+        logger.debug(`Set ${queries.length} query records for query ${queryId}: ${Logger.toJSON(queries)}`);
         this.queryTimer?.stop();
         this.nextAnnounceIntervalSeconds = START_ANNOUNCE_INTERVAL_SECONDS; // Reset query interval
         this.queryTimer = Time.getTimer("MDNS discovery", 0, () => this.sendQueries()).start();
@@ -450,7 +450,7 @@ export class MdnsScanner implements Scanner {
         } else if (Object.keys(identifier).length === 0) {
             return getCommissioningModeQname();
         }
-        throw new ImplementationError(`Invalid commissionable device identifier : ${JSON.stringify(identifier)}`); // Should neven happen
+        throw new ImplementationError(`Invalid commissionable device identifier : ${Logger.toJSON(identifier)}`); // Should neven happen
     }
 
     private extractInstanceId(instanceName: string) {

--- a/packages/matter.js/src/protocol/interaction/EventDataDecoder.ts
+++ b/packages/matter.js/src/protocol/interaction/EventDataDecoder.ts
@@ -10,6 +10,7 @@ import { UnexpectedDataError } from "../../common/MatterError.js";
 import { ClusterId } from "../../datatype/ClusterId.js";
 import { EndpointNumber } from "../../datatype/EndpointNumber.js";
 import { EventId } from "../../datatype/EventId.js";
+import { EventNumber } from "../../datatype/EventNumber.js";
 import { NodeId } from "../../datatype/NodeId.js";
 import { Logger } from "../../log/Logger.js";
 import { TlvAny } from "../../tlv/TlvAny.js";
@@ -20,7 +21,7 @@ import { TlvEventData, TlvEventReport } from "./InteractionProtocol.js";
 const logger = Logger.get("EventDataDecoder");
 
 export type DecodedEventData<T> = {
-    eventNumber: number | bigint;
+    eventNumber: EventNumber;
     priority: EventPriority;
     epochTimestamp?: number | bigint;
     systemTimestamp?: number | bigint;

--- a/packages/matter.js/src/protocol/interaction/InteractionClient.ts
+++ b/packages/matter.js/src/protocol/interaction/InteractionClient.ts
@@ -20,6 +20,7 @@ import { AttributeId } from "../../datatype/AttributeId.js";
 import { ClusterId } from "../../datatype/ClusterId.js";
 import { EndpointNumber } from "../../datatype/EndpointNumber.js";
 import { EventId } from "../../datatype/EventId.js";
+import { EventNumber } from "../../datatype/EventNumber.js";
 import { NodeId } from "../../datatype/NodeId.js";
 import { Logger } from "../../log/Logger.js";
 import { MessageExchange } from "../../protocol/MessageExchange.js";
@@ -334,7 +335,7 @@ export class InteractionClient {
         endpointId: EndpointNumber;
         clusterId: ClusterId;
         event: E;
-        minimumEventNumber?: number | bigint;
+        minimumEventNumber?: EventNumber;
         isFabricFiltered?: boolean;
     }): Promise<DecodedEventData<T>[] | undefined> {
         const { endpointId, clusterId, event, minimumEventNumber, isFabricFiltered = true } = options;
@@ -587,7 +588,7 @@ export class InteractionClient {
         minIntervalFloorSeconds: number;
         maxIntervalCeilingSeconds: number;
         isUrgent?: boolean;
-        minimumEventNumber?: number | bigint;
+        minimumEventNumber?: EventNumber;
         isFabricFiltered?: boolean;
         listener?: (value: DecodedEventData<T>) => void;
         updateTimeoutHandler?: TimerCallback;

--- a/packages/matter.js/src/protocol/interaction/InteractionProtocol.ts
+++ b/packages/matter.js/src/protocol/interaction/InteractionProtocol.ts
@@ -10,6 +10,7 @@ import { TlvClusterId } from "../../datatype/ClusterId.js";
 import { TlvCommandId } from "../../datatype/CommandId.js";
 import { TlvEndpointNumber } from "../../datatype/EndpointNumber.js";
 import { TlvEventId } from "../../datatype/EventId.js";
+import { TlvEventNumber } from "../../datatype/EventNumber.js";
 import { TlvNodeId } from "../../datatype/NodeId.js";
 import { TlvAny } from "../../tlv/TlvAny.js";
 import { TlvArray } from "../../tlv/TlvArray.js";
@@ -46,7 +47,7 @@ export const TlvEventPath = TlvTaggedList({
 export const TlvEventData = TlvObject({
     // EventDataIB
     path: TlvField(0, TlvEventPath),
-    eventNumber: TlvField(1, TlvUInt64),
+    eventNumber: TlvField(1, TlvEventNumber),
     priority: TlvField(2, TlvEnum<EventPriority>()),
     epochTimestamp: TlvOptionalField(3, TlvPosixMs),
     systemTimestamp: TlvOptionalField(4, TlvSysTimeMS),

--- a/packages/matter.js/src/protocol/interaction/InteractionServer.ts
+++ b/packages/matter.js/src/protocol/interaction/InteractionServer.ts
@@ -23,6 +23,7 @@ import { ClusterId } from "../../datatype/ClusterId.js";
 import { CommandId } from "../../datatype/CommandId.js";
 import { EndpointNumber } from "../../datatype/EndpointNumber.js";
 import { EventId } from "../../datatype/EventId.js";
+import { EventNumber } from "../../datatype/EventNumber.js";
 import { EndpointInterface } from "../../endpoint/EndpointInterface.js";
 import { Logger } from "../../log/Logger.js";
 import { MessageExchange } from "../../protocol/MessageExchange.js";
@@ -361,8 +362,8 @@ export class InteractionServer implements ProtocolHandler<MatterDevice>, Interac
                 }
                 eventReportsPayload.push(
                     ...reportsForPath.sort((a, b) => {
-                        const eventNumberA = a.eventData?.eventNumber ?? 0;
-                        const eventNumberB = b.eventData?.eventNumber ?? 0;
+                        const eventNumberA = a.eventData?.eventNumber ?? EventNumber(0);
+                        const eventNumberB = b.eventData?.eventNumber ?? EventNumber(0);
                         if (eventNumberA > eventNumberB) {
                             return 1;
                         } else if (eventNumberA < eventNumberB) {

--- a/packages/matter.js/src/protocol/interaction/SubscriptionHandler.ts
+++ b/packages/matter.js/src/protocol/interaction/SubscriptionHandler.ts
@@ -9,6 +9,7 @@ import { AnyAttributeServer, FabricScopedAttributeServer } from "../../cluster/s
 import { EventServer } from "../../cluster/server/EventServer.js";
 import { InternalError } from "../../common/MatterError.js";
 import { tryCatch, tryCatchAsync } from "../../common/TryCatchHandler.js";
+import { EventNumber } from "../../datatype/EventNumber.js";
 import { NodeId } from "../../datatype/NodeId.js";
 import { Fabric } from "../../fabric/Fabric.js";
 import { Logger } from "../../log/Logger.js";
@@ -375,8 +376,8 @@ export class SubscriptionHandler {
                 }));
             })
             .sort((a, b) => {
-                const eventNumberA = a.event?.eventNumber ?? 0;
-                const eventNumberB = b.event?.eventNumber ?? 0;
+                const eventNumberA = a.event?.eventNumber ?? EventNumber(0);
+                const eventNumberB = b.event?.eventNumber ?? EventNumber(0);
                 if (eventNumberA > eventNumberB) {
                     return 1;
                 } else if (eventNumberA < eventNumberB) {

--- a/packages/matter.js/test/protocol/interaction/EventDataDecoderTest.ts
+++ b/packages/matter.js/test/protocol/interaction/EventDataDecoderTest.ts
@@ -7,6 +7,7 @@ import { BasicInformation } from "../../../src/cluster/definitions/BasicInformat
 import { ClusterId } from "../../../src/datatype/ClusterId.js";
 import { EndpointNumber } from "../../../src/datatype/EndpointNumber.js";
 import { EventId } from "../../../src/datatype/EventId.js";
+import { EventNumber } from "../../../src/datatype/EventNumber.js";
 import { normalizeAndDecodeEventData, normalizeEventData } from "../../../src/protocol/interaction/EventDataDecoder.js";
 import { TlvEventData } from "../../../src/protocol/interaction/InteractionProtocol.js";
 import { TypeFromSchema } from "../../../src/tlv/TlvSchema.js";
@@ -18,14 +19,14 @@ describe("EventDataDecoder", () => {
             const data: TypeFromSchema<typeof TlvEventData>[] = [
                 {
                     path: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x28), eventId: EventId(0) },
-                    eventNumber: 1,
+                    eventNumber: EventNumber(1),
                     priority: 1,
                     epochTimestamp: 0,
                     data: BasicInformation.TlvStartUpEvent.encodeTlv({ softwareVersion: 1 }),
                 },
                 {
                     path: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x28), eventId: EventId(1) },
-                    eventNumber: 2,
+                    eventNumber: EventNumber(2),
                     priority: 1,
                     epochTimestamp: 0,
                     data: TlvVoid.encodeTlv(),
@@ -38,7 +39,7 @@ describe("EventDataDecoder", () => {
                 [
                     {
                         path: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x28), eventId: EventId(0) },
-                        eventNumber: 1,
+                        eventNumber: EventNumber(1),
                         priority: 1,
                         epochTimestamp: 0,
                         data: BasicInformation.TlvStartUpEvent.encodeTlv({ softwareVersion: 1 }),
@@ -47,7 +48,7 @@ describe("EventDataDecoder", () => {
                 [
                     {
                         path: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x28), eventId: EventId(1) },
-                        eventNumber: 2,
+                        eventNumber: EventNumber(2),
                         priority: 1,
                         epochTimestamp: 0,
                         data: TlvVoid.encodeTlv(),
@@ -60,21 +61,21 @@ describe("EventDataDecoder", () => {
             const data: TypeFromSchema<typeof TlvEventData>[] = [
                 {
                     path: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x28), eventId: EventId(0) },
-                    eventNumber: 1,
+                    eventNumber: EventNumber(1),
                     priority: 1,
                     epochTimestamp: 0,
                     data: BasicInformation.TlvStartUpEvent.encodeTlv({ softwareVersion: 1 }),
                 },
                 {
                     path: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x28), eventId: EventId(1) },
-                    eventNumber: 2,
+                    eventNumber: EventNumber(2),
                     priority: 1,
                     epochTimestamp: 0,
                     data: TlvVoid.encodeTlv(),
                 },
                 {
                     path: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x28), eventId: EventId(0) },
-                    eventNumber: 3,
+                    eventNumber: EventNumber(3),
                     priority: 1,
                     epochTimestamp: 0,
                     data: BasicInformation.TlvStartUpEvent.encodeTlv({ softwareVersion: 3 }),
@@ -118,7 +119,7 @@ describe("EventDataDecoder", () => {
             const data: TypeFromSchema<typeof TlvEventData>[] = [
                 {
                     path: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x28), eventId: EventId(0) },
-                    eventNumber: 1,
+                    eventNumber: EventNumber(1),
                     priority: 1,
                     epochTimestamp: 0,
                     systemTimestamp: undefined,
@@ -128,7 +129,7 @@ describe("EventDataDecoder", () => {
                 },
                 {
                     path: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x28), eventId: EventId(1) },
-                    eventNumber: 2,
+                    eventNumber: EventNumber(2),
                     priority: 1,
                     epochTimestamp: 0,
                     systemTimestamp: undefined,
@@ -151,7 +152,7 @@ describe("EventDataDecoder", () => {
                     },
                     events: [
                         {
-                            eventNumber: 1,
+                            eventNumber: EventNumber(1),
                             priority: 1,
                             epochTimestamp: 0,
                             systemTimestamp: undefined,
@@ -172,7 +173,7 @@ describe("EventDataDecoder", () => {
                     },
                     events: [
                         {
-                            eventNumber: 2,
+                            eventNumber: EventNumber(2),
                             priority: 1,
                             epochTimestamp: 0,
                             systemTimestamp: undefined,
@@ -190,7 +191,7 @@ describe("EventDataDecoder", () => {
             const data: TypeFromSchema<typeof TlvEventData>[] = [
                 {
                     path: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x28), eventId: EventId(0) },
-                    eventNumber: 1,
+                    eventNumber: EventNumber(1),
                     priority: 1,
                     epochTimestamp: 0,
                     systemTimestamp: undefined,
@@ -200,7 +201,7 @@ describe("EventDataDecoder", () => {
                 },
                 {
                     path: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x28), eventId: EventId(1) },
-                    eventNumber: 2,
+                    eventNumber: EventNumber(2),
                     priority: 1,
                     epochTimestamp: 0,
                     systemTimestamp: undefined,
@@ -210,7 +211,7 @@ describe("EventDataDecoder", () => {
                 },
                 {
                     path: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x28), eventId: EventId(0) },
-                    eventNumber: 3,
+                    eventNumber: EventNumber(3),
                     priority: 1,
                     epochTimestamp: 0,
                     systemTimestamp: undefined,
@@ -233,7 +234,7 @@ describe("EventDataDecoder", () => {
                     },
                     events: [
                         {
-                            eventNumber: 1,
+                            eventNumber: EventNumber(1),
                             priority: 1,
                             epochTimestamp: 0,
                             systemTimestamp: undefined,
@@ -243,7 +244,7 @@ describe("EventDataDecoder", () => {
                             path: undefined,
                         },
                         {
-                            eventNumber: 3,
+                            eventNumber: EventNumber(3),
                             priority: 1,
                             epochTimestamp: 0,
                             systemTimestamp: undefined,
@@ -264,7 +265,7 @@ describe("EventDataDecoder", () => {
                     },
                     events: [
                         {
-                            eventNumber: 2,
+                            eventNumber: EventNumber(2),
                             priority: 1,
                             epochTimestamp: 0,
                             systemTimestamp: undefined,
@@ -284,7 +285,7 @@ describe("EventDataDecoder", () => {
             const data: TypeFromSchema<typeof TlvEventData>[] = [
                 {
                     path: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x999), eventId: EventId(0) },
-                    eventNumber: 1,
+                    eventNumber: EventNumber(1),
                     priority: 1,
                     epochTimestamp: 0,
                     systemTimestamp: undefined,
@@ -294,7 +295,7 @@ describe("EventDataDecoder", () => {
                 },
                 {
                     path: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x999), eventId: EventId(1) },
-                    eventNumber: 2,
+                    eventNumber: EventNumber(2),
                     priority: 1,
                     epochTimestamp: 0,
                     systemTimestamp: undefined,
@@ -317,7 +318,7 @@ describe("EventDataDecoder", () => {
                     },
                     events: [
                         {
-                            eventNumber: 1,
+                            eventNumber: EventNumber(1),
                             priority: 1,
                             epochTimestamp: 0,
                             systemTimestamp: undefined,
@@ -338,7 +339,7 @@ describe("EventDataDecoder", () => {
                     },
                     events: [
                         {
-                            eventNumber: 2,
+                            eventNumber: EventNumber(2),
                             priority: 1,
                             epochTimestamp: 0,
                             systemTimestamp: undefined,


### PR DESCRIPTION
When Endpoint structures were changed then events were not updated in the subscriptions which caused events from newly added endpoints after the initial subscription were never sent out in the subscription

fixes #784 

The change was tested locally and will be validated after merge by @Luligu 