### PR TITLE
MessageExchange and Session Adjustments/Optimizations for Mattert 1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,9 @@ The main work (all changes without a GitHub username in brackets in the below li
     -   Feature: Adds all elements (clusters, attributes, events, commands, device types and datatypes) introduced in Matter 1.2 and Matter 1.3.
 -   Matter-Core functionality:
     -   Feature: Increase Data Model revision to 17 (introduced by Matter 1.2)
+    -   Enhancement: Update Session parameters in PASE/CASE to match Matter 1.3 specification
     -   Enhancement: Removes TCP and ICD TXT records from MDNS responses because both currently not supported and optional to reduce the size of the MDNS responses
+    -   Enhancement/Fix: Several fixes and optimizations in Session and Message Exchange handling
 -   matter.js New API:
     -   Feature: Adds default implementations for i18n clusters including Localization, Time Format Localization and Unit Localization.
 -   matter.js Legacy API:

--- a/packages/matter-node.js/test/IntegrationTest.ts
+++ b/packages/matter-node.js/test/IntegrationTest.ts
@@ -35,7 +35,7 @@ import {
     VendorId,
 } from "@project-chip/matter.js/datatype";
 import { NodeStateInformation, OnOffLightDevice } from "@project-chip/matter.js/device";
-import { Fabric, FabricBuilder, FabricJsonObject } from "@project-chip/matter.js/fabric";
+import { FabricBuilder, FabricJsonObject } from "@project-chip/matter.js/fabric";
 import {
     DecodedEventData,
     INTERACTION_MODEL_REVISION,
@@ -285,11 +285,9 @@ describe("Integration Test", () => {
             assert.equal(commissioningChangedCallsServer.length, 0);
             assert.equal(sessionChangedCallsServer.length, 0);
 
-            let commissionedCaseAuthenticatedTags: CaseAuthenticatedTag[] | undefined;
             // Catch the CASE Authenticated tags commissioned on the Fabric on the device
             MockTime.interceptOnce(FabricBuilder.prototype, "build", async data => {
                 assert.ok(data.resolve);
-                commissionedCaseAuthenticatedTags = (data.resolve as Fabric).caseAuthenticatedTags;
             });
 
             await commissioningController.start();
@@ -327,11 +325,6 @@ describe("Integration Test", () => {
             assert.equal(nodeStateChangesController1Node1.length, 1);
             assert.equal(nodeStateChangesController1Node1[0].nodeId, node.nodeId);
             assert.equal(nodeStateChangesController1Node1[0].nodeState, NodeStateInformation.Connected);
-
-            assert.deepEqual(commissionedCaseAuthenticatedTags, [
-                CaseAuthenticatedTag(0x12345678),
-                CaseAuthenticatedTag(0x56781234),
-            ]);
         });
 
         it("We can connect to the new commissioned device", async () => {

--- a/packages/matter-node.js/test/interaction/InteractionProtocolTest.ts
+++ b/packages/matter-node.js/test/interaction/InteractionProtocolTest.ts
@@ -1417,7 +1417,7 @@ describe("InteractionProtocol", () => {
                         } as Message,
                     ),
                 {
-                    message: "(128) Multi-command invoke requests are not supported",
+                    message: "(128) Only 1 invoke requests are supported in one message. This message contains 6",
                 },
             );
 

--- a/packages/matter-node.js/test/session/SessionManagerTest.ts
+++ b/packages/matter-node.js/test/session/SessionManagerTest.ts
@@ -105,6 +105,6 @@ describe("SessionManager", () => {
             }
             assert.strictEqual(await sessionManager.getNextAvailableSessionId(), first);
             assert.strictEqual(firstClosed, true);
-        }).timeout(10000);
+        }).timeout(20000);
     });
 });

