### PR TITLE
Sync LevelControl with chip #33204

### DIFF
--- a/packages/matter.js/src/behavior/definitions/level-control/LevelControlServer.ts
+++ b/packages/matter.js/src/behavior/definitions/level-control/LevelControlServer.ts
@@ -247,8 +247,7 @@ export class LevelControlServerLogic extends LevelControlLogicBase {
         if (!this.state.managedTransitionTimeHandling || rate === null) {
             // If null rate is requested and also no default rate is set, we should move as fast as possible, so we set
             // to min/max value directly. If rate 0 is requested no change on level should be done.
-            const level =
-                rate === 0 ? this.currentLevel : moveMode === LevelControl.MoveMode.Up ? this.maxLevel : this.minLevel;
+            const level = moveMode === LevelControl.MoveMode.Up ? this.maxLevel : this.minLevel;
             this.setRemainingTime(0);
             return this.setLevel(level, withOnOff);
         }

--- a/packages/matter.js/src/behavior/definitions/level-control/LevelControlServer.ts
+++ b/packages/matter.js/src/behavior/definitions/level-control/LevelControlServer.ts
@@ -199,10 +199,7 @@ export class LevelControlServerLogic extends LevelControlLogicBase {
     #determineEffectiveMoveRate(rate: number | null) {
         const effectiveRate = rate ?? this.state.defaultMoveRate ?? null;
         if (effectiveRate === 0) {
-            throw new StatusResponseError(
-                "A rate of 0 or null is invalid for a move command.",
-                StatusCode.InvalidCommand,
-            );
+            throw new StatusResponseError("A move rate of 0 is invalid.", StatusCode.InvalidCommand);
         }
         return effectiveRate;
     }

--- a/packages/matter.js/src/behavior/definitions/level-control/LevelControlServer.ts
+++ b/packages/matter.js/src/behavior/definitions/level-control/LevelControlServer.ts
@@ -196,6 +196,17 @@ export class LevelControlServerLogic extends LevelControlLogicBase {
         );
     }
 
+    #determineEffectiveMoveRate(rate: number | null) {
+        const effectiveRate = rate ?? this.state.defaultMoveRate ?? null;
+        if (effectiveRate === 0) {
+            throw new StatusResponseError(
+                "A rate of 0 or null is invalid for a move command.",
+                StatusCode.InvalidCommand,
+            );
+        }
+        return effectiveRate;
+    }
+
     /**
      * Default implementation notes:
      * After the options checks it uses the {@link moveLogic} method to set the level.
@@ -209,15 +220,7 @@ export class LevelControlServerLogic extends LevelControlLogicBase {
             return;
         }
 
-        const effectiveRate = rate ?? this.state.defaultMoveRate ?? null;
-        if (effectiveRate === 0) {
-            throw new StatusResponseError(
-                "A rate of 0 or null is invalid for a move command.",
-                StatusCode.InvalidCommand,
-            );
-        }
-
-        return this.moveLogic(moveMode, effectiveRate, false);
+        return this.moveLogic(moveMode, this.#determineEffectiveMoveRate(rate), false);
     }
 
     /**
@@ -229,15 +232,7 @@ export class LevelControlServerLogic extends LevelControlLogicBase {
      * level is increased or decreased by the step size every second.
      */
     override moveWithOnOff({ moveMode, rate }: MoveWithOnOffRequest) {
-        const effectiveRate = rate ?? this.state.defaultMoveRate ?? null;
-        if (effectiveRate === 0) {
-            throw new StatusResponseError(
-                "A rate of 0 or null is invalid for a move command.",
-                StatusCode.InvalidCommand,
-            );
-        }
-
-        return this.moveLogic(moveMode, effectiveRate, true);
+        return this.moveLogic(moveMode, this.#determineEffectiveMoveRate(rate), true);
     }
 
     /**


### PR DESCRIPTION
With https://github.com/project-chip/connectedhomeip/pull/33204 the behavior for rate = 0 slightly changes, so this PR brings this in sync.

@lauckhart Please check and approve, sothat I can merge whenever the otehr PR got merged, because tests will fail afterwards for all PRs (ok and now this PR before the merge too) :-)