### PR TITLE
Allow MaxPathsPerInvoke to use default logic

### DIFF
--- a/chip-testing/src/AllClustersTestInstance.ts
+++ b/chip-testing/src/AllClustersTestInstance.ts
@@ -192,7 +192,6 @@ export class AllClustersTestInstance implements TestInstance {
                         primaryColor: BasicInformation.Color.Purple,
                     },
                     reachable: true,
-                    maxPathsPerInvoke: 10,
                 },
                 generalDiagnostics: {
                     totalOperationalHours: 0, // set to enable it

--- a/models/src/local/BasicInformationOverrides.ts
+++ b/models/src/local/BasicInformationOverrides.ts
@@ -10,14 +10,15 @@ LocalMatter.children.push({
     tag: "cluster",
     name: "BasicInformation",
 
+    // We override default in Model to 0 in order to use our default settings.
+    // Both API versions use defaults when 0 would exist.
     children: [
         {
             tag: "attribute",
-            name: "ProductAppearance",
-            id: 0x14,
-            type: "ProductAppearanceStruct",
-            conformance: "O",
-            quality: "F",
+            name: "MaxPathsPerInvoke",
+            id: 0x16,
+            constraint: "min 0",
+            default: 0,
         },
     ],
 });

--- a/packages/matter.js/src/cluster/definitions/BasicInformationCluster.ts
+++ b/packages/matter.js/src/cluster/definitions/BasicInformationCluster.ts
@@ -604,7 +604,7 @@ export namespace BasicInformation {
              *
              * @see {@link MatterSpecification.v13.Core} § 11.1.5.23
              */
-            maxPathsPerInvoke: FixedAttribute(0x16, TlvUInt16.bound({ min: 1 }), { default: 1 })
+            maxPathsPerInvoke: FixedAttribute(0x16, TlvUInt16, { default: 0 })
         },
 
         events: {

--- a/packages/matter.js/src/model/standard/elements/BasicInformation.ts
+++ b/packages/matter.js/src/model/standard/elements/BasicInformation.ts
@@ -299,7 +299,7 @@ export const BasicInformation = Cluster({
 
         Attribute({
             name: "MaxPathsPerInvoke", id: 0x16, type: "uint16", access: "R V", conformance: "M",
-            constraint: "min 1", default: 1, quality: "F",
+            constraint: "min 0", default: 0, quality: "F",
 
             details: "Indicates the maximum number of elements in a single InvokeRequests list (see Section 8.8.2, " +
                 "“Invoke Request Action”) that the Node is able to process. Note that since this attribute may " +


### PR DESCRIPTION
The change adjusts the MaxPathsPerInvoke attribute to have a minimum of 0 again so the out default logic applies.