### PR TITLE
Exchange optimizations

### DIFF
--- a/packages/matter.js/src/protocol/ExchangeManager.ts
+++ b/packages/matter.js/src/protocol/ExchangeManager.ts
@@ -233,6 +233,16 @@ export class ExchangeManager<ContextT extends SessionContext> {
             const protocolHandler = this.protocols.get(message.payloadHeader.protocolId);
 
             if (protocolHandler !== undefined && message.payloadHeader.isInitiatorMessage && !isDuplicate) {
+                if (
+                    message.payloadHeader.messageType == MessageType.StandaloneAck &&
+                    !message.payloadHeader.requiresAck
+                ) {
+                    logger.debug(
+                        `Ignoring unsolicited standalone ack message ${messageId} for protocol ${message.payloadHeader.protocolId} and exchange id ${message.payloadHeader.exchangeId}.`,
+                    );
+                    return;
+                }
+
                 const exchange = MessageExchange.fromInitialMessage(
                     await this.channelManager.getOrCreateChannel(channel, session),
                     message,

--- a/packages/matter.js/src/protocol/interaction/InteractionMessenger.ts
+++ b/packages/matter.js/src/protocol/interaction/InteractionMessenger.ts
@@ -213,8 +213,10 @@ export class InteractionServerMessenger extends InteractionMessenger<MatterDevic
             if (error instanceof StatusResponseError) {
                 logger.info(`Sending status response ${error.code} for interaction error: ${error.message}`);
                 errorStatusCode = error.code;
+            } else if (error instanceof RetransmissionLimitReachedError) {
+                logger.info(error);
             } else {
-                logger.error(error);
+                logger.warn(error);
             }
             if (!isGroupSession && !(error instanceof RetransmissionLimitReachedError)) {
                 await this.sendStatus(errorStatusCode);

--- a/packages/matter.js/src/protocol/interaction/InteractionMessenger.ts
+++ b/packages/matter.js/src/protocol/interaction/InteractionMessenger.ts
@@ -216,7 +216,7 @@ export class InteractionServerMessenger extends InteractionMessenger<MatterDevic
             } else {
                 logger.error(error);
             }
-            if (!isGroupSession) {
+            if (!isGroupSession && !(error instanceof RetransmissionLimitReachedError)) {
                 await this.sendStatus(errorStatusCode);
             }
         } finally {


### PR DESCRIPTION
This PR optimizes some topics around exchange handling in cases where the devcie/server could not correctly send the response
* We detect such a case now and do not try to send another status message because we can not and it is also incorrect
* Do not create new exchange instances for "just" a standalone ack message
* Adjust some loglevels