### PR TITLE
Optimize Async Storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Feature: Automatically lock behavior state on invoke
     - Fix: Ensures to fully load the Descriptor cluster before adding additional device types 
 
+-   @matter/nodejs
+    - Fix: Makes sure that the Async storage waits that all writes are finished in some cases
+
 -   @project-chip/matter.js
     - Fix: Fixes some compatibility re-exports that got screwed up since 0.11.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,17 @@ The main work (all changes without a GitHub username in brackets in the below li
 	## __WORK IN PROGRESS__
 -->
 
+### __WORK IN PROGRESS__
+
+-   @matter/nodejs
+    - Fix: The MaybeAsyncStorage class close method is not async
+    - Fix: Makes sure that the Async storage waits that all writes are finished in some cases
+
 ## 0.11.2 (2024-11-02)
 
 -   @matter/node
     - Feature: Automatically lock behavior state on invoke
     - Fix: Ensures to fully load the Descriptor cluster before adding additional device types 
-
--   @matter/nodejs
-    - Fix: Makes sure that the Async storage waits that all writes are finished in some cases
 
 -   @project-chip/matter.js
     - Fix: Fixes some compatibility re-exports that got screwed up since 0.11.0

--- a/packages/main/README.md
+++ b/packages/main/README.md
@@ -50,6 +50,7 @@ To have Typescript and your IDE know all the relevant exported functionality you
 ```json5
 {
     compilerOptions: {
+        "target": "es2022", // Matter.js most likely won't work with older versions of ES
         moduleResolution: "node16", // Required to support package.json exports
         module: "node16", // Required to make sure all imports are js
     },

--- a/packages/node/src/endpoint/storage/EndpointStore.ts
+++ b/packages/node/src/endpoint/storage/EndpointStore.ts
@@ -69,8 +69,11 @@ export class EndpointStore {
             const behaviorValues = (this.initialValues[behaviorId] = {} as Val.Struct);
             const behaviorStorage = this.#storage.createContext(behaviorId);
 
-            for (const key of await behaviorStorage.keys()) {
-                behaviorValues[key] = await behaviorStorage.get(key);
+            const storedValues = await behaviorStorage.values();
+            for (const [key, value] of Object.entries(storedValues)) {
+                if (value !== undefined) {
+                    behaviorValues[key] = value;
+                }
             }
         }
 

--- a/packages/nodejs-shell/src/MatterNode.ts
+++ b/packages/nodejs-shell/src/MatterNode.ts
@@ -109,7 +109,7 @@ export class MatterNode {
 
     async closeStorage() {
         try {
-            this.storage?.close();
+            await this.storage?.close();
             process.exit(0);
         } catch {
             process.exit(1);

--- a/packages/nodejs/src/storage/StorageBackendDiskAsync.ts
+++ b/packages/nodejs/src/storage/StorageBackendDiskAsync.ts
@@ -42,8 +42,9 @@ export class StorageBackendDiskAsync extends MaybeAsyncStorage {
         this.isInitialized = true;
     }
 
-    close() {
+    async close() {
         this.isInitialized = false;
+        await Promise.allSettled(this.#writeFileBlocker.values());
     }
 
     filePath(fileName: string) {
@@ -160,7 +161,10 @@ export class StorageBackendDiskAsync extends MaybeAsyncStorage {
         for (const key of await this.keys(contexts)) {
             promises.push(
                 (async () => {
-                    values[key] = await this.get(contexts, key);
+                    const value = await this.get(contexts, key);
+                    if (value !== undefined) {
+                        values[key] = value;
+                    }
                 })(),
             );
         }


### PR DESCRIPTION
This PR adds some failsafes to async storage:
1.) Makes sure that all writes are processed on storage close
2.) Makes sure at least for behaviors not to set potential "undefined" values (which can happen if single storage keys got corrupt somehow)