### PR TITLE
Remove invalid length assumption in Sigma2

### DIFF
--- a/packages/matter.js/src/session/case/CaseMessages.ts
+++ b/packages/matter.js/src/session/case/CaseMessages.ts
@@ -17,8 +17,6 @@ import { TlvSessionParameters } from "../pase/PaseMessages.js";
 
 const CASE_SIGNATURE_LENGTH = CRYPTO_GROUP_SIZE_BYTES * 2;
 
-const CASE2_ENCRYPTED_LENGTH = 800 + CRYPTO_AEAD_MIC_LENGTH_BYTES + CASE_SIGNATURE_LENGTH; // NOC + ICAC + CASE-Sig + Mic
-
 export const KDFSR1_KEY_INFO = ByteArray.fromString("Sigma1_Resume");
 export const KDFSR2_KEY_INFO = ByteArray.fromString("Sigma2_Resume");
 export const RESUME1_MIC_NONCE = ByteArray.fromString("NCASE_SigmaS1");

--- a/packages/matter.js/src/session/case/CaseMessages.ts
+++ b/packages/matter.js/src/session/case/CaseMessages.ts
@@ -44,7 +44,7 @@ export const TlvCaseSigma2 = TlvObject({
     random: TlvField(1, TlvByteString.bound({ length: 32 })),
     sessionId: TlvField(2, TlvUInt16),
     ecdhPublicKey: TlvField(3, TlvByteString.bound({ length: CRYPTO_PUBLIC_KEY_SIZE_BYTES })),
-    encrypted: TlvField(4, TlvByteString.bound({ maxLength: CASE2_ENCRYPTED_LENGTH })),
+    encrypted: TlvField(4, TlvByteString),
     sessionParams: TlvOptionalField(5, TlvSessionParameters),
 });
 

--- a/packages/matter.js/src/session/case/CaseServer.ts
+++ b/packages/matter.js/src/session/case/CaseServer.ts
@@ -155,19 +155,13 @@ export class CaseServer implements ProtocolHandler<MatterDevice> {
                 peerEcdhPublicKey,
             });
             const signature = fabric.sign(signatureData);
-            logger.info("nodeOpCert", nodeOpCert.length, nodeOpCert.toHex());
-            logger.info("intermediateCACert", intermediateCACert?.length, intermediateCACert?.toHex());
-            logger.info("signature", signature.length, signature.toHex());
-            logger.info("resumptionId", resumptionId.length, resumptionId.toHex());
             const encryptedData = TlvEncryptedDataSigma2.encode({
                 nodeOpCert,
                 intermediateCACert,
                 signature,
                 resumptionId,
             });
-            logger.info("encryptedData intermediate", encryptedData.length, encryptedData.toHex());
             const encrypted = Crypto.encrypt(sigma2Key, encryptedData, TBE_DATA2_NONCE);
-            logger.info("encrypted", encrypted.length, encrypted.toHex());
             const sessionId = await server.getNextAvailableSessionId();
             const sigma2Bytes = await messenger.sendSigma2({
                 random,

--- a/packages/matter.js/src/session/case/CaseServer.ts
+++ b/packages/matter.js/src/session/case/CaseServer.ts
@@ -155,13 +155,19 @@ export class CaseServer implements ProtocolHandler<MatterDevice> {
                 peerEcdhPublicKey,
             });
             const signature = fabric.sign(signatureData);
+            logger.info("nodeOpCert", nodeOpCert.length, nodeOpCert.toHex());
+            logger.info("intermediateCACert", intermediateCACert?.length, intermediateCACert?.toHex());
+            logger.info("signature", signature.length, signature.toHex());
+            logger.info("resumptionId", resumptionId.length, resumptionId.toHex());
             const encryptedData = TlvEncryptedDataSigma2.encode({
                 nodeOpCert,
                 intermediateCACert,
                 signature,
                 resumptionId,
             });
+            logger.info("encryptedData intermediate", encryptedData.length, encryptedData.toHex());
             const encrypted = Crypto.encrypt(sigma2Key, encryptedData, TBE_DATA2_NONCE);
+            logger.info("encrypted", encrypted.length, encrypted.toHex());
             const sessionId = await server.getNextAvailableSessionId();
             const sigma2Bytes = await messenger.sendSigma2({
                 random,


### PR DESCRIPTION
Our Sigma2 schema definition contained a maximum for the encrypted data ... this was in fact correct, BUT just as maximum for the unencrypted data ... the encrypted data are obviously longer and so it crahed now with a change in the python testing caused by https://github.com/project-chip/connectedhomeip/commit/e05d08e553978cf07f809d2227a2c5f588229f8e#diff-24fd15b384a650c564ad3e7332e789ca98a3ab41a2a893efe037ec2f265ceedd

All source fields are valiidated also, so it is ok to remove that length check.

Thanks to @cecille for her suppport