### PR TITLE
Dynamically configure Switch Simulator and no Debouncing

### DIFF
--- a/chip-testing/src/NamedPipeCommandHandler.ts
+++ b/chip-testing/src/NamedPipeCommandHandler.ts
@@ -117,19 +117,19 @@ export class NamedPipeCommandHandler {
                 if (endpoint === undefined) {
                     throw new Error(`Endpoint ${endpointId} not existing`);
                 }
-                SwitchSimulator.simulateLongPress(endpoint, data);
+                await SwitchSimulator.simulateLongPress(endpoint, data);
                 break;
             case "SimulateMultiPress":
                 if (endpoint === undefined) {
                     throw new Error(`Endpoint ${endpointId} not existing`);
                 }
-                SwitchSimulator.simulateMultiPress(endpoint, data);
+                await SwitchSimulator.simulateMultiPress(endpoint, data);
                 break;
             case "SimulateLatchPosition":
                 if (endpoint === undefined) {
                     throw new Error(`Endpoint ${endpointId} not existing`);
                 }
-                await endpoint.setStateOf(SwitchServer, { rawPosition: data.PositionId });
+                await endpoint.setStateOf(SwitchServer, { currentPosition: data.PositionId });
                 break;
             default:
                 console.log(`Unknown named pipe command: ${name}`);

--- a/chip-testing/src/simulators/SwitchSimulator.ts
+++ b/chip-testing/src/simulators/SwitchSimulator.ts
@@ -41,7 +41,7 @@ export class SwitchSimulator {
         if (action) {
             this.#endpoint
                 .setStateOf(SwitchServer, {
-                    rawPosition: action.position,
+                    currentPosition: action.position,
                 })
                 .then(
                     () => {
@@ -71,9 +71,13 @@ export class SwitchSimulator {
      *   - "LongPressDelayMillis": Time in milliseconds before the LongPress
      *   - "LongPressDurationMillis": Total duration in milliseconds from start of the press to LongRelease
      */
-    static simulateLongPress(endpoint: Endpoint, command: SimulateLongPressCommand) {
+    static async simulateLongPress(endpoint: Endpoint, command: SimulateLongPressCommand) {
         const simulator = new SwitchSimulator(endpoint);
 
+        // Configure cluster according to tests
+        await endpoint.setStateOf(SwitchServer, { longPressDelay: command.LongPressDelayMillis });
+
+        // Execute tests
         simulator.executeActions([
             { position: command.ButtonId, delay: command.LongPressDurationMillis }, // LongPressDelayMillis is ignored because just used to send the LogPress event?
             { position: NEUTRAL_SWITCH_POSITION },
@@ -97,7 +101,7 @@ export class SwitchSimulator {
      *   - "FeatureMap":  The feature map to simulate
      *   - "MultiPressMax": max number of presses (from attribute).
      */
-    static simulateMultiPress(endpoint: Endpoint, command: SimulateMultiPressCommand) {
+    static async simulateMultiPress(endpoint: Endpoint, command: SimulateMultiPressCommand) {
         const simulator = new SwitchSimulator(endpoint);
 
         const features = BitmapSchema({
@@ -117,6 +121,10 @@ export class SwitchSimulator {
             ]);*/
             throw new Error("ActionSwitch not supported, so should never be called for now.");
         } else {
+            // Configure cluster according to tests
+            await endpoint.setStateOf(SwitchServer, { multiPressDelay: command.MultiPressReleasedTimeMillis + 500 });
+
+            // Collect test steps
             const actions: { position: number; delay?: number }[] = [];
 
             for (let i = 0; i < command.MultiPressNumPresses; i++) {
@@ -134,6 +142,7 @@ export class SwitchSimulator {
 
             actions.push({ position: NEUTRAL_SWITCH_POSITION });
 
+            // Execute test
             simulator.executeActions(actions);
         }
     }


### PR DESCRIPTION
The change is automatically configuring the switch endpoint according to the test expectations. Additionally, it do not uses debouncing (because not configured too).

The PR will prepare for a chip testing change where timings of the test are changed ... so it configures the test dynamically to the relevant timings