### PR TITLE
Freeze operational schema

### DIFF
--- a/packages/matter.js/src/behavior/cluster/ClusterBehaviorUtil.ts
+++ b/packages/matter.js/src/behavior/cluster/ClusterBehaviorUtil.ts
@@ -61,6 +61,9 @@ export function createType<const C extends ClusterType>(cluster: C, base: Behavi
         name = `${cluster.name}Behavior`;
     }
 
+    // Mutation of schema will almost certainly result in logic errors so ensure that can't happen
+    schema.freeze();
+
     return GeneratedClass({
         name,
         base,

--- a/packages/matter.js/src/behavior/definitions/general-diagnostics/GeneralDiagnosticsServer.ts
+++ b/packages/matter.js/src/behavior/definitions/general-diagnostics/GeneralDiagnosticsServer.ts
@@ -11,6 +11,7 @@ import { Endpoint } from "../../../endpoint/Endpoint.js";
 import { MdnsService } from "../../../environment/MdnsService.js";
 import { Logger } from "../../../log/Logger.js";
 import { FieldElement } from "../../../model/elements/FieldElement.js";
+import { ClusterModel } from "../../../model/index.js";
 import { NodeLifecycle } from "../../../node/NodeLifecycle.js";
 import { TlvInvokeResponse } from "../../../protocol/interaction/InteractionProtocol.js";
 import { INTERACTION_MODEL_REVISION } from "../../../protocol/interaction/InteractionServer.js";
@@ -28,6 +29,10 @@ const logger = Logger.get("GeneralDiagnosticsServer");
 
 // Enable DataModelTest feature by default because we use MaxPathsPerInvoke > 1 by default
 const Base = GeneralDiagnosticsBehavior.with(GeneralDiagnostics.Feature.DataModelTest);
+
+// Enhance the Schema to store the real operational hours counter we internally use and persist this
+const schema = Base.schema?.clone() as ClusterModel;
+schema.add(FieldElement({ name: "totalOperationalHoursCounter", type: "uint64", quality: "N" }));
 
 /**
  * This is the default server implementation of GeneralDiagnosticsBehavior.
@@ -48,13 +53,7 @@ const Base = GeneralDiagnosticsBehavior.with(GeneralDiagnostics.Feature.DataMode
 export class GeneralDiagnosticsServer extends Base {
     protected declare internal: GeneralDiagnosticsServer.Internal;
     declare state: GeneralDiagnosticsServer.State;
-
-    static {
-        // Enhance the Schema to store the real operational hours counter we internally use and persist this
-        GeneralDiagnosticsServer.schema?.children.push(
-            FieldElement({ name: "totalOperationalHoursCounter", type: "uint64", quality: "N" }),
-        );
-    }
+    schema = schema;
 
     override initialize() {
         if (this.state.testEventTriggersEnabled === undefined) {

--- a/packages/matter.js/src/behavior/definitions/switch/SwitchServer.ts
+++ b/packages/matter.js/src/behavior/definitions/switch/SwitchServer.ts
@@ -7,6 +7,7 @@
 import { ClusterType } from "../../../cluster/ClusterType.js";
 import { Switch } from "../../../cluster/definitions/SwitchCluster.js";
 import { FieldElement } from "../../../model/elements/FieldElement.js";
+import { ClusterModel } from "../../../model/index.js";
 import { StatusCode, StatusResponseError } from "../../../protocol/interaction/StatusCode.js";
 import { Time, Timer } from "../../../time/Time.js";
 import { Observable } from "../../../util/Observable.js";
@@ -19,6 +20,14 @@ const SwitchServerBase = SwitchBehavior.for(Switch.Complete).with(
     Switch.Feature.MomentarySwitchRelease,
     Switch.Feature.MomentarySwitchLongPress,
     Switch.Feature.MomentarySwitchMultiPress,
+);
+
+// Enhance Schema to define conformance for some of the additional state attributes
+const schema = SwitchServerBase.schema?.clone() as ClusterModel;
+schema.add(
+    FieldElement({ name: "longPressDelay", type: "uint32", quality: "M", conformance: "MSL" }),
+    FieldElement({ name: "multiPressDelay", type: "uint32", quality: "M", conformance: "MSM" }),
+    FieldElement({ name: "momentaryNeutralPosition", type: "uint8", quality: "O", conformance: "MS" }),
 );
 
 /**
@@ -47,15 +56,7 @@ export class SwitchServerLogic extends SwitchServerBase {
     protected declare internal: SwitchServerLogic.Internal;
     declare state: SwitchServerLogic.State;
     declare events: SwitchServerLogic.Events;
-
-    // Enhance Schema to define conformance for some of the additional state attributes
-    static {
-        SwitchServerLogic.schema?.children.push(
-            FieldElement({ name: "longPressDelay", type: "uint32", quality: "M", conformance: "MSL" }),
-            FieldElement({ name: "multiPressDelay", type: "uint32", quality: "M", conformance: "MSM" }),
-            FieldElement({ name: "momentaryNeutralPosition", type: "uint8", quality: "O", conformance: "MS" }),
-        );
-    }
+    schema = schema;
 
     override initialize() {
         this.state.rawPosition = this.state.currentPosition;

--- a/packages/matter.js/src/behavior/supervision/BehaviorSupervisor.ts
+++ b/packages/matter.js/src/behavior/supervision/BehaviorSupervisor.ts
@@ -28,7 +28,7 @@ import { Schema } from "./Schema.js";
 export function BehaviorSupervisor(options: BehaviorSupervisor.Options): RootSupervisor {
     const logical = options.schema ?? Schema.empty;
 
-    // Copy children for the
+    // Copy children so we can extend
     const children = logical.children.map(child => child.clone());
 
     // Add fields for programmatic extensions
@@ -50,6 +50,8 @@ export function BehaviorSupervisor(options: BehaviorSupervisor.Options): RootSup
             children,
         });
     }
+
+    schema.freeze();
 
     return new RootSupervisor(schema);
 }

--- a/packages/matter.js/src/model/aspects/Aspect.ts
+++ b/packages/matter.js/src/model/aspects/Aspect.ts
@@ -9,9 +9,8 @@ import { serialize } from "../../util/String.js";
 import { DefinitionError } from "../definitions/DefinitionError.js";
 
 /**
- * An "aspect" is metadata about a Matter element that affects implementation
- * behavior.  Aspects are mostly "qualities" in the Matter specification except
- * for "constraint" which is not formally described as a quality.
+ * An "aspect" is metadata about a Matter element that affects implementation behavior.  Aspects are mostly "qualities"
+ * in the Matter specification except for "constraint" which is not formally described as a quality.
  */
 export abstract class Aspect<D> {
     definition: D;
@@ -78,5 +77,9 @@ export abstract class Aspect<D> {
 
         const constructor = this.constructor as new (definition: any) => Aspect<D>;
         return new constructor(definition) as This;
+    }
+
+    freeze() {
+        Object.freeze(this);
     }
 }

--- a/packages/matter.js/src/model/aspects/Constraint.ts
+++ b/packages/matter.js/src/model/aspects/Constraint.ts
@@ -150,6 +150,13 @@ export class Constraint extends Aspect<Constraint.Definition> implements Constra
         }
         return Constraint.serialize(this);
     }
