### PR TITLE
Makes sure new active queries are also send out and not overridden

### DIFF
--- a/packages/matter.js/src/mdns/MdnsScanner.ts
+++ b/packages/matter.js/src/mdns/MdnsScanner.ts
@@ -215,9 +215,12 @@ export class MdnsScanner implements Scanner {
             );
             if (newQueries.length === 0) {
                 // All queries already sent out
-                logger.debug(`No new query records for query ${queryId}, keeping existing queries.`);
+                logger.debug(
+                    `No new query records for query ${queryId}, keeping existing queries and do not re-announce.`,
+                );
                 return;
             }
+            queries = [...newQueries, ...existingQueries];
             answers = [...activeExistingQuery.answers, ...answers];
         }
         this.#activeAnnounceQueries.set(queryId, { queries, answers });


### PR DESCRIPTION
In certain cases when multiple incoming records for a generic query like "discover all commissionable devices" were processed it could happen that new queries were overridden before they were sent out, and so never actively queried