### PR TITLE
Prevent committing delayed ACL updates too early

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ The main work (all changes without a GitHub username in brackets in the below li
 	## __WORK IN PROGRESS__
 -->
 
+## __WORK IN PROGRESS__
+
+-   @matter/node
+    - Fix: Fixes race condition that can partially destroy ACL entries when concurrent writes happen in parallel to ACL writes
+
+
 ## 0.11.6 (2024-11-27)
 
 -   @matter/general

--- a/packages/node/src/behaviors/access-control/AccessControlServer.ts
+++ b/packages/node/src/behaviors/access-control/AccessControlServer.ts
@@ -411,6 +411,11 @@ export class AccessControlServer extends AccessControlBehavior {
         }
     }
 
+    resetDelayedAccessControlList() {
+        this.internal.delayedAclData = undefined;
+        this.aclUpdateDelayed = false;
+    }
+
     /**
      * If set to true, the ACL will not be updated immediately when it changes, but only when the `aclUpdateDelayed`
      * property is set to false again.

--- a/packages/node/src/behaviors/access-control/AccessControlServer.ts
+++ b/packages/node/src/behaviors/access-control/AccessControlServer.ts
@@ -433,9 +433,11 @@ export class AccessControlServer extends AccessControlBehavior {
      * removed again once we somehow handle relevant sub transactions.
      */
     set aclUpdateDelayed(value: boolean) {
-        logger.info("Setting ACL update delayed to", value);
         if (!value) {
+            logger.info("Committing delayed ACL update");
             this.#updateDelayedAccessControlList();
+        } else if (!this.internal.aclUpdateDelayed) {
+            logger.info("Register ACL update to be delayed");
         }
         this.internal.aclUpdateDelayed = value;
     }


### PR DESCRIPTION
When concurrent writes happen and one of them is writing ACL entries then the first write that finished committed the ACL change. This could also happen when ACL entries were just resetted to empty to be refilled, which then in the end prevented any further ACL change or such and also changed the ACLs to an undefined state. This change tracks ACL writes based on the exchange and also just resets when this exchange completes.

There is one edge case to maybe discuss which is about multiple concurrent acl writes for usually multiple fabrics ... Resetting that in error case is not yet added but should be very  unlikely.