### PR TITLE
Further dynamic endpoint adjustments

### DIFF
--- a/packages/node/src/endpoint/Endpoint.ts
+++ b/packages/node/src/endpoint/Endpoint.ts
@@ -625,6 +625,7 @@ export class Endpoint<T extends EndpointType = EndpointType.Empty> {
     }
 
     async close() {
+        await this.env.get(EndpointInitializer).deactivateDescendant(this);
         await this.#construction.close();
     }
 

--- a/packages/node/src/endpoint/properties/EndpointInitializer.ts
+++ b/packages/node/src/endpoint/properties/EndpointInitializer.ts
@@ -23,7 +23,7 @@ export abstract class EndpointInitializer {
     abstract eraseDescendant(_endpoint: Endpoint): Promise<void>;
 
     /**
-     * Close storage a {@link Endpoint}.
+     * Deactivate the storage for a {@link Endpoint}. This mainly manages internal state to deactivate the endpoint number assignment
      */
     abstract deactivateDescendant(_endpoint: Endpoint): Promise<void>;
 

--- a/packages/node/src/endpoint/properties/EndpointInitializer.ts
+++ b/packages/node/src/endpoint/properties/EndpointInitializer.ts
@@ -23,6 +23,11 @@ export abstract class EndpointInitializer {
     abstract eraseDescendant(_endpoint: Endpoint): Promise<void>;
 
     /**
+     * Close storage a {@link Endpoint}.
+     */
+    abstract deactivateDescendant(_endpoint: Endpoint): Promise<void>;
+
+    /**
      * Create backing for a behavior of a descendent.
      *
      * @param endpoint the {@link Endpoint} the behavior belongs to

--- a/packages/node/src/node/client/ClientEndpointInitializer.ts
+++ b/packages/node/src/node/client/ClientEndpointInitializer.ts
@@ -37,6 +37,10 @@ export class ClientEndpointInitializer extends EndpointInitializer {
         await store.erase();
     }
 
+    async deactivateDescendant(_endpoint: Endpoint) {
+        // nothing to do
+    }
+
     get ready() {
         return this.#store.construction.ready;
     }

--- a/packages/node/src/node/server/ServerEndpointInitializer.ts
+++ b/packages/node/src/node/server/ServerEndpointInitializer.ts
@@ -33,13 +33,20 @@ export class ServerEndpointInitializer extends EndpointInitializer {
         endpoint.behaviors.require(DescriptorServer);
     }
 
-    override async eraseDescendant(endpoint: Endpoint) {
+    async eraseDescendant(endpoint: Endpoint) {
         if (!endpoint.lifecycle.hasId) {
             return;
         }
 
-        const store = this.#store.endpointStores.storeForEndpoint(endpoint);
-        await store.erase();
+        await this.#store.endpointStores.eraseStoreForEndpoint(endpoint);
+    }
+
+    async deactivateDescendant(endpoint: Endpoint) {
+        if (!endpoint.lifecycle.hasId || endpoint.number === 0) {
+            return;
+        }
+
+        this.#store.endpointStores.deactivateStoreForEndpoint(endpoint);
     }
 
     /**

--- a/packages/node/src/node/storage/EndpointStoreService.ts
+++ b/packages/node/src/node/storage/EndpointStoreService.ts
@@ -143,6 +143,7 @@ export class EndpointStoreFactory extends EndpointStoreService {
                     logger.warn(`Stored number ${knownNumber} is already allocated to another endpoint, ignoring`);
                 } else {
                     this.#preAllocatedNumbers.delete(knownNumber);
+                    this.#allocatedNumbers.add(knownNumber);
                     endpoint.number = knownNumber;
                     return;
                 }

--- a/packages/node/test/node/mock-node.ts
+++ b/packages/node/test/node/mock-node.ts
@@ -32,6 +32,7 @@ export class MockPartInitializer extends EndpointInitializer {
     }
 
     async eraseDescendant(_endpoint: Endpoint) {}
+    async deactivateDescendant(_endpoint: Endpoint) {}
 
     createBacking(endpoint: Endpoint, behavior: Behavior.Type) {
         return new ServerBehaviorBacking(endpoint, behavior);
@@ -52,16 +53,22 @@ class MockEndpointStoreService extends EndpointStoreService {
     #stores = Array<MockEndpointStore>();
     #nextNumber = 1;
 
-    override assignNumber(endpoint: Endpoint<EndpointType.Empty>): void {
+    assignNumber(endpoint: Endpoint<EndpointType.Empty>): void {
         endpoint.number = this.#nextNumber++;
     }
 
-    override storeForEndpoint(endpoint: Endpoint<EndpointType.Empty>): EndpointStore {
+    storeForEndpoint(endpoint: Endpoint<EndpointType.Empty>): EndpointStore {
         if (this.#stores[endpoint.number]) {
             return this.#stores[endpoint.number];
         }
 
         return (this.#stores[endpoint.number] = new MockEndpointStore(endpoint));
+    }
+
+    deactivateStoreForEndpoint(_endpoint: Endpoint<EndpointType.Empty>) {}
+
+    async eraseStoreForEndpoint(endpoint: Endpoint<EndpointType.Empty>) {
+        delete this.#stores[endpoint.number];
     }
 }
 


### PR DESCRIPTION
This PR further optimizes the allocated/preallocated numbers:
* register known numbers in allocated when used to ensure potentially broken "nextNumber" (or overflows!) to work correctly and skip assigned numbers
* Manage the allocated/pre-allocated sets in case of node close and erase