### PR TITLE
Correctly parse DataReports with duplicate non-Array data entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ The main work (all changes without a GitHub username in brackets in the below li
 
 ## __WORK IN PROGRESS__
 
+-   @matter/protocol
+    - Fix: Correctly parse DataReports with duplicate non-Array data entries
+
 -   @matter/node
     - Fix: Ensures to completely remove all stored endpoint data when endpoint is deleted 
 

--- a/packages/protocol/src/interaction/InteractionServer.ts
+++ b/packages/protocol/src/interaction/InteractionServer.ts
@@ -771,7 +771,7 @@ export class InteractionServer implements ProtocolHandler, InteractionRecipient 
                         listIndex === undefined
                             ? decodeAttributeValueWithSchema(schema, [writeRequest], defaultValue)
                             : decodeListAttributeValueWithSchema(
-                                  schema,
+                                  schema as ArraySchema<any>,
                                   [writeRequest],
                                   (
                                       await this.readAttribute(

--- a/packages/protocol/test/protocol/interaction/AttributeDataDecoderTest.ts
+++ b/packages/protocol/test/protocol/interaction/AttributeDataDecoderTest.ts
@@ -17,6 +17,7 @@ import {
     TlvArray,
     TlvAttributeData,
     TlvAttributeReport,
+    TlvBoolean,
     TlvDataReport,
     TlvField,
     TlvNullable,
@@ -903,6 +904,46 @@ describe("AttributeDataDecoder", () => {
                 { "1": 1, "2": 2, "3": null, "4": null },
                 { "1": 2, "2": 2, "3": null, "4": 6 },
             ]);
+        });
+    });
+
+    describe("decode duplicate non list values", () => {
+        it("decode chunked array with two elements", () => {
+            const data: TypeFromSchema<typeof TlvAttributeReport>[] = [
+                {
+                    attributeData: {
+                        path: {
+                            endpointId: EndpointNumber(0),
+                            clusterId: ClusterId(6),
+                            attributeId: AttributeId(0),
+                        },
+                        data: TlvBoolean.encodeTlv(true),
+                        dataVersion: 12345,
+                    },
+                },
+                {
+                    attributeData: {
+                        path: {
+                            endpointId: EndpointNumber(0),
+                            clusterId: ClusterId(6),
+                            attributeId: AttributeId(0),
+                        },
+                        data: TlvBoolean.encodeTlv(false),
+                        dataVersion: 23456,
+                    },
+                },
+            ];
+            const normalizedData = normalizeAndDecodeReadAttributeReport(data);
+
+            expect(normalizedData.length).equal(1);
+            expect(normalizedData[0].path).deep.equal({
+                attributeId: AttributeId(0),
+                attributeName: "onOff",
+                clusterId: ClusterId(6),
+                endpointId: EndpointNumber(0),
+                nodeId: undefined,
+            });
+            expect(normalizedData[0].value).deep.equal(false);
         });
     });
 


### PR DESCRIPTION
Before this we were ignoring these values because they were considered to be array data