### PR TITLE
Try real hard to surface error details

### DIFF
--- a/.github/workflows/build-test.js.yml
+++ b/.github/workflows/build-test.js.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [ 16.x, 18.x, 20.x ]
+        node-version: [ 18.x, 20.x ]
         os: [ macos-latest, windows-2019 ]
     steps:
       - uses: actions/checkout@v4
@@ -60,7 +60,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [ 16.x, 18.x, 20.x ]
+        node-version: [ 18.x, 20.x ]
     steps:
       - uses: actions/checkout@v4
       - name: Prepare testing environment

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [ 16.x, 18.x, 20.x ]
+        node-version: [ 18.x, 20.x ]
         os: [ macos-latest, windows-2019 ]
     steps:
       - uses: actions/checkout@v4
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [ 16.x, 18.x, 20.x ]
+        node-version: [ 18.x, 20.x ]
     steps:
       - uses: actions/checkout@v4
       - name: Prepare testing environment

--- a/packages/matter-node.js/src/environment/NodeJsEnvironment.ts
+++ b/packages/matter-node.js/src/environment/NodeJsEnvironment.ts
@@ -47,7 +47,8 @@ import { ProcessManager } from "./ProcessManager.js";
  * * `storage.path` - Where to store storage files, Default: "path.root"
  * * `storage.clear` - Clear storage on start? Default: false
  * * `runtime.signals` - By default register SIGINT and SIGUSR2 (diag) handlers, set to false if not wanted
