### PR TITLE
Add minimal DoorLock capabilities

### DIFF
--- a/packages/matter.js/src/behavior/definitions/door-lock/DoorLockServer.ts
+++ b/packages/matter.js/src/behavior/definitions/door-lock/DoorLockServer.ts
@@ -4,11 +4,19 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/*** THIS FILE WILL BE REGENERATED IF YOU DO NOT REMOVE THIS MESSAGE ***/
-
 import { DoorLockBehavior } from "./DoorLockBehavior.js";
+import {DoorLock} from "@project-chip/matter.js/cluster";
+import LockState = DoorLock.LockState;
 
 /**
  * This is the default server implementation of {@link DoorLockBehavior}.
  */
-export class DoorLockServer extends DoorLockBehavior {}
+export class DoorLockServer extends DoorLockBehavior {
+    override lockDoor() {
+        this.state.lockState = LockState.Locked;
+    }
+
+    override unlockDoor() {
+        this.state.lockState = LockState.Unlocked;
+    }
+}

--- a/packages/matter.js/src/behavior/definitions/door-lock/DoorLockServer.ts
+++ b/packages/matter.js/src/behavior/definitions/door-lock/DoorLockServer.ts
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { DoorLock } from "../../../cluster/definitions/index.js";
 import { DoorLockBehavior } from "./DoorLockBehavior.js";
-import {DoorLock} from "../../../cluster/definitions/index.js";
 import LockState = DoorLock.LockState;
 
 /**

--- a/packages/matter.js/src/behavior/definitions/door-lock/DoorLockServer.ts
+++ b/packages/matter.js/src/behavior/definitions/door-lock/DoorLockServer.ts
@@ -5,7 +5,7 @@
  */
 
 import { DoorLockBehavior } from "./DoorLockBehavior.js";
-import {DoorLock} from "@project-chip/matter.js/cluster";
+import {DoorLock} from "../../../cluster/definitions/index.js";
 import LockState = DoorLock.LockState;
 
 /**

--- a/packages/matter.js/src/behavior/definitions/door-lock/DoorLockServer.ts
+++ b/packages/matter.js/src/behavior/definitions/door-lock/DoorLockServer.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { DoorLock } from "../../../cluster/definitions/index.js";
+import { DoorLock } from "../../../cluster/definitions/DoorLockCluster.js";
 import { DoorLockBehavior } from "./DoorLockBehavior.js";
 import LockState = DoorLock.LockState;
 


### PR DESCRIPTION
As known in #772 this is the minimal cluster for a DoorLockDevice.

Tested the device with Home Assistant and it does not throw an error.