### PR TITLE
Update level-control.ts for nest-hub firmware 20.20240530.3.18053

### DIFF
--- a/packages/types/src/clusters/level-control.ts
+++ b/packages/types/src/clusters/level-control.ts
@@ -18,7 +18,7 @@ import {
 import { TlvUInt16, TlvUInt8, TlvBitmap, TlvEnum } from "../tlv/TlvNumber.js";
 import { TlvNullable } from "../tlv/TlvNullable.js";
 import { AccessLevel } from "#model";
-import { TlvField, TlvObject } from "../tlv/TlvObject.js";
+import { TlvField, TlvOptionalField, TlvObject } from "../tlv/TlvObject.js";
 import { TypeFromSchema } from "../tlv/TlvSchema.js";
 import { BitFlag } from "../schema/BitmapSchema.js";
 import { ClusterType } from "../cluster/ClusterType.js";
@@ -111,9 +111,9 @@ export namespace LevelControl {
      */
     export const TlvMoveToLevelRequest = TlvObject({
         level: TlvField(0, TlvUInt8.bound({ max: 254 })),
-        transitionTime: TlvField(1, TlvNullable(TlvUInt16)),
-        optionsMask: TlvField(2, TlvBitmap(TlvUInt8, Options)),
-        optionsOverride: TlvField(3, TlvBitmap(TlvUInt8, Options))
+        transitionTime: TlvOptionalField(1, TlvNullable(TlvUInt16)),
+        optionsMask: TlvOptionalField(2, TlvBitmap(TlvUInt8, Options)),
+        optionsOverride: TlvOptionalField(3, TlvBitmap(TlvUInt8, Options))
     });
 
     /**


### PR DESCRIPTION
This change is necessary for dimming lights using Google nest hub preview firmware 20.20240530.3.18053.

While transition time isn't optional, it isn't being passed by firmware 20.20240530.3.18053. The optionsMask and optionsOverride should have default values according to the spec.

I don't expect this PR to be accepted - but can anyone please confirm this behaviour with the nest hub preview firmware? Perhaps Google are doing the right thing by the spec?

Or perhaps this is fixed by https://github.com/project-chip/matter.js/pull/848 ?