- * * `runtime.exitcode` - by default we set the process.exitcode to 0 (ok) or 1 (crash), set to false if not wanted
+ * * `runtime.exitcode` - By default we set the process.exitcode to 0 (ok) or 1 (crash); set to false to disable
+ * * `runtime.unhandlederrors` - By default we log unhandled errors to matter.js log; set to false to disable
  */
 export function NodeJsEnvironment() {
     const env = new Environment("default");

--- a/packages/matter-node.js/src/environment/ProcessManager.ts
+++ b/packages/matter-node.js/src/environment/ProcessManager.ts
@@ -42,6 +42,12 @@ export class ProcessManager implements Destructable {
         this.runtime.started.on(this.startListener);
         this.runtime.stopped.on(this.stopListener);
         this.runtime.crashed.on(this.crashListener);
+
+        if (this.hasUnhandledErrorSupport) {
+            process.addListener("uncaughtExceptionMonitor", event => {
+                Logger.reportUnhandledError(event);
+            });
+        }
     }
 
     close() {
@@ -61,6 +67,10 @@ export class ProcessManager implements Destructable {
 
     protected get hasExitCodeSupport() {
         return this.env.vars.get("runtime.exitcode", true);
+    }
+
+    protected get hasUnhandledErrorSupport() {
+        return this.env.vars.get("runtime.unhandlederrors", true);
     }
 
     protected startListener = () => {

--- a/packages/matter.js/src/MatterDevice.ts
+++ b/packages/matter.js/src/MatterDevice.ts
@@ -398,7 +398,7 @@ export class MatterDevice {
         // MDNS is sent in parallel
         // TODO - untracked promise
         this.sendCommissionableAnnouncement(mode, discriminator).catch(error =>
-            logger.warn("Error sending announcement", error),
+            logger.warn("Error sending announcement:", error),
         );
     }
 
@@ -407,7 +407,7 @@ export class MatterDevice {
             return;
         }
         this.sendCommissionableAnnouncement(this.activeCommissioningMode, this.activeCommissioningDiscriminator).catch(
-            error => logger.warn("Error sending announcement", error),
+            error => logger.warn("Error sending announcement:", error),
         );
     }
 

--- a/packages/matter.js/test/common/MatterErrorTest.ts
+++ b/packages/matter.js/test/common/MatterErrorTest.ts
@@ -1,0 +1,120 @@
+/**
+ * @license
+ * Copyright 2022-2024 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { MatterAggregateError, MatterError } from "../../src/common/MatterError.js";
+import "../../src/log/Format.js";
+
+function errorFrame0() {
+    const error = new MatterError("oopsy!");
+    error.cause = new MatterAggregateError(
+        [new Error("a problem"), new MatterError("another problem")],
+        "some details",
+    );
+    (error.cause as AggregateError).errors[0].cause = new Error("your mom");
+    throw error;
+}
+
+function errorFrame1() {
+    try {
+        errorFrame0();
+    } catch (e) {
+        if (e instanceof MatterError) {
+            return e;
+        }
+
+        // Impossible
+        const error = new MatterError("Umm, error not a MatterError??");
+        error.cause = e;
+        return error;
+    }
+
+    // Impossible
+    return new MatterError("Umm, failed to throw??");
+}
+
+// This is the error we're going to test.  We create a couple of functions deep so we can ensure there are common stack
+// frames in all environments
+const error = errorFrame1();
+
+function assertExpectedText(text: string, { truncatedStack, ansi }: { truncatedStack?: boolean; ansi?: boolean } = {}) {
+    try {
+        const iterator = text.split("\n")[Symbol.iterator]();
+
+        let current = iterator.next().value as string | undefined;
+
+        let stackShouldTruncate = false;
+
+        function next() {
+            current = iterator.next().value;
+        }
+
+        function expectMessage(text: string, indents = 0) {
+            let prefix = " ".repeat(indents * 2);
+            if (ansi) {
+                prefix += "\x1b\\[(?:0;)?31m";
+            }
+            expect(current).match(new RegExp(`${prefix}${text}`));
+            next();
+        }
+
+        function expectStack(indents = 0, withReset = false) {
+            const indent = " ".repeat(2 + indents * 2);
+            const frameMarker = ansi
+                ? new RegExp(`^${indent}(?:\x1b\\[2;39m)?at \x1b\\[0m`)
+                : new RegExp(`^${indent}at `);
+            const reset = ansi && withReset ? "\x1b[0m" : "";
+
+            expect(current).match(frameMarker);
+            next();
+
+            while (current?.match(frameMarker)) {
+                next();
+            }
+
+            if (stackShouldTruncate) {
+                expect(current).equals(`${indent}(see parent frames)${reset}`);
+                next();
+            }
+        }
+
+        expectMessage("oopsy!");
+        expectStack();
+        stackShouldTruncate = truncatedStack !== false;
+        expectMessage("Caused by: some details");
+        expectStack();
+        expectMessage("Cause #0: a problem", 1);
+        expectStack(1);
+        expectMessage("Caused by: your mom", 1);
+        expectStack(1);
+        expectMessage("Cause #1: another problem", 1);
+        expectStack(1, true);
+        expect(current).undefined;
+    } catch (e) {
+        console.log("Failing formatted error follows");
+        console.log(text);
+        throw e;
+    }
+}
+
+describe("MatterError", () => {
+    it("formats plain", () => {
+        assertExpectedText(error.format());
+    });
+
+    it("formats ansi", () => {
+        assertExpectedText(error.format("ansi"), { ansi: true });
+    });
+
+    it("formats fallback", () => {
+        const originalFormatter = MatterError.formatterFor;
+        try {
+            (MatterError as any).formatterFor = undefined;
+            assertExpectedText(error.format(), { truncatedStack: false });
+        } finally {
+            MatterError.formatterFor = originalFormatter;
+        }
+    });
+});

--- a/packages/matter.js/test/log/LoggerTest.ts
+++ b/packages/matter.js/test/log/LoggerTest.ts
@@ -327,7 +327,7 @@ describe("Logger", () => {
             });
 
             expect(result?.message).equals(
-                "\u001b[2mxxxx-xx-xx xx:xx:xx.xxx INFO   \u001b[0;1;90mUnitTest             \u001b[0mstart same line\nnext line\nand more \nand more\n  indented\n  next line\n    indented deeper\n    and more\n  up again\n    and down\nand all the way up\u001b[0m",
+                "\u001b[2mxxxx-xx-xx xx:xx:xx.xxx INFO   \u001b[0;1;90mUnitTest             \u001b[0mstart same line\n  next line\n  and more \n  and more\n    indented\n    next line\n      indented deeper\n      and more\n    up again\n      and down\n  and all the way up\u001b[0m",
             );
         });
     });


### PR DESCRIPTION
Some environments do not report `Error#cause` or `AggregateError#errors`.  Or if they do they may not report them when deeply nested (e.g. with Node's default `util.inspect` implementation).

To work around this, on node.js we now monitor uncaught exceptions and report them in matter.js logs using matter.js's formatting.  We also offer error formatting via `MatterError#format()` and provide a custom inspector for node.js.

Includes related improvements:

  - Modifies object formatting so it's available outside of logging
  - Adds more comprehensive tests for error formatting logic