### PR TITLE
Ignore persisted values when features change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The main work (all changes without a GitHub username in brackets in the below li
 
 -   @matter/node
     - Enhancement: The `with` functions on endpoint and cluster behavior types now alias to `withBehaviors` and `withFeatures` respectively to make their function more explicit
+    - Enhancement: Endpoints now ignore persisted values for clusters when features change across restarts.  This allows for startup when persisted values become invalid due to conformance rules
     - Fix: Triggers CommissioningServer#initiateCommissioning when server restarts outside of factory reset
 
 -   @matter/nodejs

--- a/packages/node/src/behavior/state/managed/Datasource.ts
+++ b/packages/node/src/behavior/state/managed/Datasource.ts
@@ -231,9 +231,10 @@ function configure(options: Datasource.Options): Internals {
     let featuresKey: undefined | string;
     if (options.supervisor.featureMap.children.length) {
         featuresKey = [...options.supervisor.supportedFeatures].join(",");
-        if (storedValues?.[FEATURES_KEY] !== undefined && storedValues[FEATURES_KEY] !== featuresKey) {
+        const storedFeaturesKey = storedValues?.[FEATURES_KEY];
+        if (storedFeaturesKey !== undefined && storedFeaturesKey !== featuresKey) {
             logger.warn(
-                `Ignoring persisted values for ${options.path} because features changed from "${values.featuresKey}" to "${featuresKey}"`,
+                `Ignoring persisted values for ${options.path} because features changed from "${storedFeaturesKey}" to "${featuresKey}"`,
             );
             storedValues = undefined;
         }


### PR DESCRIPTION
Affects individual behaviors on endpoints with persisted values.  Storage must be tagged with features, so storage created by previous versions of code will not benefit from this enhancement.

Fixes #1161