### PR TITLE
Ignore missing ClusterServer elements for Controller

### DIFF
--- a/packages/matter.js/src/cluster/server/ClusterServer.ts
+++ b/packages/matter.js/src/cluster/server/ClusterServer.ts
@@ -63,6 +63,7 @@ export function ClusterServer<
     attributesInitialValues: AttributeInitialValues<A>,
     handlers: H,
     supportedEvents: SupportedEventsList<E> = <SupportedEventsList<E>>{},
+    ignoreMissingElements = false,
 ): ClusterServerObj<A, E> {
     const {
         id: clusterId,
@@ -416,7 +417,15 @@ export function ClusterServer<
     for (const eventName in eventDef) {
         const { id, schema, priority, optional, readAcl } = eventDef[eventName];
         if (!optional && (supportedEvents as any)[eventName] !== true) {
-            throw new ImplementationError(`Event ${eventName} needs to be supported by cluster ${name} (${clusterId})`);
+            if (!ignoreMissingElements) {
+                throw new ImplementationError(
+                    `Event ${eventName} needs to be supported by cluster ${name} (${clusterId})`,
+                );
+            }
+            logger.warn(
+                `Event ${eventName} should to be supported by cluster ${name} (${clusterId}) but not present and ignored.`,
+            );
+            continue;
         }
 
         if (eventDef[eventName].isConditional) {

--- a/packages/matter.js/src/device/PairedNode.ts
+++ b/packages/matter.js/src/device/PairedNode.ts
@@ -566,10 +566,13 @@ export class PairedNode {
             const clusterData = (data[clusterId] ?? {}) as AttributeInitialValues<Attributes>; // TODO correct typing
             // Todo add logic for Events
             endpointClusters.push(
-                ClusterServer(cluster, /*clusterData.featureMap,*/ clusterData, {}) as ClusterServerObj<
-                    Attributes,
-                    Events
-                >,
+                ClusterServer(
+                    cluster,
+                    /*clusterData.featureMap,*/ clusterData,
+                    {},
+                    undefined,
+                    true,
+                ) as ClusterServerObj<Attributes, Events>,
             ); // TODO Add Default handler!
         }
 


### PR DESCRIPTION
When initialization of ClusterServers in Controller use cases miss elements - mainly events for now - ignore them.

fixes #1048 