### PR TITLE
Remove $Changed from logical flow of emitter

### DIFF
--- a/packages/node/src/behavior/AccessControl.ts
+++ b/packages/node/src/behavior/AccessControl.ts
@@ -124,7 +124,7 @@ export namespace AccessControl {
     /**
      * Information about the subject that triggered a change.
      */
-    export interface Subject {
+    export interface Actor {
         /**
          * The fabric of the authorized client.
          */
@@ -148,7 +148,7 @@ export namespace AccessControl {
     /**
      * Authorization metadata that varies with session.
      */
-    export interface Session extends Subject {
+    export interface Session extends Actor {
         /**
          * Checks if the authorized client has a certain Access Privilege granted.
          */

--- a/packages/node/src/behavior/AccessControl.ts
+++ b/packages/node/src/behavior/AccessControl.ts
@@ -122,14 +122,9 @@ export namespace AccessControl {
     }
 
     /**
-     * Authorization metadata that varies with session.
+     * Information about the subject that triggered a change.
      */
-    export interface Session {
-        /**
-         * Checks if the authorized client has a certain Access Privilege granted.
-         */
-        authorizedFor(desiredAccessLevel: AccessLevel, location?: Location): boolean;
-
+    export interface Subject {
         /**
          * The fabric of the authorized client.
          */
@@ -139,6 +134,25 @@ export namespace AccessControl {
          * The authenticated {@link SubjectId} for online sessions.
          */
         readonly subject?: SubjectId;
+
+        /**
+         * Indicates the action was triggered locally, not by a remote subject.
+         *
+         * If true, access levels are not enforced and all values are read/write.  Datatypes are still enforced.
+         *
+         * Tracks "offline" rather than "online" because this makes the safer mode (full enforcement) the default.
+         */
+        offline?: boolean;
+    }
+
+    /**
+     * Authorization metadata that varies with session.
+     */
+    export interface Session extends Subject {
+        /**
+         * Checks if the authorized client has a certain Access Privilege granted.
+         */
+        authorizedFor(desiredAccessLevel: AccessLevel, location?: Location): boolean;
 
         /**
          * If this is true, fabric-scoped lists are filtered to the accessing
@@ -156,14 +170,6 @@ export namespace AccessControl {
          * active.
          */
         readonly command?: boolean;
-
-        /**
-         * If this is true then access levels are not enforced and all values are read/write.  Datatypes are still
-         * enforced.
-         *
-         * Tracks "offline" rather than "online" because this makes the safer mode (full enforcement) the default.
-         */
-        offline?: boolean;
     }
 }
 

--- a/packages/node/src/behavior/cluster/ClusterEvents.ts
+++ b/packages/node/src/behavior/cluster/ClusterEvents.ts
@@ -29,7 +29,7 @@ export namespace ClusterEvents {
      * Properties the cluster contributes to Events.
      */
     export type Properties<C> = AttributeObservables<ClusterType.AttributesOf<C>, "Changing", ActionContext> &
-        AttributeObservables<ClusterType.AttributesOf<C>, "Changed", AccessControl.Subject> &
+        AttributeObservables<ClusterType.AttributesOf<C>, "Changed", AccessControl.Actor> &
         EventObservables<ClusterType.EventsOf<C>>;
 
     export type AttributeObservables<A extends Record<string, ClusterType.Attribute>, N extends string, C> = {

--- a/packages/node/src/behavior/cluster/ClusterEvents.ts
+++ b/packages/node/src/behavior/cluster/ClusterEvents.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { AccessControl } from "#behavior/AccessControl.js";
 import type { AsyncObservable, Observable } from "#general";
 import type { ClusterType, TypeFromSchema } from "#types";
 import type { Behavior } from "../Behavior.js";
@@ -27,18 +28,18 @@ export namespace ClusterEvents {
     /**
      * Properties the cluster contributes to Events.
      */
-    export type Properties<C> = AttributeObservables<ClusterType.AttributesOf<C>, "Changing"> &
-        AttributeObservables<ClusterType.AttributesOf<C>, "Changed"> &
+    export type Properties<C> = AttributeObservables<ClusterType.AttributesOf<C>, "Changing", ActionContext> &
+        AttributeObservables<ClusterType.AttributesOf<C>, "Changed", AccessControl.Subject> &
         EventObservables<ClusterType.EventsOf<C>>;
 
-    export type AttributeObservables<A extends Record<string, ClusterType.Attribute>, N extends string> = {
+    export type AttributeObservables<A extends Record<string, ClusterType.Attribute>, N extends string, C> = {
         [K in keyof A as string extends K
             ? never
             : K extends string
               ? A[K] extends { optional: true }
                   ? never
                   : `${K}$${N}`
-              : never]: AttributeObservable<A[K]>;
+              : never]: AttributeObservable<A[K], C>;
     } & {
         [K in keyof A as string extends K
             ? never
@@ -46,12 +47,13 @@ export namespace ClusterEvents {
               ? A[K] extends { optional: true }
                   ? `${K}$${N}`
                   : never
-              : never]?: AttributeObservable<A[K]>;
+              : never]?: AttributeObservable<A[K], C>;
     };
 
-    export type AttributeObservable<A extends ClusterType.Attribute = ClusterType.Attribute> = AsyncObservable<
-        [value: TypeFromSchema<A["schema"]>, oldValue: TypeFromSchema<A["schema"]>, context: ActionContext]
-    >;
+    export type AttributeObservable<
+        A extends ClusterType.Attribute = ClusterType.Attribute,
+        C = unknown,
+    > = AsyncObservable<[value: TypeFromSchema<A["schema"]>, oldValue: TypeFromSchema<A["schema"]>, context: C]>;
 
     export type EventObservables<E extends Record<string, ClusterType.Event>> = {
         [K in keyof E as string extends K

--- a/packages/node/src/behavior/internal/ClusterServerBacking.ts
+++ b/packages/node/src/behavior/internal/ClusterServerBacking.ts
@@ -18,7 +18,6 @@ import {
     EventServer,
     FabricManager,
     Message,
-    SecureSession,
 } from "#protocol";
 import { Attribute, Command, Event, TlvNoResponse } from "#types";
 import { AccessControl } from "../AccessControl.js";
@@ -274,13 +273,16 @@ function createAttributeServer(
     // Wire events (FixedAttributeServer is not an AttributeServer so we skip that)
     if (server instanceof AttributeServer) {
         const observable = (backing.events as any)[`${name}$Changed`] as ClusterEvents.AttributeObservable | undefined;
-        observable?.on((_value, _oldValue, context) => {
-            const session = context.session;
-            if (session instanceof SecureSession) {
-                server.updated(session);
-            } else {
-                server.updatedLocal();
-            }
+        observable?.on(() => {
+            // We no longer have a session in $Changed handlers.  I think it's OK to use updatedLocal instead of
+            // updated as our use of listeners is limited.  And updated() will actually notify listeners of fabric
+            // filtered result which probably isn't correct anyway
+            // const session = context.session;
+            // if (session instanceof SecureSession) {
+            //     server.updated(session);
+            // } else {
+            server.updatedLocal();
+            // }
         });
     }
 

--- a/packages/node/src/behaviors/access-control/AccessControlServer.ts
+++ b/packages/node/src/behaviors/access-control/AccessControlServer.ts
@@ -440,7 +440,11 @@ function* computeFabricAclChanges<T>(
             adminNodeId,
             adminPasscodeId,
             changeType,
-            latestValue: newEntries[i] ?? null,
+            latestValue:
+                newEntries[i] ??
+                // Unclear why this field is nullable but cert tests fail unless this value is set to "current value
+                // or latest value before deletion"
+                oldEntries[i],
             fabricIndex,
         };
     }

--- a/packages/node/src/behaviors/access-control/AccessControlServer.ts
+++ b/packages/node/src/behaviors/access-control/AccessControlServer.ts
@@ -434,8 +434,9 @@ function* computeAclChanges<T extends { fabricIndex: FabricIndex }>(
     groupByFabrics(fabricLists, "new", newEntries);
 
     for (const fabricIndex in fabricLists) {
-        const entry = fabricLists[fabricIndex as unknown as FabricIndex];
-        yield* computeFabricAclChanges(actor, fabricIndex as unknown as FabricIndex, entry.old, entry.new);
+        const numericIndex = FabricIndex(Number.parseInt(fabricIndex));
+        const entry = fabricLists[numericIndex];
+        yield* computeFabricAclChanges(actor, numericIndex, entry.old, entry.new);
     }
 }
 

--- a/packages/node/test/behavior/cluster/ClusterBehaviorTest.ts
+++ b/packages/node/test/behavior/cluster/ClusterBehaviorTest.ts
@@ -20,6 +20,7 @@ import {
     MaybePromise,
     Observable,
 } from "#general";
+import { AccessControl } from "#index.js";
 import { AttributeElement, ClusterModel } from "#model";
 import {
     Attribute,
@@ -106,7 +107,9 @@ describe("ClusterBehavior", () => {
 
             ({}) as MyBehavior satisfies {
                 events: EventEmitter & {
-                    reqAttr$Changed: AsyncObservable<[value: string, oldValue: string, context?: ActionContext]>;
+                    reqAttr$Changed: AsyncObservable<
+                        [value: string, oldValue: string, context?: AccessControl.Subject]
+                    >;
                 };
             };
 

--- a/packages/node/test/behavior/cluster/ClusterBehaviorTest.ts
+++ b/packages/node/test/behavior/cluster/ClusterBehaviorTest.ts
@@ -107,9 +107,7 @@ describe("ClusterBehavior", () => {
 
             ({}) as MyBehavior satisfies {
                 events: EventEmitter & {
-                    reqAttr$Changed: AsyncObservable<
-                        [value: string, oldValue: string, context?: AccessControl.Subject]
-                    >;
+                    reqAttr$Changed: AsyncObservable<[value: string, oldValue: string, context?: AccessControl.Actor]>;
                 };
             };
 

--- a/packages/node/test/behavior/cluster/ClusterEventsTest.ts
+++ b/packages/node/test/behavior/cluster/ClusterEventsTest.ts
@@ -12,6 +12,7 @@ import { ActionContext } from "#behavior/context/ActionContext.js";
 import { BasicInformationBehavior, BasicInformationServer } from "#behaviors/basic-information";
 import { BasicInformation } from "#clusters/basic-information";
 import { AsyncObservable, EventEmitter, MaybePromise, Observable } from "#general";
+import { AccessControl } from "#index.js";
 import { ClusterType } from "#types";
 import { MyCluster, MySchema } from "./cluster-behavior-test-util.js";
 
@@ -45,7 +46,10 @@ describe("ClusterEvents", () => {
 
         it("includes required", () => {
             ({}) as Ep satisfies EventEmitter & {
-                reqAttr$Changed: Observable<[value: string, oldValue: string, context?: ActionContext], MaybePromise>;
+                reqAttr$Changed: Observable<
+                    [value: string, oldValue: string, context?: AccessControl.Subject],
+                    MaybePromise
+                >;
 
                 reqEv: Observable<[payload: string, context?: ActionContext]>;
             };
@@ -103,7 +107,10 @@ describe("ClusterEvents", () => {
 
         it("requires mandatory", () => {
             ({}) as Ei satisfies {
-                reqAttr$Changed: Observable<[value: string, oldValue: string, context: ActionContext], MaybePromise>;
+                reqAttr$Changed: Observable<
+                    [value: string, oldValue: string, context: AccessControl.Subject],
+                    MaybePromise
+                >;
 
                 reqEv: Observable<[payload: string, context: ActionContext]>;
             };

--- a/packages/node/test/behavior/cluster/ClusterEventsTest.ts
+++ b/packages/node/test/behavior/cluster/ClusterEventsTest.ts
@@ -47,7 +47,7 @@ describe("ClusterEvents", () => {
         it("includes required", () => {
             ({}) as Ep satisfies EventEmitter & {
                 reqAttr$Changed: Observable<
-                    [value: string, oldValue: string, context?: AccessControl.Subject],
+                    [value: string, oldValue: string, context?: AccessControl.Actor],
                     MaybePromise
                 >;
 
@@ -108,7 +108,7 @@ describe("ClusterEvents", () => {
         it("requires mandatory", () => {
             ({}) as Ei satisfies {
                 reqAttr$Changed: Observable<
-                    [value: string, oldValue: string, context: AccessControl.Subject],
+                    [value: string, oldValue: string, context: AccessControl.Actor],
                     MaybePromise
                 >;
 

--- a/packages/node/test/behavior/state/managed/DatasourceTest.ts
+++ b/packages/node/test/behavior/state/managed/DatasourceTest.ts
@@ -365,9 +365,9 @@ describe("Datasource", () => {
 
             const { promise, resolver } = createPromise<void>();
 
-            let subject: AccessControl.Subject | undefined;
+            let actor: AccessControl.Actor | undefined;
             events.foo$Changed.on(async (_v1, _v2, subj) => {
-                subject = subj;
+                actor = subj;
 
                 await withReference(ds2, ref => {
                     ref.state.bar = true;
@@ -383,7 +383,7 @@ describe("Datasource", () => {
             await promise;
 
             expect(ds2.view.bar).true;
-            expect(subject).deep.equals({ fabric: undefined, subject: undefined, offline: true });
+            expect(actor).deep.equals({ fabric: undefined, subject: undefined, offline: true });
         });
     });
 


### PR DESCRIPTION
Previously we were providing the ActionContext of the emitter to $Changed handlers.  The transaction was destroyed in this case so was not really useful.  Now we instead just provide metadata about the subject that triggered the change.

Also, the emitter was awaiting $Changed handlers if they were async.  There are advantages and disadvantages to doing this:

* Advantage is that the logical flow is more deterministic and we track the promise as a normal part of node activity
* The disadvantage is that the emitter blocks until an independent process completes

This commit makes it so $Changed handlers operate independently of the emitter.  Tests pass but effects will be subtle so will need to keep an eye on this.