### PR TITLE
Add esbuild-x64 as package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2255,6 +2255,21 @@
         "node": ">=18"
       }
     },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.23.1.tgz",
+      "integrity": "sha512-EV6+ovTsEXCPAp58g2dD68LxoP/wK5pRvgy0J/HxPGB009omFPv3Yet0HiaqvrIrgPTBuC6wCH1LTOY91EO5hQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.0",
       "dev": true,
@@ -19900,6 +19915,7 @@
         "wtfnode": "^0.9.3"
       },
       "optionalDependencies": {
+        "@esbuild/linux-x64": "^0.23.1",
         "v8-profiler-next": "^1.10.0"
       }
     }

--- a/packages/matter.js-tools/package.json
+++ b/packages/matter.js-tools/package.json
@@ -55,7 +55,8 @@
         "yargs": "^17.7.2"
     },
     "optionalDependencies": {
-        "v8-profiler-next": "^1.10.0"
+        "v8-profiler-next": "^1.10.0",
+        "@esbuild/linux-x64": "^0.23.1"
     },
     "devDependencies": {
         "@types/chai": "^4.3.16",


### PR DESCRIPTION
because gha which runs on linux always has it, irrelevant who builds package-lock from scratch