### PR TITLE
Enhance subscription time calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,44 +14,45 @@ The main work (all changes without a GitHub username in brackets in the below li
 -   IMPORTANT: As of 0.10.0 the @project-chip/matter.js module has grown quite large.  This release includes major refactoring that moves functional areas into independent NPM packages under the "@matter.js" org.  We have added exports to maintain backwards compatibility but these are not exhaustive.  In some cases you may need to update imports to reference new code locations.
 
 -   Cross-module changes
-    -   Matter.js now uses aliases via `package.json` "imports" field.  This is an internal change that simplifies imports but should not affect consumers
-    -   Previously we used a mix of snake-case and CamelCase for sub-package exports.  We have now standardized on snake case.  Compatibility packages (see below) continue to support the original module names
+    -   Info: Matter.js now uses aliases via `package.json` "imports" field.  This is an internal change that simplifies imports but should not affect consumers
+    -   Info: Previously we used a mix of snake-case and CamelCase for sub-package exports.  We have now standardized on snake case.  Compatibility packages (see below) continue to support the original module names
 
 -   @matter.js/general:
-    -   General functionality that is not Matter specific previously resided in `@project-chip/matter.js`.  It now lives in `@matter.js/general`
+    -   Info: General functionality that is not Matter specific previously resided in `@project-chip/matter.js`.  It now lives in `@matter.js/general`
     -   BREAKING: The "ByteArray" type is removed, replaced with native-JS Uint8Array and a small collection of utility functions in the "Bytes" namespace
     -   Feature: The default "Time" implementation is now fully functional across all standard JS runtimes
 
 -   @matter.js/main:
-    -   This package is a new "one-and-done" dependency for applications.  It automatically loads platform specialization and reexports pacakages above as appropriate
+    -   Info: This package is a new "one-and-done" dependency for applications.  It automatically loads platform specialization and reexports pacakages above as appropriate
 
 -   @matter.js/model:
-    -   The Matter object model previously exported as `@project-chip/matter.js/model` now resides in `@matter.js/model`
-    -   Individual elements exported by name are now models (fully funcitonal classes) rather than elements (raw JSON data).  This should be backwards compatible but makes them more useful operationally
+    -   Info: The Matter object model previously exported as `@project-chip/matter.js/model` now resides in `@matter.js/model`
+    -   Info: Individual elements exported by name are now models (fully functional classes) rather than elements (raw JSON data).  This should be backwards compatible but makes them more useful operationally
 
 -   @matter.js/node:
-    -   The high-level APIs previously defined in `@project-chip/matter.js` now reside in `@matter.js/node`.  The Node API includes node management, behavior definitions and endpoint definitions
-    -   We export behaviors under `@matter.js/node/behaviors` or individually (e.g. `@matter.js/node/behaviors/on-off`)
-    -   We export device type definitions for system endpoints and devices under `@matter.js/node/endpoints` and `@matter.js/node/devices` respectively.  You may also import these via inddex or individually
+    -   Info: The high-level APIs previously defined in `@project-chip/matter.js` now reside in `@matter.js/node`.  The Node API includes node management, behavior definitions and endpoint definitions
+    -   Info: We export behaviors under `@matter.js/node/behaviors` or individually (e.g. `@matter.js/node/behaviors/on-off`)
+    -   Info: We export device type definitions for system endpoints and devices under `@matter.js/node/endpoints` and `@matter.js/node/devices` respectively.  You may also import these via index or individually
 
 -   @matter.js/nodejs:
-    -   Node.js specialization is moved here.  `@project-chip/matter-node.js` remains as a compatibility import.
+    -   Info: Node.js specialization is moved here.  `@project-chip/matter-node.js` remains as a compatibility import.
     -   BREAKING: The previously deprecated re-exports in matter-node.js from matter.js are removed.
 
 -   @matter.js/nodejs-ble
-    -   The BLE specialization for Node.js is moved here.  `@project-chip/matter-node-ble.js` remains as a compatibility import.
+    -   Info: The BLE specialization for Node.js is moved here.  `@project-chip/matter-node-ble.js` remains as a compatibility import.
 
 -   @matter.js/nodejs-shell:
     -   Enhancement: Added option to specify if attributes are loaded from remote or locally
 
 -   @matter.js/protocol:
-    -   Low-level Matter logic previously defined in `@project-chip/matter.js` now resides in `@matter.js/protocol`.  This includes network communication, fabric management and cluster invocation, read/write, events, etc.
+    -   Info: Low-level Matter logic previously defined in `@project-chip/matter.js` now resides in `@matter.js/protocol`.  This includes network communication, fabric management and cluster invocation, read/write, events, etc.
     -   BREAKING: Various types that were previously specialized with template parameters are no longer generic.  This should be largely transparent to API consumers.  Compatibility exports still support the generic parameters in some, but not all, cases.
-    -   Limits the number of parallel exchanges to 5
+    -   Enhancement: Limits the number of parallel exchanges to 5
+    -   Enhancement: Uses the session timing details to calculate the timeout for subscription messages when received as client additionally to the subscription maxInterval  
 
 -   @matter.js/types:
-    -   Various definitions previously defined in `@project-chip/matter.js` now reside in `@matter.js/types`.  This includes most TLV structures, cluster definitions, and various support types
-    -   Clusters are not exported in `@project-chip/matter.js`.  You can import via `@project-chip/types/clusters` or individually (e.g. `@project-chip/types/clusters/window-covering`)
+    -   Info: Various definitions previously defined in `@project-chip/matter.js` now reside in `@matter.js/types`.  This includes most TLV structures, cluster definitions, and various support types
+    -   Info: Clusters are not exported in `@project-chip/matter.js`.  You can import via `@project-chip/types/clusters` or individually (e.g. `@project-chip/types/clusters/window-covering`)
 
 ## 0.10.4 (2024-09-16)
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "matter-composeddevice": "matter-run packages/examples/src/examples/ComposedDeviceNode.ts",
     "matter-multidevice": "matter-run packages/examples/src/examples/MultiDeviceNode.ts",
     "matter-controller": "matter-run packages/examples/src/examples/ControllerNode.ts",
-    "shell": "matter-run packages/matter-node-shell.js/src/app.ts"
+    "shell": "matter-run packages/nodejs-shell/src/app.ts"
 },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^7.16.1",

