### PR TITLE
Add optional diagnostic name for offline tx

### DIFF
--- a/packages/matter.js/src/behavior/definitions/general-commissioning/ServerNodeFailsafeContext.ts
+++ b/packages/matter.js/src/behavior/definitions/general-commissioning/ServerNodeFailsafeContext.ts
@@ -77,7 +77,7 @@ export class ServerNodeFailsafeContext extends FailsafeContext {
     }
 
     override async restoreNetworkState() {
-        await this.#node.act(async agent => {
+        await this.#node.act(this.restoreNetworkState.name, async agent => {
             const context = agent.context;
 
             await this.#node.visit(async endpoint => {
@@ -96,7 +96,7 @@ export class ServerNodeFailsafeContext extends FailsafeContext {
     }
 
     override async restoreBreadcrumb() {
-        await this.#node.act(agent => {
+        await this.#node.act(this.restoreBreadcrumb.name, agent => {
             agent.generalCommissioning.state.breadcrumb = 0;
         });
     }

--- a/packages/matter.js/src/behavior/definitions/general-diagnostics/GeneralDiagnosticsServer.ts
+++ b/packages/matter.js/src/behavior/definitions/general-diagnostics/GeneralDiagnosticsServer.ts
@@ -75,7 +75,7 @@ export class GeneralDiagnosticsServer extends Base {
         const lifecycle = this.endpoint.lifecycle as NodeLifecycle;
 
         if (lifecycle.online !== undefined) {
-            this.reactTo(lifecycle.online, this.#online);
+            this.reactTo(lifecycle.online, this.#online, { lock: true });
         }
 
         if (this.events.activeHardwareFaults$Changed !== undefined) {

--- a/packages/matter.js/src/behavior/definitions/operational-credentials/OperationalCredentialsServer.ts
+++ b/packages/matter.js/src/behavior/definitions/operational-credentials/OperationalCredentialsServer.ts
@@ -471,9 +471,9 @@ export class OperationalCredentialsServer extends OperationalCredentialsBehavior
 
     async #nodeOnline() {
         const fabricManager = this.endpoint.env.get(FabricManager);
-        this.reactTo(fabricManager.events.added, this.#handleAddedFabric);
-        this.reactTo(fabricManager.events.updated, this.#handleUpdatedFabric);
-        this.reactTo(fabricManager.events.deleted, this.#handleRemovedFabric);
+        this.reactTo(fabricManager.events.added, this.#handleAddedFabric, { lock: true });
+        this.reactTo(fabricManager.events.updated, this.#handleUpdatedFabric, { lock: true });
+        this.reactTo(fabricManager.events.deleted, this.#handleRemovedFabric, { lock: true });
         await this.#updateFabrics();
     }
 }

--- a/packages/matter.js/src/behavior/state/managed/values/StructManager.ts
+++ b/packages/matter.js/src/behavior/state/managed/values/StructManager.ts
@@ -50,8 +50,13 @@ export function StructManager(owner: RootSupervisor, schema: Schema): ValueSuper
         }
     }
 
+    let name = schema.name;
+    if (schema.tag === ElementTag.Cluster && !name.endsWith("$State")) {
+        name = `${name}$State`;
+    }
+
     const Wrapper = GeneratedClass({
-        name: schema.tag === ElementTag.Cluster ? `${schema.name}$State` : `${schema.name}`,
+        name,
 
         initialize(this: Wrapper, ref: Val.Reference, session: ValueSupervisor.Session) {
             // Only objects are acceptable

--- a/packages/matter.js/src/behavior/system/network/NetworkRuntime.ts
+++ b/packages/matter.js/src/behavior/system/network/NetworkRuntime.ts
@@ -42,7 +42,9 @@ export abstract class NetworkRuntime {
         try {
             await this.start();
 
-            await this.#owner.act(agent => this.owner.lifecycle.online.emit(agent.context));
+            await this.#owner.act(`emit-online<${this.#owner}>`, agent =>
+                this.owner.lifecycle.online.emit(agent.context),
+            );
         } catch (e) {
             await this.#stop();
             throw e;
@@ -59,7 +61,9 @@ export abstract class NetworkRuntime {
         try {
             await this.#stop();
         } finally {
-            await this.#owner.act(agent => this.owner.lifecycle.offline.emit(agent.context));
+            await this.#owner.act(`emit-offline<${this.#owner}>`, agent =>
+                this.owner.lifecycle.offline.emit(agent.context),
+            );
         }
 
         this.#resolveClosed();
@@ -74,7 +78,10 @@ export abstract class NetworkRuntime {
         try {
             await this.stop();
         } finally {
-            await this.#owner.act(agent => (agent.get(NetworkBehavior).internal.runtime = undefined));
+            await this.#owner.act(
+                "clear-network-runtime",
+                agent => (agent.get(NetworkBehavior).internal.runtime = undefined),
+            );
         }
     }
 

--- a/packages/matter.js/src/behavior/system/network/ServerNetworkRuntime.ts
+++ b/packages/matter.js/src/behavior/system/network/ServerNetworkRuntime.ts
@@ -266,7 +266,7 @@ export class ServerNetworkRuntime extends NetworkRuntime {
 
     protected override async start() {
         const mdnsScanner = (await this.owner.env.load(MdnsService)).scanner;
-        await this.owner.act(agent => agent.load(ProductDescriptionServer));
+        await this.owner.act("start-network", agent => agent.load(ProductDescriptionServer));
 
         this.#interactionServer = await TransactionalInteractionServer.create(this.owner);
 
@@ -305,7 +305,7 @@ export class ServerNetworkRuntime extends NetworkRuntime {
         this.owner.env.set(FabricManager, matterDevice.fabricManager);
         this.owner.env.set(ExchangeManager, this.#matterDevice.exchangeManager);
 
-        await this.owner.act(agent => agent.load(SessionsBehavior));
+        await this.owner.act("load-sessions", agent => agent.load(SessionsBehavior));
         this.owner.eventsOf(CommissioningBehavior).commissioned.on(() => this.endUncommissionedMode());
 
         await this.addTransports(matterDevice);

--- a/packages/matter.js/src/endpoint/properties/Behaviors.ts
+++ b/packages/matter.js/src/endpoint/properties/Behaviors.ts
@@ -425,7 +425,7 @@ export class Behaviors {
     async reset() {
         for (const backing of Object.values(this.#backings)) {
             try {
-                await this.#endpoint.act(async agent => {
+                await this.#endpoint.act(`close<${this}>`, async agent => {
                     await backing.close(agent);
                 });
             } catch (e) {

--- a/packages/matter.js/src/node/ServerNode.ts
+++ b/packages/matter.js/src/node/ServerNode.ts
@@ -193,7 +193,7 @@ export class ServerNode<T extends ServerNode.RootEndpoint = ServerNode.RootEndpo
     }
 
     async advertiseNow() {
-        await this.act(agent => agent.get(NetworkServer).advertiseNow());
+        await this.act(`advertiseNow<${this}>`, agent => agent.get(NetworkServer).advertiseNow());
     }
 
     protected override async initialize(agent: Agent.Instance<T>) {

--- a/packages/matter.js/src/util/Error.ts
+++ b/packages/matter.js/src/util/Error.ts
@@ -1,0 +1,23 @@
+/**
+ * @license
+ * Copyright 2022-2024 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Access value as an {@link Error}ish object.
+ */
+export function errorOf(cause: unknown) {
+    if (cause instanceof Error) {
+        // An actual error
+        return cause;
+    }
+    const { name, message } = (Error ?? {}) as { name?: string; message?: string };
+    if (name !== undefined && name !== null && message !== undefined && message !== null) {
+        // Fulfills minimal error interface
+        return cause;
+    }
+
+    // Create an actual error
+    return new Error((cause ?? "Unknown error").toString());
+}

--- a/packages/matter.js/src/util/Mutex.ts
+++ b/packages/matter.js/src/util/Mutex.ts
@@ -59,7 +59,9 @@ export class Mutex implements PromiseLike<unknown> {
                 }
 
                 this.#cancel = cancel;
-                return this.initiateTask(task).finally((this.#cancel = undefined));
+                return this.initiateTask(task).finally(() => {
+                    this.#cancel = undefined;
+                });
             });
         }
     }


### PR DESCRIPTION
Makes logs more informative as previously these were just named "offline$x".

Also added additional locks for reactors as required by #988