### PR TITLE
Mark "next number" for future persistence on reset

### DIFF
--- a/packages/node/src/node/storage/EndpointStoreService.ts
+++ b/packages/node/src/node/storage/EndpointStoreService.ts
@@ -101,7 +101,8 @@ export class EndpointStoreFactory extends EndpointStoreService {
         this.#construction.start();
 
         this.#allocatedNumbers = new Set();
-        this.#persistedNextNumber = this.#nextNumber = (this.#defaultNextNumber ?? 1) % 0xffff;
+        this.#nextNumber = (this.#defaultNextNumber ?? 1) % 0xffff;
+        this.#persistedNextNumber = undefined;
         this.#root = new EndpointStore(this.#storage, false);
 
         await this.construction;


### PR DESCRIPTION
This should only have an effect when node numbers are allocated manually but adding just for consistency with startup of a new node.