### PR TITLE
Backport #1200 as 0.10.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ The main work (all changes without a GitHub username in brackets in the below li
 -   Matter-Core functionality:
     -   Fix: Fixes channel cleanup
     -   Fix: Fixes Subscription error handling
-    
+
 ## 0.10.1 (2024-09-08)
 
 -   Matter-Core functionality:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,19 @@ The main work (all changes without a GitHub username in brackets in the below li
 	## __WORK IN PROGRESS__
 -->
 
+
+## __WORK IN PROGRESS__
+
+-   matter.js API:
+    -   Fix: Prevent trying to access PowerTopology attribute which is not always present
+    -   Fix: Always add the endpoint device types first to the device type list
+
 ## 0.10.3 (2024-09-15)
 
 -   Matter-Core functionality:
     -   Fix: Fixes channel cleanup
     -   Fix: Fixes Subscription error handling
-
+    
 ## 0.10.1 (2024-09-08)
 
 -   Matter-Core functionality:

--- a/packages/matter.js/src/behavior/definitions/descriptor/DescriptorServer.ts
+++ b/packages/matter.js/src/behavior/definitions/descriptor/DescriptorServer.ts
@@ -43,7 +43,12 @@ export class DescriptorServer extends DescriptorBehavior {
         // Initialize ServerList
         this.state.serverList = this.#serverList;
 
-        // Initialize device type list
+        // Initialize DeviceTypeList
+        this.#initializeDeviceTypeList();
+    }
+
+    /** Initialize device type list when it is not already initialized. */
+    #initializeDeviceTypeList() {
         if (!this.state.deviceTypeList.length) {
             const partType = this.endpoint.type;
             this.state.deviceTypeList = [
@@ -78,6 +83,7 @@ export class DescriptorServer extends DescriptorBehavior {
      * @param deviceTypes an array of objects or named device types as defined in {@link MatterModel.standard}
      */
     addDeviceTypes(...deviceTypes: (DescriptorServer.DeviceType | string)[]) {
+        this.#initializeDeviceTypeList(); // Initialize if not already done
         const list = this.state.deviceTypeList;
 
         nextInput: for (let newDeviceType of deviceTypes) {

--- a/packages/matter.js/src/behavior/definitions/power-topology/PowerTopologyServer.ts
+++ b/packages/matter.js/src/behavior/definitions/power-topology/PowerTopologyServer.ts
@@ -33,9 +33,10 @@ export class PowerTopologyServerLogic extends PowerTopologyBase {
             this.agent.get(DescriptorServer).addDeviceTypes("ElectricalSensor");
         }
 
-        this.#assertActiveEndpointsAllowed(this.state.activeEndpoints);
-
-        this.reactTo(this.events.activeEndpoints$Changing, this.#assertActiveEndpointsAllowed);
+        if (this.state.activeEndpoints !== undefined) {
+            this.#assertActiveEndpointsAllowed(this.state.activeEndpoints);
+            this.reactTo(this.events.activeEndpoints$Changing, this.#assertActiveEndpointsAllowed);
+        }
     }
 
     #assertActiveEndpointsAllowed(list: EndpointNumber[]) {


### PR DESCRIPTION
Backports 

    -   Fix: Prevent trying to access PowerTopology attribute which is not always present
    -   Fix: Always add the endpoint device types first to the device type list