### PR TITLE
Clear subscriptions from the subscriber node

### DIFF
--- a/packages/matter.js/src/MatterDevice.ts
+++ b/packages/matter.js/src/MatterDevice.ts
@@ -504,6 +504,10 @@ export class MatterDevice {
         return { session, channel: await networkInterface.openChannel(device.addresses[0]) };
     }
 
+    async clearSubscriptionsForNode(peerNodeId: NodeId, flushSubscriptions?: boolean) {
+        await this.#sessionManager.clearSubscriptionsForNode(peerNodeId, flushSubscriptions);
+    }
+
     async close() {
         this.#isClosing = true;
         await this.endCommissioning();

--- a/packages/matter.js/src/protocol/interaction/InteractionServer.ts
+++ b/packages/matter.js/src/protocol/interaction/InteractionServer.ts
@@ -1062,8 +1062,10 @@ export class InteractionServer implements ProtocolHandler<MatterDevice>, Interac
         }
 
         if (!keepSubscriptions) {
-            logger.debug(`Clear subscriptions for Session ${session.name} because keepSubscriptions=false`);
-            await session.clearSubscriptions(true);
+            logger.debug(
+                `Clear subscriptions for Subscriber node ${session.peerNodeId} because keepSubscriptions=false`,
+            );
+            await session.context.clearSubscriptionsForNode(session.peerNodeId, true);
         }
 
         const maxInterval = subscriptionHandler.getMaxInterval();

--- a/packages/matter.js/src/session/SecureSession.ts
+++ b/packages/matter.js/src/session/SecureSession.ts
@@ -293,7 +293,8 @@ export class SecureSession<T> extends Session<T> {
     }
 
     async clearSubscriptions(flushSubscriptions = false) {
-        for (const subscription of this.#subscriptions) {
+        const subscriptions = [...this.#subscriptions]; // get all values because subscriptions will remove themselves when cancelled
+        for (const subscription of subscriptions) {
             await subscription.cancel(flushSubscriptions);
         }
         this.#subscriptions.length = 0;

--- a/packages/matter.js/src/session/SessionManager.ts
+++ b/packages/matter.js/src/session/SessionManager.ts
@@ -382,6 +382,14 @@ export class SessionManager<ContextT> {
             }));
     }
 
+    async clearSubscriptionsForNode(nodeId: NodeId, flushSubscriptions?: boolean) {
+        for (const session of this.#sessions) {
+            if (session.peerNodeId === nodeId) {
+                await session.clearSubscriptions(flushSubscriptions);
+            }
+        }
+    }
+
     async close() {
         await this.storeResumptionRecords();
         for (const session of this.#sessions) {


### PR DESCRIPTION
This PR includes two changes. First we remove all subscriptions from the same peerNode when "keepSubscriptions=false" is used for a new subscription and not only subscriptions from the same session. Additionally, it fixes a bug where not all subscriptions from the sessions were really cleared.