### PR TITLE
Fix commissioning on server restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The main work (all changes without a GitHub username in brackets in the below li
 
 -   @matter/node
     - Enhancement: The `with` functions on endpoint and cluster behavior types now alias to `withBehaviors` and `withFeatures` respectively to make their function more explicit
+    - Fix: Trigger CommissioningServer#initiateCommissioning when server restarts outside of factory reset
 
 -   @matter/nodejs
     - Feature: New export @matter/nodejs/config allows for fine-grained configuration of Node.js bootstrap logic

--- a/packages/node/src/behavior/system/commissioning/CommissioningServer.ts
+++ b/packages/node/src/behavior/system/commissioning/CommissioningServer.ts
@@ -151,7 +151,7 @@ export class CommissioningServer extends Behavior {
     }
 
     #triggerFactoryReset() {
-        this.env.runtime.add((this.endpoint as ServerNode).erase().then(this.callback(this.initiateCommissioning)));
+        this.env.runtime.add((this.endpoint as ServerNode).erase());
     }
 
     #monitorFailsafe(failsafe: FailsafeContext) {

--- a/packages/node/src/behavior/system/network/ServerNetworkRuntime.ts
+++ b/packages/node/src/behavior/system/network/ServerNetworkRuntime.ts
@@ -275,16 +275,16 @@ export class ServerNetworkRuntime extends NetworkRuntime {
         // Monitor CommissioningServer to end "uncommissioned" mode when we are commissioned
         this.#observers.on(this.owner.eventsOf(CommissioningServer).commissioned, this.endUncommissionedMode);
 
+        // When first going online, enable commissioning by controllers unless we ourselves are configured as a
+        // controller
+        if (owner.state.commissioning.enabled === undefined) {
+            await owner.set({
+                commissioning: { enabled: true },
+            });
+        }
+
         // Ensure the environment will convey the commissioning configuration to the DeviceCommissioner
         if (!env.has(CommissioningConfigProvider)) {
-            // When first going online, enable commissioning by controllers unless we ourselves are configured as a
-            // controller
-            if (owner.state.commissioning.enabled === undefined) {
-                await owner.set({
-                    commissioning: { enabled: true },
-                });
-            }
-
             // Configure the DeviceCommissioner
             env.set(
                 CommissioningConfigProvider,


### PR DESCRIPTION
The commissioning window opened on restart but initiateCommissioning was not triggered except in the case of factory reset triggered by decommissioning.  The resulted in the QR code not appearing.