--- a/packages/matter.js/src/behavior/definitions/operational-credentials/DeviceCertification.ts
+++ b/packages/matter.js/src/behavior/definitions/operational-credentials/DeviceCertification.ts
@@ -23,7 +23,7 @@ export class DeviceCertification {
     #certificate?: ByteArray;
     #intermediateCertificate?: ByteArray;
     #declaration?: ByteArray;
-    #construction: AsyncConstruction<DeviceCertification>;
+    readonly #construction: AsyncConstruction<DeviceCertification>;
 
     get construction() {
         return this.#construction;
@@ -81,11 +81,11 @@ export class DeviceCertification {
     }
 
     sign(session: SecureSession<MatterDevice>, data: ByteArray) {
-        return Crypto.sign(this.#assertInitialized().privateKey, [data, session.getAttestationChallengeKey()]);
+        return Crypto.sign(this.#assertInitialized().privateKey, [data, session.attestationChallengeKey]);
     }
 
     /**
-     * Makes sure that the device certification is initialized and construction is completed and returns "Non undefined"
+     * Makes sure that the device certification is initialized and construction is completed and returns "Non-undefined"
      * values
      */
     #assertInitialized() {

--- a/packages/matter.js/src/fabric/Fabric.ts
+++ b/packages/matter.js/src/fabric/Fabric.ts
@@ -50,7 +50,6 @@ export type FabricJsonObject = {
     intermediateCACert: ByteArray | undefined;
     operationalCert: ByteArray;
     label: string;
-    caseAuthenticatedTags?: CaseAuthenticatedTag[];
     scopedClusterData: Map<number, Map<string, SupportedStorageTypes>>;
 };
 
@@ -125,7 +124,6 @@ export class Fabric {
         readonly intermediateCACert: ByteArray | undefined,
         readonly operationalCert: ByteArray,
         public label: string,
-        readonly caseAuthenticatedTags = new Array<CaseAuthenticatedTag>(),
         scopedClusterData?: Map<number, Map<string, SupportedStorageTypes>>,
     ) {
         this.#keyPair = keyPair;
@@ -148,7 +146,6 @@ export class Fabric {
             intermediateCACert: this.intermediateCACert,
             operationalCert: this.operationalCert,
             label: this.label,
-            caseAuthenticatedTags: this.caseAuthenticatedTags,
             scopedClusterData: this.#scopedClusterData,
         };
     }
@@ -169,7 +166,6 @@ export class Fabric {
             fabricObject.intermediateCACert,
             fabricObject.operationalCert,
             fabricObject.label,
-            fabricObject.caseAuthenticatedTags,
             fabricObject.scopedClusterData,
         );
     }
@@ -365,7 +361,6 @@ export class FabricBuilder {
     #identityProtectionKey?: ByteArray;
     #fabricIndex?: FabricIndex;
     #label = "";
-    #caseAuthenticatedTags = new Array<CaseAuthenticatedTag>();
 
     get publicKey() {
         return this.#keyPair.publicKey;
@@ -401,6 +396,9 @@ export class FabricBuilder {
         logger.debug(
             `FabricBuilder setOperationalCert: nodeId=${nodeId}, fabricId=${fabricId}, caseAuthenticatedTags=${caseAuthenticatedTags}`,
         );
+        if (caseAuthenticatedTags !== undefined) {
+            CaseAuthenticatedTag.validateNocTagList(caseAuthenticatedTags);
+        }
 
         if (!ellipticCurvePublicKey.equals(this.#keyPair.publicKey)) {
             throw new PublicKeyError("Operational Certificate does not match public key.");
@@ -431,10 +429,7 @@ export class FabricBuilder {
         this.#intermediateCACert = intermediateCACert;
         this.#fabricId = FabricId(fabricId);
         this.#nodeId = nodeId;
-        if (caseAuthenticatedTags !== undefined) {
-            CaseAuthenticatedTag.validateNocTagList(caseAuthenticatedTags);
-            this.#caseAuthenticatedTags = caseAuthenticatedTags;
-        }
+
         return this;
     }
 
@@ -516,7 +511,6 @@ export class FabricBuilder {
             this.#intermediateCACert,
             this.#operationalCert,
             this.#label,
-            this.#caseAuthenticatedTags,
         );
     }
 }

--- a/packages/matter.js/src/mdns/MdnsBroadcaster.ts
+++ b/packages/matter.js/src/mdns/MdnsBroadcaster.ts
@@ -157,8 +157,8 @@ export class MdnsBroadcaster {
             vendorId,
             productId,
             discriminator,
-            sessionIdleInterval = SESSION_ACTIVE_INTERVAL_MS,
-            sessionActiveInterval = SESSION_IDLE_INTERVAL_MS,
+            sessionIdleInterval = SESSION_IDLE_INTERVAL_MS,
+            sessionActiveInterval = SESSION_ACTIVE_INTERVAL_MS,
             sessionActiveThreshold = SESSION_ACTIVE_THRESHOLD_MS,
             pairingHint = DEFAULT_PAIRING_HINT,
             pairingInstructions = "",
@@ -237,8 +237,8 @@ export class MdnsBroadcaster {
         announcedNetPort: number,
         fabrics: Fabric[],
         {
-            sessionIdleInterval = SESSION_ACTIVE_INTERVAL_MS,
-            sessionActiveInterval = SESSION_IDLE_INTERVAL_MS,
+            sessionIdleInterval = SESSION_IDLE_INTERVAL_MS,
+            sessionActiveInterval = SESSION_ACTIVE_INTERVAL_MS,
             sessionActiveThreshold = SESSION_ACTIVE_THRESHOLD_MS,
         }: OperationalInstanceData = {},
     ) {
@@ -307,8 +307,8 @@ export class MdnsBroadcaster {
             deviceType,
             vendorId,
             productId,
-            sessionIdleInterval = SESSION_ACTIVE_INTERVAL_MS,
-            sessionActiveInterval = SESSION_IDLE_INTERVAL_MS,
+            sessionIdleInterval = SESSION_IDLE_INTERVAL_MS,
+            sessionActiveInterval = SESSION_ACTIVE_INTERVAL_MS,
             sessionActiveThreshold = SESSION_ACTIVE_THRESHOLD_MS,
         }: CommissionerInstanceData,
     ) {

--- a/packages/matter.js/src/model/definitions/Specification.ts
+++ b/packages/matter.js/src/model/definitions/Specification.ts
@@ -60,4 +60,9 @@ export namespace Specification {
      * Data model revision associated with the default revision of Matter.
      */
     export const DATA_MODEL_REVISION = 17;
+
+    /**
+     * Interaction model revision associated with the default revision of Matter.
+     */
+    export const INTERACTION_MODEL_REVISION = 11; // For now still Matter 1.2, change to 12 when relevant features are included
 }

--- a/packages/matter.js/src/protocol/ChannelManager.ts
+++ b/packages/matter.js/src/protocol/ChannelManager.ts
@@ -36,7 +36,7 @@ export class ChannelManager {
     #findLeastActiveChannel(channels: MessageChannel<any>[]) {
         let oldest = channels[0];
         for (const channel of channels) {
-            if (channel.session.activeTimestamp < oldest.session.activeTimestamp) {
+            if (channel.session.timestamp < oldest.session.timestamp) {
                 oldest = channel;
             }
         }

--- a/packages/matter.js/src/protocol/ExchangeManager.ts
+++ b/packages/matter.js/src/protocol/ExchangeManager.ts
@@ -90,7 +90,11 @@ export class ExchangeManager<ContextT> {
                     return;
                 }
 
-                this.onMessage(socket, data).catch(error => logger.error(error));
+                try {
+                    this.onMessage(socket, data).catch(error => logger.error(error));
+                } catch (error) {
+                    logger.warn("Ignoring UDP message with error", error);
+                }
             }),
         );
     }

--- a/packages/matter.js/src/protocol/MessageExchange.ts
+++ b/packages/matter.js/src/protocol/MessageExchange.ts
@@ -121,7 +121,7 @@ export class MessageExchange<ContextT> {
     private readonly activeIntervalMs: number;
     private readonly idleIntervalMs: number;
     private readonly activeThresholdMs: number;
-    private readonly retransmissionRetries: number;
+    private readonly maxTransmissions: number;
     private readonly messagesQueue = new Queue<Message>();
     private receivedMessageToAck: Message | undefined;
     private receivedMessageAckTimer = Time.getTimer("Ack receipt timeout", MRP_STANDALONE_ACK_TIMEOUT_MS, () => {
@@ -156,7 +156,7 @@ export class MessageExchange<ContextT> {
         this.activeIntervalMs = activeIntervalMs ?? SESSION_ACTIVE_INTERVAL_MS;
         this.idleIntervalMs = idleIntervalMs ?? SESSION_IDLE_INTERVAL_MS;
         this.activeThresholdMs = activeThresholdMs ?? SESSION_ACTIVE_THRESHOLD_MS;
-        this.retransmissionRetries = MRP_MAX_TRANSMISSIONS;
+        this.maxTransmissions = MRP_MAX_TRANSMISSIONS;
         logger.debug(
             "New exchange",
             Diagnostic.dict({
@@ -167,7 +167,7 @@ export class MessageExchange<ContextT> {
                 "active threshold ms": this.activeThresholdMs,
                 "active interval ms": this.activeIntervalMs,
                 "idle interval ms": this.idleIntervalMs,
-                retries: this.retransmissionRetries,
+                maxTransmissions: this.maxTransmissions,
             }),
         );
     }
@@ -369,7 +369,7 @@ export class MessageExchange<ContextT> {
     private retransmitMessage(message: Message, retransmissionCount: number, notTimeoutBeforeTimeMs?: number) {
         retransmissionCount++;
         if (
-            retransmissionCount >= this.retransmissionRetries &&
+            retransmissionCount >= this.maxTransmissions &&
             (notTimeoutBeforeTimeMs === undefined || Time.nowMs() > notTimeoutBeforeTimeMs)
         ) {
             if (this.sentMessageToAck !== undefined && this.sentMessageAckFailure !== undefined) {

--- a/packages/matter.js/src/protocol/MessageExchange.ts
+++ b/packages/matter.js/src/protocol/MessageExchange.ts
@@ -189,6 +189,13 @@ export class MessageExchange<ContextT> {
         } = message;
 
         logger.debug("Message «", MessageCodec.messageDiagnostics(message, isDuplicate));
+
+        if (protocolId !== this.protocolId) {
+            throw new MatterFlowError(
+                `Drop received a message for an unexpected protocol. Expected: ${this.protocolId}, received: ${protocolId}`,
+            );
+        }
+
         this.session.notifyActivity(true);
 
         if (isDuplicate) {
@@ -234,11 +241,6 @@ export class MessageExchange<ContextT> {
         if (SecureChannelProtocol.isStandaloneAck(protocolId, messageType)) {
             // Don't include standalone acks in the message stream
             return;
-        }
-        if (protocolId !== this.protocolId) {
-            throw new MatterFlowError(
-                `Received a message for an unexpected protocol. Expected: ${this.protocolId}, received: ${protocolId}`,
-            );
         }
         if (requiresAck) {
             // We still have a message to ack, so ack this one as standalone ack directly

--- a/packages/matter.js/src/protocol/MessageExchange.ts
+++ b/packages/matter.js/src/protocol/MessageExchange.ts
@@ -168,7 +168,7 @@ export class MessageExchange<ContextT> {
         this.#protocolId = protocolId;
         this.#closeCallback = closeCallback;
 
-        const { activeIntervalMs, idleIntervalMs, activeThresholdMs } = session.getSessionParameters();
+        const { activeIntervalMs, idleIntervalMs, activeThresholdMs } = session.parameters;
         this.#activeIntervalMs = activeIntervalMs ?? SESSION_ACTIVE_INTERVAL_MS;
         this.#idleIntervalMs = idleIntervalMs ?? SESSION_IDLE_INTERVAL_MS;
         this.#activeThresholdMs = activeThresholdMs ?? SESSION_ACTIVE_THRESHOLD_MS;

--- a/packages/matter.js/src/protocol/MessageExchange.ts
+++ b/packages/matter.js/src/protocol/MessageExchange.ts
@@ -10,7 +10,6 @@ import { NodeId } from "../datatype/NodeId.js";
 import { Diagnostic } from "../log/Diagnostic.js";
 import { Logger } from "../log/Logger.js";
 import {
-    MRP_MAX_TRANSMISSIONS,
     SESSION_ACTIVE_INTERVAL_MS,
     SESSION_ACTIVE_THRESHOLD_MS,
     SESSION_IDLE_INTERVAL_MS,
@@ -58,6 +57,12 @@ export type ExchangeSendOptions = {
     /** Use the provided acknowledge MessageId instead checking the latest to send one */
     includeAcknowledgeMessageId?: number;
 };
+
+/**
+ * The maximum number of transmission attempts for a given reliable message. The sender MAY choose this value as it
+ * sees fit.
+ */
+const MRP_MAX_TRANSMISSIONS = 5;
 
 /** The base number for the exponential backoff equation. */
 const MRP_BACKOFF_BASE = 1.6;

--- a/packages/matter.js/src/protocol/interaction/InteractionServer.ts
+++ b/packages/matter.js/src/protocol/interaction/InteractionServer.ts
@@ -28,6 +28,7 @@ import { NodeId } from "../../datatype/NodeId.js";
 import { EndpointInterface } from "../../endpoint/EndpointInterface.js";
 import { Diagnostic } from "../../log/Diagnostic.js";
 import { Logger } from "../../log/Logger.js";
+import { Specification } from "../../model/definitions/Specification.js";
 import { MessageExchange } from "../../protocol/MessageExchange.js";
 import { ProtocolHandler } from "../../protocol/ProtocolHandler.js";
 import { EventHandler } from "../../protocol/interaction/EventHandler.js";
@@ -72,8 +73,14 @@ import { StatusCode, StatusResponseError } from "./StatusCode.js";
 import { SubscriptionHandler } from "./SubscriptionHandler.js";
 import { SubscriptionOptions } from "./SubscriptionOptions.js";
 
+/** Protocol ID for the Interaction Protocol as per Matter specification. */
 export const INTERACTION_PROTOCOL_ID = 0x0001;
-export const INTERACTION_MODEL_REVISION = 11;
+
+/** Backward compatible re-export for Interaction Model version we support currently. */
+export const INTERACTION_MODEL_REVISION = Specification.INTERACTION_MODEL_REVISION;
+
+/** Number of Invoke Path setting from our Interaction model implementation. */
+export const MAX_PATHS_PER_INVOKE = 1;
 
 const logger = Logger.get("InteractionServer");
 
@@ -1066,8 +1073,11 @@ export class InteractionServer implements ProtocolHandler<MatterDevice>, Interac
             }
         }
 
-        if (invokeRequests.length > 1) {
-            throw new StatusResponseError("Multi-command invoke requests are not supported", StatusCode.InvalidAction);
+        if (invokeRequests.length > MAX_PATHS_PER_INVOKE) {
+            throw new StatusResponseError(
+                `We only support ${MAX_PATHS_PER_INVOKE} invoke requests in one message. This message contained ${invokeRequests.length}`,
+                StatusCode.InvalidAction,
+            );
         }
 
         const invokeResponses: TypeFromSchema<typeof TlvInvokeResponseData>[] = [];

--- a/packages/matter.js/src/protocol/interaction/InteractionServer.ts
+++ b/packages/matter.js/src/protocol/interaction/InteractionServer.ts
@@ -1075,7 +1075,7 @@ export class InteractionServer implements ProtocolHandler<MatterDevice>, Interac
 
         if (invokeRequests.length > MAX_PATHS_PER_INVOKE) {
             throw new StatusResponseError(
-                `We only support ${MAX_PATHS_PER_INVOKE} invoke requests in one message. This message contained ${invokeRequests.length}`,
+                `Only ${MAX_PATHS_PER_INVOKE} invoke requests are supported in one message. This message contains ${invokeRequests.length}`,
                 StatusCode.InvalidAction,
             );
         }

--- a/packages/matter.js/src/protocol/securechannel/SecureChannelMessages.ts
+++ b/packages/matter.js/src/protocol/securechannel/SecureChannelMessages.ts
@@ -4,20 +4,59 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export const SECURE_CHANNEL_PROTOCOL_ID = 0x00000000;
+export const SECURE_CHANNEL_PROTOCOL_ID = 0x0000;
 
 export enum MessageType {
+    /**
+     * The Message Counter Synchronization Request message queries the current message counter from a peer to bootstrap
+     * replay protection.
+     */
+    MsgCounterSyncReq = 0x00,
+
+    /**
+     * The Message Counter Synchronization Response message provides the current message counter from a peer to
+     * bootstrap replay protection.
+     */
+    MsgCounterSyncRsp = 0x01,
+
+    /**
+     * This message is dedicated for the purpose of sending a stand-alone acknowledgement when there is no other data
+     * message available to piggyback an acknowledgement on top of.
+     */
     StandaloneAck = 0x10,
+
+    /** The request for PBKDF parameters necessary to complete the PASE protocol. */
     PbkdfParamRequest = 0x20,
+
+    /** The PBKDF parameters sent in response to PBKDFParamRequest during the PASE protocol. */
     PbkdfParamResponse = 0x21,
+
+    /** The first PAKE message of the PASE protocol. */
     PasePake1 = 0x22,
+
+    /** The second PAKE message of the PASE protocol. */
     PasePake2 = 0x23,
+
+    /** The third PAKE message of the PASE protocol. */
     PasePake3 = 0x24,
+
+    /** The first message of the CASE protocol. */
     Sigma1 = 0x30,
+
+    /** The second message of the CASE protocol. */
     Sigma2 = 0x31,
+
+    /** The third message of the CASE protocol. */
     Sigma3 = 0x32,
+
+    /** The second resumption message of the CASE protocol. */
     Sigma2Resume = 0x33,
+
+    /** The Status Report message encodes the result of an operation in the Secure Channel as well as other protocols. */
     StatusReport = 0x40,
+
+    /** The Check-in message notifies a client that the ICD is available for communication. */
+    IcdCheckInMessage = 0x50,
 }
 
 export enum ProtocolStatusCode {

--- a/packages/matter.js/src/protocol/securechannel/SecureChannelMessages.ts
+++ b/packages/matter.js/src/protocol/securechannel/SecureChannelMessages.ts
@@ -60,10 +60,19 @@ export enum MessageType {
 }
 
 export enum ProtocolStatusCode {
+    /** Indication that the last session establishment message was successfully processed. */
     Success = 0x0000,
+
+    /** Failure to find a common set of shared roots. */
     NoSharedTrustRoots = 0x0001,
+
+    /** Generic failure during session establishment. */
     InvalidParam = 0x0002,
+
+    /** Indication that the sender will close the current session. See Section “CloseSession” for more details. */
     CloseSession = 0x0003,
+
+    /** Indication that the sender cannot currently fulfill the request. See Section “Busy” for more details. */
     Busy = 0x0004,
 }
 

--- a/packages/matter.js/src/session/InsecureSession.ts
+++ b/packages/matter.js/src/session/InsecureSession.ts
@@ -54,7 +54,7 @@ export class InsecureSession<T> extends Session<T> {
         return MessageCodec.encodePayload(message);
     }
 
-    getAttestationChallengeKey(): ByteArray {
+    get attestationChallengeKey(): ByteArray {
         throw new MatterFlowError("Not supported on an unsecure session");
     }
 

--- a/packages/matter.js/src/session/SecureSession.ts
+++ b/packages/matter.js/src/session/SecureSession.ts
@@ -161,6 +161,10 @@ export class SecureSession<T> extends Session<T> {
                 idleIntervalMs: this.idleIntervalMs,
                 activeIntervalMs: this.activeIntervalMs,
                 activeThresholdMs: this.activeThresholdMs,
+                dataModelRevision: this.dataModelRevision,
+                interactionModelRevision: this.interactionModelRevision,
+                specificationVersion: this.specificationVersion,
+                maxPathsPerInvoke: this.maxPathsPerInvoke,
             }),
         );
     }
@@ -221,7 +225,7 @@ export class SecureSession<T> extends Session<T> {
         return { header, applicationPayload: Crypto.encrypt(this.#encryptKey, applicationPayload, nonce, headerBytes) };
     }
 
-    getAttestationChallengeKey(): ByteArray {
+    get attestationChallengeKey(): ByteArray {
         return this.#attestationKey;
     }
 

--- a/packages/matter.js/src/session/SecureSession.ts
+++ b/packages/matter.js/src/session/SecureSession.ts
@@ -150,7 +150,7 @@ export class SecureSession<T> extends Session<T> {
         this.#encryptKey = encryptKey;
         this.#attestationKey = attestationKey;
         this.#subscriptionChangedCallback = subscriptionChangedCallback;
-        this.#caseAuthenticatedTags = caseAuthenticatedTags ?? fabric?.caseAuthenticatedTags ?? [];
+        this.#caseAuthenticatedTags = caseAuthenticatedTags ?? [];
 
         fabric?.addSession(this);
 
@@ -238,7 +238,6 @@ export class SecureSession<T> extends Session<T> {
             throw new MatterFlowError("Session already has an associated Fabric. Cannot change this.");
         }
         this.#fabric = fabric;
-        this.#caseAuthenticatedTags = fabric.caseAuthenticatedTags;
     }
 
     get id() {

--- a/packages/matter.js/src/session/Session.ts
+++ b/packages/matter.js/src/session/Session.ts
@@ -27,10 +27,32 @@ export const SESSION_IDLE_INTERVAL_MS = 500;
 /** Minimum amount of time the node SHOULD stay active after network activity. */
 export const SESSION_ACTIVE_THRESHOLD_MS = 4000;
 
+/** Fallback value for Data Model Revision when not provided in Session parameters. We use Matter 1.2 as assumption. */
+export const FALLBACK_DATAMODEL_REVISION = 17;
+
+/** Fallback value for Interaction Model Revision when not provided in Session parameters. We use Matter 1.2 as assumption. */
+export const FALLBACK_INTERACTIONMODEL_REVISION = 11;
+
+/**
+ * Fallback value for Specification Version when not provided in Session parameters. We use 0 as assumption which is
+ * "before 1.3".
+ */
+export const FALLBACK_SPECIFICATION_VERSION = 0;
+
+/**
+ * Fallback value for Maximum Paths per Invoke when not provided in Session parameters. We assume only one Path is
+ * supported per Invoke interaction.
+ */
+export const FALLBACK_MAX_PATHS_PER_INVOKE = 1;
+
 export interface SessionParameters {
     idleIntervalMs: number;
     activeIntervalMs: number;
     activeThresholdMs: number;
+    dataModelRevision: number;
+    interactionModelRevision: number;
+    specificationVersion: number;
+    maxPathsPerInvoke: number;
 }
 
 export type SessionParameterOptions = Partial<SessionParameters>;
@@ -43,6 +65,10 @@ export abstract class Session<T> {
     protected readonly idleIntervalMs: number;
     protected readonly activeIntervalMs: number;
     protected readonly activeThresholdMs: number;
+    protected readonly dataModelRevision: number;
+    protected readonly interactionModelRevision: number;
+    protected readonly specificationVersion: number;
+    protected readonly maxPathsPerInvoke: number;
     protected readonly closeCallback: () => Promise<void>;
     protected readonly messageCounter: MessageCounter;
     protected readonly messageReceptionState: MessageReceptionState;
@@ -62,6 +88,10 @@ export abstract class Session<T> {
                 idleIntervalMs = SESSION_IDLE_INTERVAL_MS,
                 activeIntervalMs = SESSION_ACTIVE_INTERVAL_MS,
                 activeThresholdMs = SESSION_ACTIVE_THRESHOLD_MS,
+                dataModelRevision = FALLBACK_DATAMODEL_REVISION,
+                interactionModelRevision = FALLBACK_INTERACTIONMODEL_REVISION,
+                specificationVersion = FALLBACK_SPECIFICATION_VERSION,
+                maxPathsPerInvoke = FALLBACK_MAX_PATHS_PER_INVOKE,
             } = {},
             setActiveTimestamp,
         } = args;
@@ -71,6 +101,10 @@ export abstract class Session<T> {
         this.idleIntervalMs = idleIntervalMs;
         this.activeIntervalMs = activeIntervalMs;
         this.activeThresholdMs = activeThresholdMs;
+        this.dataModelRevision = dataModelRevision;
+        this.interactionModelRevision = interactionModelRevision;
+        this.specificationVersion = specificationVersion;
+        this.maxPathsPerInvoke = maxPathsPerInvoke;
         if (setActiveTimestamp) {
             this.activeTimestamp = this.timestamp;
         }
@@ -96,12 +130,24 @@ export abstract class Session<T> {
         this.messageReceptionState.updateMessageCounter(messageCounter);
     }
 
-    getSessionParameters(): SessionParameters {
-        const { idleIntervalMs, activeIntervalMs, activeThresholdMs } = this;
+    get parameters(): SessionParameters {
+        const {
+            idleIntervalMs,
+            activeIntervalMs,
+            activeThresholdMs,
+            dataModelRevision,
+            interactionModelRevision,
+            specificationVersion,
+            maxPathsPerInvoke,
+        } = this;
         return {
             idleIntervalMs,
             activeIntervalMs,
             activeThresholdMs,
+            dataModelRevision,
+            interactionModelRevision,
+            specificationVersion,
+            maxPathsPerInvoke,
         };
     }
 

--- a/packages/matter.js/src/session/Session.ts
+++ b/packages/matter.js/src/session/Session.ts
@@ -12,13 +12,19 @@ import { MessageReceptionState } from "../protocol/MessageReceptionState.js";
 import { Time } from "../time/Time.js";
 import { ByteArray } from "../util/ByteArray.js";
 
-/** Maximum sleep interval of node when in active mode. */
-export const SESSION_ACTIVE_INTERVAL_MS = 500;
+/**
+ * Minimum amount of time between sender retries when the destination node is Active. This SHALL be greater than or
+ * equal to the maximum amount of time a node may be non-responsive to incoming messages when Active.
+ */
+export const SESSION_ACTIVE_INTERVAL_MS = 300;
 
-/** Maximum sleep interval of node when in idle mode. */
-export const SESSION_IDLE_INTERVAL_MS = 300;
+/**
+ * Minimum amount of time between sender retries when the destination node is Idle. This SHALL be greater than or equal
+ * to the maximum amount of time a node may be non-responsive to incoming messages when Idle.
+ */
+export const SESSION_IDLE_INTERVAL_MS = 500;
 
-/** Minimum amount the node SHOULD stay awake after network activity. */
+/** Minimum amount of time the node SHOULD stay active after network activity. */
 export const SESSION_ACTIVE_THRESHOLD_MS = 4000;
 
 export interface SessionParameters {

--- a/packages/matter.js/src/session/Session.ts
+++ b/packages/matter.js/src/session/Session.ts
@@ -12,12 +12,6 @@ import { MessageReceptionState } from "../protocol/MessageReceptionState.js";
 import { Time } from "../time/Time.js";
 import { ByteArray } from "../util/ByteArray.js";
 
-/**
- * The maximum number of transmission attempts for a given reliable message. The sender MAY choose this value as it
- * sees fit.
- */
-export const MRP_MAX_TRANSMISSIONS = 5;
-
 /** Maximum sleep interval of node when in active mode. */
 export const SESSION_ACTIVE_INTERVAL_MS = 500;
 

--- a/packages/matter.js/src/session/SessionManager.ts
+++ b/packages/matter.js/src/session/SessionManager.ts
@@ -181,7 +181,6 @@ export class SessionManager<ContextT> {
         this.#sessions.add(session);
         this.#sessionOpened.emit(session);
 
-        // TODO: Add a maximum of sessions and respect/close the "least recently used" session. See Core Specs 4.10.1.1
         return session;
     }
 

--- a/packages/matter.js/src/session/SessionManager.ts
+++ b/packages/matter.js/src/session/SessionManager.ts
@@ -11,14 +11,26 @@ import { FabricId } from "../datatype/FabricId.js";
 import { NodeId } from "../datatype/NodeId.js";
 import { Fabric } from "../fabric/Fabric.js";
 import { Logger } from "../log/Logger.js";
+import { Specification } from "../model/definitions/Specification.js";
 import { MessageCounter } from "../protocol/MessageCounter.js";
+import { MAX_PATHS_PER_INVOKE } from "../protocol/interaction/InteractionServer.js";
 import { StorageContext } from "../storage/StorageContext.js";
 import { ByteArray } from "../util/ByteArray.js";
 import { AsyncObservable, Observable } from "../util/Observable.js";
 import { BasicSet } from "../util/Set.js";
 import { InsecureSession } from "./InsecureSession.js";
 import { SecureSession } from "./SecureSession.js";
-import { SessionParameterOptions, SessionParameters } from "./Session.js";
+import {
+    FALLBACK_DATAMODEL_REVISION,
+    FALLBACK_INTERACTIONMODEL_REVISION,
+    FALLBACK_MAX_PATHS_PER_INVOKE,
+    FALLBACK_SPECIFICATION_VERSION,
+    SESSION_ACTIVE_INTERVAL_MS,
+    SESSION_ACTIVE_THRESHOLD_MS,
+    SESSION_IDLE_INTERVAL_MS,
+    SessionParameterOptions,
+    SessionParameters,
+} from "./Session.js";
 
 const logger = Logger.get("SessionManager");
 
@@ -43,6 +55,10 @@ type ResumptionStorageRecord = {
         idleIntervalMs: number;
         activeIntervalMs: number;
         activeThresholdMs: number;
+        dataModelRevision: number;
+        interactionModelRevision: number;
+        specificationVersion: number;
+        maxPathsPerInvoke: number;
     };
     caseAuthenticatedTags?: CaseAuthenticatedTag[];
 };
@@ -97,7 +113,14 @@ export class SessionManager<ContextT> {
                     this.#insecureSessions.delete(session.nodeId);
                 },
                 initiatorNodeId,
-                sessionParameters,
+                sessionParameters: {
+                    // We initiate the session, so we choose the parameters
+                    dataModelRevision: Specification.DATA_MODEL_REVISION,
+                    interactionModelRevision: Specification.INTERACTION_MODEL_REVISION,
+                    specificationVersion: Specification.SPECIFICATION_VERSION, // TODO: formally wrong?
+                    maxPathsPerInvoke: MAX_PATHS_PER_INVOKE,
+                    ...sessionParameters,
+                },
                 isInitiator: isInitiator ?? false,
             });
 
@@ -306,7 +329,15 @@ export class SessionManager<ContextT> {
                 resumptionId,
                 fabricId,
                 peerNodeId,
-                sessionParameters,
+                sessionParameters: {
+                    idleIntervalMs,
+                    activeIntervalMs,
+                    activeThresholdMs,
+                    dataModelRevision,
+                    interactionModelRevision,
+                    specificationVersion,
+                    maxPathsPerInvoke,
+                },
                 caseAuthenticatedTags,
             }) => {
                 logger.info("restoring resumption record for node", nodeId);
@@ -320,7 +351,16 @@ export class SessionManager<ContextT> {
                     resumptionId,
                     fabric,
                     peerNodeId,
-                    sessionParameters,
+                    sessionParameters: {
+                        // Make sure to initialize default values when restoring an older resumption record
+                        idleIntervalMs: idleIntervalMs ?? SESSION_IDLE_INTERVAL_MS,
+                        activeIntervalMs: activeIntervalMs ?? SESSION_ACTIVE_INTERVAL_MS,
+                        activeThresholdMs: activeThresholdMs ?? SESSION_ACTIVE_THRESHOLD_MS,
+                        dataModelRevision: dataModelRevision ?? FALLBACK_DATAMODEL_REVISION,
+                        interactionModelRevision: interactionModelRevision ?? FALLBACK_INTERACTIONMODEL_REVISION,
+                        specificationVersion: specificationVersion ?? FALLBACK_SPECIFICATION_VERSION,
+                        maxPathsPerInvoke: maxPathsPerInvoke ?? FALLBACK_MAX_PATHS_PER_INVOKE,
+                    },
                     caseAuthenticatedTags,
                 });
             },

--- a/packages/matter.js/src/session/case/CaseClient.ts
+++ b/packages/matter.js/src/session/case/CaseClient.ts
@@ -79,7 +79,7 @@ export class CaseClient {
             const { sessionId: peerSessionId, resumptionId, resumeMic } = sigma2Resume;
 
             const sessionParameters = {
-                ...exchange.session.getSessionParameters(),
+                ...exchange.session.parameters,
                 ...(resumptionSessionParams ?? {}),
             };
 
@@ -103,7 +103,7 @@ export class CaseClient {
             logger.info(`Case client: session resumed with ${messenger.getChannelName()}`);
 
             resumptionRecord.resumptionId = resumptionId; /* update resumptionId */
-            resumptionRecord.sessionParameters = secureSession.getSessionParameters(); /* update mrpParams */
+            resumptionRecord.sessionParameters = secureSession.parameters; /* update mrpParams */
         } else {
             // Process sigma2
             const {
@@ -114,7 +114,7 @@ export class CaseClient {
                 sessionParams: sigma2SessionParams,
             } = sigma2;
             const sessionParameters = {
-                ...exchange.session.getSessionParameters(),
+                ...exchange.session.parameters,
                 ...(sigma2SessionParams ?? {}),
             };
             const sharedSecret = Crypto.ecdhGenerateSecret(peerEcdhPublicKey, ecdh);
@@ -213,7 +213,7 @@ export class CaseClient {
                 peerNodeId,
                 sharedSecret,
                 resumptionId: peerResumptionId,
-                sessionParameters: secureSession.getSessionParameters(),
+                sessionParameters: secureSession.parameters,
             };
         }
 

--- a/packages/matter.js/src/session/case/CaseServer.ts
+++ b/packages/matter.js/src/session/case/CaseServer.ts
@@ -237,7 +237,7 @@ export class CaseServer implements ProtocolHandler<MatterDevice> {
                 fabric,
                 sharedSecret,
                 resumptionId,
-                sessionParameters: secureSession.getSessionParameters(),
+                sessionParameters: secureSession.parameters,
                 caseAuthenticatedTags,
             };
 

--- a/packages/matter.js/src/session/pase/PaseClient.ts
+++ b/packages/matter.js/src/session/pase/PaseClient.ts
@@ -58,7 +58,7 @@ export class PaseClient {
             throw new UnexpectedDataError("Missing requested PbkdfParameters in the response.");
 
         const sessionParameters = {
-            ...exchange.session.getSessionParameters(),
+            ...exchange.session.parameters,
             ...(pbkdfSessionParams ?? {}),
         };
 

--- a/packages/matter.js/src/session/pase/PaseMessages.ts
+++ b/packages/matter.js/src/session/pase/PaseMessages.ts
@@ -13,13 +13,25 @@ import { TlvByteString } from "../../tlv/TlvString.js";
 /** @see {@link MatterSpecification.v12.Core} § 4.11.8 */
 export const TlvSessionParameters = TlvObject({
     /** Maximum sleep interval of node when in idle mode. */
-    idleIntervalMs: TlvOptionalField(1, TlvUInt32) /* default: 500ms */,
+    idleIntervalMs: TlvOptionalField(1, TlvUInt32) /* default: SESSION_IDLE_INTERVAL */,
 
     /** Maximum sleep interval of node when in active mode. */
-    activeIntervalMs: TlvOptionalField(2, TlvUInt32) /* default: 300ms */,
+    activeIntervalMs: TlvOptionalField(2, TlvUInt32) /* default: SESSION_ACTIVE_INTERVAL */,
 
     /** Minimum amount of time the node SHOULD stay active after network activity. */
-    activeThresholdMs: TlvOptionalField(3, TlvUInt16) /* default: 4000ms */,
+    activeThresholdMs: TlvOptionalField(3, TlvUInt16) /* default: SESSION_ACTIVE_THRESHOLD */,
+
+    /** Data model revision. */
+    dataModelRevision: TlvOptionalField(4, TlvUInt16) /* default: 16 OR 17, we choose 17 aka Matter 1.2 */,
+
+    /** Interaction model revision. */
+    interactionModelRevision: TlvOptionalField(5, TlvUInt16) /* default 10 OR 11, we choose 11 aka Matter 1.2 */,
+
+    /** Specification version. */
+    specificationVersion: TlvOptionalField(6, TlvUInt32) /* default: STRICTLY SMALLER THAN 0x01030000, we choose 0 */,
+
+    /** Maximum Paths pert Invoke */
+    maxPathsPerInvoke: TlvOptionalField(7, TlvUInt16) /* default: 1 */,
 });
 
 /** @see {@link MatterSpecification.v10.Core} § 4.13.1.2 */


### PR DESCRIPTION
This PR adjusts and optimizes some things around MessageExchange and Sessions regarding Matter (1.3) specs
* Sync SecureChannel messages with specs (even currently unused ones that will be implemented soon)
* Evicting sessions should use the Session Timestamp and not Active Timestamp as per specs
* Optimize Message handling and drop invalid messages earlier
* Catch Message handling errors ourself instead of letting them throw in dgram/net handlers
* Dynamically calculate the session close timer
* Sync session intervals with Specs and fix bugs where variables were switched
* Add new Matter 1.3 Session Params values including fallback values and default values when we initiate sessions
* Cleanups