### PR TITLE
Fix Subscription clearing

### DIFF
--- a/packages/matter.js/src/MatterDevice.ts
+++ b/packages/matter.js/src/MatterDevice.ts
@@ -528,8 +528,8 @@ export class MatterDevice {
         return { session, channel: await networkInterface.openChannel(device.addresses[0]) };
     }
 
-    async clearSubscriptionsForNode(peerNodeId: NodeId, flushSubscriptions?: boolean) {
-        await this.#sessionManager.clearSubscriptionsForNode(peerNodeId, flushSubscriptions);
+    async clearSubscriptionsForNode(fabricIndex: FabricIndex, peerNodeId: NodeId, flushSubscriptions?: boolean) {
+        await this.#sessionManager.clearSubscriptionsForNode(fabricIndex, peerNodeId, flushSubscriptions);
     }
 
     async close() {

--- a/packages/matter.js/src/protocol/interaction/InteractionServer.ts
+++ b/packages/matter.js/src/protocol/interaction/InteractionServer.ts
@@ -1087,7 +1087,7 @@ export class InteractionServer implements ProtocolHandler<MatterDevice>, Interac
             logger.debug(
                 `Clear subscriptions for Subscriber node ${session.peerNodeId} because keepSubscriptions=false`,
             );
-            await session.context.clearSubscriptionsForNode(session.peerNodeId, true);
+            await session.context.clearSubscriptionsForNode(fabric.fabricIndex, session.peerNodeId, true);
         }
 
         const maxInterval = subscriptionHandler.maxInterval;

--- a/packages/matter.js/src/session/SessionManager.ts
+++ b/packages/matter.js/src/session/SessionManager.ts
@@ -8,6 +8,7 @@ import { MatterFlowError } from "../common/MatterError.js";
 import { Crypto } from "../crypto/Crypto.js";
 import { CaseAuthenticatedTag } from "../datatype/CaseAuthenticatedTag.js";
 import { FabricId } from "../datatype/FabricId.js";
+import { FabricIndex } from "../datatype/FabricIndex.js";
 import { NodeId } from "../datatype/NodeId.js";
 import { Fabric } from "../fabric/Fabric.js";
 import { Logger } from "../log/Logger.js";
@@ -373,9 +374,9 @@ export class SessionManager<ContextT> {
             }));
     }
 
-    async clearSubscriptionsForNode(nodeId: NodeId, flushSubscriptions?: boolean) {
+    async clearSubscriptionsForNode(fabricIndex: FabricIndex, nodeId: NodeId, flushSubscriptions?: boolean) {
         for (const session of this.#sessions) {
-            if (session.peerNodeId === nodeId) {
+            if (session.fabric?.fabricIndex === fabricIndex && session.peerNodeId === nodeId) {
                 await session.clearSubscriptions(flushSubscriptions);
             }
         }


### PR DESCRIPTION
The most current definition of subscriber is a node on a fabric ... and we missed the fabric in the last adjustment. This might be just a special case for testing because of overlapping peerNodeIds but better fix properly