### PR TITLE
Do not limit exchanges for PASE/CASE session id 0

### DIFF
--- a/packages/protocol/src/protocol/ExchangeManager.ts
+++ b/packages/protocol/src/protocol/ExchangeManager.ts
@@ -364,6 +364,10 @@ export class ExchangeManager {
     }
 
     #cleanupSessionExchanges(sessionId: number) {
+        if (sessionId === UNICAST_UNSECURE_SESSION_ID) {
+            // PASE/CASE exchanges are not relevant for this limit
+            return;
+        }
         const sessionExchanges = Array.from(this.exchanges.values()).filter(
             exchange => exchange.session.id === sessionId && !exchange.isClosing,
         );


### PR DESCRIPTION
fixes #1152

... Limiting on session 0 would limit how many parallel connections a controller could do. The limit is also not relevant fpr this session type