### PR TITLE
Implement new "fieldName$Changing" event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The main work (all changes without a GitHub username in brackets in the below li
   * Enhancement: Adjusted handling of TlvList order to match better with matter specification and ensure field orders are preserved
   * Enhancement: Adds Certificate validation and cryptographic verification during commissioning and CASE session establishment
   * Enhancement: Adds additional logging information for PASE and CASE to better understand errors without debug logging
+  * Enhancement: Adds several Optimizations and adjustments for Obervers (e.g. Observable.isObserved)
   * Fix: Corrects returned errors for two commands on OperationalCredentials cluster 
 * matter.js New API code flows:
   * Breaking: The name of the *$Change Events for attributes and such are changed to *$Changed . Please adjust your code!
@@ -27,9 +28,11 @@ The main work (all changes without a GitHub username in brackets in the below li
   * Enhancement: Conditionally enables the ReachableChanged event on the Root Endpoint BasicInformation cluster if the reachable attribute is defined in the defaults
   * Enhancement: Allow to register events directly when initializing endpoints like in legacy API
   * Enhancement: Allows for cluster implementations to dynamically add/enable state attributes and events
-  * Enhancement: Allows "$Changed" event handlers to be async
+  * Enhancement: Added "fieldName$Changing" event handlers that emit in transaction pre-commit and allow for state mutation and will cycle for a limited number of times until state is stable
+  * Enhancement: Allows "fieldName$Changed" and "fieldName$Changing" event handlers to be async
   * Fix: Fixes some issues around event handling in the new API and makes sure events are not de-registered on factory resets
   * Fix: Corrects the returned status error code when an Enum value is set to an invalid value
+  * Fix: Fixes a floating promise in FailsafeTimer; it tended to kill a test run without an easy way to identify the cause
 * Chip testing:
   * Enhancement: Adds automatic CI testing for all clusters listed in [matter.js Readme](./packages/matter.js/README.md)
 * matter.js tooling:

--- a/packages/matter.js/src/behavior/cluster/ClusterBehaviorUtil.ts
+++ b/packages/matter.js/src/behavior/cluster/ClusterBehaviorUtil.ts
@@ -185,9 +185,14 @@ function createDerivedEvents(cluster: ClusterType, base: Behavior.Type, stateNam
 
     // Add events for mandatory attributes that are not present in the base class
     for (const attrName of stateNames) {
-        const name = `${attrName}$Changed`;
-        if (baseInstance[name] === undefined) {
-            names.add(name);
+        const changing = `${attrName}$Changing`;
+        if (baseInstance[changing] === undefined) {
+            names.add(changing);
+        }
+
+        const changed = `${attrName}$Changed`;
+        if (baseInstance[changed] === undefined) {
+            names.add(changed);
         }
     }
 

--- a/packages/matter.js/src/behavior/cluster/ClusterEvents.ts
+++ b/packages/matter.js/src/behavior/cluster/ClusterEvents.ts
@@ -6,7 +6,7 @@
 
 import type { ClusterType } from "../../cluster/ClusterType.js";
 import type { TypeFromSchema } from "../../tlv/TlvSchema.js";
-import type { Observable } from "../../util/Observable.js";
+import type { AsyncObservable, Observable } from "../../util/Observable.js";
 import type { Behavior } from "../Behavior.js";
 import type { ActionContext } from "../context/ActionContext.js";
 import type { ClusterOf } from "./ClusterBehaviorUtil.js";
@@ -28,28 +28,29 @@ export namespace ClusterEvents {
     /**
      * Properties the cluster contributes to Events.
      */
-    export type Properties<C> = AttributeObservables<ClusterType.AttributesOf<C>> &
+    export type Properties<C> = AttributeObservables<ClusterType.AttributesOf<C>, "Changing"> &
+        AttributeObservables<ClusterType.AttributesOf<C>, "Changed"> &
         EventObservables<ClusterType.EventsOf<C>>;
 
-    export type AttributeObservables<A extends Record<string, ClusterType.Attribute>> = {
+    export type AttributeObservables<A extends Record<string, ClusterType.Attribute>, N extends string> = {
         [K in keyof A as string extends K
             ? never
             : K extends string
               ? A[K] extends { optional: true }
                   ? never
-                  : `${K}$Changed`
+                  : `${K}$${N}`
               : never]: AttributeObservable<A[K]>;
     } & {
         [K in keyof A as string extends K
             ? never
             : K extends string
               ? A[K] extends { optional: true }
-                  ? `${K}$Changed`
+                  ? `${K}$${N}`
                   : never
               : never]?: AttributeObservable<A[K]>;
     };
 
-    export type AttributeObservable<A extends ClusterType.Attribute = ClusterType.Attribute> = Observable<
+    export type AttributeObservable<A extends ClusterType.Attribute = ClusterType.Attribute> = AsyncObservable<
         [value: TypeFromSchema<A["schema"]>, oldValue: TypeFromSchema<A["schema"]>, context: ActionContext]
     >;
 

--- a/packages/matter.js/src/behavior/internal/BackingEvents.ts
+++ b/packages/matter.js/src/behavior/internal/BackingEvents.ts
@@ -6,7 +6,7 @@
 
 import type { Endpoint } from "../../endpoint/Endpoint.js";
 import { GeneratedClass } from "../../util/GeneratedClass.js";
-import { BasicObservable, EventEmitter, Observable } from "../../util/Observable.js";
+import { EventEmitter, Observable, ObservableProxy } from "../../util/Observable.js";
 import { BehaviorBacking } from "./BehaviorBacking.js";
 
 type Implementation = new (target: EventEmitter) => EventEmitter;
@@ -39,38 +39,6 @@ export function BackingEvents(backing: BehaviorBacking): EventEmitter {
 }
 
 const TARGET = Symbol("target");
-
-/**
- * A single event on a behavior.
- *
- * Emits emitted here instead emit on the target {@link Observable}.  Events emitted on the target emit locally via
- * a listener installed by the proxy.
- *
- * "Proxy" acts as a proxy but is not a {@link Proxy}.
- */
-class ObservableProxy extends BasicObservable {
-    #target: Observable;
-    #emitter = (...args: unknown[]) => super.emit(...args);
-
-    constructor(target: Observable) {
-        super();
-        this.#target = target;
-        this.#target.on(this.#emitter);
-    }
-
-    override [Symbol.dispose]() {
-        this.#target.off(this.#emitter);
-        super[Symbol.dispose]();
-    }
-
-    override get isAsync() {
-        return this.#target.isAsync;
-    }
-
-    override emit(...payload: any[]): void | undefined {
-        this.#target.emit(...payload);
-    }
-}
 
 /**
  * Generates a proxy {@link EventEmitter} for the given {@link EventEmitter} instance.

--- a/packages/matter.js/src/behavior/state/managed/Datasource.ts
+++ b/packages/matter.js/src/behavior/state/managed/Datasource.ts
@@ -10,6 +10,7 @@ import { Crypto } from "../../../crypto/Crypto.js";
 import { ClusterId } from "../../../datatype/ClusterId.js";
 import { DataModelPath } from "../../../endpoint/DataModelPath.js";
 import { Logger } from "../../../log/Logger.js";
+import { deepCopy } from "../../../util/DeepCopy.js";
 import { isDeepEqual } from "../../../util/DeepEqual.js";
 import { Observable } from "../../../util/Observable.js";
 import { MaybePromise } from "../../../util/Promises.js";
@@ -68,7 +69,11 @@ export function Datasource<const T extends StateType = StateType>(options: Datas
         },
 
         reference(session: ValueSupervisor.Session) {
-            return options.supervisor.manage(createRootReference(this, internals, session), session) as InstanceType<T>;
+            let context = internals.sessions?.get(session);
+            if (!context) {
+                context = createSessionContext(this, internals, session);
+            }
+            return context.managed as InstanceType<T>;
         },
 
         get version() {
@@ -92,10 +97,7 @@ export function Datasource<const T extends StateType = StateType>(options: Datas
                     },
                     transaction: ReadOnlyTransaction,
                 };
-                readOnlyView = options.supervisor.manage(
-                    createRootReference(this, internals, session),
-                    session,
-                ) as InstanceType<T>;
+                readOnlyView = createSessionContext(this, internals, session).managed as InstanceType<T>;
             }
             return readOnlyView;
         },
@@ -106,7 +108,7 @@ export namespace Datasource {
     /**
      * Datasource events.
      */
-    export interface Events extends Record<string, Observable<Parameters<ValueObserver>>> {}
+    export interface Events extends Record<string, Observable<Parameters<ValueObserver>, MaybePromise>> {}
 
     /**
      * Datasource configuration options.
@@ -128,7 +130,10 @@ export namespace Datasource {
         path: DataModelPath;
 
         /**
-         * Events of the form "fieldName$Changed", if present, emit after field changes commit.
+         * Events triggered automatically.
+         *
+         * Events named "fieldName$Changing", if present, emit before changes commit.  Events named "fieldName$Changed",
+         * if present, emit after field changes commit.
          */
         events?: Events;
 
@@ -178,17 +183,31 @@ export namespace Datasource {
     }
 }
 
+/**
+ * Detail on all active references associated with the datasource.
+ */
+interface SessionContext {
+    managed: Val.Struct;
+    onChange(oldValues: Val.Struct): void;
+}
+
+/**
+ * Internal datasource state.
+ */
 interface Internals extends Datasource.Options {
     path: DataModelPath;
     values: Val.Struct;
     version: number;
-    changed?: Observable<[oldValues: Val.Struct]>;
+    sessions?: Map<ValueSupervisor.Session, SessionContext>;
 }
 
-interface Changes {
+/**
+ * Changes that are applied during a commit (computed post-commit).
+ */
+interface CommitChanges {
     persistent?: Val.Struct;
     notifications: Array<{
-        event: Observable;
+        event: Observable<any[], MaybePromise>;
         params: Parameters<Datasource.ValueObserver>;
     }>;
 }
@@ -217,15 +236,17 @@ function configure(options: Datasource.Options): Internals {
  *
  * This reference provides external access to the {@link Val.Struct} in the context of a specific session.
  */
-function createRootReference(resource: Resource, internals: Internals, session: ValueSupervisor.Session) {
+function createSessionContext(resource: Resource, internals: Internals, session: ValueSupervisor.Session) {
     let values = internals.values;
-    let changes: Changes | undefined;
+    let precommitValues: Val.Struct | undefined;
+    let changes: CommitChanges | undefined;
     let expired = false;
 
     const participant = {
         toString() {
             return internals.path.toString();
         },
+        preCommit,
         commit1,
         commit2,
         postCommit,
@@ -245,32 +266,6 @@ function createRootReference(resource: Resource, internals: Internals, session: 
                     e,
                 );
             }
-        }
-    });
-
-    // Register a listener on the datasource so we can update our reference when the datasource changes
-    const changeListener = (oldValues: Val.Struct) => {
-        if (values === oldValues) {
-            values = internals.values;
-            refreshSubrefs();
-        }
-    };
-    if (!internals.changed) {
-        internals.changed = Observable();
-    }
-    internals.changed.on(changeListener);
-
-    // When the transaction is destroyed, decouple from the datasource and expire
-    void transaction.onClose(() => {
-        try {
-            internals.changed?.off(changeListener);
-            expired = true;
-            refreshSubrefs();
-        } catch (e) {
-            logger.error(
-                `Error detaching reference to ${internals.path} from closed transaction ${transaction.via}:`,
-                e,
-            );
         }
     });
 
@@ -348,7 +343,37 @@ function createRootReference(resource: Resource, internals: Internals, session: 
 
     reference.toString = () => `ref<${resource}>`;
 
-    return reference;
+    // Register a listener on the datasource so we can update our reference when the datasource changes
+    const context: SessionContext = {
+        managed: internals.supervisor.manage(reference, session) as Val.Struct,
+
+        onChange(oldValues: Val.Struct) {
+            if (values === oldValues) {
+                values = internals.values;
+                refreshSubrefs();
+            }
+        },
+    };
+    if (!internals.sessions) {
+        internals.sessions = new Map();
+    }
+    internals.sessions.set(session, context);
+
+    // When the transaction is destroyed, decouple from the datasource and expire
+    void transaction.onClose(() => {
+        try {
+            internals.sessions?.delete(session);
+            expired = true;
+            refreshSubrefs();
+        } catch (e) {
+            logger.error(
+                `Error detaching reference to ${internals.path} from closed transaction ${transaction.via}:`,
+                e,
+            );
+        }
+    });
+
+    return context;
 
     function startWrite() {
         // Add myself as a resource so I can be locked
@@ -380,8 +405,88 @@ function createRootReference(resource: Resource, internals: Internals, session: 
         }
     }
 
-    // In "changed" state, values !== data.values, but here we identify logical changes on a per-property basis
-    function computeChanges() {
+    // On the first pre-commit cycle, any change is a "pre-commit" change.  On subsequent cycles we only consider
+    // changes since the previous cycle
+    function computePreCommitChange(name: string): undefined | { newValue: unknown; oldValue: unknown } {
+        let oldValue;
+        if (precommitValues && name in precommitValues) {
+            oldValue = precommitValues[name];
+        } else {
+            oldValue = internals.values[name];
+        }
+
+        const newValue = values[name];
+        if (isDeepEqual(oldValue, newValue)) {
+            return;
+        }
+
+        if (!precommitValues) {
+            precommitValues = {};
+        }
+        precommitValues[name] = deepCopy(newValue);
+
+        return { newValue, oldValue };
+    }
+
+    /**
+     * For pre-commit we trigger "fieldName$Changing" events for any fields that have changed since the previous
+     * pre-commit cycle.
+     *
+     * Tracking data here is relatively expensive so we limit to events with registered observers.
+     */
+    function preCommit() {
+        // We do nothing if there are not events registered
+        const { events } = internals;
+        if (!events) {
+            return false;
+        }
+
+        // Mutation is only possible if we emit a $Changing event
+        let mayHaveMutated = false;
+
+        // Emit is optionally async so we must iterate manually
+        const keyIterator = Object.keys(values)[Symbol.iterator]();
+
+        // Proceed with next key on first iteration or after async notification
+        function nextKey(): MaybePromise<boolean> {
+            while (true) {
+                const n = keyIterator.next();
+                if (n.done) {
+                    return mayHaveMutated;
+                }
+
+                const name = n.value;
+
+                // Eventing here is relatively expensive because we need deep clones and will trigger another pre-commit
+                // cycle across all participants.  So we only process properties that are observed
+                const event = events?.[`${name}$Changing`];
+                if (!event?.isObserved) {
+                    continue;
+                }
+
+                const change = computePreCommitChange(name);
+                if (change) {
+                    // The pre-commit cycle will need to re-run
+                    mayHaveMutated = true;
+
+                    // Notify observers
+                    const result = event.emit(change.newValue, change.oldValue, session);
+
+                    // For pre-commit we run observers serially.  If the observer is async then we continue the loop
+                    // after the observer completes
+                    if (MaybePromise.is(result)) {
+                        return result.then(nextKey);
+                    }
+                }
+            }
+        }
+
+        return nextKey();
+    }
+
+    // In "changed" state, values !== data.values, but here we identify logical changes on a per-property basis.  For
+    // each change we record the "changed" event to trigger and collect those we must persist
+    function computePostCommitChanges() {
         changes = undefined;
 
         if (internals.values === values) {
@@ -404,7 +509,7 @@ function createRootReference(resource: Resource, internals: Internals, session: 
                 }
 
                 const event = internals.events?.[`${name}$Changed`];
-                if (event) {
+                if (event?.isObserved) {
                     changes.notifications.push({
                         event,
                         params: [values[name], internals.values[name], session],
@@ -424,9 +529,9 @@ function createRootReference(resource: Resource, internals: Internals, session: 
      * For commit phase one we pass values to the persistence layer if present.
      */
     function commit1() {
-        computeChanges();
+        computePostCommitChanges();
 
-        // No phase one commit if there are not persistent changes
+        // No phase one commit if there are no persistent changes
         const persistent = changes?.persistent;
         if (!persistent) {
             return;
@@ -445,7 +550,11 @@ function createRootReference(resource: Resource, internals: Internals, session: 
 
         const oldValues = internals.values;
         internals.values = values;
-        internals.changed?.emit(oldValues);
+        if (internals.sessions) {
+            for (const context of internals.sessions.values()) {
+                context.onChange(oldValues);
+            }
+        }
 
         if (session.trace && changes.persistent) {
             let mutations = session.trace.mutations;
@@ -459,11 +568,15 @@ function createRootReference(resource: Resource, internals: Internals, session: 
         }
     }
 
+    /**
+     * Post-commit logic.  Emit "changed" events.  Observers may be synchronous or asynchronous.
+     */
     function postCommit() {
         if (!changes || !internals.events) {
             return;
         }
 
+        // Emit is optionally async so we must iterate manually
         const iterator = changes.notifications[Symbol.iterator]();
 
         function emitChanged(): MaybePromise<void> {

--- a/packages/matter.js/src/behavior/state/transaction/Participant.ts
+++ b/packages/matter.js/src/behavior/state/transaction/Participant.ts
@@ -22,6 +22,17 @@ export interface Participant {
     role?: {};
 
     /**
+     * Pre-commit logic.
+     *
+     * Pre-commit logic returns a boolean indicating whether it performed an action that affects state.  The transaction
+     * will cycle through participants continuously until all participants return false.
+     *
+     * Thus `preCommit` implementations must be stateful and expect to be invoked more than once for a single
+     * transaction.
+     */
+    preCommit?: () => MaybePromise<boolean>;
+
+    /**
      * Commit phase one.
      */
     commit1(): MaybePromise;

--- a/packages/matter.js/src/behavior/state/transaction/Tx.ts
+++ b/packages/matter.js/src/behavior/state/transaction/Tx.ts
@@ -19,6 +19,10 @@ import { Transaction } from "./Transaction.js";
 
 const logger = Logger.get("Transaction");
 
+// Controls the number of times we will cycle pre-commit handlers waiting for state to settle
+const MAX_PRECOMMIT_CYCLES = 5;
+
+// Controls the number of commits that may occur due to mutation in post-commit handlers
 const MAX_CHAINED_COMMITS = 5;
 
 /**
@@ -35,7 +39,7 @@ export function act<T>(via: string, actor: (transaction: Transaction) => T): T {
 
         if (commits > MAX_CHAINED_COMMITS) {
             throw new TransactionFlowError(
-                `Transaction commits have cascaded ${MAX_CHAINED_COMMITS} times which likely indicates a logic error`,
+                `Transaction commits have cascaded ${MAX_CHAINED_COMMITS} times which likely indicates an infinite loop`,
             );
         }
 
@@ -299,14 +303,21 @@ class Tx implements Transaction {
             return this.rollback();
         }
 
-        const participants = [...this.#participants];
+        // Perform the actual commit once preCommit completes
+        const finalizeCommit = () => {
+            const participants = [...this.#participants];
+            const result = this.#finalize(Status.CommittingPhaseOne, "committed", this.#executeCommit.bind(this));
+            if (MaybePromise.is(result)) {
+                return result.then(() => this.#executePostCommit(participants));
+            }
+            return this.#executePostCommit(participants);
+        };
 
-        // Perform the actual commit
-        const result = this.#finalize(Status.CommittingPhaseOne, "committed", this.#executeCommit.bind(this));
+        const result = this.#executePreCommit();
         if (MaybePromise.is(result)) {
-            return result.then(() => this.#executePostCommit(participants));
+            return result.then(finalizeCommit);
         }
-        return this.#executePostCommit(participants);
+        return finalizeCommit();
     }
 
     rollback() {
@@ -392,7 +403,102 @@ class Tx implements Transaction {
     }
 
     /**
-     * Commit logic passed to #finish.
+     * Iteratively execute pre-commit until all participants "settle" and report no possible mutation.
+     */
+    #executePreCommit(): MaybePromise<void> {
+        let mayHaveMutated = false;
+        let abortedDueToError = false;
+        let iterator = this.participants[Symbol.iterator]();
+        let cycles = 1;
+
+        const errorRollback = () => {
+            const result = this.#executeRollback();
+
+            if (MaybePromise.is(result)) {
+                return result.then(() => {
+                    throw new FinalizationError("Rolled back due to pre-commit error");
+                });
+            }
+
+            throw new FinalizationError("Rolled back due to pre-commit error");
+        };
+
+        const nextCycle = () => {
+            // Guard against infinite loops
+            cycles++;
+            if (cycles > MAX_PRECOMMIT_CYCLES) {
+                logger.error(
+                    `State has not settled after ${MAX_PRECOMMIT_CYCLES} pre-commit cycles which likely indicates an infinite loop`,
+                );
+                return errorRollback();
+            }
+
+            // Restart iteration at the first participant
+            mayHaveMutated = false;
+            iterator = this.participants[Symbol.iterator]();
+        };
+
+        const nextPreCommit = (previousResult?: boolean): MaybePromise<void> => {
+            // If an error occurred
+            if (abortedDueToError) {
+                return;
+            }
+
+            // When resuming after an async pre-commit handler, "previousResult" is the handler's return value
+            // indicating whether mutation may have occurred
+            if (previousResult) {
+                mayHaveMutated = true;
+            }
+
+            // Cycle through participants until exhausted, there is an error or a pre-commit function is async
+            while (true) {
+                const n = iterator.next();
+
+                // If we've exhausted participants, we are either done or need to restart the cycle
+                if (n.done) {
+                    // Restart the cycle if necessary
+                    if (mayHaveMutated) {
+                        const result = nextCycle();
+                        if (MaybePromise.is(result)) {
+                            return result;
+                        }
+                        continue;
+                    }
+
+                    // Done
+                    break;
+                }
+
+                // Process the next participant
+                const participant = n.value;
+
+                // When an error occurs this function performs rollback then throws
+                const handleError = (error: any) => {
+                    abortedDueToError = true;
+                    logger.error(`Error pre-commit of ${participant}:`, error);
+                    return errorRollback();
+                };
+
+                // Execute the pre-commit for this participant
+                try {
+                    const result = participant.preCommit?.();
+                    if (MaybePromise.is(result)) {
+                        return Promise.resolve(result).catch(handleError).then(nextPreCommit);
+                    }
+                    if (result) {
+                        mayHaveMutated = true;
+                    }
+                } catch (e) {
+                    return handleError(e);
+                }
+            }
+        };
+
+        return nextPreCommit();
+    }
+
+    /**
+     * Commit logic passed to #finalize.
      */
     #executeCommit(): MaybePromise {
         //this.#log("commit");

--- a/packages/matter.js/src/common/FailsafeContext.ts
+++ b/packages/matter.js/src/common/FailsafeContext.ts
@@ -174,7 +174,7 @@ export abstract class FailsafeContext {
         await this.#construction;
         await this.#construction.close(async () => {
             if (this.#failsafe) {
-                this.#failsafe.close();
+                await this.#failsafe.close();
                 this.#failsafe = undefined;
                 await this.rollback();
             }

--- a/packages/matter.js/src/util/DeepCopy.ts
+++ b/packages/matter.js/src/util/DeepCopy.ts
@@ -1,0 +1,47 @@
+/**
+ * @license
+ * Copyright 2022-2024 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Create a deep copy of a data structure.
+ *
+ * Only copies enumerable properties.  Handles typed arrays and graphs.
+ */
+export function deepCopy<T>(value: T): T {
+    let clones: undefined | Map<unknown, unknown>;
+
+    function copy(value: unknown) {
+        if (typeof value === "object") {
+            if (value === null) {
+                return null;
+            }
+
+            let clone = clones?.get(value);
+            if (clone) {
+                return clone;
+            }
+
+            if (Array.isArray(value)) {
+                clone = [...value];
+            } else if (ArrayBuffer.isView(value)) {
+                const ViewType = value.constructor as new (buffer: ArrayBuffer) => unknown;
+                clone = new ViewType(value.buffer.slice(value.byteOffset, value.byteOffset + value.byteLength));
+            } else {
+                clone = { ...value };
+            }
+
+            if (!clones) {
+                clones = new Map();
+            }
+            clones.set(value, clone);
+
+            return clone;
+        }
+
+        return value;
+    }
+
+    return copy(value) as T;
+}

--- a/packages/matter.js/src/util/DeepEqual.ts
+++ b/packages/matter.js/src/util/DeepEqual.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// TODO - implement more efficient specialization for Array and ArrayBuffer
+// TODO - currently will hang on self-referential data structures
 export function isDeepEqual(a: any, b: any) {
     if (
         a === null ||
@@ -19,8 +21,7 @@ export function isDeepEqual(a: any, b: any) {
     const aProps = Object.getOwnPropertyNames(a);
     const bProps = Object.getOwnPropertyNames(b);
 
-    // If number of properties is different,
-    // objects are not equivalent
+    // If number of properties is different, objects are not equivalent
     if (aProps.length !== bProps.length) {
         return false;
     }
@@ -36,15 +37,13 @@ export function isDeepEqual(a: any, b: any) {
                 return false;
             }
         } else {
-            // If values of same property are not equal,
-            // objects are not equivalent
+            // If values of same property are not equal, objects are not equivalent
             if (a[propName] !== b[propName]) {
                 return false;
             }
         }
     }
 
-    // If we made it this far, objects
-    // are considered equal
+    // If we made it this far, objects are considered equal
     return true;
 }

--- a/packages/matter.js/test/behavior/cluster/ClusterBehaviorTest.ts
+++ b/packages/matter.js/test/behavior/cluster/ClusterBehaviorTest.ts
@@ -21,7 +21,7 @@ import { TlvBoolean } from "../../../src/tlv/TlvBoolean.js";
 import { TlvNullable } from "../../../src/tlv/TlvNullable.js";
 import { TlvInt32 } from "../../../src/tlv/TlvNumber.js";
 import { TlvString } from "../../../src/tlv/TlvString.js";
-import { BasicObservable, EventEmitter, Observable } from "../../../src/util/Observable.js";
+import { AsyncObservable, BasicObservable, EventEmitter, Observable } from "../../../src/util/Observable.js";
 import { MaybePromise } from "../../../src/util/Promises.js";
 import { MockEndpoint } from "../../endpoint/mock-endpoint.js";
 import { My, MyBehavior, MyCluster } from "./cluster-behavior-test-util.js";
@@ -98,7 +98,7 @@ describe("ClusterBehavior", () => {
 
             ({}) as MyBehavior satisfies {
                 events: EventEmitter & {
-                    reqAttr$Changed: Observable<[value: string, oldValue: string, context?: ActionContext]>;
+                    reqAttr$Changed: AsyncObservable<[value: string, oldValue: string, context?: ActionContext]>;
                 };
             };
 

--- a/packages/matter.js/test/behavior/cluster/ClusterEventsTest.ts
+++ b/packages/matter.js/test/behavior/cluster/ClusterEventsTest.ts
@@ -13,7 +13,8 @@ import { BasicInformationBehavior } from "../../../src/behavior/definitions/basi
 import { BasicInformationServer } from "../../../src/behavior/definitions/basic-information/BasicInformationServer.js";
 import { ClusterType } from "../../../src/cluster/ClusterType.js";
 import { BasicInformation } from "../../../src/cluster/definitions/BasicInformationCluster.js";
-import { EventEmitter, Observable } from "../../../src/util/Observable.js";
+import { AsyncObservable, EventEmitter, Observable } from "../../../src/util/Observable.js";
+import { MaybePromise } from "../../../src/util/Promises.js";
 import { MyCluster, MySchema } from "./cluster-behavior-test-util.js";
 
 const MyClusterWithOptEvent = MyCluster.enable({ events: { optEv: true } });
@@ -46,7 +47,7 @@ describe("ClusterEvents", () => {
 
         it("includes required", () => {
             ({}) as Ep satisfies EventEmitter & {
-                reqAttr$Changed: Observable<[value: string, oldValue: string, context?: ActionContext]>;
+                reqAttr$Changed: Observable<[value: string, oldValue: string, context?: ActionContext], MaybePromise>;
 
                 reqEv: Observable<[payload: string, context?: ActionContext]>;
             };
@@ -54,7 +55,7 @@ describe("ClusterEvents", () => {
 
         it("allows optional", () => {
             undefined satisfies Ep["optAttr$Changed"];
-            ({}) as Observable<[boolean, boolean, context: ActionContext]> satisfies Ep["optAttr$Changed"];
+            ({}) as AsyncObservable<[boolean, boolean, context: ActionContext]> satisfies Ep["optAttr$Changed"];
             undefined satisfies Ep["optEv"];
             ({}) as Observable<[string, context: ActionContext]> satisfies Ep["optEv"];
         });
@@ -104,7 +105,7 @@ describe("ClusterEvents", () => {
 
         it("requires mandatory", () => {
             ({}) as Ei satisfies {
-                reqAttr$Changed: Observable<[value: string, oldValue: string, context: ActionContext]>;
+                reqAttr$Changed: Observable<[value: string, oldValue: string, context: ActionContext], MaybePromise>;
 
                 reqEv: Observable<[payload: string, context: ActionContext]>;
             };
@@ -112,7 +113,7 @@ describe("ClusterEvents", () => {
 
         it("allows optional", () => {
             undefined satisfies Ei["optAttr$Changed"];
-            ({}) as Observable<[boolean, boolean, context: ActionContext]> satisfies Ei["optAttr$Changed"];
+            ({}) as AsyncObservable<[boolean, boolean, context: ActionContext]> satisfies Ei["optAttr$Changed"];
             undefined satisfies Ei["optEv"];
             ({}) as Observable<[string, context: ActionContext]> satisfies Ei["optEv"];
         });
@@ -146,7 +147,13 @@ describe("ClusterEvents", () => {
     describe("Properties", () => {
         it("specifies correct properties with enabled", () => {
             type Props = ClusterEvents.Properties<MyClusterWithOptEvent>;
-            ({}) as keyof Props satisfies "reqEv" | "optEv" | "reqAttr$Changed" | "optAttr$Changed";
+            ({}) as keyof Props satisfies
+                | "reqEv"
+                | "optEv"
+                | "reqAttr$Changing"
+                | "reqAttr$Changed"
+                | "optAttr$Changing"
+                | "optAttr$Changed";
             "" as "reqEv" | "optEv" | "reqAttr$Changed" | "optAttr$Changed" satisfies keyof Props;
         });
 

--- a/packages/matter.js/test/behavior/definitions/descriptor/DescriptorServerTest.ts
+++ b/packages/matter.js/test/behavior/definitions/descriptor/DescriptorServerTest.ts
@@ -77,9 +77,15 @@ describe("DescriptorServer", () => {
     it("adds servers automatically", async () => {
         const device = await MockEndpoint.create(MockEndpointType);
 
+        const promise = new Promise<void>(resolve => {
+            device.events.descriptor.serverList$Changed.once(() => {
+                resolve();
+            });
+        });
+
         device.behaviors.require(OnOffServer);
 
-        await device.events.descriptor.serverList$Changed;
+        await promise;
 
         expect(device.state.descriptor.serverList).deep.equals([29, 6]);
     });


### PR DESCRIPTION
- Transaction commit now supports a "pre-commit" phase that executes before phase-1 commit
- Adds attribute$Changing events to Behaviors that emit in transaction pre-commit
- $Changing events allow for state mutation and will cycle for a limited number of times until state is stable
- Datasource.reference now always returns the same managed value for a supervisor session
- Observable.isObserved allows for emitter optimization if an Observable has no observers
- Adds isObserved to ObservableProxy and moves into Observable.ts
- Fixes the floating promise in FailsafeTimer; it tended to kill a test run without an easy way to identify the cause
- Adds "deep copy" functionality for cloning an object.  Supports circular references and data views
- Includes a bunch of new tests for $Changing events