### PR TITLE
Bump react-native-quick-crypto and typescript 

### DIFF
--- a/codegen/package.json
+++ b/codegen/package.json
@@ -38,7 +38,7 @@
         "@project-chip/matter.js-tools": "0.10.0-alpha.0-20240709-9d45732c",
         "@types/jsdom": "^21.1.6",
         "jsdom": "^24.1.0",
-        "typescript": "~5.5.2",
+        "typescript": "~5.5.3",
         "word-list": "^4.0.0",
         "yargs": "^17.7.2"
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "typedoc": "^0.26.3",
         "typedoc-plugin-markdown": "^3.17.1",
         "typedoc-plugin-missing-exports": "^3.0.0",
-        "typescript": "~5.5.2"
+        "typescript": "~5.5.3"
       }
     },
     "chip-testing": {
@@ -55,7 +55,7 @@
         "@project-chip/matter.js-tools": "0.10.0-alpha.0-20240709-9d45732c",
         "@types/jsdom": "^21.1.6",
         "jsdom": "^24.1.0",
-        "typescript": "~5.5.2",
+        "typescript": "~5.5.3",
         "word-list": "^4.0.0",
         "yargs": "^17.7.2"
       },
@@ -18311,9 +18311,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.2.tgz",
-      "integrity": "sha512-NcRtPEOsPFFWjobJEtfihkLCZCXZt/os3zf8nTxjVH3RvTSxjrCamJpbExGvYOF+tFHc3pA65qpdwPbzjohhew==",
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.3.tgz",
+      "integrity": "sha512-/hreyEujaB0w76zKo6717l3L0o/qEUtRgdvUBvlkhoWeOVMjMuHNHk0BRBzikzuGDqNmPQbg5ifMEqsHLiIUcQ==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -19588,7 +19588,7 @@
       "devDependencies": {
         "@project-chip/matter.js-tools": "0.10.0-alpha.0-20240709-9d45732c",
         "ts-node": "^10.9.2",
-        "typescript": "~5.5.2"
+        "typescript": "~5.5.3"
       },
       "engines": {
         "node": ">=16.0.0"
@@ -19615,7 +19615,7 @@
         "matter-shell": "dist/cjs/app.js"
       },
       "devDependencies": {
-        "typescript": "~5.5.2"
+        "typescript": "~5.5.3"
       },
       "engines": {
         "_comment": "For Crypto.hkdf support",
@@ -19635,7 +19635,7 @@
         "@types/bytebuffer": "^5.0.49",
         "@types/node-localstorage": "^1.3.3",
         "ts-node": "^10.9.2",
-        "typescript": "~5.5.2"
+        "typescript": "~5.5.3"
       },
       "engines": {
         "_comment": "For Crypto.hkdf support",
@@ -19669,7 +19669,7 @@
         "matter-sensor": "dist/esm/examples/SensorDeviceNode.js"
       },
       "devDependencies": {
-        "typescript": "~5.5.2"
+        "typescript": "~5.5.3"
       },
       "engines": {
         "_comment": "For Crypto.hkdf support",
@@ -19691,7 +19691,7 @@
         "chai": "^4.4.1",
         "embedme": "^1.22.1",
         "mocha": "^10.4.0",
-        "typescript": "~5.5.2"
+        "typescript": "~5.5.3"
       }
     },
     "packages/matter.js-react-native": {
@@ -19711,7 +19711,7 @@
       "devDependencies": {
         "@project-chip/matter.js-tools": "0.10.0-alpha.0-20240709-9d45732c",
         "ts-node": "^10.9.2",
-        "typescript": "~5.5.2"
+        "typescript": "~5.5.3"
       }
     },
     "packages/matter.js-tools": {
@@ -19730,7 +19730,7 @@
         "glob": "^10.4.1",
         "mocha": "^10.4.0",
         "playwright": "^1.44.1",
-        "typescript": "~5.5.2",
+        "typescript": "~5.5.3",
         "yargs": "^17.7.2"
       },
       "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5865,9 +5865,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.14.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.9.tgz",
-      "integrity": "sha512-06OCtnTXtWOZBJlRApleWndH4JsRVs1pDCc8dLSQp+7PpUpX3ePdHyeNSFTeSe7FtKyQkrlPvHwJOW3SLd8Oyg==",
+      "version": "20.14.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.10.tgz",
+      "integrity": "sha512-MdiXf+nDuMvY0gJKxyfZ7/6UFsETO7mGKF54MVD/ekJS6HdFtpZFBgrh6Pseu64XTb2MLyFPlbW6hj8HYRQNOQ==",
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -16060,9 +16060,9 @@
       }
     },
     "node_modules/react-native-quick-crypto": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/react-native-quick-crypto/-/react-native-quick-crypto-0.7.0.tgz",
