### PR TITLE
Add another workaround for TS 27965

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The main work (all changes without a GitHub username in brackets in the below li
   * Fix: Corrects returned errors for two commands on OperationalCredentials cluster 
 * matter.js New API code flows:
   * Breaking: The name of the *$Change Events for attributes and such are changed to *$Changed . Please adjust your code!
+  * Breaking: Introduced ExtensionInterface to define extensible/custom methods for behavior/Cluster-Server implementation to be available when extending this class (needed because of a TS bug 27965)
   * Enhancement: Optimized constraint validations and conformance error messages
   * Enhancement: Conditionally enables the ReachableChanged event on the Root Endpoint BasicInformation cluster if the reachable attribute is defined in the defaults
   * Enhancement: Allow to register events directly when initializing endpoints like in legacy API

--- a/packages/matter.js/src/behavior/cluster/ClusterBehaviorUtil.ts
+++ b/packages/matter.js/src/behavior/cluster/ClusterBehaviorUtil.ts
@@ -89,6 +89,13 @@ export type ClusterOf<B extends Behavior.Type> = B extends { cluster: infer C ex
     : ClusterType.Unknown;
 
 /**
+ * The extension interface for a behavior.
+ */
+export type ExtensionInterfaceOf<B extends Behavior.Type> = B extends { ExtensionInterface: infer I extends {} }
+    ? I
+    : {};
+
+/**
  * Create a new state subclass that inherits relevant default values from a base Behavior.Type and adds new default
  * values from cluster attributes.
  */

--- a/packages/matter.js/src/behavior/cluster/ClusterInterface.ts
+++ b/packages/matter.js/src/behavior/cluster/ClusterInterface.ts
@@ -13,28 +13,32 @@ import type { MaybePromise } from "../../util/Promises.js";
 /**
  * This type defines methods for a behavior grouped by named cluster component.
  *
- * Ideally we would do this using a simple mapped type.  Unfortunately as of
- * TypeScript 5.2 there is no way to define a method using a mapped type.
- * Instead the mapped type defines function properties.
+ * Ideally we would do this using a simple mapped type.  Unfortunately as of TypeScript 5.2 there is no way to define a
+ * method using a mapped type. Instead the mapped type defines function properties.
  *
- * Function properties work identically to methods semantically but TypeScript
- * doesn't allow you to override them with standard methods (see error TS2425).
+ * Function properties work identically to methods semantically but TypeScript doesn't allow you to override them with
+ * standard methods (see error TS2425).
  *
- * Thus we are forced to generate an interface for every cluster component
- * and assemble based on selected features using logic that mirrors
- * {@link ClusterComposer.Of}.
+ * Thus we are forced to generate an interface for every cluster component and assemble based on selected features using
+ * logic that mirrors {@link ClusterComposer.Of}.
  *
- * Note that we only need to do this for commands.  The public interface for
- * attributes and events consists solely of properties so we generate using
- * mapped types.  This is handled by ClusterState and
- * ClusterEvents respectively.
+ * Note that we only need to do this for commands.  The public interface for attributes and events consists solely of
+ * properties so we generate using mapped types.  This is handled by ClusterState and ClusterEvents respectively.
  *
  * If TS team ever fixes:
  *
  *   https://github.com/microsoft/TypeScript/issues/27965
  *
- * ...then we can remove the interface and just use
- * {@link ClusterInterface.MappedMethodsOf}.
+ * ...then we can remove the interface and just use {@link ClusterInterface.MappedMethodsOf}.
+ *
+ * This appears to be a duplicate (but is still open):
+ *
+ *   https://github.com/microsoft/TypeScript/issues/27689
+ *
+ * Proposed solution is to just remove the error:
+ *
+ *   https://github.com/microsoft/TypeScript/issues/48125
+ *
  */
 export type ClusterInterface<F extends BitSchema = {}> = {
     components: ClusterInterface.Component<F>[];
@@ -56,7 +60,7 @@ export namespace ClusterInterface {
     export type MethodsOf<I extends ClusterInterface, C extends ClusterType> =
         // This is the workaround for TS issue #27965
         InterfaceMethodsOf<I, C["supportedFeatures"]> &
-            // Fall back to mapping for ommands not defined in an interface
+            // Fall back to mapping for methods not defined in an interface
             Omit<MappedMethodsOf<C["commands"]>, keyof InterfaceMethodsOf<I, C["supportedFeatures"]>>;
 
     export type InterfaceMethodsOf<


### PR DESCRIPTION
Due to TS bug with mapped types (the same one that forced "ClusterInterface" on us) we need to manually designate methods that should be carried forward for altered behaviors.  Otherwise TS considers the methods function properties and won't allow for override with a method (though it's still easy to override with slightly uglier property syntax).