--- a/packages/nodejs/test/interaction/InteractionProtocolTest.ts
+++ b/packages/nodejs/test/interaction/InteractionProtocolTest.ts
@@ -728,15 +728,23 @@ const INVOKE_COMMAND_REQUEST_MULTI: InvokeRequest = {
     invokeRequests: [
         {
             commandPath: { endpointId: EndpointNumber(0), clusterId: ClusterId(6), commandId: CommandId(0) },
+            commandFields: TlvNoArguments.encodeTlv(undefined),
+            commandRef: 1,
         },
         {
             commandPath: { endpointId: EndpointNumber(0), clusterId: ClusterId(6), commandId: CommandId(1) },
+            commandFields: TlvNoArguments.encodeTlv(undefined),
+            commandRef: 2,
         },
         {
             commandPath: { endpointId: EndpointNumber(0), clusterId: ClusterId(6), commandId: CommandId(2) },
+            commandFields: TlvNoArguments.encodeTlv(undefined),
+            commandRef: 3,
         },
         {
             commandPath: { endpointId: EndpointNumber(0), clusterId: ClusterId(6), commandId: CommandId(100) },
+            commandFields: TlvNoArguments.encodeTlv(undefined),
+            commandRef: 4,
         },
     ],
 };
@@ -798,24 +806,28 @@ const INVOKE_COMMAND_RESPONSE_MULTI: InvokeResponse = {
         {
             status: {
                 commandPath: { clusterId: ClusterId(6), commandId: CommandId(0), endpointId: EndpointNumber(0) },
+                commandRef: 1,
                 status: { status: 0 },
             },
         },
         {
             status: {
                 commandPath: { clusterId: ClusterId(6), commandId: CommandId(1), endpointId: EndpointNumber(0) },
+                commandRef: 2,
                 status: { status: 0 },
             },
         },
         {
             status: {
                 commandPath: { clusterId: ClusterId(6), commandId: CommandId(2), endpointId: EndpointNumber(0) },
+                commandRef: 3,
                 status: { status: 0 },
             },
         },
         {
             status: {
                 commandPath: { clusterId: ClusterId(6), commandId: CommandId(100), endpointId: EndpointNumber(0) },
+                commandRef: 4,
                 status: { status: 129 },
             },
         },
@@ -1651,6 +1663,8 @@ describe("InteractionProtocol", () => {
                         clusterId: ClusterId(6),
                         commandId: CommandId(100 + i),
                     },
+                    commandFields: TlvNoArguments.encodeTlv(undefined),
+                    commandRef: i + 4,
                 });
             }
 