+
+    override freeze() {
+        if (this.parts) {
+            Object.freeze(this.parts);
+        }
+        super.freeze();
+    }
 }
 
 export namespace Constraint {

--- a/packages/matter.js/src/model/models/Children.ts
+++ b/packages/matter.js/src/model/models/Children.ts
@@ -60,6 +60,11 @@ export interface Children<M extends Model = Model, E extends AnyElement = AnyEle
      * Models invoke this when their name changes so we can update internal bookkeeping.
      */
     updateName(child: Model, oldName: string): void;
+
+    /**
+     * Freeze the set of children.
+     */
+    freeze(): void;
 }
 
 type IndexEntry = Model | Model[];
@@ -478,6 +483,13 @@ export function Children<M extends Model = Model, E extends AnyElement = AnyElem
         });
     }
 
+    function freeze() {
+        for (const child of self) {
+            (child as Model).freeze();
+        }
+        Object.freeze(children);
+    }
+
     const self = new Proxy(children, {
         get: (_target, p, receiver) => {
             if (typeof p === "string" && p.match(/^[0-9]+$/)) {
@@ -512,6 +524,9 @@ export function Children<M extends Model = Model, E extends AnyElement = AnyElem
 
                 case "splice":
                     return splice;
+
+                case "freeze":
+                    return freeze;
 
                 case "toString":
                     return () => `[Children: ${children.length}]`;

--- a/packages/matter.js/src/model/models/ClusterModel.ts
+++ b/packages/matter.js/src/model/models/ClusterModel.ts
@@ -146,7 +146,12 @@ export class ClusterModel extends Model implements ClusterElement {
     set supportedFeatures(features: FeatureSet.Definition | undefined) {
         const featureSet = new FeatureSet(features);
 
-        const featureMap = this.featureMap;
+        let featureMap = this.featureMap;
+
+        if (featureMap.parent !== this) {
+            featureMap = featureMap.clone();
+            this.add(featureMap);
+        }
 
         for (const feature of featureMap.children) {
             const desc = feature.description && camelize(feature.description);
@@ -195,6 +200,11 @@ export class ClusterModel extends Model implements ClusterElement {
             result.quality = this.quality.valueOf();
         }
         return result as ClusterElement;
+    }
+
+    override freeze() {
+        this.quality.freeze();
+        super.freeze();
     }
 
     constructor(definition: ClusterElement.Properties) {

--- a/packages/matter.js/src/model/models/Model.ts
+++ b/packages/matter.js/src/model/models/Model.ts
@@ -413,6 +413,20 @@ export abstract class Model {
         }
     }
 
+    /**
+     * Freeze the model hierarchy rooted at this model.
+     *
+     * When using a model as operational schema we implement various optimizations that assume the schema is immutable.
+     * This function enforces that assumption.
+     *
+     * To make changes to a frozen model use {@link clone}.
+     */
+    freeze() {
+        Object.freeze(this);
+        this.children.freeze();
+        this.base?.freeze();
+    }
+
     toString() {
         return `${this.tag}${this.type ? `<${this.type}>` : ""}#${this.path}`;
     }

--- a/packages/matter.js/src/model/models/ValueModel.ts
+++ b/packages/matter.js/src/model/models/ValueModel.ts
@@ -304,6 +304,14 @@ export abstract class ValueModel extends Model implements ValueElement {
         return result as AnyElement;
     }
 
+    override freeze() {
+        this.constraint.freeze();
+        this.conformance.freeze();
+        this.access.freeze();
+        this.quality.freeze();
+        super.freeze();
+    }
+
     constructor(definition: ValueElement.Properties) {
         super(definition);
 

--- a/packages/matter.js/test/behavior/definitions/concentration-measurement/ConcentrationMeasurementServerTest.ts
+++ b/packages/matter.js/test/behavior/definitions/concentration-measurement/ConcentrationMeasurementServerTest.ts
@@ -1,0 +1,92 @@
+/**
+ * @license
+ * Copyright 2022-2024 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { CarbonDioxideConcentrationMeasurementServer } from "../../../../src/behavior/definitions/carbon-dioxide-concentration-measurement/CarbonDioxideConcentrationMeasurementServer.js";
+import { CarbonMonoxideConcentrationMeasurementServer } from "../../../../src/behavior/definitions/carbon-monoxide-concentration-measurement/CarbonMonoxideConcentrationMeasurementServer.js";
+import { ConcentrationMeasurement } from "../../../../src/cluster/definitions/ConcentrationMeasurementCluster.js";
+import { FanControl } from "../../../../src/cluster/definitions/FanControlCluster.js";
+import { AirPurifierDevice } from "../../../../src/endpoint/definitions/device/AirPurifierDevice.js";
+import { Endpoint } from "../../../../src/endpoint/Endpoint.js";
+import { MockServerNode } from "../../../node/mock-server-node.js";
+
+const fanControl = { fanModeSequence: FanControl.FanModeSequence.OffHigh, percentCurrent: 50 };
+
+describe("ConcentrationMeasurementServer", () => {
+    it("supports numeric measurement mode", async () => {
+        const node = await MockServerNode.create();
+        const Co2MeasurementServer = CarbonDioxideConcentrationMeasurementServer.with("NumericMeasurement");
+
+        const PurifierDevice = AirPurifierDevice.with(Co2MeasurementServer);
+        const purifier = new Endpoint(PurifierDevice, {
+            fanControl,
+            carbonDioxideConcentrationMeasurement: {
+                measurementMedium: ConcentrationMeasurement.MeasurementMedium.Air,
+                measurementUnit: ConcentrationMeasurement.MeasurementUnit.Ppm,
+            },
+        });
+
+        await node.add(purifier);
+
+        await purifier.set({
+            carbonDioxideConcentrationMeasurement: {
+                measuredValue: 4,
+            },
+        });
+    });
+
+    it("supports level indication mode", async () => {
+        const node = await MockServerNode.create();
+        const CoMeasurementServer = CarbonDioxideConcentrationMeasurementServer.with("LevelIndication");
+
+        const PurifierDevice = AirPurifierDevice.with(CoMeasurementServer);
+        const purifier = new Endpoint(PurifierDevice, {
+            fanControl,
+            carbonDioxideConcentrationMeasurement: {
+                measurementMedium: ConcentrationMeasurement.MeasurementMedium.Air,
+            },
+        });
+
+        await node.add(purifier);
+
+        await purifier.set({
+            carbonDioxideConcentrationMeasurement: {
+                levelValue: ConcentrationMeasurement.LevelValue.High,
+            },
+        });
+    });
+
+    it("supports one value mode with sibling with different value mode", async () => {
+        const node = await MockServerNode.create();
+        const Co2MeasurementServer = CarbonDioxideConcentrationMeasurementServer.with("NumericMeasurement");
+        const CoMeasurementServer = CarbonMonoxideConcentrationMeasurementServer.with("LevelIndication");
+
+        const PurifierDevice = AirPurifierDevice.with(Co2MeasurementServer, CoMeasurementServer);
+        const purifier = new Endpoint(PurifierDevice, {
+            fanControl,
+
+            carbonDioxideConcentrationMeasurement: {
+                measurementMedium: ConcentrationMeasurement.MeasurementMedium.Air,
+                measurementUnit: ConcentrationMeasurement.MeasurementUnit.Ppm,
+            },
+
+            carbonMonoxideConcentrationMeasurement: {
+                measurementMedium: ConcentrationMeasurement.MeasurementMedium.Air,
+            },
+        });
+
+        await node.add(purifier);
+
+        await purifier.set({
+            carbonDioxideConcentrationMeasurement: {
+                measuredValue: 4,
+            },
+
+            carbonMonoxideConcentrationMeasurement: {
+                levelValue: ConcentrationMeasurement.LevelValue.High,
+            },
+        });
+    });
+});


### PR DESCRIPTION
When we use models operationally as schema we treat them as immutable.  We now formalize this by freezing constituent objects.  This results in an error (assuming strict mode) for operations that would otherwise change the schema.

Includes tests for ConcentrationMeasurement cluster and a related fix for feature map configuration for derived clusters.