### PR TITLE
Thermostat cluster override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The main work (all changes without a GitHub username in brackets in the below li
 
 -   @matter/nodejs
     - Feature: New export @matter/nodejs/config allows for fine-grained configuration of Node.js bootstrap logic
+    - Fix: Restores backward compatibility to sync storages from matter.js <0.11 in case ideas used special characters (uncommon)
 
 -   @matter/create
     - Feature: Added command line option "--verbose" to enable informational NPM messages during initialization
@@ -28,7 +29,10 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Multi-project test runs now use a single process to improve performance
 
 -   Matter cluster definitions and implementations
+    - Enhancement: Removes default value from attribute ControlSequenceOfOperation of Thermostat cluster because feature specific enum value was used
     - Fix: Reverts MoveToLevel workaround from 0.11.4
+    - Fix: ColorControl: Round calculated Kelvin values when calculated from Mireds
+    - Fix: GeneralDiagnostics: Network interface names are now correctly shortened to 32 characters
 
 -   matter.js git repository
     - Feature: We've added project configuration for VS code including recommended extensions, code snippets and launch configurations

--- a/models/src/local/ThermostatOverrides.ts
+++ b/models/src/local/ThermostatOverrides.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { FieldValue } from "@matter/model";
 import { LocalMatter } from "../local.js";
 
 LocalMatter.children.push({
@@ -18,6 +19,12 @@ LocalMatter.children.push({
             tag: "datatype",
             name: "OccupancyBitmap",
             type: "OccupancySensing.OccupancyBitmap",
+        },
+        {
+            tag: "attribute",
+            id: 0x1b,
+            name: "ControlSequenceOfOperation",
+            default: FieldValue.None,
         },
     ],
 });

--- a/packages/model/src/common/FieldValue.ts
+++ b/packages/model/src/common/FieldValue.ts
@@ -23,7 +23,8 @@ export type FieldValue =
     | FieldValue.Reference
     | FieldValue.Percent
     | FieldValue.Celsius
-    | FieldValue.Bytes;
+    | FieldValue.Bytes
+    | FieldValue.None;
 
 export namespace FieldValue {
     // Typing with constants should be just as type safe as using an enum but simplifies type definitions
@@ -43,10 +44,13 @@ export namespace FieldValue {
     export const bytes = "bytes";
     export type bytes = typeof bytes;
 
+    export const none = "none";
+    export type none = typeof none;
+
     /**
      * If a field value isn't a primitive type, it's an object with a type field indicating one of these types.
      */
-    export type Type = percent | celsius | reference | properties | bytes;
+    export type Type = percent | celsius | reference | properties | bytes | none;
 
     /**
      * Test for one of the special placeholder types.
@@ -61,6 +65,17 @@ export namespace FieldValue {
      */
     export const Invalid: unique symbol = Symbol("invalid");
     export type Invalid = typeof Invalid;
+
+    /**
+     * Flag for an "Undefined"/No value. Can be used in overrides to reset fields
+     */
+    export type None = {
+        type: none;
+    };
+
+    export const None: None = {
+        type: none,
+    };
 
     /**
      * Reference to a named field
@@ -124,6 +139,9 @@ export namespace FieldValue {
     export function serialize(value: FieldValue): string {
         if (value === null) {
             return "null";
+        }
+        if (is(value, none)) {
+            return "";
         }
         if (is(value, reference)) {
             return (value as Reference).name;
@@ -203,6 +221,9 @@ export namespace FieldValue {
             case "reference":
                 // This needs to be handled at a higher level
                 return;
+
+            case "none":
+                return; // undefined
 
             case "percent":
             case "celsius":

--- a/packages/model/src/standard/elements/Thermostat.ts
+++ b/packages/model/src/standard/elements/Thermostat.ts
@@ -340,7 +340,7 @@ export const Thermostat = Cluster({
 
         Attribute({
             name: "ControlSequenceOfOperation", id: 0x1b, type: "ControlSequenceOfOperationEnum",
-            access: "RW VM", conformance: "M", constraint: "desc", default: 4, quality: "N",
+            access: "RW VM", conformance: "M", constraint: "desc", quality: "N",
             details: "Indicates the overall operating environment of the thermostat, and thus the possible system modes " +
                 "that the thermostat can operate in.",
             xref: { document: "cluster", section: "4.3.9.24" }

--- a/packages/types/src/clusters/thermostat.ts
+++ b/packages/types/src/clusters/thermostat.ts
@@ -1425,11 +1425,7 @@ export namespace Thermostat {
             controlSequenceOfOperation: WritableAttribute(
                 0x1b,
                 TlvEnum<ControlSequenceOfOperation>(),
-                {
-                    persistent: true,
-                    default: ControlSequenceOfOperation.CoolingAndHeating,
-                    writeAcl: AccessLevel.Manage
-                }
+                { persistent: true, writeAcl: AccessLevel.Manage }
             ),
 
             /**


### PR DESCRIPTION
This PR removes the default of the ControlSequenceOfOperation attribute which was defined as one feature specific value which makes no sense. Better have no default

For this we added FieldValue.None as an option to express "undefined" to reset fields in e.g. overrides