### PR TITLE
Log params with objects correctly for invokes

### DIFF
--- a/packages/matter.js/src/log/Format.ts
+++ b/packages/matter.js/src/log/Format.ts
@@ -9,6 +9,7 @@ import { ImplementationError, InternalError } from "../common/MatterError.js";
 import { ByteArray } from "../util/ByteArray.js";
 import { Diagnostic } from "./Diagnostic.js";
 import { Level } from "./Level.js";
+import { Logger } from "./Logger.js";
 
 /**
  * Get a formatter for the specified format.
@@ -418,6 +419,9 @@ function renderValue(value: unknown, formatter: Formatter, squash: boolean): str
                 return renderDiagnostic(e, formatter);
             })
             .join(squash ? "" : " ");
+    }
+    if (typeof value === "object") {
+        return formatter.text(Logger.toJSON(value));
     }
 
     const text = typeof value === "string" || value instanceof String ? value : value.toString().trim();

--- a/packages/matter.js/src/log/Format.ts
+++ b/packages/matter.js/src/log/Format.ts
@@ -7,9 +7,9 @@
 import { Lifecycle } from "../common/Lifecycle.js";
 import { ImplementationError, InternalError } from "../common/MatterError.js";
 import { ByteArray } from "../util/ByteArray.js";
+import { serialize } from "../util/String.js";
 import { Diagnostic } from "./Diagnostic.js";
 import { Level } from "./Level.js";
-import { Logger } from "./Logger.js";
 
 /**
  * Get a formatter for the specified format.
@@ -420,8 +420,11 @@ function renderValue(value: unknown, formatter: Formatter, squash: boolean): str
             })
             .join(squash ? "" : " ");
     }
+    if (value instanceof Date) {
+        return formatter.text(formatTime(value));
+    }
     if (typeof value === "object") {
-        return formatter.text(Logger.toJSON(value));
+        return formatter.text(serialize(value) ?? "undefined");
     }
 
     const text = typeof value === "string" || value instanceof String ? value : value.toString().trim();


### PR DESCRIPTION
When invoke data contained sub objects these were not correctly logged, e.g.

> Invoke binford-6100.onoff1.colorControl.moveToColorTemperature online#9065e96@1b669 colorTemperatureMireds: 32639 transitionTime: 0 optionsMask: [object Object] optionsOverride: [object Object]


With this change it loggs it as

> Invoke binford-6100.onoff1.colorControl.moveToColor online#5d3525a@1b669 colorX: 33000 colorY: 20000 transitionTime: 0 optionsMask: {"executeIfOff":false} optionsOverride: {"executeIfOff":false}

... still not perfect but better. I decided for now to not enhance the whole logging to support such sub structs (or did I miss anything?)

@lauckhart  if you have a better idea just shoot