### PR TITLE
Correctly erases child store on endpointstore erase

### DIFF
--- a/packages/node/src/endpoint/storage/EndpointStore.ts
+++ b/packages/node/src/endpoint/storage/EndpointStore.ts
@@ -188,6 +188,18 @@ export class EndpointStore {
         await this.#storage.clearAll();
     }
 
+    /**
+     * Erase the child storage for one part
+     */
+    async eraseChildStoreFor(endpoint: Endpoint) {
+        await this.#construction;
+
+        const partId = endpoint.id;
+        const store = this.#childStores[partId];
+        await store.erase();
+        delete this.#childStores[partId];
+    }
+
     async #loadSubparts() {
         const knownParts = await this.#childStorage.contexts();
         for (const partId of knownParts) {

--- a/packages/node/src/node/storage/EndpointStoreService.ts
+++ b/packages/node/src/node/storage/EndpointStoreService.ts
@@ -216,8 +216,13 @@ export class EndpointStoreFactory extends EndpointStoreService {
     async eraseStoreForEndpoint(endpoint: Endpoint) {
         this.#construction.assert();
 
-        const store = this.storeForEndpoint(endpoint);
-        await store.erase();
+        if (!endpoint.owner) {
+            throw new InternalError(
+                "Endpoint storage inaccessible because endpoint is not a node and is not owned by another endpoint",
+            );
+        }
+
+        await this.storeForEndpoint(endpoint.owner).eraseChildStoreFor(endpoint);
 
         this.#allocatedNumbers.delete(endpoint.number);
         this.#preAllocatedNumbers.delete(endpoint.number);

--- a/packages/node/test/endpoints/BridgedNodeEndpointTest.ts
+++ b/packages/node/test/endpoints/BridgedNodeEndpointTest.ts
@@ -60,7 +60,7 @@ describe("BridgedNodeEndpointTest", () => {
             await bridge.owner?.close();
         });
 
-        it("dynamically", async () => {
+        it("adding endpoint dynamically", async () => {
             const bridge = await createBridge(AggregatorEndpoint);
 
             await bridge.add({
@@ -74,7 +74,7 @@ describe("BridgedNodeEndpointTest", () => {
             await bridge.owner?.close();
         });
 
-        it("with multiple dynamic endpoints in different re-init order", async () => {
+        it("with multiple dynamic endpoints in different re-init order on restart", async () => {
             const environment = new Environment("test");
             const storages = new Map<string, StorageBackendMemory>();
             const storage = environment.get(StorageService);
@@ -160,7 +160,7 @@ describe("BridgedNodeEndpointTest", () => {
             await bridge2.owner?.close();
         });
 
-        it("with multiple dynamic endpoints in different re-init order with reset nextNumber", async () => {
+        it("with multiple dynamic endpoints in different re-init order with reset nextNumber on restart", async () => {
             const environment = new Environment("test");
             const storages = new Map<string, StorageBackendMemory>();
             const storage = environment.get(StorageService);
@@ -205,6 +205,7 @@ describe("BridgedNodeEndpointTest", () => {
             // Store their numbers
             const light1 = bridge.parts.require("light1").number;
             const light2 = bridge.parts.require("light2").number;
+            const light21 = bridge.parts.require("light2-1").number;
             const light3 = bridge.parts.require("light3").number;
 
             await bridge.owner?.close();
@@ -247,13 +248,24 @@ describe("BridgedNodeEndpointTest", () => {
             assert.strictEqual(bridge2.parts.require("light1").number, light1);
             assert.strictEqual(bridge2.parts.require("light2").number, light2);
             assert.strictEqual(bridge2.parts.require("light3").number, light3);
-            assert.strictEqual(bridge2.parts.require("light4").number, light3 + 1);
-            assert.deepEqual(store.get(["root"], "__nextNumber__"), 7);
+            assert.deepEqual(store.get(["root", "parts", "part0", "parts", "light1"], "__number__"), light1);
+            assert.deepEqual(store.get(["root.parts.part0.parts.light2"], "__number__"), light2);
+            assert.deepEqual(store.get(["root.parts.part0.parts.light3"], "__number__"), light3);
+            assert.deepEqual(store.get(["root.parts.part0.parts.light2-1"], "__number__"), light21);
+            assert.deepEqual(store.get(["root.parts.part0.parts.light4"], "__number__"), light3 + 1);
 
             await bridge2.owner?.close();
+
+            store.initialize();
+
+            assert.deepEqual(store.get(["root", "parts", "part0", "parts", "light1"], "__number__"), light1);
+            assert.deepEqual(store.get(["root", "parts", "part0", "parts", "light2"], "__number__"), light2);
+            assert.deepEqual(store.get(["root", "parts", "part0", "parts", "light3"], "__number__"), light3);
+            assert.deepEqual(store.get(["root", "parts", "part0", "parts", "light2-1"], "__number__"), light21);
+            assert.deepEqual(store.get(["root", "parts", "part0", "parts", "light4"], "__number__"), light3 + 1);
         });
 
-        it("removing and re-adding dynamic endpoints", async () => {
+        it("closing and re-adding dynamic endpoints during runtime", async () => {
             // Have a bridge with 4 endpoints
             const bridge = await createBridge(AggregatorEndpoint);
 
@@ -281,16 +293,196 @@ describe("BridgedNodeEndpointTest", () => {
             await ep2.close();
             await MockTime.yield();
 
-            const ep2New = new Endpoint({
+            await bridge.add({
                 type: BridgedLightDevice,
                 id: "light2",
             });
-            await bridge.add(ep2New);
             await MockTime.yield();
 
+            // Numbers are reused
             assert.strictEqual(bridge.parts.require("light2").number, light2);
 
             await bridge.owner?.close();
+        });
+
+        it("with multiple dynamic endpoints close and re-add during runtime", async () => {
+            const environment = new Environment("test");
+            const storages = new Map<string, StorageBackendMemory>();
+            const storage = environment.get(StorageService);
+            storage.location = "(memory-for-test)";
+            storage.factory = namespace => {
+                const existing = storages.get(namespace);
+                if (existing) {
+                    return existing;
+                }
+                const store = new StorageBackendMemory();
+                storages.set(namespace, store);
+                return store;
+            };
+
+            // Have a bridge with 4 endpoints
+            const bridge = await createBridge(AggregatorEndpoint, { environment });
+
+            const endpoint1 = await bridge.add({
+                type: BridgedLightDevice,
+                id: "light1",
+            });
+            await MockTime.yield();
+
+            const endpoint2 = await bridge.add({
+                type: BridgedLightDevice,
+                id: "light2",
+            });
+            await MockTime.yield();
+
+            await bridge.add({
+                type: BridgedLightDevice,
+                id: "light3",
+            });
+            await MockTime.yield();
+
+            // Store their numbers
+            const light1 = bridge.parts.require("light1").number;
+            const light2 = bridge.parts.require("light2").number;
+            const light3 = bridge.parts.require("light3").number;
+
+            // Close 2 endpoints
+            await endpoint2.close();
+            await MockTime.yield();
+            await endpoint1.close();
+            await MockTime.yield();
+
+            // Verify data are still existing in storage
+            const store = storages.get("node0")!;
+            assert.deepEqual(store.get(["root", "parts", "part0", "parts", "light1"], "__number__"), light1);
+            assert.deepEqual(store.get(["root", "parts", "part0", "parts", "light2"], "__number__"), light2);
+            assert.deepEqual(store.get(["root", "parts", "part0", "parts", "light3"], "__number__"), light3);
+            assert.deepEqual(store.get(["root", "parts", "part0", "parts", "light4"], "__number__"), undefined);
+
+            // Add one endpoint again
+            await bridge.add({
+                type: BridgedLightDevice,
+                id: "light1",
+            });
+            await MockTime.yield();
+
+            // Add one endpoint again
+            await bridge.add({
+                type: BridgedLightDevice,
+                id: "light4",
+            });
+            await MockTime.yield();
+
+            // Verify that the endpoint numbers are preserved and new ones are allocated
+            assert.strictEqual(bridge.parts.require("light1").number, light1);
+            assert.strictEqual(bridge.parts.require("light3").number, light3);
+            assert.strictEqual(bridge.parts.require("light4").number, light3 + 1);
+
+            await bridge.owner?.close();
+
+            store.initialize();
+
+            assert.deepEqual(store.get(["root", "parts", "part0", "parts", "light1"], "__number__"), light1);
+            assert.deepEqual(store.get(["root", "parts", "part0", "parts", "light2"], "__number__"), light2);
+            assert.deepEqual(store.get(["root", "parts", "part0", "parts", "light3"], "__number__"), light3);
+            assert.deepEqual(store.get(["root", "parts", "part0", "parts", "light4"], "__number__"), light3 + 1);
+        });
+
+        it("with multiple dynamic endpoints delete and re-add during runtime", async () => {
+            const environment = new Environment("test");
+            const storages = new Map<string, StorageBackendMemory>();
+            const storage = environment.get(StorageService);
+            storage.location = "(memory-for-test)";
+            storage.factory = namespace => {
+                const existing = storages.get(namespace);
+                if (existing) {
+                    return existing;
+                }
+                const store = new StorageBackendMemory();
+                storages.set(namespace, store);
+                return store;
+            };
+
+            // Have a bridge with 4 endpoints
+            const bridge = await createBridge(AggregatorEndpoint, { environment });
+
+            const endpoint1 = await bridge.add({
+                type: BridgedLightDevice,
+                id: "light1",
+            });
+            await MockTime.yield();
+
+            const endpoint2 = await bridge.add({
+                type: BridgedLightDevice,
+                id: "light2",
+            });
+            await MockTime.yield();
+
+            await bridge.add({
+                type: BridgedLightDevice,
+                id: "light3",
+            });
+            await MockTime.yield();
+
+            // Store their numbers
+            const light1 = bridge.parts.require("light1").number;
+            const light2 = bridge.parts.require("light2").number;
+            const light3 = bridge.parts.require("light3").number;
+
+            // Verify the entries are existing in storage
+            const store = storages.get("node0")!;
+            assert.deepEqual(store.get(["root", "parts", "part0", "parts", "light1"], "__number__"), light1);
+            assert.deepEqual(store.get(["root", "parts", "part0", "parts", "light2"], "__number__"), light2);
+            assert.deepEqual(store.get(["root", "parts", "part0", "parts", "light3"], "__number__"), light3);
+
+            // Close 2 endpoints
+            await endpoint2.delete();
+            await MockTime.yield();
+            await endpoint1.delete();
+            await MockTime.yield();
+
+            // Verify the entries are deleted in storage
+            assert.deepEqual(store.get(["root", "parts", "part0", "parts", "light1"], "__number__"), undefined);
+            assert.deepEqual(store.get(["root", "parts", "part0", "parts", "light2"], "__number__"), undefined);
+            assert.deepEqual(store.get(["root", "parts", "part0", "parts", "light3"], "__number__"), light3);
+
+            // Add one endpoint again
+            await bridge.add({
+                type: BridgedLightDevice,
+                id: "light1",
+            });
+            await MockTime.yield();
+
+            // Add one endpoint again
+            await bridge.add({
+                type: BridgedLightDevice,
+                id: "light4",
+            });
+            await MockTime.yield();
+
+            assert.deepEqual(store.get(["root", "parts", "part0", "parts", "light1"], "__number__"), light3 + 1);
+            assert.deepEqual(store.get(["root", "parts", "part0", "parts", "light2"], "__number__"), undefined);
+            assert.deepEqual(store.get(["root", "parts", "part0", "parts", "light3"], "__number__"), light3);
+            assert.deepEqual(store.get(["root", "parts", "part0", "parts", "light4"], "__number__"), light3 + 2);
+
+            // Verify that the endpoint numbers are preserved and new ones are allocated
+            assert.strictEqual(bridge.parts.require("light1").number, light3 + 1);
+            assert.strictEqual(bridge.parts.require("light3").number, light3);
+            assert.strictEqual(bridge.parts.require("light4").number, light3 + 2);
+
+            assert.deepEqual(store.get(["root", "parts", "part0", "parts", "light1"], "__number__"), light3 + 1);
+            assert.deepEqual(store.get(["root", "parts", "part0", "parts", "light2"], "__number__"), undefined);
+            assert.deepEqual(store.get(["root", "parts", "part0", "parts", "light3"], "__number__"), light3);
+            assert.deepEqual(store.get(["root", "parts", "part0", "parts", "light4"], "__number__"), light3 + 2);
+
+            await bridge.owner?.close();
+
+            store.initialize();
+
+            assert.deepEqual(store.get(["root", "parts", "part0", "parts", "light1"], "__number__"), light3 + 1);
+            assert.deepEqual(store.get(["root", "parts", "part0", "parts", "light2"], "__number__"), undefined);
+            assert.deepEqual(store.get(["root", "parts", "part0", "parts", "light3"], "__number__"), light3);
+            assert.deepEqual(store.get(["root", "parts", "part0", "parts", "light4"], "__number__"), light3 + 2);
         });
     });
 });


### PR DESCRIPTION
... before this the storage was cleared but the endpoint store was still remembered. This had the side effect that the endpoint number was also reused partially and not stored again. Now this is cleaned up.