### PR TITLE
Fix CAT parsing

### DIFF
--- a/packages/matter.js/src/datatype/NodeId.ts
+++ b/packages/matter.js/src/datatype/NodeId.ts
@@ -103,7 +103,7 @@ export namespace NodeId {
         if (!isCaseAuthenticatedTag(nodeId)) {
             throw new UnexpectedDataError(`Invalid CASE Authenticated tag: ${nodeId}`);
         }
-        return CaseAuthenticatedTag(Number(nodeId.toString(16).slice(8)));
+        return CaseAuthenticatedTag(parseInt(nodeId.toString(16).slice(8), 16));
     };
 
     /**

--- a/packages/matter.js/test/datatype/NodeIdTests.ts
+++ b/packages/matter.js/test/datatype/NodeIdTests.ts
@@ -51,6 +51,11 @@ describe("NodeId", () => {
         expect(nodeId).to.be.a("bigint");
     });
 
+    it("should successfully extract CASE authenticated tag", () => {
+        const cat = NodeId.extractAsCaseAuthenticatedTag(NodeId(BigInt("0xFFFFFFFD0011002A")));
+        expect(cat).equals(0x11002a);
+    });
+
     it("should throw an error when creating a NodeId from a CASE authenticated tag with negative value", () => {
         expect(() => NodeId.fromCaseAuthenticatedTag(CaseAuthenticatedTag(-1))).to.throw(UnexpectedDataError);
     });

--- a/packages/matter.js/test/datatype/NodeIdTests.ts
+++ b/packages/matter.js/test/datatype/NodeIdTests.ts
@@ -54,6 +54,8 @@ describe("NodeId", () => {
     it("should successfully extract CASE authenticated tag", () => {
         const cat = NodeId.extractAsCaseAuthenticatedTag(NodeId(BigInt("0xFFFFFFFD0011002A")));
         expect(cat).equals(0x11002a);
+        expect(CaseAuthenticatedTag.getVersion(cat)).equals(0x002a);
+        expect(CaseAuthenticatedTag.getIdentifyValue(cat)).equals(0x0011);
     });
 
     it("should throw an error when creating a NodeId from a CASE authenticated tag with negative value", () => {


### PR DESCRIPTION
As discovered by @JimBuzbee seems we got a bug in CAT parsing. And yes Number() is not doing hex-to-number parsing :-)