### PR TITLE
Fixes for NPM packages

### DIFF
--- a/packages/matter-node-shell.js/package.json
+++ b/packages/matter-node-shell.js/package.json
@@ -29,7 +29,7 @@
         "shell": "matter-run src/app.ts"
     },
     "bin": {
-        "shell": "./dist/cjs/app.js"
+        "matter-shell": "./dist/cjs/app.js"
     },
     "devDependencies": {
         "typescript": "~5.4.5"

--- a/packages/matter-node-shell.js/src/app.ts
+++ b/packages/matter-node-shell.js/src/app.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 /**
  * @license
  * Copyright 2022-2024 Matter.js Authors

--- a/packages/matter-node.js-examples/src/examples/BridgedDevicesNode.ts
+++ b/packages/matter-node.js-examples/src/examples/BridgedDevicesNode.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 /**
  * @license
  * Copyright 2022-2024 Matter.js Authors

--- a/packages/matter-node.js-examples/src/examples/ComposedDeviceNode.ts
+++ b/packages/matter-node.js-examples/src/examples/ComposedDeviceNode.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 /**
  * @license
  * Copyright 2022-2024 Matter.js Authors

--- a/packages/matter-node.js-examples/src/examples/ControllerNode.ts
+++ b/packages/matter-node.js-examples/src/examples/ControllerNode.ts
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
-
 /**
  * @license
  * Copyright 2022-2024 Matter.js Authors

--- a/packages/matter-node.js-examples/src/examples/ControllerNodeLegacy.ts
+++ b/packages/matter-node.js-examples/src/examples/ControllerNodeLegacy.ts
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
-
 /**
  * @license
  * Copyright 2022-2023 Project CHIP Authors

--- a/packages/matter-node.js-examples/src/examples/DeviceNode.ts
+++ b/packages/matter-node.js-examples/src/examples/DeviceNode.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 /**
  * @license
  * Copyright 2022-2024 Matter.js Authors

--- a/packages/matter-node.js-examples/src/examples/DeviceNodeFull.ts
+++ b/packages/matter-node.js-examples/src/examples/DeviceNodeFull.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 /**
  * @license
  * Copyright 2022-2024 Matter.js Authors

--- a/packages/matter-node.js-examples/src/examples/IlluminatedRollerShade.ts
+++ b/packages/matter-node.js-examples/src/examples/IlluminatedRollerShade.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 /**
  * @license
  * Copyright 2022-2024 Matter.js Authors

--- a/packages/matter-node.js-examples/src/examples/LegacyStorageConverter.ts
+++ b/packages/matter-node.js-examples/src/examples/LegacyStorageConverter.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 /**
  * @license
  * Copyright 2022-2024 Matter.js Authors

--- a/packages/matter-node.js-examples/src/examples/LightDevice.ts
+++ b/packages/matter-node.js-examples/src/examples/LightDevice.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 /**
  * @license
  * Copyright 2022-2024 Matter.js Authors

--- a/packages/matter-node.js-examples/src/examples/MultiDeviceNode.ts
+++ b/packages/matter-node.js-examples/src/examples/MultiDeviceNode.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 /**
  * @license
  * Copyright 2022-2024 Matter.js Authors

--- a/packages/matter-node.js-examples/src/examples/SensorDeviceNode.ts
+++ b/packages/matter-node.js-examples/src/examples/SensorDeviceNode.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 /**
  * @license
  * Copyright 2022-2024 Matter.js Authors

--- a/packages/matter.js-tools/src/building/cli.ts
+++ b/packages/matter.js-tools/src/building/cli.ts
@@ -55,7 +55,11 @@ export async function main(argv = process.argv) {
             break;
 
         case Mode.BuildProjectWithDependencies:
-            await (await Graph.forProject(args.prefix)).build(builder());
+            const graph = await Graph.forProject(args.prefix);
+            if (graph === undefined) {
+                throw new Error(`Cannot build with dependencies because ${args.prefix} is not in a workspace`);
+            }
+            await graph.build(builder());
             break;
 
         case Mode.BuildWorkspace:

--- a/packages/matter.js-tools/src/testing/cli.ts
+++ b/packages/matter.js-tools/src/testing/cli.ts
@@ -103,7 +103,11 @@ export async function main(argv = process.argv) {
 
     const builder = new Builder();
     const dependencies = await Graph.forProject(packageLocation);
-    await dependencies.build(builder, false);
+    if (dependencies) {
+        await dependencies.build(builder, false);
+    } else {
+        await builder.build(project);
+    }
 
     const progress = project.pkg.start("Testing");
     const runner = new TestRunner(project.pkg, progress, args);

--- a/packages/matter.js-tools/src/util/package.ts
+++ b/packages/matter.js-tools/src/util/package.ts
@@ -10,6 +10,8 @@ import { dirname, relative, resolve } from "path";
 import { ignoreError, ignoreErrorSync } from "./errors.js";
 import { Progress } from "./progress.js";
 
+export class JsonNotFoundError extends Error {}
+
 function findJson(filename: string, path: string = ".", title?: string) {
     path = resolve(path);
     while (true) {
@@ -23,7 +25,7 @@ function findJson(filename: string, path: string = ".", title?: string) {
         }
         const parent = dirname(path);
         if (parent === path) {
-            throw new Error(`Could not locate ${title ?? filename}`);
+            throw new JsonNotFoundError(`Could not locate ${title ?? filename}`);
         }
         path = parent;
     }


### PR DESCRIPTION
- Adds shebang line to all app .ts files.  Currently npm run/npx fails for many of the examples.

- Make builds ignore dependencies if package is not within a workspace.  This allows matter-run to operate outside of git which in turns enables "npm run" outside of git.  Should fix "Could not locate package.json" error described in comments in #898

- Installs shell CLI as "matter-shell" to avoid name conflicts and match convention of our other scripts.