### PR TITLE
Cleanup of peer components

### DIFF
--- a/packages/protocol/src/common/FailsafeContext.ts
+++ b/packages/protocol/src/common/FailsafeContext.ts
@@ -144,7 +144,7 @@ export abstract class FailsafeContext {
 
     async updateFabric(fabric: Fabric) {
         await this.#fabrics.updateFabric(fabric);
-        await this.#sessions.updateFabricForResumptionRecords(fabric);
+        await this.#sessions.deleteResumptionRecordsForFabric(fabric);
     }
 
     /**

--- a/packages/protocol/src/peer/ControllerCommissioningFlow.ts
+++ b/packages/protocol/src/peer/ControllerCommissioningFlow.ts
@@ -134,12 +134,6 @@ class RecoverableCommissioningError extends CommissioningError {}
 const DEFAULT_FAILSAFE_TIME_MS = 60_000; // 60 seconds
 
 /**
- * The operative connection callback may return this value to skip PASE commissioning.
- */
-export const SKIP_CASE_COMMISSIONING = Symbol("skip-pase-commissioning");
-export type SKIP_PASE_COMMISSIONING = typeof SKIP_CASE_COMMISSIONING;
-
-/**
  * Class to abstract the Device commission flow in a step wise way as defined in Specs. The specs are not 100%
  */
 export class ControllerCommissioningFlow {

--- a/packages/protocol/src/peer/PeerSet.ts
+++ b/packages/protocol/src/peer/PeerSet.ts
@@ -76,13 +76,6 @@ interface RunningDiscovery {
 }
 
 /**
- * API for establishing a connection to a peer.
- */
-export interface PeerConnector {
-    connect(address: PeerAddress, discoveryOptions: DiscoveryOptions): Promise<InteractionClient>;
-}
-
-/**
  * Interfaces {@link PeerSet} with other components.
  */
 export interface PeerSetContext {
@@ -97,7 +90,7 @@ export interface PeerSetContext {
 /**
  * Manages operational connections to peers on shared fabric.
  */
-export class PeerSet implements ImmutableSet<OperationalPeer>, ObservableSet<OperationalPeer>, PeerConnector {
+export class PeerSet implements ImmutableSet<OperationalPeer>, ObservableSet<OperationalPeer> {
     readonly #sessions: SessionManager;
     readonly #channels: ChannelManager;
     readonly #exchanges: ExchangeManager;
@@ -280,7 +273,7 @@ export class PeerSet implements ImmutableSet<OperationalPeer>, ObservableSet<Ope
         this.#peers.delete(actual);
         await this.#store.deletePeer(actual.address);
         await this.disconnect(actual);
-        await this.#sessions.removeResumptionRecord(actual.address);
+        await this.#sessions.deleteResumptionRecord(actual.address);
     }
 
     async close() {

--- a/packages/protocol/src/protocol/DeviceCommissioner.ts
+++ b/packages/protocol/src/protocol/DeviceCommissioner.ts
@@ -22,7 +22,7 @@ import {
 import { SecureChannelProtocol } from "#securechannel/SecureChannelProtocol.js";
 import { PaseServer, SessionManager } from "#session/index.js";
 import { CommissioningOptions, StatusCode, StatusResponseError } from "#types";
-import type { ControllerCommissioningFlow } from "../peer/ControllerCommissioningFlow.js";
+import type { ControllerCommissioner } from "../peer/ControllerCommissioner.js";
 import { DeviceAdvertiser } from "./DeviceAdvertiser.js";
 
 const logger = Logger.get("DeviceCommissioner");
@@ -48,7 +48,7 @@ export interface DeviceCommissionerContext {
 /**
  * Implements commissioning for devices.
  *
- * Note this implements commissioning for a *local* device; use {@link ControllerCommissioningFlow} to commission a *remote*
+ * Note this implements commissioning for a *local* device; use {@link ControllerCommissioner} to commission a *remote*
  * device.
  */
 export class DeviceCommissioner {


### PR DESCRIPTION
Removes several bits of cruft left over from refactor.  Modifies session resumption record cleanup slightly after Discord conversation.