### PR TITLE
Messagetiming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ The main work (all changes without a GitHub username in brackets in the below li
 	## __WORK IN PROGRESS__
 -->
 
+## __WORK IN PROGRESS__
+
+-   Matter-Core functionality:
+    -   Enhancement: Added an "expected processing time" for interactions to be executed by the peer
+    -   Enhancement: Added additional wait time after last resubmission was done to allow a full resubmission cycle from the peer
+    -   Enhancement: Optimized PASE/CASE message timing comparable to chip sdk (expects 30s processing time for crypto related calls)
+-   matter.js New API:
+    -   Fix: Optimized some special cases in the ColorControl cluster default implementation
+
 ## 0.10.0 (2024-08-31)
 
 -   IMPORTANT: This release upgrades Matter support from Matter 1.1 to the latest release, Matter 1.3.0.1. This includes BREAKING CHANGES in a number of areas due to specification changes and some improvements in how we define datatypes. For the most part these changes are transparent because they involve low-level APIs, implicit type names, or Matter features that were never adopted elsewhere. However, some small code changes may be necessary depending on how you use Matter.js.

--- a/packages/matter-node.js/test/session/SessionManagerTest.ts
+++ b/packages/matter-node.js/test/session/SessionManagerTest.ts
@@ -5,7 +5,7 @@
  */
 
 import { NodeId } from "@project-chip/matter.js/datatype";
-import { SessionManager } from "@project-chip/matter.js/session";
+import { SessionManager, SessionParameters } from "@project-chip/matter.js/session";
 import { StorageBackendMemory, StorageContext } from "@project-chip/matter.js/storage";
 import { ByteArray } from "@project-chip/matter.js/util";
 import * as assert from "assert";
@@ -22,7 +22,10 @@ describe("SessionManager", () => {
             storage = new StorageBackendMemory();
             storageContext = new StorageContext(storage, ["context"]);
 
-            sessionManager = new SessionManager({}, storageContext);
+            sessionManager = new SessionManager(
+                { sessionParameters: {} as SessionParameters, handleResubmissionStarted: () => {} },
+                storageContext,
+            );
         });
 
         it("next number is increasing", async () => {

--- a/packages/matter.js/src/MatterController.ts
+++ b/packages/matter.js/src/MatterController.ts
@@ -686,6 +686,10 @@ export class MatterController implements SessionContext {
         await this.fabricStorage?.set("fabric", this.fabric.toStorageObject());
     }
 
+    handleResubmissionStarted(_peerNodeId: NodeId) {
+        // TODO discover the device again
+    }
+
     private async reconnectLastKnownAddress(
         peerNodeId: NodeId,
         operationalAddress: ServerAddressIp,

--- a/packages/matter.js/src/MatterController.ts
+++ b/packages/matter.js/src/MatterController.ts
@@ -50,6 +50,7 @@ import {
     SESSION_ACTIVE_INTERVAL_MS,
     SESSION_ACTIVE_THRESHOLD_MS,
     SESSION_IDLE_INTERVAL_MS,
+    SessionContext,
     SessionParameters,
 } from "./session/Session.js";
 import { ResumptionRecord, SessionManager } from "./session/SessionManager.js";
@@ -101,7 +102,7 @@ const logger = Logger.get("MatterController");
  */
 export class PairRetransmissionLimitReachedError extends RetransmissionLimitReachedError {}
 
-export class MatterController {
+export class MatterController implements SessionContext {
     public static async create(options: {
         sessionStorage: StorageContext;
         rootCertificateStorage: StorageContext;
@@ -346,7 +347,7 @@ export class MatterController {
         return this.fabric.toStorageObject();
     }
 
-    /** Returns our default session parameters for us as a controller. */
+    /** Our own client/controller session parameters. */
     get sessionParameters(): SessionParameters {
         return {
             idleIntervalMs: SESSION_IDLE_INTERVAL_MS,

--- a/packages/matter.js/src/MatterDevice.ts
+++ b/packages/matter.js/src/MatterDevice.ts
@@ -334,6 +334,11 @@ export class MatterDevice implements SessionContext {
         }
     }
 
+    handleResubmissionStarted(nodeId: NodeId) {
+        logger.debug(`Resubmission started, re-announce node ${nodeId}`);
+        this.announce(true).catch(error => logger.warn("Error sending announcement:", error));
+    }
+
     async announce(announceOnce = false) {
         if (!announceOnce) {
             // Stop announcement if duration is reached

--- a/packages/matter.js/src/MatterDevice.ts
+++ b/packages/matter.js/src/MatterDevice.ts
@@ -45,6 +45,7 @@ import {
     SESSION_ACTIVE_THRESHOLD_MS,
     SESSION_IDLE_INTERVAL_MS,
     Session,
+    SessionContext,
     SessionParameters,
 } from "./session/Session.js";
 import { ResumptionRecord, SessionManager } from "./session/SessionManager.js";
@@ -57,7 +58,7 @@ import { Mutex } from "./util/Mutex.js";
 
 const logger = Logger.get("MatterDevice");
 
-export class MatterDevice {
+export class MatterDevice implements SessionContext {
     private readonly scanners = new Array<Scanner>();
     private readonly broadcasters = new Array<InstanceBroadcaster>();
     private readonly transportInterfaces = new Array<TransportInterface | NetInterface>();
@@ -73,6 +74,8 @@ export class MatterDevice {
     readonly #fabricManager: FabricManager;
     readonly #sessionManager: SessionManager<MatterDevice>;
     #failsafeContext?: FailsafeContext;
+
+    /** The own server session parameters. */
     readonly sessionParameters: SessionParameters;
 
     // Currently we do not put much effort into synchronizing announcements as it probably isn't really necessary.  But

--- a/packages/matter.js/src/protocol/ExchangeManager.ts
+++ b/packages/matter.js/src/protocol/ExchangeManager.ts
@@ -16,7 +16,7 @@ import { Logger } from "../log/Logger.js";
 import { UdpInterface } from "../net/UdpInterface.js";
 import { INTERACTION_PROTOCOL_ID } from "../protocol/interaction/InteractionServer.js";
 import { SecureSession } from "../session/SecureSession.js";
-import { Session } from "../session/Session.js";
+import { Session, SessionContext } from "../session/Session.js";
 import { SessionManager, UNICAST_UNSECURE_SESSION_ID } from "../session/SessionManager.js";
 import { ByteArray } from "../util/ByteArray.js";
 import { ChannelManager } from "./ChannelManager.js";
@@ -30,7 +30,7 @@ const logger = Logger.get("ExchangeManager");
 
 export class ChannelNotConnectedError extends MatterError {}
 
-export class MessageChannel<ContextT> implements Channel<Message> {
+export class MessageChannel<ContextT extends SessionContext> implements Channel<Message> {
     public closed = false;
     #closeCallback?: () => Promise<void>;
 
@@ -90,7 +90,7 @@ export class MessageChannel<ContextT> implements Channel<Message> {
     }
 }
 
-export class ExchangeManager<ContextT> {
+export class ExchangeManager<ContextT extends SessionContext> {
     private readonly exchangeCounter = new ExchangeCounter();
     private readonly exchanges = new Map<number, MessageExchange<ContextT>>();
     private readonly protocols = new Map<number, ProtocolHandler<ContextT>>();

--- a/packages/matter.js/src/protocol/MessageExchange.ts
+++ b/packages/matter.js/src/protocol/MessageExchange.ts
@@ -15,6 +15,7 @@ import {
     SESSION_ACTIVE_THRESHOLD_MS,
     SESSION_IDLE_INTERVAL_MS,
     Session,
+    SessionContext,
 } from "../session/Session.js";
 import { Time, Timer } from "../time/Time.js";
 import { ByteArray } from "../util/ByteArray.js";
@@ -89,8 +90,11 @@ const MRP_STANDALONE_ACK_TIMEOUT_MS = 200;
  */
 export const MATTER_MESSAGE_OVERHEAD = 26 + 12 + CRYPTO_AEAD_MIC_LENGTH_BYTES;
 
-export class MessageExchange<ContextT> {
-    static fromInitialMessage<ContextT>(channel: MessageChannel<ContextT>, initialMessage: Message) {
+export class MessageExchange<ContextT extends SessionContext> {
+    static fromInitialMessage<ContextT extends SessionContext>(
+        channel: MessageChannel<ContextT>,
+        initialMessage: Message,
+    ) {
         const { session } = channel;
         return new MessageExchange<ContextT>(
             session,
@@ -104,7 +108,11 @@ export class MessageExchange<ContextT> {
         );
     }
 
-    static initiate<ContextT>(channel: MessageChannel<ContextT>, exchangeId: number, protocolId: number) {
+    static initiate<ContextT extends SessionContext>(
+        channel: MessageChannel<ContextT>,
+        exchangeId: number,
+        protocolId: number,
+    ) {
         const { session } = channel;
         return new MessageExchange(
             session,

--- a/packages/matter.js/src/protocol/MessageExchange.ts
+++ b/packages/matter.js/src/protocol/MessageExchange.ts
@@ -453,7 +453,7 @@ export class MessageExchange<ContextT extends SessionContext> {
         this.session.notifyActivity(false);
 
         if (this.#retransmissionCounter === 1) {
-            // this.session.context.announce(); // TODO: announce
+            this.session.context.handleResubmissionStarted(this.session.nodeId);
         }
         const resubmissionBackoffTime = this.getResubmissionBackOffTime(this.#retransmissionCounter);
         logger.debug(

--- a/packages/matter.js/src/protocol/ProtocolHandler.ts
+++ b/packages/matter.js/src/protocol/ProtocolHandler.ts
@@ -5,9 +5,10 @@
  */
 
 import { Message } from "../codec/MessageCodec.js";
+import { SessionContext } from "../session/Session.js";
 import { MessageExchange } from "./MessageExchange.js";
 
-export interface ProtocolHandler<ContextT> {
+export interface ProtocolHandler<ContextT extends SessionContext> {
     getId(): number;
     onNewExchange(exchange: MessageExchange<ContextT>, message: Message): Promise<void>;
     close(): Promise<void>;

--- a/packages/matter.js/src/protocol/interaction/InteractionMessenger.ts
+++ b/packages/matter.js/src/protocol/interaction/InteractionMessenger.ts
@@ -17,6 +17,7 @@ import {
     RetransmissionLimitReachedError,
     UnexpectedMessageError,
 } from "../../protocol/MessageExchange.js";
+import { SessionContext } from "../../session/Session.js";
 import { TlvAny } from "../../tlv/TlvAny.js";
 import { TlvSchema, TypeFromSchema } from "../../tlv/TlvSchema.js";
 import { ByteArray } from "../../util/ByteArray.js";
@@ -70,7 +71,7 @@ export type WriteResponse = TypeFromSchema<typeof TlvWriteResponse>;
 
 const logger = Logger.get("InteractionMessenger");
 
-class InteractionMessenger<ContextT> {
+class InteractionMessenger<ContextT extends SessionContext> {
     constructor(protected exchange: MessageExchange<ContextT>) {}
 
     send(messageType: number, payload: ByteArray, options?: ExchangeSendOptions) {

--- a/packages/matter.js/src/protocol/securechannel/SecureChannelMessenger.ts
+++ b/packages/matter.js/src/protocol/securechannel/SecureChannelMessenger.ts
@@ -6,7 +6,7 @@
 
 import { Message } from "../../codec/MessageCodec.js";
 import { MatterError, UnexpectedDataError } from "../../common/MatterError.js";
-import { MessageExchange } from "../../protocol/MessageExchange.js";
+import { ExchangeSendOptions, MessageExchange } from "../../protocol/MessageExchange.js";
 import { SessionContext } from "../../session/Session.js";
 import { TlvSchema } from "../../tlv/TlvSchema.js";
 import {
@@ -28,11 +28,25 @@ export class ChannelStatusResponseError extends MatterError {
     }
 }
 
+/** This value is used by chip SDK when performance wise heavy crypto operations are expected. */
+export const EXPECTED_CRYPTO_PROCESSING_TIME_MS = 30_000;
+
+/** This value is used by chip SDK when normal processing time is expected. */
+export const DEFAULT_NORMAL_PROCESSING_TIME_MS = 2_000;
+
 export class SecureChannelMessenger<ContextT extends SessionContext> {
     constructor(protected readonly exchange: MessageExchange<ContextT>) {}
 
-    async nextMessage(expectedMessageInfo: string, expectedMessageType?: number) {
-        const message = await this.exchange.nextMessage();
+    /**
+     * Waits for the next message and returns it.
+     * When no expectedProcessingTimeMs is provided, the default value of EXPECTED_CRYPTO_PROCESSING_TIME_MS is used.
+     */
+    async nextMessage(
+        expectedMessageInfo: string,
+        expectedMessageType?: number,
+        expectedProcessingTimeMs = EXPECTED_CRYPTO_PROCESSING_TIME_MS,
+    ) {
+        const message = await this.exchange.nextMessage(expectedProcessingTimeMs);
         const messageType = message.payloadHeader.messageType;
         this.throwIfErrorStatusReport(message, expectedMessageInfo);
         if (expectedMessageType !== undefined && messageType !== expectedMessageType)
@@ -42,18 +56,42 @@ export class SecureChannelMessenger<ContextT extends SessionContext> {
         return message;
     }
 
-    async nextMessageDecoded<T>(expectedMessageType: number, schema: TlvSchema<T>, expectedMessageInfo: string) {
-        return schema.decode((await this.nextMessage(expectedMessageInfo, expectedMessageType)).payload);
+    /**
+     * Waits for the next message and decodes it.
+     * When no expectedProcessingTimeMs is provided, the default value of EXPECTED_CRYPTO_PROCESSING_TIME_MS is used.
+     */
+    async nextMessageDecoded<T>(
+        expectedMessageType: number,
+        schema: TlvSchema<T>,
+        expectedMessageInfo: string,
+        expectedProcessingTimeMs = EXPECTED_CRYPTO_PROCESSING_TIME_MS,
+    ) {
+        return schema.decode(
+            (await this.nextMessage(expectedMessageInfo, expectedMessageType, expectedProcessingTimeMs)).payload,
+        );
     }
 
-    async waitForSuccess(expectedMessageInfo: string) {
+    /**
+     * Waits for the next message and returns it.
+     * When no expectedProcessingTimeMs is provided, the default value of EXPECTED_CRYPTO_PROCESSING_TIME_MS is used.
+     */
+    async waitForSuccess(expectedMessageInfo: string, expectedProcessingTimeMs = EXPECTED_CRYPTO_PROCESSING_TIME_MS) {
         // If the status is not Success, this would throw an Error.
-        await this.nextMessage(expectedMessageInfo, MessageType.StatusReport);
+        await this.nextMessage(expectedMessageInfo, MessageType.StatusReport, expectedProcessingTimeMs);
     }
 
-    async send<T>(message: T, type: number, schema: TlvSchema<T>) {
+    /**
+     * Sends a message of the given type with the given payload.
+     * If no ExchangeSendOptions are provided, the expectedProcessingTimeMs will be set to
+     * EXPECTED_CRYPTO_PROCESSING_TIME_MS.
+     */
+    async send<T>(message: T, type: number, schema: TlvSchema<T>, options?: ExchangeSendOptions) {
+        options = {
+            ...options,
+            expectedProcessingTimeMs: options?.expectedProcessingTimeMs ?? EXPECTED_CRYPTO_PROCESSING_TIME_MS,
+        };
         const payload = schema.encode(message);
-        await this.exchange.send(type, payload);
+        await this.exchange.send(type, payload, options);
         return payload;
     }
 

--- a/packages/matter.js/src/protocol/securechannel/SecureChannelMessenger.ts
+++ b/packages/matter.js/src/protocol/securechannel/SecureChannelMessenger.ts
@@ -7,6 +7,7 @@
 import { Message } from "../../codec/MessageCodec.js";
 import { MatterError, UnexpectedDataError } from "../../common/MatterError.js";
 import { MessageExchange } from "../../protocol/MessageExchange.js";
+import { SessionContext } from "../../session/Session.js";
 import { TlvSchema } from "../../tlv/TlvSchema.js";
 import {
     GeneralStatusCode,
@@ -27,7 +28,7 @@ export class ChannelStatusResponseError extends MatterError {
     }
 }
 
-export class SecureChannelMessenger<ContextT> {
+export class SecureChannelMessenger<ContextT extends SessionContext> {
     constructor(protected readonly exchange: MessageExchange<ContextT>) {}
 
     async nextMessage(expectedMessageInfo: string, expectedMessageType?: number) {

--- a/packages/matter.js/src/session/InsecureSession.ts
+++ b/packages/matter.js/src/session/InsecureSession.ts
@@ -12,10 +12,10 @@ import { MessageCounter } from "../protocol/MessageCounter.js";
 import { MessageReceptionStateUnencryptedWithRollover } from "../protocol/MessageReceptionState.js";
 import { ByteArray } from "../util/ByteArray.js";
 import { NoAssociatedFabricError } from "./SecureSession.js";
-import { Session, SessionParameterOptions } from "./Session.js";
+import { Session, SessionContext, SessionParameterOptions } from "./Session.js";
 import { UNICAST_UNSECURE_SESSION_ID } from "./SessionManager.js";
 
-export class InsecureSession<T> extends Session<T> {
+export class InsecureSession<T extends SessionContext> extends Session<T> {
     readonly #initiatorNodeId: NodeId;
     readonly closingAfterExchangeFinished = false;
     readonly #context: T;

--- a/packages/matter.js/src/session/SecureSession.ts
+++ b/packages/matter.js/src/session/SecureSession.ts
@@ -18,7 +18,7 @@ import { StatusCode, StatusResponseError } from "../protocol/interaction/StatusC
 import { SubscriptionHandler } from "../protocol/interaction/SubscriptionHandler.js";
 import { ByteArray, Endian } from "../util/ByteArray.js";
 import { DataWriter } from "../util/DataWriter.js";
-import { Session, SessionParameterOptions } from "./Session.js";
+import { Session, SessionContext, SessionParameterOptions } from "./Session.js";
 
 const logger = Logger.get("SecureSession");
 
@@ -31,7 +31,7 @@ export class NoAssociatedFabricError extends StatusResponseError {
     }
 }
 
-export class SecureSession<T> extends Session<T> {
+export class SecureSession<T extends SessionContext> extends Session<T> {
     readonly #subscriptions = new Array<SubscriptionHandler>();
     #closingAfterExchangeFinished = false;
     #sendCloseMessageWhenClosing = true;
@@ -47,7 +47,7 @@ export class SecureSession<T> extends Session<T> {
     #caseAuthenticatedTags: CaseAuthenticatedTag[];
     readonly supportsMRP = true;
 
-    static async create<T>(args: {
+    static async create<T extends SessionContext>(args: {
         context: T;
         id: number;
         fabric: Fabric | undefined;
@@ -332,7 +332,10 @@ export class SecureSession<T> extends Session<T> {
     }
 }
 
-export function assertSecureSession<T>(session: Session<T>, errorText?: string): asserts session is SecureSession<T> {
+export function assertSecureSession<T extends SessionContext>(
+    session: Session<T>,
+    errorText?: string,
+): asserts session is SecureSession<T> {
     if (!session.isSecure) {
         throw new MatterFlowError(errorText ?? "Insecure session in secure context");
     }

--- a/packages/matter.js/src/session/Session.ts
+++ b/packages/matter.js/src/session/Session.ts
@@ -57,7 +57,15 @@ export interface SessionParameters {
 
 export type SessionParameterOptions = Partial<SessionParameters>;
 
-export abstract class Session<T> {
+export interface SessionContext {
+    /** Own session parameters. */
+    sessionParameters: SessionParameters;
+
+    /** This method is called when a message is resubmitted the first time and can handle announcements or discoveries. */
+    handleResubmissionStarted(nodeId?: NodeId): void;
+}
+
+export abstract class Session<T extends SessionContext> {
     abstract get name(): string;
     abstract get closingAfterExchangeFinished(): boolean;
     timestamp = Time.nowMs();
@@ -130,6 +138,9 @@ export abstract class Session<T> {
         this.messageReceptionState.updateMessageCounter(messageCounter);
     }
 
+    /**
+     * The peer's session parameters.
+     */
     get parameters(): SessionParameters {
         const {
             idleIntervalMs,

--- a/packages/matter.js/src/session/SessionManager.ts
+++ b/packages/matter.js/src/session/SessionManager.ts
@@ -27,6 +27,7 @@ import {
     SESSION_ACTIVE_INTERVAL_MS,
     SESSION_ACTIVE_THRESHOLD_MS,
     SESSION_IDLE_INTERVAL_MS,
+    SessionContext,
     SessionParameterOptions,
     SessionParameters,
 } from "./Session.js";
@@ -62,7 +63,7 @@ type ResumptionStorageRecord = {
     caseAuthenticatedTags?: CaseAuthenticatedTag[];
 };
 
-export class SessionManager<ContextT> {
+export class SessionManager<ContextT extends SessionContext> {
     readonly #insecureSessions = new Map<NodeId, InsecureSession<ContextT>>();
     readonly #sessions = new BasicSet<SecureSession<ContextT>>();
     #nextSessionId = Crypto.getRandomUInt16();

--- a/packages/matter.js/src/session/pase/PaseMessenger.ts
+++ b/packages/matter.js/src/session/pase/PaseMessenger.ts
@@ -7,7 +7,10 @@
 import { MatterController } from "../../MatterController.js";
 import { MatterDevice } from "../../MatterDevice.js";
 import { MessageType } from "../../protocol/securechannel/SecureChannelMessages.js";
-import { SecureChannelMessenger } from "../../protocol/securechannel/SecureChannelMessenger.js";
+import {
+    DEFAULT_NORMAL_PROCESSING_TIME_MS,
+    SecureChannelMessenger,
+} from "../../protocol/securechannel/SecureChannelMessenger.js";
 import { TypeFromSchema } from "../../tlv/TlvSchema.js";
 import { ByteArray } from "../../util/ByteArray.js";
 import {
@@ -29,12 +32,18 @@ type PasePake3 = TypeFromSchema<typeof TlvPasePake3>;
 
 export class PaseServerMessenger extends SecureChannelMessenger<MatterDevice> {
     async readPbkdfParamRequest() {
-        const { payload } = await this.nextMessage("PASE PbkdfParamRequest", MessageType.PbkdfParamRequest);
+        const { payload } = await this.nextMessage(
+            "PASE PbkdfParamRequest",
+            MessageType.PbkdfParamRequest,
+            DEFAULT_NORMAL_PROCESSING_TIME_MS,
+        );
         return { requestPayload: payload, request: TlvPbkdfParamRequest.decode(payload) };
     }
 
     async sendPbkdfParamResponse(response: PbkdfParamResponse) {
-        return this.send(response, MessageType.PbkdfParamResponse, TlvPbkdfParamResponse);
+        return this.send(response, MessageType.PbkdfParamResponse, TlvPbkdfParamResponse, {
+            expectedProcessingTimeMs: DEFAULT_NORMAL_PROCESSING_TIME_MS,
+        });
     }
 
     readPasePake1() {
@@ -52,11 +61,17 @@ export class PaseServerMessenger extends SecureChannelMessenger<MatterDevice> {
 
 export class PaseClientMessenger extends SecureChannelMessenger<MatterController> {
     sendPbkdfParamRequest(request: PbkdfParamRequest) {
-        return this.send(request, MessageType.PbkdfParamRequest, TlvPbkdfParamRequest);
+        return this.send(request, MessageType.PbkdfParamRequest, TlvPbkdfParamRequest, {
+            expectedProcessingTimeMs: DEFAULT_NORMAL_PROCESSING_TIME_MS,
+        });
     }
 
     async readPbkdfParamResponse() {
-        const { payload } = await this.nextMessage("PASE PbkdfParamResponse", MessageType.PbkdfParamResponse);
+        const { payload } = await this.nextMessage(
+            "PASE PbkdfParamResponse",
+            MessageType.PbkdfParamResponse,
+            DEFAULT_NORMAL_PROCESSING_TIME_MS,
+        );
         return { responsePayload: payload, response: TlvPbkdfParamResponse.decode(payload) };
     }
 


### PR DESCRIPTION
This PR will enhance and fix several aspects of message timing to be more close to chip sdk handling which is not really included in the specs. It basically includes:

* When MRP is used for reliable sending then we now consider a general 2s "expected processing time" from the peer and also consider a full maximum resubmission cycle calculated based on the MRP parameters we sent out to the peer. The processing time can be adjusted on need
* When we wait for a response message we also consider the same details plus a bit buffer time when MRP is used, else we use hard coded values of 30s like chip. 
* I also added the device announcements whenever the device start to resubmit. For controller side the discovery is also added but not implemented

The PR can be reviewed by commit