### PR TITLE
Adding On demand Certificate determination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,9 +26,13 @@ The main work (all changes without a GitHub username in brackets in the below li
   * Enhancement: Adds additional logging information for PASE and CASE to better understand errors without debug logging
   * Enhancement: Adds several Optimizations and adjustments for Obervers (e.g. Observable.isObserved)
   * Fix: Corrects returned errors for two commands on OperationalCredentials cluster 
-* matter.js New API code flows:
+* matter.js Legacy API:
+  * Breaking: The object type for providing custom production certificates has changed to be now in sync with the DeviceCertification class (just the property names changed)
+  * Feature: Added on demand certification determination via an async certificate provider method (alternative to provideing certs directly) to determine certificates on first commissioning request
+* matter.js New API:
   * Breaking: The name of the *$Change Events for attributes and such are changed to *$Changed . Please adjust your code!
   * Breaking: Introduced ExtensionInterface to define extensible/custom methods for behavior/Cluster-Server implementation to be available when extending this class (needed because of a TS bug 27965)
+  * Feature: Added on demand certification determination via an async certificate provider method (alternative to provideing certs directly) to determine certificates on first commissioning request
   * Enhancement: Optimized constraint validations and conformance error messages
   * Enhancement: Conditionally enables the ReachableChanged event on the Root Endpoint BasicInformation cluster if the reachable attribute is defined in the defaults
   * Enhancement: Allow to register events directly when initializing endpoints like in legacy API

--- a/packages/matter.js/src/CommissioningServer.ts
+++ b/packages/matter.js/src/CommissioningServer.ts
@@ -169,12 +169,7 @@ export interface CommissioningServerOptions {
      * Vendor specific certificates to be used for the OperationalCredentials cluster. If not set Test certificates
      * (official Chip tool test Root certificate is used) are generated automatically.
      */
-    certificates?: {
-        devicePrivateKey: ByteArray;
-        deviceCertificate: ByteArray;
-        deviceIntermediateCertificate: ByteArray;
-        certificationDeclaration: ByteArray;
-    };
+    certificates?: DeviceCertification.Configuration | DeviceCertification.ProviderFunction;
 
     /**
      * Optional configuration for the GeneralCommissioning cluster. If not set the default values are used.
@@ -222,7 +217,6 @@ export class CommissioningServer extends MatterNode {
     private readonly discriminator: number;
     private readonly flowType: CommissioningFlowType;
     private readonly productDescription: ProductDescription;
-    private readonly certification: DeviceCertification;
 
     private storage?: StorageContext<SyncStorage>;
     private endpointStructureStorage?: StorageContext<SyncStorage>;
@@ -319,13 +313,13 @@ export class CommissioningServer extends MatterNode {
         if (certificates == undefined) {
             const paa = new AttestationCertificateManager(vendorId);
             const { keyPair: dacKeyPair, dac } = paa.getDACert(productId);
-            const certificationDeclaration = CertificationDeclarationManager.generate(vendorId, productId);
+            const declaration = CertificationDeclarationManager.generate(vendorId, productId);
 
             certificates = {
-                devicePrivateKey: dacKeyPair.privateKey,
-                deviceCertificate: dac,
-                deviceIntermediateCertificate: paa.getPAICert(),
-                certificationDeclaration,
+                privateKey: dacKeyPair.privateKey,
+                certificate: dac,
+                intermediateCertificate: paa.getPAICert(),
+                declaration,
             };
         }
 
@@ -335,16 +329,6 @@ export class CommissioningServer extends MatterNode {
             vendorId: vendorId,
             productId: productId,
         };
-
-        this.certification = new DeviceCertification(
-            {
-                certificate: certificates.deviceCertificate,
-                declaration: certificates.certificationDeclaration,
-                intermediateCertificate: certificates.deviceIntermediateCertificate,
-                privateKey: certificates.devicePrivateKey,
-            },
-            this.productDescription,
-        );
 
         // Add Operational credentials cluster to root directly because it is not allowed to be changed afterward
         // TODO Get the defaults from the cluster meta details
@@ -359,7 +343,7 @@ export class CommissioningServer extends MatterNode {
                     trustedRootCertificates: [],
                     currentFabricIndex: FabricIndex.NO_FABRIC,
                 },
-                OperationalCredentialsClusterHandler(this.certification),
+                OperationalCredentialsClusterHandler(certificates, this.productDescription),
             ),
         );
 

--- a/packages/matter.js/src/behavior/definitions/operational-credentials/DeviceCertification.ts
+++ b/packages/matter.js/src/behavior/definitions/operational-credentials/DeviceCertification.ts
@@ -11,6 +11,7 @@ import { ImplementationError } from "../../../common/MatterError.js";
 import { Crypto } from "../../../crypto/Crypto.js";
 import { PrivateKey } from "../../../crypto/Key.js";
 import { SecureSession } from "../../../session/SecureSession.js";
+import { AsyncConstruction } from "../../../util/AsyncConstruction.js";
 import { ByteArray } from "../../../util/ByteArray.js";
 import { ProductDescription } from "../../system/product-description/ProductDescription.js";
 
@@ -18,31 +19,46 @@ import { ProductDescription } from "../../system/product-description/ProductDesc
  * Device certification used by the OperationalCredentials cluster.
  */
 export class DeviceCertification {
-    #privateKey: PrivateKey;
-    #certificate: ByteArray;
-    #intermediateCertificate: ByteArray;
-    #declaration: ByteArray;
+    #privateKey?: PrivateKey;
+    #certificate?: ByteArray;
+    #intermediateCertificate?: ByteArray;
+    #declaration?: ByteArray;
+    #construction: AsyncConstruction<DeviceCertification>;
+
+    get construction() {
+        return this.#construction;
+    }
 
     get certificate() {
-        return this.#certificate;
+        return this.#assertInitialized().certificate;
     }
 
     get intermediateCertificate() {
-        return this.#intermediateCertificate;
+        return this.#assertInitialized().intermediateCertificate;
     }
 
     get declaration() {
-        return this.#declaration;
+        return this.#assertInitialized().declaration;
     }
 
-    constructor(config?: DeviceCertification.Configuration, product?: ProductDescription) {
-        if (config) {
-            this.#privateKey =
-                config.privateKey instanceof ByteArray ? PrivateKey(config.privateKey) : config.privateKey;
-            this.#certificate = config.certificate;
-            this.#intermediateCertificate = config.intermediateCertificate;
-            this.#declaration = config.declaration;
-        } else {
+    constructor(
+        config?: DeviceCertification.Configuration | DeviceCertification.ProviderFunction,
+        product?: ProductDescription,
+    ) {
+        // Certification Provider function is used to request the certificates delayed
+        if (typeof config === "function") {
+            const configProvider = config;
+            this.#construction = AsyncConstruction(this, async () => {
+                this.#initializeFromConfig(await configProvider());
+            });
+            return;
+        }
+
+        // We need a dummy construction to avoid errors
+        this.#construction = AsyncConstruction(this, () => {});
+
+        // With a directly provided config or without we con initialize directly
+        if (config === undefined) {
             if (product === undefined) {
                 throw new ImplementationError(`Cannot generate device certification without product information`);
             }
@@ -50,15 +66,47 @@ export class DeviceCertification {
             const paa = new AttestationCertificateManager(product.vendorId);
             const { keyPair: dacKeyPair, dac } = paa.getDACert(product.productId);
 
-            this.#privateKey = PrivateKey(dacKeyPair.privateKey);
-            this.#certificate = dac;
-            this.#intermediateCertificate = paa.getPAICert();
-            this.#declaration = CertificationDeclarationManager.generate(product.vendorId, product.productId);
+            config = {
+                privateKey: PrivateKey(dacKeyPair.privateKey),
+                certificate: dac,
+                intermediateCertificate: paa.getPAICert(),
+                declaration: CertificationDeclarationManager.generate(product.vendorId, product.productId),
+            };
         }
+        this.#initializeFromConfig(config);
+    }
+
+    #initializeFromConfig(config: DeviceCertification.Configuration) {
+        this.#privateKey = config.privateKey instanceof ByteArray ? PrivateKey(config.privateKey) : config.privateKey;
+        this.#certificate = config.certificate;
+        this.#intermediateCertificate = config.intermediateCertificate;
+        this.#declaration = config.declaration;
     }
 
     sign(session: SecureSession<MatterDevice>, data: ByteArray) {
-        return Crypto.sign(this.#privateKey, [data, session.getAttestationChallengeKey()]);
+        return Crypto.sign(this.#assertInitialized().privateKey, [data, session.getAttestationChallengeKey()]);
+    }
+
+    /**
+     * Makes sure that the device certification is initialized and construction is completed and returns "Non undefined"
+     * values
+     */
+    #assertInitialized() {
+        this.#construction.assert();
+        if (
+            this.#certificate === undefined ||
+            this.#intermediateCertificate === undefined ||
+            this.#declaration === undefined ||
+            this.#privateKey === undefined
+        ) {
+            throw new ImplementationError(`Device certification not initialized`);
+        }
+        return {
+            certificate: this.#certificate,
+            intermediateCertificate: this.#intermediateCertificate,
+            declaration: this.#declaration,
+            privateKey: this.#privateKey,
+        };
     }
 }
 
@@ -69,4 +117,6 @@ export namespace DeviceCertification {
         intermediateCertificate: ByteArray;
         declaration: ByteArray;
     }
+
+    export type ProviderFunction = () => Promise<DeviceCertification.Configuration>;
 }

--- a/packages/matter.js/src/cluster/server/OperationalCredentialsServer.ts
+++ b/packages/matter.js/src/cluster/server/OperationalCredentialsServer.ts
@@ -11,6 +11,7 @@ import {
     TlvAttestation,
     TlvCertSigningRequest,
 } from "../../behavior/definitions/operational-credentials/OperationalCredentialsTypes.js";
+import { ProductDescription } from "../../behavior/system/product-description/ProductDescription.js";
 import { CertificateError } from "../../certificate/CertificateManager.js";
 import { MatterFabricConflictError } from "../../common/FailsafeTimer.js";
 import { MatterFlowError, UnexpectedDataError } from "../../common/MatterError.js";
@@ -59,404 +60,426 @@ OperationalCredentials.Cluster.commands = {
 };
 
 export const OperationalCredentialsClusterHandler: (
-    cert: DeviceCertification,
-) => ClusterServerHandlers<typeof OperationalCredentials.Cluster> = cert => ({
-    attestationRequest: async ({ request: { attestationNonce }, session }) => {
-        if (attestationNonce.length !== 32) {
-            throw new StatusResponseError("Invalid attestation nonce length", StatusCode.InvalidCommand);
+    certificates: DeviceCertification.Configuration | DeviceCertification.ProviderFunction,
+    productDescription?: ProductDescription,
+) => ClusterServerHandlers<typeof OperationalCredentials.Cluster> = (certificates, productDescription) => {
+    let certification: DeviceCertification | undefined = undefined;
+    const cert = () => {
+        if (certification !== undefined) {
+            return certification;
         }
-        assertSecureSession(session);
-        const elements = TlvAttestation.encode({
-            declaration: cert.declaration,
-            attestationNonce,
-            timestamp: 0,
-        });
-        return { attestationElements: elements, attestationSignature: cert.sign(session, elements) };
-    },
+        return (certification = new DeviceCertification(certificates, productDescription));
+    };
 
-    csrRequest: async ({ request: { csrNonce, isForUpdateNoc }, session }) => {
-        if (csrNonce.length !== 32) {
-            throw new StatusResponseError("Invalid CSR nonce length", StatusCode.InvalidCommand);
+    const assureCertification = async () => {
+        if (!cert().construction.ready) {
+            return cert().construction;
         }
-        assertSecureSession(session);
-        if (isForUpdateNoc && session.isPase) {
-            throw new StatusResponseError(
-                "csrRequest for UpdateNoc received on a PASE session.",
-                StatusCode.InvalidCommand,
-            );
-        }
-        const device = session.context;
-        device.assertFailSafeArmed("csrRequest received while failsafe is not armed.");
+    };
 
-        const timedOp = device.failsafeContext;
-        if (timedOp.fabricIndex !== undefined) {
-            throw new StatusResponseError(
-                `csrRequest received after ${timedOp.forUpdateNoc ? "UpdateNOC" : "AddNOC"} already invoked.`,
-                StatusCode.ConstraintError,
-            );
-        }
+    return {
+        attestationRequest: async ({ request: { attestationNonce }, session }) => {
+            if (attestationNonce.length !== 32) {
+                throw new StatusResponseError("Invalid attestation nonce length", StatusCode.InvalidCommand);
+            }
+            assertSecureSession(session);
+            await assureCertification();
+            const elements = TlvAttestation.encode({
+                declaration: cert().declaration,
+                attestationNonce,
+                timestamp: 0,
+            });
+            return { attestationElements: elements, attestationSignature: cert().sign(session, elements) };
+        },
 
-        const certSigningRequest = timedOp.createCertificateSigningRequest(isForUpdateNoc ?? false, session.id);
-        const nocsrElements = TlvCertSigningRequest.encode({ certSigningRequest, csrNonce });
-        return { nocsrElements, attestationSignature: cert.sign(session, nocsrElements) };
-    },
-
-    certificateChainRequest: async ({ request: { certificateType } }) => {
-        switch (certificateType) {
-            case OperationalCredentials.CertificateChainType.DacCertificate:
-                return { certificate: cert.certificate };
-            case OperationalCredentials.CertificateChainType.PaiCertificate:
-                return { certificate: cert.intermediateCertificate };
-            default:
+        csrRequest: async ({ request: { csrNonce, isForUpdateNoc }, session }) => {
+            if (csrNonce.length !== 32) {
+                throw new StatusResponseError("Invalid CSR nonce length", StatusCode.InvalidCommand);
+            }
+            assertSecureSession(session);
+            if (isForUpdateNoc && session.isPase) {
                 throw new StatusResponseError(
-                    `Unsupported certificate type: ${certificateType}`,
+                    "csrRequest for UpdateNoc received on a PASE session.",
                     StatusCode.InvalidCommand,
                 );
-        }
-    },
+            }
+            const device = session.context;
+            device.assertFailSafeArmed("csrRequest received while failsafe is not armed.");
 
-    addNoc: async ({
-        request: { nocValue, icacValue, ipkValue, caseAdminSubject, adminVendorId },
-        attributes: { nocs, commissionedFabrics, fabrics, trustedRootCertificates, supportedFabrics },
-        session,
-    }) => {
-        if (!session.isSecure) throw new MatterFlowError("addOperationalCert should be called on a secure session.");
+            const timedOp = device.failsafeContext;
+            if (timedOp.fabricIndex !== undefined) {
+                throw new StatusResponseError(
+                    `csrRequest received after ${timedOp.forUpdateNoc ? "UpdateNOC" : "AddNOC"} already invoked.`,
+                    StatusCode.ConstraintError,
+                );
+            }
 
-        const device = session.context;
+            await assureCertification();
 
-        const failsafeContext = device.failsafeContext;
+            const certSigningRequest = timedOp.createCertificateSigningRequest(isForUpdateNoc ?? false, session.id);
+            const nocsrElements = TlvCertSigningRequest.encode({ certSigningRequest, csrNonce });
+            return { nocsrElements, attestationSignature: cert().sign(session, nocsrElements) };
+        },
 
-        if (failsafeContext.fabricIndex !== undefined) {
-            throw new StatusResponseError(
-                `addNoc received after ${failsafeContext.forUpdateNoc ? "UpdateNOC" : "AddNOC"} already invoked.`,
-                StatusCode.ConstraintError,
-            );
-        }
+        certificateChainRequest: async ({ request: { certificateType } }) => {
+            await assureCertification();
+            switch (certificateType) {
+                case OperationalCredentials.CertificateChainType.DacCertificate:
+                    return { certificate: cert().certificate };
+                case OperationalCredentials.CertificateChainType.PaiCertificate:
+                    return { certificate: cert().intermediateCertificate };
+                default:
+                    throw new StatusResponseError(
+                        `Unsupported certificate type: ${certificateType}`,
+                        StatusCode.InvalidCommand,
+                    );
+            }
+        },
 
-        if (!failsafeContext.hasRootCert) {
-            return {
-                statusCode: OperationalCredentials.NodeOperationalCertStatus.InvalidNoc,
-                debugText: "Root certificate not found.",
-            };
-        }
+        addNoc: async ({
+            request: { nocValue, icacValue, ipkValue, caseAdminSubject, adminVendorId },
+            attributes: { nocs, commissionedFabrics, fabrics, trustedRootCertificates, supportedFabrics },
+            session,
+        }) => {
+            if (!session.isSecure)
+                throw new MatterFlowError("addOperationalCert should be called on a secure session.");
 
-        if (failsafeContext.csrSessionId !== session.id) {
-            return {
-                statusCode: OperationalCredentials.NodeOperationalCertStatus.MissingCsr,
-                debugText: "CSR not found in failsafe context.",
-            };
-        }
+            const device = session.context;
 
-        if (failsafeContext.forUpdateNoc) {
-            throw new StatusResponseError(
-                `addNoc received after csr request was invoked for UpdateNOC.`,
-                StatusCode.ConstraintError,
-            );
-        }
+            const failsafeContext = device.failsafeContext;
 
-        if (device.getFabrics().length === supportedFabrics.getLocal()) {
-            return {
-                statusCode: OperationalCredentials.NodeOperationalCertStatus.TableFull,
-                debugText: `No more fabrics can be added because limit ${supportedFabrics.getLocal()} reached.`,
-            };
-        }
+            if (failsafeContext.fabricIndex !== undefined) {
+                throw new StatusResponseError(
+                    `addNoc received after ${failsafeContext.forUpdateNoc ? "UpdateNOC" : "AddNOC"} already invoked.`,
+                    StatusCode.ConstraintError,
+                );
+            }
 
-        let fabric;
-        try {
-            fabric = await failsafeContext.buildFabric({
-                nocValue,
-                icacValue,
-                adminVendorId,
-                ipkValue,
-                caseAdminSubject,
-            });
-        } catch (error) {
-            logger.info("building fabric failed", error);
-            if (error instanceof MatterFabricConflictError) {
-                return {
-                    statusCode: OperationalCredentials.NodeOperationalCertStatus.FabricConflict,
-                    debugText: error.message,
-                };
-            } else if (error instanceof FabricTableFullError) {
-                return {
-                    statusCode: OperationalCredentials.NodeOperationalCertStatus.TableFull,
-                    debugText: error.message,
-                };
-            } else if (
-                error instanceof CertificateError ||
-                error instanceof ValidationError ||
-                error instanceof UnexpectedDataError
-            ) {
+            if (!failsafeContext.hasRootCert) {
                 return {
                     statusCode: OperationalCredentials.NodeOperationalCertStatus.InvalidNoc,
-                    debugText: error.message,
-                };
-            } else if (error instanceof PublicKeyError) {
-                return {
-                    statusCode: OperationalCredentials.NodeOperationalCertStatus.InvalidPublicKey,
-                    debugText: error.message,
+                    debugText: "Root certificate not found.",
                 };
             }
-            throw error;
-        }
-        await failsafeContext.addFabric(fabric);
 
-        assertSecureSession(session);
-        if (session.isPase) {
-            logger.debug(`Add Fabric with index ${fabric.fabricIndex} to PASE session ${session.name}.`);
-            session.addAssociatedFabric(fabric);
-        }
+            if (failsafeContext.csrSessionId !== session.id) {
+                return {
+                    statusCode: OperationalCredentials.NodeOperationalCertStatus.MissingCsr,
+                    debugText: "CSR not found in failsafe context.",
+                };
+            }
 
-        // Update connected attributes
-        nocs.updated(session);
-        commissionedFabrics.updated(session);
-        fabrics.updated(session);
-        trustedRootCertificates.updated(session);
+            if (failsafeContext.forUpdateNoc) {
+                throw new StatusResponseError(
+                    `addNoc received after csr request was invoked for UpdateNOC.`,
+                    StatusCode.ConstraintError,
+                );
+            }
 
-        // TODO: The receiver SHALL create and add a new Access Control Entry using the CaseAdminSubject field to grant
-        //  subsequent Administer access to an Administrator member of the new Fabric. It is RECOMMENDED that the
-        //  Administrator presented in CaseAdminSubject exist within the same entity that is currently invoking the
-        //  AddNOC command, within another of the Fabrics of which it is a member.
+            if (device.getFabrics().length === supportedFabrics.getLocal()) {
+                return {
+                    statusCode: OperationalCredentials.NodeOperationalCertStatus.TableFull,
+                    debugText: `No more fabrics can be added because limit ${supportedFabrics.getLocal()} reached.`,
+                };
+            }
 
-        // TODO The incoming IPKValue SHALL be stored in the Fabric-scoped slot within the Group Key Management cluster
-        //  (see KeySetWrite), for subsequent use during CASE.
+            let fabric;
+            try {
+                fabric = await failsafeContext.buildFabric({
+                    nocValue,
+                    icacValue,
+                    adminVendorId,
+                    ipkValue,
+                    caseAdminSubject,
+                });
+            } catch (error) {
+                logger.info("building fabric failed", error);
+                if (error instanceof MatterFabricConflictError) {
+                    return {
+                        statusCode: OperationalCredentials.NodeOperationalCertStatus.FabricConflict,
+                        debugText: error.message,
+                    };
+                } else if (error instanceof FabricTableFullError) {
+                    return {
+                        statusCode: OperationalCredentials.NodeOperationalCertStatus.TableFull,
+                        debugText: error.message,
+                    };
+                } else if (
+                    error instanceof CertificateError ||
+                    error instanceof ValidationError ||
+                    error instanceof UnexpectedDataError
+                ) {
+                    return {
+                        statusCode: OperationalCredentials.NodeOperationalCertStatus.InvalidNoc,
+                        debugText: error.message,
+                    };
+                } else if (error instanceof PublicKeyError) {
+                    return {
+                        statusCode: OperationalCredentials.NodeOperationalCertStatus.InvalidPublicKey,
+                        debugText: error.message,
+                    };
+                }
+                throw error;
+            }
+            await failsafeContext.addFabric(fabric);
 
-        // TODO If the current secure session was established with PASE, the receiver SHALL:
-        //  a. Augment the secure session context with the FabricIndex generated above, such that subsequent interactions
-        //     have the proper accessing fabric.
-
-        logger.info(`addNoc success, adminVendorId ${adminVendorId}, caseAdminSubject ${caseAdminSubject}`);
-
-        return { statusCode: OperationalCredentials.NodeOperationalCertStatus.Ok, fabricIndex: fabric.fabricIndex };
-    },
-
-    fabricsAttributeGetter: ({ session, isFabricFiltered }) => {
-        if (session === undefined || !session.isSecure) return []; // ???
-        const fabrics = isFabricFiltered ? [session.associatedFabric] : session.context.getFabrics();
-
-        return fabrics.map(fabric => ({
-            fabricId: fabric.fabricId,
-            label: fabric.label,
-            nodeId: fabric.nodeId,
-            rootPublicKey: fabric.rootPublicKey,
-            vendorId: fabric.rootVendorId,
-            fabricIndex: fabric.fabricIndex,
-        }));
-    },
-
-    // Needed because FabricScopedAttributeServer clas requires both getter and setter if custom
-    fabricsAttributeSetter: () => {
-        throw new MatterFlowError("fabrics attribute is read-only.");
-    },
-
-    nocsAttributeGetter: ({ session, isFabricFiltered }) => {
-        if (session === undefined || !session.isSecure) return []; // ???
-        const fabrics = isFabricFiltered ? [session.associatedFabric] : session.context.getFabrics();
-        return fabrics.map(fabric => ({
-            noc: fabric.operationalCert,
-            icac: fabric.intermediateCACert ?? null,
-            fabricIndex: fabric.fabricIndex,
-        }));
-    },
-
-    // Needed because FabricScopedAttributeServer clas requires both getter and setter if custom
-    nocsAttributeSetter: () => {
-        throw new MatterFlowError("fabrics attribute is read-only.");
-    },
-
-    commissionedFabricsAttributeGetter: ({ session }) => {
-        if (session === undefined || !session.isSecure) return 0; // ???
-        return session.context.getFabrics().length;
-    },
-
-    trustedRootCertificatesAttributeGetter: ({ session, isFabricFiltered }) => {
-        if (session === undefined || !session.isSecure) return []; // ???
-        const fabrics = isFabricFiltered ? [session.associatedFabric] : session.context.getFabrics();
-        return fabrics.map(fabric => fabric.rootCert);
-    },
-
-    currentFabricIndexAttributeGetter: ({ session }) => {
-        if (session === undefined || !session.isSecure) return FabricIndex.NO_FABRIC;
-        assertSecureSession(session);
-        return session.fabric?.fabricIndex ?? FabricIndex.NO_FABRIC;
-    },
-
-    updateNoc: async ({ request: { nocValue, icacValue }, attributes: { nocs, fabrics }, session }) => {
-        assertSecureSession(session);
-
-        tryCatch(
-            () => session.associatedFabric,
-            NoAssociatedFabricError,
-            () => {
-                throw new StatusResponseError("No associated fabric existing", StatusCode.UnsupportedAccess);
-            },
-        );
-
-        const device = session.context;
-
-        const failsafeContext = device.failsafeContext;
-
-        if (failsafeContext.fabricIndex !== undefined) {
-            throw new StatusResponseError(
-                `updateNoc received after ${failsafeContext.forUpdateNoc ? "UpdateNOC" : "AddNOC"} already invoked.`,
-                StatusCode.ConstraintError,
-            );
-        }
-
-        if (failsafeContext.forUpdateNoc) {
-            throw new StatusResponseError(
-                `addNoc received after csr request was invoked for UpdateNOC.`,
-                StatusCode.ConstraintError,
-            );
-        }
-
-        if (failsafeContext.hasRootCert) {
-            throw new StatusResponseError(
-                "Trusted root certificate added in this session which is now allowed for UpdateNOC.",
-                StatusCode.ConstraintError,
-            );
-        }
-
-        if (!failsafeContext.forUpdateNoc) {
-            throw new StatusResponseError("csrRequest not invoked for UpdateNOC.", StatusCode.ConstraintError);
-        }
-
-        if (session.associatedFabric.fabricIndex !== failsafeContext.associatedFabric?.fabricIndex) {
-            throw new StatusResponseError(
-                "Fabric of this session and the failsafe context do not match.",
-                StatusCode.ConstraintError,
-            );
-        }
-
-        try {
-            // Build a new Fabric with the updated NOC and ICAC
-            const updateFabric = await failsafeContext.buildUpdatedFabric(nocValue, icacValue);
-
-            // update FabricManager and Resumption records but leave current session intact
-            await failsafeContext.updateFabric(updateFabric);
+            assertSecureSession(session);
+            if (session.isPase) {
+                logger.debug(`Add Fabric with index ${fabric.fabricIndex} to PASE session ${session.name}.`);
+                session.addAssociatedFabric(fabric);
+            }
 
             // Update connected attributes
             nocs.updated(session);
+            commissionedFabrics.updated(session);
             fabrics.updated(session);
+            trustedRootCertificates.updated(session);
+
+            // TODO: The receiver SHALL create and add a new Access Control Entry using the CaseAdminSubject field to grant
+            //  subsequent Administer access to an Administrator member of the new Fabric. It is RECOMMENDED that the
+            //  Administrator presented in CaseAdminSubject exist within the same entity that is currently invoking the
+            //  AddNOC command, within another of the Fabrics of which it is a member.
+
+            // TODO The incoming IPKValue SHALL be stored in the Fabric-scoped slot within the Group Key Management cluster
+            //  (see KeySetWrite), for subsequent use during CASE.
+
+            // TODO If the current secure session was established with PASE, the receiver SHALL:
+            //  a. Augment the secure session context with the FabricIndex generated above, such that subsequent interactions
+            //     have the proper accessing fabric.
+
+            logger.info(`addNoc success, adminVendorId ${adminVendorId}, caseAdminSubject ${caseAdminSubject}`);
+
+            return { statusCode: OperationalCredentials.NodeOperationalCertStatus.Ok, fabricIndex: fabric.fabricIndex };
+        },
+
+        fabricsAttributeGetter: ({ session, isFabricFiltered }) => {
+            if (session === undefined || !session.isSecure) return []; // ???
+            const fabrics = isFabricFiltered ? [session.associatedFabric] : session.context.getFabrics();
+
+            return fabrics.map(fabric => ({
+                fabricId: fabric.fabricId,
+                label: fabric.label,
+                nodeId: fabric.nodeId,
+                rootPublicKey: fabric.rootPublicKey,
+                vendorId: fabric.rootVendorId,
+                fabricIndex: fabric.fabricIndex,
+            }));
+        },
+
+        // Needed because FabricScopedAttributeServer clas requires both getter and setter if custom
+        fabricsAttributeSetter: () => {
+            throw new MatterFlowError("fabrics attribute is read-only.");
+        },
+
+        nocsAttributeGetter: ({ session, isFabricFiltered }) => {
+            if (session === undefined || !session.isSecure) return []; // ???
+            const fabrics = isFabricFiltered ? [session.associatedFabric] : session.context.getFabrics();
+            return fabrics.map(fabric => ({
+                noc: fabric.operationalCert,
+                icac: fabric.intermediateCACert ?? null,
+                fabricIndex: fabric.fabricIndex,
+            }));
+        },
+
+        // Needed because FabricScopedAttributeServer clas requires both getter and setter if custom
+        nocsAttributeSetter: () => {
+            throw new MatterFlowError("fabrics attribute is read-only.");
+        },
+
+        commissionedFabricsAttributeGetter: ({ session }) => {
+            if (session === undefined || !session.isSecure) return 0; // ???
+            return session.context.getFabrics().length;
+        },
+
+        trustedRootCertificatesAttributeGetter: ({ session, isFabricFiltered }) => {
+            if (session === undefined || !session.isSecure) return []; // ???
+            const fabrics = isFabricFiltered ? [session.associatedFabric] : session.context.getFabrics();
+            return fabrics.map(fabric => fabric.rootCert);
+        },
+
+        currentFabricIndexAttributeGetter: ({ session }) => {
+            if (session === undefined || !session.isSecure) return FabricIndex.NO_FABRIC;
+            assertSecureSession(session);
+            return session.fabric?.fabricIndex ?? FabricIndex.NO_FABRIC;
+        },
+
+        updateNoc: async ({ request: { nocValue, icacValue }, attributes: { nocs, fabrics }, session }) => {
+            assertSecureSession(session);
+
+            tryCatch(
+                () => session.associatedFabric,
+                NoAssociatedFabricError,
+                () => {
+                    throw new StatusResponseError("No associated fabric existing", StatusCode.UnsupportedAccess);
+                },
+            );
+
+            const device = session.context;
+
+            const failsafeContext = device.failsafeContext;
+
+            if (failsafeContext.fabricIndex !== undefined) {
+                throw new StatusResponseError(
+                    `updateNoc received after ${failsafeContext.forUpdateNoc ? "UpdateNOC" : "AddNOC"} already invoked.`,
+                    StatusCode.ConstraintError,
+                );
+            }
+
+            if (failsafeContext.forUpdateNoc) {
+                throw new StatusResponseError(
+                    `addNoc received after csr request was invoked for UpdateNOC.`,
+                    StatusCode.ConstraintError,
+                );
+            }
+
+            if (failsafeContext.hasRootCert) {
+                throw new StatusResponseError(
+                    "Trusted root certificate added in this session which is now allowed for UpdateNOC.",
+                    StatusCode.ConstraintError,
+                );
+            }
+
+            if (!failsafeContext.forUpdateNoc) {
+                throw new StatusResponseError("csrRequest not invoked for UpdateNOC.", StatusCode.ConstraintError);
+            }
+
+            if (session.associatedFabric.fabricIndex !== failsafeContext.associatedFabric?.fabricIndex) {
+                throw new StatusResponseError(
+                    "Fabric of this session and the failsafe context do not match.",
+                    StatusCode.ConstraintError,
+                );
+            }
+
+            try {
+                // Build a new Fabric with the updated NOC and ICAC
+                const updateFabric = await failsafeContext.buildUpdatedFabric(nocValue, icacValue);
+
+                // update FabricManager and Resumption records but leave current session intact
+                await failsafeContext.updateFabric(updateFabric);
+
+                // Update connected attributes
+                nocs.updated(session);
+                fabrics.updated(session);
+
+                return {
+                    statusCode: OperationalCredentials.NodeOperationalCertStatus.Ok,
+                    fabricIndex: updateFabric.fabricIndex,
+                };
+            } catch (error) {
+                logger.info("building fabric for update failed", error);
+                if (
+                    error instanceof CertificateError ||
+                    error instanceof ValidationError ||
+                    error instanceof UnexpectedDataError
+                ) {
+                    return {
+                        statusCode: OperationalCredentials.NodeOperationalCertStatus.InvalidNoc,
+                        debugText: error.message,
+                    };
+                } else if (error instanceof PublicKeyError) {
+                    return {
+                        statusCode: OperationalCredentials.NodeOperationalCertStatus.InvalidPublicKey,
+                        debugText: error.message,
+                    };
+                }
+                throw error;
+            }
+        },
+
+        updateFabricLabel: async ({ request: { label }, attributes: { fabrics }, session }) => {
+            assertSecureSession(session, "updateOperationalCert should be called on a secure session.");
+
+            const fabric = tryCatch(
+                () => session.associatedFabric,
+                NoAssociatedFabricError,
+                () => {
+                    throw new StatusResponseError("No associated fabric existing", StatusCode.UnsupportedAccess);
+                },
+            );
+
+            const currentFabricIndex = fabric.fabricIndex;
+            const device = session.context;
+            const conflictingLabelFabric = device
+                .getFabrics()
+                .find(f => f.label === label && f.fabricIndex !== currentFabricIndex);
+            if (conflictingLabelFabric !== undefined) {
+                return {
+                    statusCode: OperationalCredentials.NodeOperationalCertStatus.LabelConflict,
+                    debugText: `Label ${label} already used by fabric ${conflictingLabelFabric.fabricIndex}`,
+                };
+            }
+
+            await fabric.setLabel(label);
+
+            fabrics.updated(session);
+
+            return { statusCode: OperationalCredentials.NodeOperationalCertStatus.Ok, fabricIndex: fabric.fabricIndex };
+        },
+
+        removeFabric: async ({
+            request: { fabricIndex },
+            attributes: { nocs, commissionedFabrics, fabrics, trustedRootCertificates },
+            session,
+            endpoint,
+        }) => {
+            const device = session.context;
+
+            const fabric = device.getFabricByIndex(fabricIndex);
+
+            if (fabric === undefined) {
+                return {
+                    statusCode: OperationalCredentials.NodeOperationalCertStatus.InvalidFabricIndex,
+                    debugText: `Fabric ${fabricIndex} not found`,
+                };
+            }
+
+            const basicInformationCluster = endpoint.getClusterServer(BasicInformation.Cluster);
+            basicInformationCluster?.triggerLeaveEvent?.({ fabricIndex });
+
+            assertSecureSession(session);
+
+            await fabric.remove(session.id);
+            nocs.updated(session);
+            commissionedFabrics.updated(session);
+            fabrics.updated(session);
+            trustedRootCertificates.updated(session);
 
             return {
                 statusCode: OperationalCredentials.NodeOperationalCertStatus.Ok,
-                fabricIndex: updateFabric.fabricIndex,
+                fabricIndex,
             };
-        } catch (error) {
-            logger.info("building fabric for update failed", error);
-            if (
-                error instanceof CertificateError ||
-                error instanceof ValidationError ||
-                error instanceof UnexpectedDataError
-            ) {
-                return {
-                    statusCode: OperationalCredentials.NodeOperationalCertStatus.InvalidNoc,
-                    debugText: error.message,
-                };
-            } else if (error instanceof PublicKeyError) {
-                return {
-                    statusCode: OperationalCredentials.NodeOperationalCertStatus.InvalidPublicKey,
-                    debugText: error.message,
-                };
+        },
+
+        addTrustedRootCertificate: async ({ request: { rootCaCertificate }, session }) => {
+            const failsafeContext = session.context.failsafeContext;
+
+            if (failsafeContext.hasRootCert) {
+                throw new StatusResponseError(
+                    "Trusted root certificate already added in this FailSafe context.",
+                    StatusCode.ConstraintError,
+                );
             }
-            throw error;
-        }
-    },
 
-    updateFabricLabel: async ({ request: { label }, attributes: { fabrics }, session }) => {
-        assertSecureSession(session, "updateOperationalCert should be called on a secure session.");
-
-        const fabric = tryCatch(
-            () => session.associatedFabric,
-            NoAssociatedFabricError,
-            () => {
-                throw new StatusResponseError("No associated fabric existing", StatusCode.UnsupportedAccess);
-            },
-        );
-
-        const currentFabricIndex = fabric.fabricIndex;
-        const device = session.context;
-        const conflictingLabelFabric = device
-            .getFabrics()
-            .find(f => f.label === label && f.fabricIndex !== currentFabricIndex);
-        if (conflictingLabelFabric !== undefined) {
-            return {
-                statusCode: OperationalCredentials.NodeOperationalCertStatus.LabelConflict,
-                debugText: `Label ${label} already used by fabric ${conflictingLabelFabric.fabricIndex}`,
-            };
-        }
-
-        await fabric.setLabel(label);
-
-        fabrics.updated(session);
-
-        return { statusCode: OperationalCredentials.NodeOperationalCertStatus.Ok, fabricIndex: fabric.fabricIndex };
-    },
-
-    removeFabric: async ({
-        request: { fabricIndex },
-        attributes: { nocs, commissionedFabrics, fabrics, trustedRootCertificates },
-        session,
-        endpoint,
-    }) => {
-        const device = session.context;
-
-        const fabric = device.getFabricByIndex(fabricIndex);
-
-        if (fabric === undefined) {
-            return {
-                statusCode: OperationalCredentials.NodeOperationalCertStatus.InvalidFabricIndex,
-                debugText: `Fabric ${fabricIndex} not found`,
-            };
-        }
-
-        const basicInformationCluster = endpoint.getClusterServer(BasicInformation.Cluster);
-        basicInformationCluster?.triggerLeaveEvent?.({ fabricIndex });
-
-        assertSecureSession(session);
-
-        await fabric.remove(session.id);
-        nocs.updated(session);
-        commissionedFabrics.updated(session);
-        fabrics.updated(session);
-        trustedRootCertificates.updated(session);
-
-        return {
-            statusCode: OperationalCredentials.NodeOperationalCertStatus.Ok,
-            fabricIndex,
-        };
-    },
-
-    addTrustedRootCertificate: async ({ request: { rootCaCertificate }, session }) => {
-        const failsafeContext = session.context.failsafeContext;
-
-        if (failsafeContext.hasRootCert) {
-            throw new StatusResponseError(
-                "Trusted root certificate already added in this FailSafe context.",
-                StatusCode.ConstraintError,
-            );
-        }
-
-        if (failsafeContext.fabricIndex !== undefined) {
-            throw new StatusResponseError(
-                `Can not add trusted root certificates after ${failsafeContext.forUpdateNoc ? "UpdateNOC" : "AddNOC"}.`,
-                StatusCode.ConstraintError,
-            );
-        }
-
-        try {
-            failsafeContext.setRootCert(rootCaCertificate);
-        } catch (error) {
-            logger.info("setting root certificate failed", error);
-            if (
-                error instanceof CertificateError ||
-                error instanceof ValidationError ||
-                error instanceof UnexpectedDataError
-            ) {
-                throw new StatusResponseError(error.message, StatusCode.InvalidCommand);
+            if (failsafeContext.fabricIndex !== undefined) {
+                throw new StatusResponseError(
+                    `Can not add trusted root certificates after ${failsafeContext.forUpdateNoc ? "UpdateNOC" : "AddNOC"}.`,
+                    StatusCode.ConstraintError,
+                );
             }
-            throw error;
-        }
-    },
-});
+
+            try {
+                failsafeContext.setRootCert(rootCaCertificate);
+            } catch (error) {
+                logger.info("setting root certificate failed", error);
+                if (
+                    error instanceof CertificateError ||
+                    error instanceof ValidationError ||
+                    error instanceof UnexpectedDataError
+                ) {
+                    throw new StatusResponseError(error.message, StatusCode.InvalidCommand);
+                }
+                throw error;
+            }
+        },
+    };
+};

--- a/packages/matter.js/test/device/MatterNodeStructureTest.ts
+++ b/packages/matter.js/test/device/MatterNodeStructureTest.ts
@@ -5,7 +5,6 @@
  */
 
 import { CommissioningServer } from "../../src/CommissioningServer.js";
-import { DeviceCertification } from "../../src/behavior/definitions/operational-credentials/DeviceCertification.js";
 import { AccessControlCluster } from "../../src/cluster/definitions/AccessControlCluster.js";
 import { AdministratorCommissioning } from "../../src/cluster/definitions/AdministratorCommissioningCluster.js";
 import { BasicInformationCluster } from "../../src/cluster/definitions/BasicInformationCluster.js";
@@ -94,14 +93,12 @@ function addRequiredRootClusters(
                     trustedRootCertificates: [],
                     currentFabricIndex: FabricIndex.NO_FABRIC,
                 },
-                OperationalCredentialsClusterHandler(
-                    new DeviceCertification({
-                        privateKey: DUMMY_KEY,
-                        certificate: ByteArray.fromHex("00"),
-                        intermediateCertificate: ByteArray.fromHex("00"),
-                        declaration: ByteArray.fromHex("00"),
-                    }),
-                ),
+                OperationalCredentialsClusterHandler({
+                    privateKey: DUMMY_KEY,
+                    certificate: ByteArray.fromHex("00"),
+                    intermediateCertificate: ByteArray.fromHex("00"),
+                    declaration: ByteArray.fromHex("00"),
+                }),
             ),
         );
     }
@@ -253,10 +250,10 @@ async function commissioningServer({ storage, values }: { storage?: boolean; val
             serialNumber: `node-matter-0000`,
         },
         certificates: {
-            devicePrivateKey: PRIVATE_KEY,
-            deviceCertificate: ByteArray.fromHex("00"),
-            deviceIntermediateCertificate: ByteArray.fromHex("00"),
-            certificationDeclaration: ByteArray.fromHex("00"),
+            privateKey: PRIVATE_KEY,
+            certificate: ByteArray.fromHex("00"),
+            intermediateCertificate: ByteArray.fromHex("00"),
+            declaration: ByteArray.fromHex("00"),
         },
     });
 

--- a/packages/matter.js/test/node/mock-server-node.ts
+++ b/packages/matter.js/test/node/mock-server-node.ts
@@ -44,8 +44,10 @@ Crypto.get().hkdf = async () => {
 };
 
 export class MockServerNode<T extends ServerNode.RootEndpoint = ServerNode.RootEndpoint> extends ServerNode<T> {
-    constructor(type: T = ServerNode.RootEndpoint as T, options?: Node.Options<T>) {
-        const config = Node.nodeConfigFor(ServerNode.RootEndpoint, type, options);
+    constructor(type?: T, options?: Node.Options<T>);
+    constructor(config: Partial<Node.Configuration<T>>);
+    constructor(definition: T | Node.Configuration<T>, options?: Node.Options<T>) {
+        const config = Node.nodeConfigFor(ServerNode.RootEndpoint as T, definition, options);
 
         const environment = config.environment ?? new Environment("test");
 


### PR DESCRIPTION
To allow cost effectiveness for devices build with matter.js this PR adds an on demain option to determine device certificates (for legacy API and also new API). When setting up the certificates for the node you can either provide the certificates as before or you provide an async provider method instead.

This method is then called as soon as certificates are required the first time in the commissioning flow. With this it is possible to dynamically generate the certificates when really needed. Becauseof the fact that while commissioning happens (and failsafe timer is active) the default command timeout is 30s there should be enough time to even request the certificates from remote at exactly that timepoint.

This PR adds this feature to the new API and also to the Legacy API. For the Legacy API this PR contains a breaking change by syncing the "certificate" data properties to be in synv with the DeviceCertification types, which basically means that the name of the properties changes.