### PR TITLE
More updates for matter.js-tools installed via NPM

### DIFF
--- a/packages/matter.js-tools/src/tsconfig.json
+++ b/packages/matter.js-tools/src/tsconfig.json
@@ -4,5 +4,5 @@
         "outDir": "../dist/esm",
         "types": ["node"]
     },
-    "include": ["**/*.ts", "testing/mocharc.cjs"]
+    "include": ["**/*.ts", "testing/mocharc.cjs", "util/tools-path.d.cts"]
 }

--- a/packages/matter.js-tools/src/util/package.ts
+++ b/packages/matter.js-tools/src/util/package.ts
@@ -9,6 +9,7 @@ import { readdir, stat } from "fs/promises";
 import { dirname, relative, resolve } from "path";
 import { ignoreError, ignoreErrorSync } from "./errors.js";
 import { Progress } from "./progress.js";
+import { toolsPath } from "./tools-path.cjs";
 
 export class JsonNotFoundError extends Error {}
 
@@ -146,7 +147,7 @@ export class Package {
 
     static get tools() {
         if (!tools) {
-            tools = new Package({ path: this.workspace.resolve("packages/matter.js-tools") });
+            tools = new Package({ path: toolsPath });
         }
         return tools;
     }

--- a/packages/matter.js-tools/src/util/tools-path.cjs
+++ b/packages/matter.js-tools/src/util/tools-path.cjs
@@ -1,0 +1,13 @@
+/**
+ * @license
+ * Copyright 2022-2024 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+const { resolve } = require("path");
+
+// Node makes it impossible to obtain the path of the current file in a matter that transpiles cleanly to both ESM and
+// CJS.  __dirname is not available in ESM but you can't reference import.meta.url in CJS even conditionally because it
+// is a compile-time error.  So instead we locate the root of the tools package in this file which always runs as CJS
+// and is thus importable into both ESM and CJS.
+exports.toolsPath = resolve(__dirname, "../..");

--- a/packages/matter.js-tools/src/util/tools-path.d.cts
+++ b/packages/matter.js-tools/src/util/tools-path.d.cts
@@ -1,0 +1,7 @@
+/**
+ * @license
+ * Copyright 2022-2024 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export declare const toolsPath: string;


### PR DESCRIPTION
- Skip build if the target package is installed via NPM
- Support building when matter.js-tools is installed via NPM but the target package is not

Should fix #948