-      "integrity": "sha512-zM/lfBgg1bXdQLigsOlfflVt2erRRps/IFLuJ+HKwp5Nh2E3+mMRMTK+UOHMoNYJiE5fpcb4GSh23+YK9KHkAg==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/react-native-quick-crypto/-/react-native-quick-crypto-0.7.1.tgz",
+      "integrity": "sha512-1F8D8oYdociccdiU5hciSJ+rvehdmaJRV2hIv/LgEwBthwkVdD7pSf6kFKwoY9Y2Ly6f7tfBCjYg4/uQRge8Jg==",
       "dependencies": {
         "@craftzdog/react-native-buffer": "^6.0.5",
         "events": "^3.3.0",
@@ -19703,8 +19703,9 @@
         "@project-chip/matter.js": "0.10.0-alpha.0-20240709-9d45732c",
         "@react-native-async-storage/async-storage": "^1.23.1",
         "@react-native-community/netinfo": "^11.3.2",
+        "@types/node": "^20.14.10",
         "react-native-ble-plx": "^3.2.0",
-        "react-native-quick-crypto": "^0.7.0-rc.9",
+        "react-native-quick-crypto": "^0.7.1",
         "react-native-udp": "^4.1.7"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,6 @@
     "typedoc": "^0.26.3",
     "typedoc-plugin-markdown": "^3.17.1",
     "typedoc-plugin-missing-exports": "^3.0.0",
-    "typescript": "~5.5.2"
+    "typescript": "~5.5.3"
   }
 }

--- a/packages/matter-node-ble.js/package.json
+++ b/packages/matter-node-ble.js/package.json
@@ -31,7 +31,7 @@
     "devDependencies": {
         "@project-chip/matter.js-tools": "0.10.0-alpha.0-20240709-9d45732c",
         "ts-node": "^10.9.2",
-        "typescript": "~5.5.2"
+        "typescript": "~5.5.3"
     },
     "dependencies": {
         "@project-chip/matter.js": "0.10.0-alpha.0-20240709-9d45732c"

--- a/packages/matter-node-shell.js/package.json
+++ b/packages/matter-node-shell.js/package.json
@@ -32,7 +32,7 @@
         "matter-shell": "./dist/cjs/app.js"
     },
     "devDependencies": {
-        "typescript": "~5.5.2"
+        "typescript": "~5.5.3"
     },
     "dependencies": {
         "@project-chip/matter-node-ble.js": "0.10.0-alpha.0-20240709-9d45732c",

--- a/packages/matter-node.js-examples/package.json
+++ b/packages/matter-node.js-examples/package.json
@@ -61,7 +61,7 @@
         "matter-legacystorageconverter": "./dist/esm/examples/LegacyStorageConverter.js"
     },
     "devDependencies": {
-        "typescript": "~5.5.2"
+        "typescript": "~5.5.3"
     },
     "dependencies": {
         "@project-chip/matter-node-ble.js": "0.10.0-alpha.0-20240709-9d45732c",

--- a/packages/matter-node.js/package.json
+++ b/packages/matter-node.js/package.json
@@ -35,7 +35,7 @@
         "@types/bytebuffer": "^5.0.49",
         "@types/node-localstorage": "^1.3.3",
         "ts-node": "^10.9.2",
-        "typescript": "~5.5.2"
+        "typescript": "~5.5.3"
     },
     "dependencies": {
         "@project-chip/matter.js": "0.10.0-alpha.0-20240709-9d45732c",

--- a/packages/matter.js-react-native/package.json
+++ b/packages/matter.js-react-native/package.json
@@ -37,9 +37,10 @@
         "@project-chip/matter-node.js": "0.10.0-alpha.0-20240709-9d45732c",
         "@project-chip/matter.js": "0.10.0-alpha.0-20240709-9d45732c",
         "@react-native-async-storage/async-storage": "^1.23.1",
-        "react-native-ble-plx": "^3.2.0",
         "@react-native-community/netinfo": "^11.3.2",
-        "react-native-quick-crypto": "^0.7.0-rc.9",
+        "@types/node": "^20.14.10",
+        "react-native-ble-plx": "^3.2.0",
+        "react-native-quick-crypto": "^0.7.1",
         "react-native-udp": "^4.1.7"
     },
     "files": [

--- a/packages/matter.js-react-native/package.json
+++ b/packages/matter.js-react-native/package.json
@@ -31,7 +31,7 @@
     "devDependencies": {
         "@project-chip/matter.js-tools": "0.10.0-alpha.0-20240709-9d45732c",
         "ts-node": "^10.9.2",
-        "typescript": "~5.5.2"
+        "typescript": "~5.5.3"
     },
     "dependencies": {
         "@project-chip/matter-node.js": "0.10.0-alpha.0-20240709-9d45732c",

--- a/packages/matter.js-tools/package.json
+++ b/packages/matter.js-tools/package.json
@@ -51,7 +51,7 @@
         "glob": "^10.4.1",
         "mocha": "^10.4.0",
         "playwright": "^1.44.1",
-        "typescript": "~5.5.2",
+        "typescript": "~5.5.3",
         "yargs": "^17.7.2"
     },
     "optionalDependencies": {

--- a/packages/matter.js/package.json
+++ b/packages/matter.js/package.json
@@ -43,7 +43,7 @@
         "chai": "^4.4.1",
         "embedme": "^1.22.1",
         "mocha": "^10.4.0",
-        "typescript": "~5.5.2"
+        "typescript": "~5.5.3"
     },
     "files": [
         "dist/**/*",


### PR DESCRIPTION
replaces https://github.com/project-chip/matter.js/pull/997 which returned an error on dgram types with this upgrade. And also updated typescript to 5.5.3