### PR TITLE
Add Metro configuration instructions for React Native

### DIFF
--- a/packages/matter.js-react-native/README.md
+++ b/packages/matter.js-react-native/README.md
@@ -23,3 +23,21 @@ This package uses the following react-native libraries to provide the needed fun
 ## Tests
 
 No tests available for now
+
+## React Native Configuration
+To use \`**matter.js**\` with React Native, you need to modify your Metro configuration to ensure that the packages are resolved correctly. You need to add a special resolver entry and merge it with your existing Metro configuration. Below is an example of how to do this:
+```javascript
+/* eslint-env node */
+const { mergeConfig } = require('@react-native/metro-config');
+const { getSentryExpoConfig } = require('@sentry/react-native/metro');
+
+// Your existing Sentry configuration (or any other configuration you have)
+const sentryConfig = getSentryExpoConfig(__dirname);
+
+// New resolver configuration to fix the package resolution issue
+const customConfig = { resolver: { unstable_enablePackageExports: true } };
+
+// Merging your existing configuration with the new resolver configuration
+module.exports = mergeConfig(sentryConfig, customConfig);
+```
+In this example, \`**customConfig**\` includes the necessary resolver configuration, and \`**mergeConfig**\` is used to combine it with your existing configuration (\`**sentryConfig**\` in this case). Adjust \`**sentryConfig**\` to fit your existing Metro configuration step.


### PR DESCRIPTION
### Summary

This PR updates the `README.md` file in the `matter.js-react-native` package to include necessary Metro bundler configuration instructions for React Native projects.

### Changes

- Added a section to `README.md` detailing the required Metro configuration for resolving `matter.js` packages in React Native.

### Why

Without this configuration, users may encounter module resolution errors when integrating `matter.js` with React Native. This update aims to provide clear guidance to prevent such issues.

### Related Issues

- Fixes module resolution error as discussed in the project’s discussions.

### Checklist

- [x] Updated documentation
- [x] Verified changes locally