--- a/packages/protocol/src/interaction/InteractionMessenger.ts
+++ b/packages/protocol/src/interaction/InteractionMessenger.ts
@@ -71,6 +71,10 @@ const logger = Logger.get("InteractionMessenger");
 class InteractionMessenger {
     constructor(protected exchange: MessageExchange) {}
 
+    calculateMaximumPeerResponseTime(expectedProcessingTimeMs?: number) {
+        return this.exchange.calculateMaximumPeerResponseTime(expectedProcessingTimeMs);
+    }
+
     send(messageType: number, payload: Uint8Array, options?: ExchangeSendOptions) {
         return this.exchange.send(messageType, payload, options);
     }

--- a/packages/protocol/src/protocol/MessageExchange.ts
+++ b/packages/protocol/src/protocol/MessageExchange.ts
@@ -90,7 +90,7 @@ const MRP_STANDALONE_ACK_TIMEOUT_MS = 200;
  * from chip implementation. This is basically the default used with different names, also kExpectedLowProcessingTime or
  * kExpectedSigma1ProcessingTime.
  */
-const DEFAULT_EXPECTED_PROCESSING_TIME_MS = 2_000;
+export const DEFAULT_EXPECTED_PROCESSING_TIME_MS = 2_000;
 
 /**
  * The buffer time in milliseconds to add to the peer response time to also consider network delays and other factors.
@@ -429,7 +429,7 @@ export class MessageExchange {
                 if (!this.#useMRP) {
                     throw new MatterFlowError("No response expected for this message exchange because UDP and no MRP.");
                 }
-                timeout = this.#maximumPeerResponseTime(expectedProcessingTimeMs);
+                timeout = this.calculateMaximumPeerResponseTime(expectedProcessingTimeMs);
                 break;
             case "ble":
                 // chip sdk uses BTP_ACK_TIMEOUT_MS which is wrong in my eyes, so we use static 30s as like TCP here
@@ -467,7 +467,7 @@ export class MessageExchange {
         );
     }
 
-    #maximumPeerResponseTime(expectedProcessingTimeMs = DEFAULT_EXPECTED_PROCESSING_TIME_MS) {
+    calculateMaximumPeerResponseTime(expectedProcessingTimeMs = DEFAULT_EXPECTED_PROCESSING_TIME_MS) {
         // We use the expected processing time and deduct the time we already waited since last resubmission
         let finalWaitTime = expectedProcessingTimeMs;
 
@@ -488,7 +488,7 @@ export class MessageExchange {
             if (expectedProcessingTimeMs !== undefined) {
                 // We already have waited after the last message was sent, so deduct this time from the final wait time
                 const finalWaitTime =
-                    this.#maximumPeerResponseTime(expectedProcessingTimeMs) -
+                    this.calculateMaximumPeerResponseTime(expectedProcessingTimeMs) -
                     (this.#retransmissionTimer?.intervalMs ?? 0);
                 if (finalWaitTime > 0) {
                     this.#retransmissionCounter--; // We will not resubmit the message again

--- a/packages/protocol/src/protocol/MessageExchange.ts
+++ b/packages/protocol/src/protocol/MessageExchange.ts
@@ -476,7 +476,7 @@ export class MessageExchange {
             finalWaitTime += this.getResubmissionBackOffTime(i, this.session.context.sessionParameters);
         }
 
-        // TODO: Also add any network latency buffer, for now lets consider it's included in the max already
+        // TODO: Also add any network latency buffer, for now lets consider it's included in the processing time already
         return finalWaitTime;
     }
 

--- a/packages/protocol/src/session/SessionManager.ts
+++ b/packages/protocol/src/session/SessionManager.ts
@@ -332,8 +332,15 @@ export class SessionManager {
                 } = {},
                 caseAuthenticatedTags,
             }) => {
-                logger.info("restoring resumption record for node", nodeId);
                 const fabric = fabrics.find(fabric => fabric.fabricId === fabricId);
+                logger.info(
+                    "restoring resumption record for node",
+                    nodeId,
+                    "and peer node",
+                    peerNodeId,
+                    "for fabric index",
+                    fabric?.fabricIndex,
+                );
                 if (!fabric) {
                     logger.error("fabric not found for resumption record", fabricId);
                     return;


### PR DESCRIPTION
Now that we calculate the normal resubmission cycle also for the peer in Message exchange we can also utilize this for subscriptions from a peer node to us as controller.

I also added some mini adjustments in two places