### PR TITLE
Pre-allocate numbers when stores are loaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Enhancement: The `with` functions on endpoint and cluster behavior types now alias to `withBehaviors` and `withFeatures` respectively to make their function more explicit
     - Enhancement: Endpoints now ignore persisted values for clusters when features change across restarts.  This allows for startup when persisted values become invalid due to conformance rules
     - Fix: Triggers CommissioningServer#initiateCommissioning when server restarts outside of factory reset
+    - Fix: Ensures to initialize all known endpoint numbers to prevent dpuplicate number assignment edge cases
 
 -   @matter/nodejs
     - Feature: New export @matter/nodejs/config allows for fine-grained configuration of Node.js bootstrap logic

--- a/packages/node/src/endpoint/storage/EndpointStore.ts
+++ b/packages/node/src/endpoint/storage/EndpointStore.ts
@@ -1,3 +1,9 @@
+/**
+ * @license
+ * Copyright 2022-2024 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { Val } from "#behavior/state/Val.js";
 import { Datasource } from "#behavior/state/managed/Datasource.js";
 import { Endpoint } from "#endpoint/Endpoint.js";
@@ -83,6 +89,16 @@ export class EndpointStore {
         }
 
         await this.#loadSubparts();
+    }
+
+    /**
+     * Invoke a function on this store and the stores of descendant parts.
+     */
+    visit(fn: (store: EndpointStore) => void) {
+        fn(this);
+        for (const child of Object.values(this.#childStores)) {
+            child.visit(fn);
+        }
     }
 
     /**

--- a/packages/node/src/node/storage/EndpointStoreService.ts
+++ b/packages/node/src/node/storage/EndpointStoreService.ts
@@ -80,6 +80,14 @@ export class EndpointStoreFactory extends EndpointStoreService {
 
         // Preload stores so we can access synchronously going forward
         this.#root = await asyncNew(EndpointStore, this.#storage);
+
+        // Ensure all known numbers are allocated.  This protects them when unknown endpoints initialize before known
+        // endpoints and #nextNumber is somehow invalid
+        this.#root.visit(({ number }) => {
+            if (number !== undefined) {
+                this.#allocatedNumbers.add(number);
+            }
+        });
     }
 
     async erase() {


### PR DESCRIPTION
This protects the numbers of known endpoints if unknown endpoints load first.