### PR TITLE
Skip network commissioning when devcie is already on IP network

### DIFF
--- a/packages/matter-node-ble.js/src/ble/BlenoBleServer.ts
+++ b/packages/matter-node-ble.js/src/ble/BlenoBleServer.ts
@@ -10,8 +10,8 @@ import {
     BLE_MATTER_C2_CHARACTERISTIC_UUID,
     BLE_MATTER_C3_CHARACTERISTIC_UUID,
     BLE_MATTER_SERVICE_UUID,
-    BLE_MAX_MATTER_PAYLOAD_SIZE,
     BTP_CONN_RSP_TIMEOUT_MS,
+    BleChannel,
     BleError,
     BtpFlowError,
     BtpSessionHandler,
@@ -126,7 +126,7 @@ function initializeBleno(server: BlenoBleServer, hciId?: number) {
  * Note: Bleno is only supporting a single connection at a time right now - mainly because it also only can announce
  * one BLE device at a time!
  */
-export class BlenoBleServer implements Channel<ByteArray> {
+export class BlenoBleServer extends BleChannel<ByteArray> {
     private state = "unknown";
     isAdvertising = false;
     private additionalAdvertisingData: Buffer = Buffer.alloc(0);
@@ -144,10 +144,9 @@ export class BlenoBleServer implements Channel<ByteArray> {
     );
 
     private readonly matterBleService;
-    readonly maxPayloadSize = BLE_MAX_MATTER_PAYLOAD_SIZE;
-    readonly isReliable = true; // BTP is reliable
 
     constructor(options?: BleOptions) {
+        super();
         this.matterBleService = initializeBleno(this, options?.hciId);
 
         // Write Bleno into this class
@@ -402,6 +401,6 @@ export class BlenoBleServer implements Channel<ByteArray> {
 
     // Channel<ByteArray>
     get name() {
-        return `ble://${this.clientAddress}`;
+        return `${this.type}://${this.clientAddress}`;
     }
 }

--- a/packages/matter-node-ble.js/src/ble/NobleBleChannel.ts
+++ b/packages/matter-node-ble.js/src/ble/NobleBleChannel.ts
@@ -10,11 +10,11 @@ import {
     BLE_MATTER_C3_CHARACTERISTIC_UUID,
     BLE_MATTER_SERVICE_UUID,
     BLE_MAXIMUM_BTP_MTU,
-    BLE_MAX_MATTER_PAYLOAD_SIZE,
     BTP_CONN_RSP_TIMEOUT_MS,
     BTP_MAXIMUM_WINDOW_SIZE,
     BTP_SUPPORTED_VERSIONS,
     Ble,
+    BleChannel,
     BleError,
     BtpFlowError,
     BtpSessionHandler,
@@ -208,7 +208,7 @@ export class NobleBleCentralInterface implements NetInterface {
     }
 }
 
-export class NobleBleChannel implements Channel<ByteArray> {
+export class NobleBleChannel extends BleChannel<ByteArray> {
     static async create(
         peripheral: Peripheral,
         characteristicC1ForWrite: Characteristic,
@@ -283,13 +283,12 @@ export class NobleBleChannel implements Channel<ByteArray> {
     }
 
     private connected = true;
-    readonly maxPayloadSize = BLE_MAX_MATTER_PAYLOAD_SIZE;
-    readonly isReliable = true; // BTP is reliable
 
     constructor(
         private readonly peripheral: Peripheral,
         private readonly btpSession: BtpSessionHandler,
     ) {
+        super();
         peripheral.once("disconnect", () => {
             logger.debug(`Disconnected from peripheral ${peripheral.address}`);
             this.connected = false;
@@ -315,7 +314,7 @@ export class NobleBleChannel implements Channel<ByteArray> {
 
     // Channel<ByteArray>
     get name() {
-        return `ble://${this.peripheral.address}`;
+        return `${this.type}://${this.peripheral.address}`;
     }
 
     async close() {

--- a/packages/matter.js-react-native/src/ble/ReactNativeBleChannel.ts
+++ b/packages/matter.js-react-native/src/ble/ReactNativeBleChannel.ts
@@ -10,11 +10,11 @@ import {
     BLE_MATTER_C3_CHARACTERISTIC_UUID,
     BLE_MATTER_SERVICE_UUID,
     BLE_MAXIMUM_BTP_MTU,
-    BLE_MAX_MATTER_PAYLOAD_SIZE,
     BTP_CONN_RSP_TIMEOUT_MS,
     BTP_MAXIMUM_WINDOW_SIZE,
     BTP_SUPPORTED_VERSIONS,
     Ble,
+    BleChannel,
     BleError,
     BtpFlowError,
     BtpSessionHandler,
@@ -149,7 +149,7 @@ export class ReactNativeBleCentralInterface implements NetInterface {
     }
 }
 
-export class ReactNativeBleChannel implements Channel<ByteArray> {
+export class ReactNativeBleChannel extends BleChannel<ByteArray> {
     static async create(
         peripheral: Device,
         characteristicC1ForWrite: Characteristic,
@@ -259,13 +259,12 @@ export class ReactNativeBleChannel implements Channel<ByteArray> {
 
     private connected = true;
     private disconnectSubscription: Subscription;
-    readonly maxPayloadSize = BLE_MAX_MATTER_PAYLOAD_SIZE;
-    readonly isReliable = true; // BTP is reliable
 
     constructor(
         private readonly peripheral: Device,
         private readonly btpSession: BtpSessionHandler,
     ) {
+        super();
         this.disconnectSubscription = peripheral.onDisconnected(error => {
             logger.debug(`Disconnected from peripheral ${peripheral.id}: ${error}`);
             this.connected = false;

--- a/packages/matter.js/src/ble/Ble.ts
+++ b/packages/matter.js/src/ble/Ble.ts
@@ -4,12 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { Channel, ChannelType } from "../common/Channel.js";
 import { InstanceBroadcaster } from "../common/InstanceBroadcaster.js";
 import { MatterError, NoProviderError } from "../common/MatterError.js";
 import { Scanner } from "../common/Scanner.js";
 import { TransportInterface } from "../common/TransportInterface.js";
 import { NetInterface } from "../net/NetInterface.js";
 import { ByteArray } from "../util/ByteArray.js";
+import { BLE_MAX_MATTER_PAYLOAD_SIZE } from "./BleConsts.js";
 
 export class BleError extends MatterError {}
 
@@ -28,4 +30,14 @@ export abstract class Ble {
     abstract getBleCentralInterface(): NetInterface;
     abstract getBleBroadcaster(additionalAdvertisementData?: ByteArray): InstanceBroadcaster;
     abstract getBleScanner(): Scanner;
+}
+
+export abstract class BleChannel<T> implements Channel<T> {
+    readonly maxPayloadSize = BLE_MAX_MATTER_PAYLOAD_SIZE;
+    readonly isReliable = true; // BLE uses BTP which is reliable
+    readonly type = ChannelType.BLE;
+
+    abstract name: string;
+    abstract send(data: T): Promise<void>;
+    abstract close(): Promise<void>;
 }

--- a/packages/matter.js/src/common/Channel.ts
+++ b/packages/matter.js/src/common/Channel.ts
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+export enum ChannelType {
+    UDP = "udp",
+    BLE = "ble",
+    TCP = "tcp",
+}
+
 export interface Channel<T> {
     /** Maximum Payload size for this channel */
     maxPayloadSize: number;
@@ -13,6 +19,8 @@ export interface Channel<T> {
 
     /** Channel name */
     name: string;
+
+    type: ChannelType;
 
     /** Method to send data to the remote endpoint */
     send(data: T): Promise<void>;

--- a/packages/matter.js/src/net/UdpInterface.ts
+++ b/packages/matter.js/src/net/UdpInterface.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Channel } from "../common/Channel.js";
+import { Channel, ChannelType } from "../common/Channel.js";
 import { ServerAddress } from "../common/ServerAddress.js";
 import { Listener } from "../common/TransportInterface.js";
 import { ByteArray } from "../util/ByteArray.js";
@@ -46,6 +46,7 @@ export class UdpInterface implements NetInterface {
 
 class UdpConnection implements Channel<ByteArray> {
     readonly isReliable = false;
+    readonly type = ChannelType.UDP;
 
     constructor(
         private readonly server: UdpChannel,
@@ -62,7 +63,7 @@ class UdpConnection implements Channel<ByteArray> {
     }
 
     get name() {
-        return `udp://${this.peerAddress}:${this.peerPort}`;
+        return `${this.type}://${this.peerAddress}:${this.peerPort}`;
     }
 
     async close() {

--- a/packages/matter.js/src/protocol/ControllerCommissioner.ts
+++ b/packages/matter.js/src/protocol/ControllerCommissioner.ts
@@ -16,6 +16,7 @@ import { GeneralCommissioning } from "../cluster/definitions/GeneralCommissionin
 import { NetworkCommissioning } from "../cluster/definitions/NetworkCommissioningCluster.js";
 import { OperationalCredentials } from "../cluster/definitions/OperationalCredentialsCluster.js";
 import { TimeSynchronizationCluster } from "../cluster/definitions/TimeSynchronizationCluster.js";
+import { ChannelType } from "../common/Channel.js";
 import { MatterError, UnexpectedDataError } from "../common/MatterError.js";
 import { Crypto } from "../crypto/Crypto.js";
 import { ClusterId } from "../datatype/ClusterId.js";
@@ -252,27 +253,30 @@ export class ControllerCommissioner {
             stepLogic: () => this.configureAccessControlLists(),
         });
 
-        this.commissioningSteps.push({
-            stepNumber: 11,
-            subStepNumber: 1,
-            name: "NetworkCommissioning.Validate",
-            stepLogic: () => this.validateNetwork(),
-        });
-        if (this.commissioningOptions.wifiNetwork !== undefined) {
+        // Care about Network commissioning only when we are on BLE, because else we are already on IP network
+        if (this.interactionClient.channelType === ChannelType.BLE) {
             this.commissioningSteps.push({
                 stepNumber: 11,
-                subStepNumber: 2,
-                name: "NetworkCommissioning.Wifi",
-                stepLogic: () => this.configureNetworkWifi(),
+                subStepNumber: 1,
+                name: "NetworkCommissioning.Validate",
+                stepLogic: () => this.validateNetwork(),
             });
-        }
-        if (this.commissioningOptions.threadNetwork !== undefined) {
-            this.commissioningSteps.push({
-                stepNumber: 11,
-                subStepNumber: 3,
-                name: "NetworkCommissioning.Thread",
-                stepLogic: () => this.configureNetworkThread(),
-            });
+            if (this.commissioningOptions.wifiNetwork !== undefined) {
+                this.commissioningSteps.push({
+                    stepNumber: 11,
+                    subStepNumber: 2,
+                    name: "NetworkCommissioning.Wifi",
+                    stepLogic: () => this.configureNetworkWifi(),
+                });
+            }
+            if (this.commissioningOptions.threadNetwork !== undefined) {
+                this.commissioningSteps.push({
+                    stepNumber: 11,
+                    subStepNumber: 3,
+                    name: "NetworkCommissioning.Thread",
+                    stepLogic: () => this.configureNetworkThread(),
+                });
+            }
         }
 
         this.commissioningSteps.push({

--- a/packages/matter.js/src/protocol/ControllerCommissioner.ts
+++ b/packages/matter.js/src/protocol/ControllerCommissioner.ts
@@ -277,6 +277,10 @@ export class ControllerCommissioner {
                     stepLogic: () => this.configureNetworkThread(),
                 });
             }
+        } else {
+            logger.info(
+                `Skipping NetworkCommissioning steps because the device is already on IP network (${this.interactionClient.channelType})`,
+            );
         }
 
         this.commissioningSteps.push({

--- a/packages/matter.js/src/protocol/ExchangeManager.ts
+++ b/packages/matter.js/src/protocol/ExchangeManager.ts
@@ -51,6 +51,10 @@ export class MessageChannel<ContextT> implements Channel<Message> {
         return this.channel.isReliable;
     }
 
+    get type() {
+        return this.channel.type;
+    }
+
     /**
      * Max Payload size of the exchange which bases on the maximum payload size of the channel. The full encoded matter
      * message payload sent here can be as huge as allowed by the channel.
@@ -386,5 +390,9 @@ export class ExchangeProvider {
 
     get session() {
         return this.channel.session;
+    }
+
+    get channelType() {
+        return this.channel.type;
     }
 }

--- a/packages/matter.js/src/protocol/interaction/InteractionClient.ts
+++ b/packages/matter.js/src/protocol/interaction/InteractionClient.ts
@@ -1020,4 +1020,8 @@ export class InteractionClient {
     get session() {
         return this.exchangeProvider.session;
     }
+
+    get channelType() {
+        return this.exchangeProvider.channelType;
+    }
 }


### PR DESCRIPTION
This PR adjusts the Commissioner to skip the Commissioning checks when the device connection already is on IP network

@digitaldan Could you check if this change fixes your issue and so support in review? Thank you

fixes #1106