### PR TITLE
New model algorithms and APIs for scope analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,15 @@ The main work (all changes without a GitHub username in brackets in the below li
 
 -   @project-chip/matter.js
     - Enhancement: Considers a node in reconnection state that should be decommissioned as already factory reset
+    - Fix: Do not try to convert color mode details if they are not defined
+    - Fix: Clusters generated for extensions of base clusters such as Alarm Base and Mode Base now include full details of extended types; in particular extended enums such as Mode Tag were previously insufficiently defined
+    - BREAKING: In `ContentLauncher` cluster `ParameterEnum` is renamed to `Parameter` and `Parameter` is renamed to `ParameterStruct`
+
+-   @matter/model
+    - Feature: New `Scope` component analyzes scope of a model, caches analysis results, and implements algorithms that require analysis to perform efficiently
+    - Enhancement: Models that define datatypes now inherit from common `ScopeModel` base class
+    - Fix: Extended enums and other types now report the full set of members via `Scope#membersOf`
+    - BREAKING: `ClusterModel` and `ValueModel` properties `members`, `activeMembers` and `conformantMembers` are removed; use `Scope#membersOf` instead
 
 ## 0.11.8 (2024-11-29)
 

--- a/codegen/src/clusters/generate-cluster.ts
+++ b/codegen/src/clusters/generate-cluster.ts
@@ -12,6 +12,7 @@ import {
     CommandModel,
     conditionToBitmaps,
     Conformance,
+    DefaultValue,
     FeatureBitmap,
     translateBitmap,
     ValueModel,
@@ -136,7 +137,7 @@ function generateMutableCluster(
 
         // Identify features enabled by default.  This is controlled by the default value of supportedFeatures
         const defaultFeatures = new Set<string>();
-        const supportedFeatures = featureMap.effectiveDefault;
+        const supportedFeatures = DefaultValue(file.cluster.scope, featureMap);
         if (typeof supportedFeatures === "number" && supportedFeatures) {
             // There are default supported features
             featureMap.children.forEach(feature => {

--- a/codegen/src/mom/spec/add-documentation.ts
+++ b/codegen/src/mom/spec/add-documentation.ts
@@ -57,6 +57,10 @@ function extractUsefulDocumentation(p: HTMLElement) {
         .replace(/This attribute shall be null/, "Null")
         .replace(/The following tags are defined in this namespace\./, "")
         .replace(/This section contains the (.*) as part of the semantic tag feature\./i, "")
+        .replace(
+            /The table below lists the changes relative to the Mode Base Cluster for the fields of the ModeOptionStruct type\./,
+            "",
+        )
         .trim();
 }
 

--- a/codegen/src/util/ScopeFile.ts
+++ b/codegen/src/util/ScopeFile.ts
@@ -6,29 +6,29 @@
 
 import { decamelize, InternalError } from "#general";
 import { ClusterModel, DatatypeModel, Model } from "#model";
-import { Scope } from "../clusters/Scope.js";
+import { GeneratorScope } from "../clusters/GeneratorScope.js";
 import { TsFile } from "./TsFile.js";
 import { camelize } from "./string.js";
 
 /**
- * A TS file that understands {@link Scope} semantics.
+ * A TS file that understands {@link GeneratorScope} semantics.
  */
 export class ScopeFile extends TsFile {
     #definesScope: boolean;
-    #scope: Scope;
+    #scope: GeneratorScope;
 
     constructor(options: ScopeFile.Options) {
         let filename: string;
-        let scope: Scope | undefined;
+        let scope: GeneratorScope | undefined;
         let definesScope: boolean;
 
         if (options.name === undefined) {
             definesScope = true;
-            scope = Scope(options.scope);
+            scope = GeneratorScope(options.scope);
             filename = ScopeFile.filenameFor(scope.owner).replace(/.js$/, "");
         } else {
             definesScope = false;
-            scope = options.scope && Scope(options.scope);
+            scope = options.scope && GeneratorScope(options.scope);
             filename = options.name;
         }
 
@@ -70,7 +70,7 @@ export class ScopeFile extends TsFile {
         }
 
         if (sourceScope === undefined) {
-            sourceScope = Scope(model);
+            sourceScope = GeneratorScope(model);
         }
 
         // Cluster definitions are namespaced so we must import the namespace.  Otherwise there is no namespace so we
@@ -123,6 +123,7 @@ export class ScopeFile extends TsFile {
         if (model instanceof ClusterModel) {
             return `!clusters/${decamelize(name)}.js`;
         }
+
         if (model instanceof DatatypeModel) {
             name = name.replace(/(?:Struct|Enum|Bitmap)$/, "");
 
@@ -157,7 +158,7 @@ export namespace ScopeFile {
      */
     interface ScopeDefinitionOptions {
         name?: undefined;
-        scope: Scope | Model;
+        scope: GeneratorScope | Model;
         editable?: boolean;
     }
 
@@ -168,7 +169,7 @@ export namespace ScopeFile {
      */
     interface ScopeAwareOptions {
         name: string;
-        scope: Scope | Model;
+        scope: GeneratorScope | Model;
         editable?: boolean;
     }
 

--- a/codegen/src/util/finalize-model.ts
+++ b/codegen/src/util/finalize-model.ts
@@ -23,6 +23,27 @@ import {
 const logger = Logger.get("create-model");
 
 /**
+ * Create and validate the final model for export
+ **/
+export function finalizeModel(matter: MatterModel) {
+    matter.children.forEach(c => {
+        if (c instanceof ClusterModel) {
+            patchClusterTypes(c);
+            patchOptionsTypes(c);
+            patchStatusTypes(c);
+        }
+    });
+
+    ejectZigbee(matter);
+
+    logger.info(`validate ${matter.name}`);
+
+    return Logger.nest(() => {
+        return ValidateModel(matter);
+    });
+}
+
+/**
  * Get the properties of children without xrefs so we can compare types using isDeepEqual
  */
 function childrenIdentity(model: ValueModel) {
@@ -225,25 +246,4 @@ function ejectZigbee(model: Model, zigbeeFeatures?: string[]) {
     if (filtered.length !== model.children.length) {
         model.children = filtered as AnyElement[];
     }
-}
-
-/**
- * Create and validate the final model for export
- **/
-export function finalizeModel(matter: MatterModel) {
-    matter.children.forEach(c => {
-        if (c instanceof ClusterModel) {
-            patchClusterTypes(c);
-            patchOptionsTypes(c);
-            patchStatusTypes(c);
-        }
-    });
-
-    ejectZigbee(matter);
-
-    logger.info(`validate ${matter.name}`);
-
-    return Logger.nest(() => {
-        return ValidateModel(matter);
-    });
 }

--- a/models/src/local.ts
+++ b/models/src/local.ts
@@ -14,5 +14,4 @@ export const LocalMatter = MatterElement({
     name: "LocalMatter",
     description: "Matter.js Matter overrides",
     revision: "1.1",
-    children: [],
 });

--- a/models/src/local/ModeBaseOverrides.ts
+++ b/models/src/local/ModeBaseOverrides.ts
@@ -1,0 +1,28 @@
+/**
+ * @license
+ * Copyright 2022-2024 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { LocalMatter } from "../local.js";
+
+LocalMatter.children.push({
+    tag: "cluster",
+    name: "ModeBase",
+
+    children: [
+        {
+            tag: "datatype",
+            name: "ModeTagStruct",
+
+            children: [
+                {
+                    tag: "field",
+                    id: 1,
+                    name: "Value",
+                    type: "ModeTag",
+                },
+            ],
+        },
+    ],
+});

--- a/models/src/local/WildcardPathFlagsBitmap.ts
+++ b/models/src/local/WildcardPathFlagsBitmap.ts
@@ -1,0 +1,21 @@
+/**
+ * @license
+ * Copyright 2022-2024 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { LocalMatter } from "../local.js";
+
+LocalMatter.children.push({
+    tag: "datatype",
+    name: "WildcardPathFlagsBitmap",
+
+    children: [
+        {
+            tag: "field",
+            name: "Reserved",
+            constraint: "3",
+            description: "Reserved",
+        },
+    ],
+});

--- a/models/src/local/WindowCoveringOverrides.ts
+++ b/models/src/local/WindowCoveringOverrides.ts
@@ -209,10 +209,13 @@ LocalMatter.children.push(
                 tag: "datatype",
                 name: "OperationalStatusBitmap",
 
+                // The type is correct but need to set here so model logic knows to use the constraint for matching
+                type: "map8",
+
                 children: [
-                    { tag: "field", name: "Global", type: "MovementStatus" },
-                    { tag: "field", name: "Lift", type: "MovementStatus" },
-                    { tag: "field", name: "Tilt", type: "MovementStatus" },
+                    { tag: "field", name: "Global", type: "MovementStatus", constraint: "0 to 2" },
+                    { tag: "field", name: "Lift", type: "MovementStatus", constraint: "2 to 4" },
+                    { tag: "field", name: "Tilt", type: "MovementStatus", constraint: "4 to 6" },
                 ],
             },
 

--- a/models/src/local/index.ts
+++ b/models/src/local/index.ts
@@ -13,6 +13,7 @@
 // matching.
 
 import "./AdministratorCommissioningOverrides.js";
+import "./any.js";
 import "./BasicInformationOverrides.js";
 import "./ChannelOverrides.js";
 import "./ColorControlOverrides.js";
@@ -24,19 +25,20 @@ import "./GroupsOverrides.js";
 import "./IlluminanceMeasurementOverrides.js";
 import "./LevelControlOverrides.js";
 import "./LocalizationConfigurationOverrides.js";
+import "./ModeBaseOverrides.js";
 import "./ModeSelectOverrides.js";
+import "./namespace.js";
 import "./OperationalCredentialsOverrides.js";
 import "./PumpConfigurationAndControlOverrides.js";
 import "./ScenesOverrides.js";
+import "./semtag.js";
+import "./subject-id.js";
+import "./tag.js";
 import "./TemperatureMeasurementOverrides.js";
 import "./ThermostatOverrides.js";
 import "./TimeFormatLocalizationOverrides.js";
 import "./TimeSynchronizationOverrides.js";
-import "./UserLabelOverrides.js";
-import "./WindowCoveringOverrides.js";
-import "./any.js";
-import "./namespace.js";
-import "./semtag.js";
-import "./subject-id.js";
-import "./tag.js";
 import "./todOverrides.js";
+import "./UserLabelOverrides.js";
+import "./WildcardPathFlagsBitmap.js";
+import "./WindowCoveringOverrides.js";

--- a/packages/model/src/elements/MatterElement.ts
+++ b/packages/model/src/elements/MatterElement.ts
@@ -24,14 +24,19 @@ export type MatterElement = BaseElement & {
     children: MatterElement.Child[];
 };
 
-export function MatterElement(definition: MatterElement.Properties, ...children: MatterElement.Child[]) {
-    return BaseElement(MatterElement.Tag, definition, children) as MatterElement;
+export function MatterElement(definition: MatterElement.Definition, ...children: MatterElement.Child[]) {
+    return BaseElement(MatterElement.Tag, { name: "Matter", children: [], ...definition }, children) as MatterElement;
 }
 
 export namespace MatterElement {
     export type Tag = ElementTag.Matter;
     export const Tag = ElementTag.Matter;
     export type Properties = BaseElement.Properties<MatterElement>;
+    export type Definition = Omit<MatterElement.Properties, "name" | "children"> & {
+        name?: string;
+        children?: MatterElement.Properties["children"];
+    };
+
     export type Child =
         | ClusterElement
         | DeviceTypeElement

--- a/packages/model/src/logic/ModelVariantTraversal.ts
+++ b/packages/model/src/logic/ModelVariantTraversal.ts
@@ -321,7 +321,6 @@ export abstract class ModelVariantTraversal<S = void> {
             // For each applicable child of this variant, associated it with a slot
             for (let i = 0; i < variant.children.length; i++) {
                 const child = variant.children[i];
-
                 if (!child.appliesTo(this.revision)) {
                     continue;
                 }

--- a/packages/model/src/logic/Scope.ts
+++ b/packages/model/src/logic/Scope.ts
@@ -1,0 +1,404 @@
+/**
+ * @license
+ * Copyright 2022-2024 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ElementTag } from "#common/ElementTag.js";
+import { SchemaImplementationError } from "#common/errors.js";
+import { FeatureSet } from "#common/FeatureSet.js";
+import { ImplementationError } from "@matter/general";
+import { ModelTraversal } from "./ModelTraversal.js";
+
+// These must be types to avoid circular references
+import type { ClusterModel, Model, ScopeModel, ValueModel } from "#models/index.js";
+
+const DEFAULT_TAGS = new Set([ElementTag.Field, ElementTag.Attribute]);
+const GLOBAL_IDS = new Set([0xfffd, 0xfffc, 0xfffb, 0xfffa, 0xfff9, 0xfff8]);
+
+const cache = new WeakMap<Model, Scope>();
+
+/**
+ * Tracks extensions for a scope to models in parent scopes.
+ *
+ * A child model with the same {tag, name, type} tuple in a derived scope is a semantic extension of the model in the
+ * parent scope even if it does not explicitly inherit from the parent via {@link Model#type}.  We refer to the implicit
+ * base class as a *shadow* and the implicit child class as an *extension*.
+ *
+ * Note that "type" in above tuple includes either undefined, the model's own name, or extension of the exact same type
+ * in both the shadow and the extension.  In the former case the shadow is implicit; in the latter case it is explicit.
+ *
+ * This utility provideds optimized lookup of extensions present in a particular scope.
+ *
+ * If the scope is frozen the analysis is cached.
+ *
+ * TODO - there is remaining ambiguity in shadow selection, fine for now but could be eliminated with conformance
+ *
+ * TODO - currently we only consider shadows at scope root but shadows of nested children is possible with this approach
+ */
+export interface Scope {
+    /**
+     * The model analyzed.
+     */
+    owner: Model;
+
+    /**
+     * Determine if the model is a shadow.
+     */
+    isShadow(model?: Model): boolean;
+
+    /**
+     * Retrieve the extension for an element if it is a shadow.
+     */
+    extensionOf<T extends Model>(model?: T): undefined | T;
+
+    /**
+     * Obtain canonical definition for model.  If the input model is a shadow returns the extension, otherwise returns
+     * the input model.
+     */
+    modelFor<T extends Model>(model: T): T;
+
+    /**
+     * Identify members (child properties) of the designated model in this scope.
+     */
+    membersOf<T extends Model>(parent: T, options?: Scope.MemberOptions): Model.ChildOf<T>[];
+}
+
+/**
+ * Obtain the scope for a model.
+ *
+ * By default, if {@link subject} is not a {@link ScopeModel} the scope returned is for the nearest owning
+ * {@link ScopeModel}.
+ */
+export function Scope(subject: Model, options: Scope.ScopeOptions = {}) {
+    let owner: Model;
+
+    if ((subject as ScopeModel).isScope || options.forceOwner) {
+        owner = subject as ScopeModel;
+    } else {
+        const scope = new ModelTraversal().findScope(subject);
+
+        if (scope === undefined) {
+            throw new SchemaImplementationError(subject, `No parent scope`);
+        }
+
+        owner = scope;
+    }
+
+    const useCache = options.forceCache || Object.isFrozen(owner);
+
+    let deconflictedMemberCache: Map<Model, Model[]> | undefined;
+    let conformantMemberCache: Map<Model, Model[]> | undefined;
+
+    let { featureNames, supportedFeatures } = owner as ClusterModel;
+    if (!featureNames) {
+        featureNames = new FeatureSet();
+    }
+    if (!supportedFeatures) {
+        supportedFeatures = new FeatureSet();
+    }
+
+    if (useCache && !options.disableCache) {
+        const cached = cache.get(owner);
+        if (cached) {
+            return cached;
+        }
+        deconflictedMemberCache = new Map();
+        conformantMemberCache = new Map();
+    }
+
+    let shadows: undefined | WeakMap<Model /* shadow */, Model[] /* canonical */>;
+    const canonicalIdentityLevels = {} as Record<string, { level: number; models: Model[] }>;
+    let level = 0;
+
+    new ModelTraversal().visitInheritance(owner, scope => {
+        level++;
+
+        for (const model of scope.children) {
+            for (const identity of [`n${model.tag}␜${model.name}␜${model.discriminator ?? ""}`]) {
+                const canonical = canonicalIdentityLevels[identity];
+                if (canonical === undefined) {
+                    canonicalIdentityLevels[identity] = {
+                        level,
+                        models: [model],
+                    };
+                } else if (canonical.level === level) {
+                    canonical.models.push(model);
+                } else {
+                    if (!shadows) {
+                        shadows = new WeakMap();
+                    }
+                    shadows.set(model, canonical.models);
+                }
+            }
+        }
+    });
+
+    const result: Scope = {
+        owner,
+        isShadow: shadows ? model => shadows!.has(model as ValueModel) : () => false,
+        extensionOf: shadows
+            ? <T extends Model>(model?: T) => shadows!.get(model as unknown as ValueModel)?.[0] as T | undefined
+            : <T extends Model>(model?: T) => model,
+        modelFor: shadows
+            ? <T extends Model>(model: T) =>
+                  (shadows!.get(model as unknown as ValueModel)?.[0] as T | undefined) ?? model
+            : <T extends Model>(model: T) => model,
+        membersOf,
+    };
+
+    function membersOf<T extends Model>(parent: T, options: Scope.MemberOptions = {}) {
+        const { conformance: conformanceMode, tags } = options;
+        const allMembers = findAllMembers(parent, Array.isArray(tags) ? new Set(tags) : (tags ?? DEFAULT_TAGS), result);
+
+        if (parent.tag === ElementTag.Cluster) {
+            injectGlobalAttributes(owner, allMembers);
+        }
+
+        if (!conformanceMode || conformanceMode === "ignore") {
+            return allMembers as Model.ChildOf<T>[];
+        }
+
+        const conformantOnly = conformanceMode === "conformant";
+
+        if (!conformantOnly && conformanceMode !== "deconflicted") {
+            throw new ImplementationError(`Invalid member conformance mode ${conformanceMode}`);
+        }
+
+        return filterWithConformance(
+            parent,
+            allMembers,
+            featureNames,
+            supportedFeatures,
+            conformantOnly,
+            conformantOnly ? deconflictedMemberCache : conformantMemberCache,
+        ) as Model.ChildOf<T>[];
+    }
+
+    if (useCache) {
+        cache.set(owner, result);
+    }
+
+    return result;
+}
+
+export namespace Scope {
+    /**
+     * Configuration for scope creation.
+     */
+    export interface ScopeOptions {
+        /**
+         * Force the result to cache regardless of whether model is frozen.
+         */
+        forceCache?: boolean;
+
+        /**
+         * Disable loading of model from cache.  Will still write to cache if {@link forceCache} is true.
+         */
+        disableCache?: boolean;
+
+        /**
+         * Force the input model as an owner even if it is not a {@link ScopeOwner}.
+         */
+        forceOwner?: boolean;
+    }
+
+    /**
+     * Return all members regardless of conformance.
+     */
+    export const IgnoreConformance = "ignore";
+
+    /**
+     * Use conformance to resolve conflicts but otherwise return all members.  Useful to detect errors in input
+     * that may contain non-conformant values.
+     */
+    export const DeconflictedConformance = "deconflicted";
+
+    /**
+     * Only return conformant members.
+     */
+    export const ConformantConformance = "conformant";
+
+    /**
+     * Determines how to apply conformance when selecting members.
+     */
+    export type ConformanceMode =
+        | typeof IgnoreConformance
+        | typeof DeconflictedConformance
+        | typeof ConformantConformance;
+
+    export interface MemberOptions {
+        /**
+         * Conformance filtering mode.
+         */
+        conformance?: ConformanceMode;
+
+        /**
+         * Applicable tags.  Defaults to "field" and "attribute".
+         */
+        tags?: Set<ElementTag> | ElementTag[];
+    }
+}
+
+/**
+ * Selects all candidate members for a model.
+ */
+function findAllMembers(parent: Model, tags: Set<ElementTag>, scope: Scope) {
+    const members = Array<Model>();
+
+    // This is a map of identity (based on tag + id/name + discriminator) to a priority based on inheritance depth
+    const defined = {} as Record<string, number | undefined>;
+
+    const visited = new Set<Model>();
+
+    const traversal = new ModelTraversal();
+
+    let level = 0;
+    const childSearchVisitor = (model: Model) => {
+        // If the model has an extension that we haven't yet visited, we need to move search to the extension.  This
+        // occurs if e.g. an attribute extends an attribute in a base cluster that references a datatype that is
+        // extended in the extended cluster
+        const extension = scope.modelFor(model);
+        if (extension !== model && !visited.has(extension)) {
+            traversal.visitInheritance(extension, childSearchVisitor);
+            return false;
+        }
+
+        visited.add(model);
+
+        level++;
+        for (const child of model.children) {
+            if (!tags.has(child.tag)) {
+                continue;
+            }
+
+            // Omit shadows
+            const nameIdentity = `s␜${child.tag}␜${child.name}␜${child.discriminator ?? ""}`;
+            const nameLevel = defined[nameIdentity];
+            if (nameLevel !== undefined && nameLevel < level) {
+                continue;
+            }
+
+            // Mark the level in which we saw these members
+            defined[nameIdentity] = level;
+
+            // Found a member
+            members.push(child);
+        }
+    };
+    traversal.visitInheritance(parent, childSearchVisitor);
+
+    return members;
+}
+
+/**
+ * We consider the standard set of "global" attributes members of all clusters.  This injects those members that are
+ * not otherwise defined in the cluster.
+ */
+function injectGlobalAttributes(scope: Model, members: Model[]) {
+    const missingGlobalIds = new Set(GLOBAL_IDS);
+    for (const m of members) {
+        if (m.tag === ElementTag.Attribute && m.id) {
+            missingGlobalIds.delete(m.id);
+        }
+    }
+
+    if (missingGlobalIds.size) {
+        const root = new ModelTraversal().findRoot(scope);
+        if (root) {
+            for (const id of missingGlobalIds) {
+                const global = root.children.select(id, [ElementTag.Attribute]);
+                if (global) {
+                    members.push(global);
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Filter selected members as follows:
+ *
+ *   - If the member is deprecated, ignore it
+ *
+ *   - If there is only a single member of a given name, select that member
+ *
+ *   - If there are multiple members with the same name but there is no cluster, throw an error
+ *
+ *   - If there are multiple members with the same name, use conformance to select the member that is applicable based
+ *     on active features in the provided cluster
+ *
+ *   - If there are multiple applicable members based on conformance the definitions conflict; and throw an error
+ *
+ * If the model is frozen we cache the return value.
+ *
+ * Note that "active" in this case does not imply the member is conformant, only that conflicts are resolved.
+ *
+ * Note 2 - members may not be differentiated with conformance rules that rely on field values in this way. That will
+ * probably never be necessary and would require an entirely different (more complicated) structure.
+ */
+function filterWithConformance(
+    parent: Model,
+    members: Model[],
+    features: FeatureSet,
+    supportedFeatures: FeatureSet,
+    conformantOnly: boolean,
+    cache?: Map<Model, Model[]>,
+) {
+    const cached = cache?.get(parent);
+    if (cached) {
+        return cached;
+    }
+
+    const selectedMembers = {} as Record<string, Model>;
+    for (const member of members) {
+        const { isDeprecated, conformance } = member as ValueModel;
+
+        if (isDeprecated) {
+            continue;
+        }
+
+        if (!conformance) {
+            throw new ImplementationError(
+                `Conformance filtering invoked on ${member} which does not support conformance`,
+            );
+        }
+
+        if (conformantOnly && !conformance.isApplicable(features, supportedFeatures)) {
+            continue;
+        }
+
+        const other = selectedMembers[member.name];
+        if (other !== undefined) {
+            if (!conformantOnly && !conformance.isApplicable(features, supportedFeatures)) {
+                continue;
+            }
+
+            const { conformance: otherConformance } = other as ValueModel;
+            if (!otherConformance) {
+                throw new ImplementationError(
+                    `Conformance filtering invoked on ${other} which does not support conformance`,
+                );
+            }
+
+            if (otherConformance.isApplicable(features, supportedFeatures)) {
+                throw new SchemaImplementationError(
+                    parent,
+                    `There are multiple definitions of "${member.name}" that cannot be differentiated by conformance`,
+                );
+            }
+
+            // This member takes precedence and will overwrite below
+        }
+
+        selectedMembers[member.name] = member;
+    }
+
+    const result = Object.values(selectedMembers);
+
+    if (cache) {
+        cache.set(parent, result);
+    }
+
+    return result;
+}

--- a/packages/model/src/logic/index.ts
+++ b/packages/model/src/logic/index.ts
@@ -13,5 +13,6 @@ export * from "./ClusterVariance.js";
 export * from "./DefaultValue.js";
 export * from "./MergedModel.js";
 export * from "./ModelVariantTraversal.js";
+export * from "./Scope.js";
 export * from "./ValidateModel.js";
 import "./definition-validation/index.js";

--- a/packages/model/src/models/AttributeModel.ts
+++ b/packages/model/src/models/AttributeModel.ts
@@ -36,6 +36,10 @@ export class AttributeModel extends PropertyModel<AttributeElement> implements A
         return this.effectiveQuality.changesOmitted;
     }
 
+    override get requiredFields() {
+        return { ...super.requiredFields, id: this.id };
+    }
+
     constructor(definition: AttributeElement.Properties) {
         super(definition);
     }

--- a/packages/model/src/models/CommandModel.ts
+++ b/packages/model/src/models/CommandModel.ts
@@ -36,6 +36,10 @@ export class CommandModel extends ValueModel<CommandElement> implements CommandE
         return this.direction ?? (new ModelTraversal().findShadow(this) as CommandModel | undefined)?.direction;
     }
 
+    override get requiredFields() {
+        return { ...super.requiredFields, id: this.id };
+    }
+
     /**
      * Commands may re-use the ID for request and response so identification requires the ID in conjunction with the
      * direction.

--- a/packages/model/src/models/DatatypeModel.ts
+++ b/packages/model/src/models/DatatypeModel.ts
@@ -27,5 +27,3 @@ export class DatatypeModel extends ValueModel<DatatypeElement> implements Dataty
         Model.types[DatatypeElement.Tag] = this;
     }
 }
-const x = {} as DatatypeModel;
-x.children;

--- a/packages/model/src/models/EventModel.ts
+++ b/packages/model/src/models/EventModel.ts
@@ -22,6 +22,10 @@ export class EventModel extends ValueModel<EventElement> implements EventElement
         return this.effectiveAccess.fabricSensitive;
     }
 
+    override get requiredFields() {
+        return { ...super.requiredFields, id: this.id };
+    }
+
     static {
         Model.types[EventElement.Tag] = this;
     }

--- a/packages/model/src/models/MatterModel.ts
+++ b/packages/model/src/models/MatterModel.ts
@@ -16,14 +16,14 @@ import { FabricModel } from "./FabricModel.js";
 import { FieldModel } from "./FieldModel.js";
 import { Globals } from "./Globals.js";
 import { Model } from "./Model.js";
+import { ScopeModel } from "./ScopeModel.js";
 import { SemanticNamespaceModel } from "./SemanticNamespaceModel.js";
 
 /**
  * The root of a Matter model.  This is the parent for global models.
  */
-export class MatterModel extends Model<MatterElement> implements MatterElement {
+export class MatterModel extends ScopeModel<MatterElement> implements MatterElement {
     override tag: MatterElement.Tag = MatterElement.Tag;
-    override isTypeScope = true;
     declare revision?: Specification.Revision;
 
     override get children(): Children<MatterModel.Child> {
@@ -89,9 +89,10 @@ export class MatterModel extends Model<MatterElement> implements MatterElement {
      *
      * @param definition the MatterElement that defines the model
      */
-    constructor(definition: MatterElement.Properties = { name: "Matter", children: [] }) {
-        const children = [...(definition.children || [])];
-        super({ ...definition, name: definition.name, children });
+    constructor(definition: MatterElement.Definition, ...children: Model.Definition<MatterModel.Child>[]) {
+        const name = definition.name ?? "Matter";
+        const definitionChildren = [...(definition.children || [])];
+        super({ ...definition, name, children: definitionChildren }, ...children);
     }
 
     /**

--- a/packages/model/src/models/ScopeModel.ts
+++ b/packages/model/src/models/ScopeModel.ts
@@ -1,0 +1,55 @@
+/**
+ * @license
+ * Copyright 2022-2024 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { SchemaImplementationError } from "#common/errors.js";
+import { BaseElement } from "#elements/BaseElement.js";
+import { ModelTraversal } from "#logic/ModelTraversal.js";
+import { Scope } from "#logic/Scope.js";
+import { Model } from "./Model.js";
+
+/**
+ * A "scope" is a model provides name resolution for other models.
+ *
+ * {@link Model#type} must reference a model named in a parent scope.
+ */
+export abstract class ScopeModel<T extends BaseElement = BaseElement> extends Model<T> {
+    #operationalScope: undefined | Scope;
+
+    readonly isScope = true;
+
+    get scope() {
+        if (this.#operationalScope !== undefined) {
+            return this.#operationalScope;
+        }
+        return Scope(this);
+    }
+
+    override freeze() {
+        if (!this.#operationalScope) {
+            this.#operationalScope = Scope(this);
+        }
+        super.freeze();
+        return this;
+    }
+
+    static is(model: Model): model is ScopeModel {
+        return !!(model as ScopeModel).isScope;
+    }
+
+    static of(model: Model) {
+        if ((model as ScopeModel).isScope) {
+            return model as ScopeModel;
+        }
+
+        const scope = new ModelTraversal().findScope(model);
+
+        if (scope === undefined) {
+            throw new SchemaImplementationError(model, `No parent scope`);
+        }
+
+        return scope;
+    }
+}

--- a/packages/model/src/models/index.ts
+++ b/packages/model/src/models/index.ts
@@ -19,6 +19,7 @@ export * from "./Model.js";
 export * from "./NodeModel.js";
 export * from "./PropertyModel.js";
 export * from "./RequirementModel.js";
+export * from "./ScopeModel.js";
 export * from "./SemanticNamespaceModel.js";
 export * from "./SemanticTagModel.js";
 export * from "./ValueModel.js";

--- a/packages/model/src/standard/elements/ModeBase.ts
+++ b/packages/model/src/standard/elements/ModeBase.ts
@@ -204,7 +204,7 @@ export const ModeBase = Cluster({
                 }),
 
                 Field({
-                    name: "Value", id: 0x1, type: "enum16", conformance: "M",
+                    name: "Value", id: 0x1, type: "ModeTag", conformance: "M",
                     details: "This field shall indicate the mode tag within a mode tag namespace which is either manufacturer " +
                         "specific or standard.",
                     xref: { document: "cluster", section: "1.10.5.1.2" }

--- a/packages/model/src/standard/elements/UserLabel.ts
+++ b/packages/model/src/standard/elements/UserLabel.ts
@@ -18,18 +18,14 @@ export const UserLabel = Cluster({
     details: "This cluster provides a feature to tag an endpoint with zero or more labels.",
     xref: { document: "core", section: "9.9" },
 
-    children: [
-        Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 1 }),
-
-        Attribute({
-            name: "LabelList", id: 0x0, type: "list", access: "RW VM", conformance: "M", constraint: "min 0",
-            default: [], quality: "N",
-            details: "An implementation shall support at least 4 list entries per node for all User Label cluster " +
-                "instances on the node.",
-            xref: { document: "core", section: "9.9.4.1" },
-            children: [Field({ name: "entry", type: "LabelStruct" })]
-        })
-    ]
+    children: [Attribute({
+        name: "LabelList", id: 0x0, type: "list", access: "RW VM", conformance: "M", constraint: "min 0",
+        default: [], quality: "N",
+        details: "An implementation shall support at least 4 list entries per node for all User Label cluster " +
+            "instances on the node.",
+        xref: { document: "core", section: "9.9.4.1" },
+        children: [Field({ name: "entry", type: "LabelStruct" })]
+    })]
 });
 
 MatterDefinition.children.push(UserLabel);

--- a/packages/model/src/standard/elements/WildcardPathFlagsBitmap.ts
+++ b/packages/model/src/standard/elements/WildcardPathFlagsBitmap.ts
@@ -28,10 +28,7 @@ export const WildcardPathFlagsBitmap = Datatype({
             name: "WildcardSkipAttributeList", constraint: "2",
             description: "Skip the AttributeList global attribute during wildcard expansion."
         }),
-        Field({
-            name: "WildcardSkipEventList", constraint: "3",
-            description: "Skip the EventList global attribute during wildcard expansion."
-        }),
+        Field({ name: "Reserved", constraint: "3", description: "Reserved" }),
         Field({
             name: "WildcardSkipCommandLists", constraint: "4",
             description: "Skip the AcceptedCommandList and GeneratedCommandList global attributes during wildcard expansion."

--- a/packages/model/test/logic/ScopeTest.ts
+++ b/packages/model/test/logic/ScopeTest.ts
@@ -1,0 +1,219 @@
+/**
+ * @license
+ * Copyright 2022-2024 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+    AttributeElement as Attribute,
+    bool,
+    EnergyEvseMode,
+    enum16,
+    FieldElement as Field,
+    map32,
+    ModeBase,
+    FeatureMap as RealFeatureMap,
+    struct as realStruct,
+    Scope,
+    uint16,
+    uint32,
+    uint8,
+} from "#index.js";
+import { AttributeModel, ClusterModel, DatatypeModel, FieldModel, MatterModel, Model } from "#models/index.js";
+
+const struct = realStruct.clone();
+const FeatureMap = RealFeatureMap.clone();
+
+const ThingType = new DatatypeModel({
+    name: "Type",
+    type: "enum16",
+});
+
+const Thing = new ClusterModel(
+    {
+        name: "Thing",
+    },
+
+    ThingType,
+
+    Attribute({
+        name: "Type",
+        id: 1,
+        type: "Type",
+    }),
+);
+
+const PhysicalThingFeatureMap = FeatureMap.extend(
+    {},
+    Field({
+        name: "XL",
+        constraint: 0,
+    }),
+    Field({
+        name: "XS",
+        constraint: 1,
+    }),
+);
+
+const PhysicalThingType = new DatatypeModel(
+    {
+        name: "Type",
+        type: "enum16",
+    },
+
+    Field({ name: "Large", id: 0x0001 }),
+    Field({ name: "Small", id: 0x0002 }),
+    Field({ name: "ExtraLarge", id: 0x0003, conformance: "[XL]" }),
+    Field({ name: "ExtraSmall", id: 0x0004, conformance: "[XS]" }),
+);
+
+const PhysicalThing = new ClusterModel(
+    {
+        name: "PhysicalThing",
+        type: "Thing",
+    },
+
+    PhysicalThingFeatureMap,
+    PhysicalThingType,
+);
+
+const BuildingType = new DatatypeModel(
+    {
+        name: "Type",
+        type: "enum16",
+    },
+
+    Field({ name: "Tower", id: 0x1001 }),
+    Field({ name: "House", id: 0x1002 }),
+);
+
+const XsBuildingHeight = new AttributeModel({
+    name: "Height",
+    id: 2,
+    type: "uint8",
+    conformance: "XS",
+});
+
+const NormalBuildingHeight = new AttributeModel({
+    name: "Height",
+    id: 2,
+    type: "uint16",
+    conformance: "!XS & !XL",
+});
+
+const XlBuildingHeight = new AttributeModel({
+    name: "Height",
+    id: 2,
+    type: "uint32",
+    conformance: "XL",
+});
+
+const ZoningViolation = new AttributeModel({
+    name: "ZoningViolation",
+    id: 3,
+    type: "bool",
+    conformance: "XL",
+});
+
+const Building = new ClusterModel(
+    {
+        name: "Building",
+        type: "PhysicalThing",
+    },
+
+    BuildingType,
+    NormalBuildingHeight,
+    XsBuildingHeight,
+    XlBuildingHeight,
+    ZoningViolation,
+);
+
+const Matter = new MatterModel(
+    {},
+
+    map32.clone(),
+    enum16.clone(),
+    uint8.clone(),
+    uint16.clone(),
+    uint32.clone(),
+    bool.clone(),
+    FeatureMap,
+    struct,
+    Thing,
+    PhysicalThing,
+    Building,
+);
+
+Building.supportedFeatures = ["XS"];
+
+Matter.freeze();
+
+const scope = Building.scope;
+
+function expectNames(model: Model, names: string[], options?: Scope.MemberOptions) {
+    expect(scope.membersOf(model, options).map(child => child.name)).deep.equals(names);
+}
+
+describe("Scope", () => {
+    it("finds shadows", () => {
+        expect(scope.isShadow(BuildingType)).false;
+        expect(scope.isShadow(PhysicalThingType)).true;
+        expect(scope.isShadow(ThingType)).true;
+    });
+
+    it("identifies extension", () => {
+        expect(scope.extensionOf(BuildingType)).undefined;
+        expect(scope.extensionOf(PhysicalThingType)).equals(BuildingType);
+        expect(scope.extensionOf(ThingType)).equals(BuildingType);
+    });
+
+    it("finds all members of root", () => {
+        const names = ["Height", "Height", "Height", "ZoningViolation", "FeatureMap", "Type"];
+        expectNames(Building, names);
+    });
+
+    it("finds all members of child", () => {
+        const names = ["Tower", "House", "Large", "Small", "ExtraLarge", "ExtraSmall"];
+        expectNames(BuildingType, names);
+        expectNames(PhysicalThingType, names);
+        expectNames(ThingType, names);
+    });
+
+    it("finds deconflicted members of root", () => {
+        const options = { conformance: "deconflicted" } as const;
+        const names = ["Height", "ZoningViolation", "FeatureMap", "Type"];
+        expectNames(Building, names, options);
+    });
+
+    it("finds conformant members of root", () => {
+        const options = { conformance: "conformant" } as const;
+        const names = ["Height", "FeatureMap", "Type"];
+        expectNames(Building, names, options);
+    });
+
+    it("finds conformant members of child", () => {
+        const options = { conformance: "conformant" } as const;
+        const names = ["Tower", "House", "Large", "Small", "ExtraSmall"];
+        expectNames(BuildingType, names, options);
+        expectNames(PhysicalThingType, names, options);
+        expectNames(ThingType, names, options);
+    });
+
+    it("finds members of extended base", () => {
+        const ModeTag = ModeBase.get(DatatypeModel, "ModeTag");
+        expect(ModeTag).not.undefined;
+
+        const baseModeTagCount = ModeBase.scope.membersOf(ModeTag!).length;
+        const modeTagCount = EnergyEvseMode.scope.membersOf(ModeTag!).length;
+
+        expect(modeTagCount).greaterThan(baseModeTagCount);
+
+        const ModeTagStruct = ModeBase.get(DatatypeModel, "ModeTagStruct");
+        expect(ModeTagStruct).not.undefined;
+        const Value = ModeTagStruct!.get(FieldModel, "Value");
+        expect(Value).not.undefined;
+
+        const valueTagCount = EnergyEvseMode.scope.membersOf(Value!).length;
+        expect(modeTagCount).equals(valueTagCount);
+    });
+});

--- a/packages/node/src/behavior/internal/ServerBehaviorBacking.ts
+++ b/packages/node/src/behavior/internal/ServerBehaviorBacking.ts
@@ -59,7 +59,7 @@ export class ServerBehaviorBacking extends BehaviorBacking {
             return;
         }
 
-        for (const member of schema.activeMembers) {
+        for (const member of this.type.supervisor.membersOf(schema)) {
             const name = camelize(member.name);
             if (state[name] === undefined) {
                 const referenced = FieldValue.referenced(member.default);

--- a/packages/node/src/behavior/state/managed/values/BitmapManager.ts
+++ b/packages/node/src/behavior/state/managed/values/BitmapManager.ts
@@ -32,7 +32,7 @@ interface Wrapper extends Val.Struct, Internal.Collection {
 /**
  * For bitmaps we generate a class with accessors for each bitmap value or range.
  */
-export function BitmapManager(_owner: RootSupervisor, schema: Schema): ValueSupervisor.Manage {
+export function BitmapManager(owner: RootSupervisor, schema: Schema): ValueSupervisor.Manage {
     const instanceDescriptors = {} as PropertyDescriptorMap;
 
     const byteSize = (schema as ValueModel).metabase?.byteSize;
@@ -41,7 +41,7 @@ export function BitmapManager(_owner: RootSupervisor, schema: Schema): ValueSupe
     }
     const maxBit = byteSize * 8;
 
-    for (const member of schema.activeMembers) {
+    for (const member of owner.membersOf(schema)) {
         if (member.isDeprecated) {
             continue;
         }

--- a/packages/node/src/behavior/state/managed/values/StructManager.ts
+++ b/packages/node/src/behavior/state/managed/values/StructManager.ts
@@ -30,7 +30,7 @@ export function StructManager(owner: RootSupervisor, schema: Schema): ValueSuper
     let hasFabricIndex = false;
 
     // Scan the schema and configure each member (field or attribute) as a property
-    for (const member of schema.activeMembers) {
+    for (const member of owner.membersOf(schema)) {
         const name = camelize(member.name);
 
         const { access, descriptor } = configureProperty(owner, member);

--- a/packages/node/src/behavior/state/managed/values/ValueCaster.ts
+++ b/packages/node/src/behavior/state/managed/values/ValueCaster.ts
@@ -32,7 +32,7 @@ export function ValueCaster(schema: Schema, owner: RootSupervisor) {
 
 function StructCaster(schema: ValueModel | ClusterModel, owner: RootSupervisor) {
     const memberConfigs = {} as Record<string, { name: string; cast: ValueSupervisor.Cast }>;
-    for (const member of schema.activeMembers) {
+    for (const member of owner.membersOf(schema)) {
         if (member.isDeprecated) {
             continue;
         }

--- a/packages/node/src/behavior/state/validation/conformance-compiler.ts
+++ b/packages/node/src/behavior/state/validation/conformance-compiler.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { RootSupervisor } from "#behavior/supervision/RootSupervisor.js";
 import { camelize } from "#general";
 import { Conformance, DataModelPath, FeatureSet, FieldValue, Metatype, ValueModel } from "#model";
 import { AccessControl } from "../../AccessControl.js";
@@ -49,13 +50,12 @@ import { ValidationLocation } from "./location.js";
  *   - "runtime" means conformance depends on sibling fields in an object. These result in a {@link RuntimeNode} with
  *     additional logic that applies to operational state.
  */
-export function astToFunction(
-    schema: ValueModel,
-    featureMap: ValueModel,
-    supportedFeatures: FeatureSet,
-): ValueSupervisor.Validate | undefined {
+export function astToFunction(schema: ValueModel, supervisor: RootSupervisor): ValueSupervisor.Validate | undefined {
     const ast = schema.conformance.ast;
-    const { featuresAvailable, featuresSupported } = FeatureSet.normalize(featureMap, supportedFeatures);
+    const { featuresAvailable, featuresSupported } = FeatureSet.normalize(
+        supervisor.featureMap,
+        supervisor.supportedFeatures,
+    );
 
     // Compile the AST
     const compiledNode = compile(ast);
@@ -537,7 +537,7 @@ export function astToFunction(
         mainValidator: ValueSupervisor.Validate | undefined,
     ): ValueSupervisor.Validate | undefined {
         // If there are no members we can't enforce anything
-        const members = schema.activeMembers;
+        const members = supervisor.membersOf(schema);
         if (!members.length) {
             return mainValidator;
         }

--- a/packages/node/src/behavior/state/validation/conformance.ts
+++ b/packages/node/src/behavior/state/validation/conformance.ts
@@ -4,7 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { FeatureSet, ValueModel } from "#model";
+import { RootSupervisor } from "#behavior/supervision/RootSupervisor.js";
+import { ValueModel } from "#model";
 import { ValueSupervisor } from "../../supervision/ValueSupervisor.js";
 import { astToFunction } from "./conformance-compiler.js";
 
@@ -16,11 +17,10 @@ import { astToFunction } from "./conformance-compiler.js";
  */
 export function createConformanceValidator(
     schema: ValueModel,
-    featureMap: ValueModel,
-    supportedFeatures: FeatureSet,
+    supervisor: RootSupervisor,
     nextValidator?: ValueSupervisor.Validate,
 ): ValueSupervisor.Validate | undefined {
-    const validate = astToFunction(schema, featureMap, supportedFeatures);
+    const validate = astToFunction(schema, supervisor);
 
     if (!validate && !nextValidator) {
         return undefined;

--- a/packages/node/src/behavior/supervision/BehaviorSupervisor.ts
+++ b/packages/node/src/behavior/supervision/BehaviorSupervisor.ts
@@ -5,7 +5,7 @@
  */
 
 import { camelize } from "#general";
-import { Access, FieldModel } from "#model";
+import { Access, FieldModel, Scope } from "#model";
 import type { Behavior } from "../Behavior.js";
 import type { StateType } from "../state/StateType.js";
 import type { Val } from "../state/Val.js";
@@ -61,7 +61,8 @@ const extendedSchemaCache = new Map<Schema, Record<string, Schema>>();
  */
 function addExtensionFields(schema: Schema, defaultState: Val.Struct) {
     const props = new Set<string>();
-    for (const field of schema.activeMembers) {
+    const scope = Scope(schema, { forceOwner: true });
+    for (const field of scope.membersOf(schema, { conformance: "deconflicted" })) {
         props.add(camelize(field.name));
     }
 

--- a/packages/node/test/behaviors/energy-evse-mode/EnergyEvsModeServerTest.ts
+++ b/packages/node/test/behaviors/energy-evse-mode/EnergyEvsModeServerTest.ts
@@ -1,0 +1,44 @@
+/**
+ * @license
+ * Copyright 2022-2024 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { EnergyEvseModeServer } from "#behaviors/energy-evse-mode";
+import { EnergyEvseMode } from "#clusters/energy-evse-mode";
+import { OnOffPlugInUnitDevice } from "#devices/on-off-plug-in-unit";
+import { MockServerNode } from "../../node/mock-server-node.js";
+
+describe("EnergyEvseModeServer", () => {
+    it("accepts local mode tags", async () => {
+        const node = await MockServerNode.create();
+        const DeviceType = OnOffPlugInUnitDevice.with(EnergyEvseModeServer);
+        await node.add(DeviceType, {
+            energyEvseMode: {
+                currentMode: 0,
+                supportedModes: [
+                    {
+                        label: "Manual",
+                        mode: 0,
+                        modeTags: [
+                            {
+                                value: EnergyEvseMode.ModeTag.Manual,
+                            },
+                        ],
+                    },
+                    {
+                        label: "Quick",
+                        mode: 1,
+                        modeTags: [
+                            {
+                                value: EnergyEvseMode.ModeTag.TimeOfUse,
+                            },
+                        ],
+                    },
+                ],
+            },
+        });
+        await node.start();
+        await node.close();
+    });
+});

--- a/packages/types/src/clusters/bridged-device-basic-information.ts
+++ b/packages/types/src/clusters/bridged-device-basic-information.ts
@@ -21,11 +21,55 @@ import { AccessLevel } from "#model";
 import { TlvUInt16, TlvUInt32 } from "../tlv/TlvNumber.js";
 import { TlvBoolean } from "../tlv/TlvBoolean.js";
 import { BasicInformation } from "./basic-information.js";
+import { TlvField, TlvObject } from "../tlv/TlvObject.js";
+import { TypeFromSchema } from "../tlv/TlvSchema.js";
 import { TlvNoArguments } from "../tlv/TlvNoArguments.js";
 import { Identity } from "#general";
 import { ClusterRegistry } from "../cluster/ClusterRegistry.js";
 
 export namespace BridgedDeviceBasicInformation {
+    /**
+     * Body of the BridgedDeviceBasicInformation startUp event
+     *
+     * @see {@link MatterSpecification.v13.Core} § 9.13.5
+     */
+    export const TlvStartUpEvent = TlvObject({
+        /**
+         * This field shall be set to the same value as the one available in the SoftwareVersion attribute.
+         *
+         * @see {@link MatterSpecification.v13.Core} § 11.1.6.1.1
+         */
+        softwareVersion: TlvField(0, TlvUInt32)
+    });
+
+    /**
+     * Body of the BridgedDeviceBasicInformation startUp event
+     *
+     * @see {@link MatterSpecification.v13.Core} § 9.13.5
+     */
+    export interface StartUpEvent extends TypeFromSchema<typeof TlvStartUpEvent> {}
+
+    /**
+     * Body of the BridgedDeviceBasicInformation reachableChanged event
+     *
+     * @see {@link MatterSpecification.v13.Core} § 9.13.5.2
+     */
+    export const TlvReachableChangedEvent = TlvObject({
+        /**
+         * This field shall indicate the value of the Reachable attribute after it was changed.
+         *
+         * @see {@link MatterSpecification.v13.Core} § 11.1.6.4.1
+         */
+        reachableNewValue: TlvField(0, TlvBoolean)
+    });
+
+    /**
+     * Body of the BridgedDeviceBasicInformation reachableChanged event
+     *
+     * @see {@link MatterSpecification.v13.Core} § 9.13.5.2
+     */
+    export interface ReachableChangedEvent extends TypeFromSchema<typeof TlvReachableChangedEvent> {}
+
     /**
      * @see {@link Cluster}
      */
@@ -124,7 +168,7 @@ export namespace BridgedDeviceBasicInformation {
             /**
              * @see {@link MatterSpecification.v13.Core} § 9.13.5
              */
-            startUp: OptionalEvent(0x0, EventPriority.Critical, BasicInformation.TlvStartUpEvent),
+            startUp: OptionalEvent(0x0, EventPriority.Critical, TlvStartUpEvent),
 
             /**
              * @see {@link MatterSpecification.v13.Core} § 9.13.5
@@ -154,7 +198,7 @@ export namespace BridgedDeviceBasicInformation {
              *
              * @see {@link MatterSpecification.v13.Core} § 9.13.5.2
              */
-            reachableChanged: Event(0x3, EventPriority.Critical, BasicInformation.TlvReachableChangedEvent)
+            reachableChanged: Event(0x3, EventPriority.Critical, TlvReachableChangedEvent)
         }
     });
 

--- a/packages/types/src/clusters/content-launcher.ts
+++ b/packages/types/src/clusters/content-launcher.ts
@@ -451,7 +451,7 @@ export namespace ContentLauncher {
     /**
      * @see {@link MatterSpecification.v13.Cluster} § 6.7.5.3
      */
-    export enum ParameterEnum {
+    export enum Parameter {
         /**
          * Actor represents an actor credited in video media content; for example, “Gaby Hoffman”
          */
@@ -580,13 +580,13 @@ export namespace ContentLauncher {
      *
      * @see {@link MatterSpecification.v13.Cluster} § 6.7.5.6
      */
-    export const TlvParameter = TlvObject({
+    export const TlvParameterStruct = TlvObject({
         /**
          * This field shall indicate the entity type.
          *
          * @see {@link MatterSpecification.v13.Cluster} § 6.7.5.6.1
          */
-        type: TlvField(0, TlvEnum<ParameterEnum>()),
+        type: TlvField(0, TlvEnum<Parameter>()),
 
         /**
          * This field shall indicate the entity value, which is a search string, ex. “Manchester by the Sea”.
@@ -608,7 +608,7 @@ export namespace ContentLauncher {
      *
      * @see {@link MatterSpecification.v13.Cluster} § 6.7.5.6
      */
-    export interface Parameter extends TypeFromSchema<typeof TlvParameter> {}
+    export interface ParameterStruct extends TypeFromSchema<typeof TlvParameterStruct> {}
 
     /**
      * This object defines inputs to a search for content for display or playback.
@@ -623,7 +623,7 @@ export namespace ContentLauncher {
          *
          * @see {@link MatterSpecification.v13.Cluster} § 6.7.5.7.1
          */
-        parameterList: TlvField(0, TlvArray(TlvParameter))
+        parameterList: TlvField(0, TlvArray(TlvParameterStruct))
     });
 
     /**

--- a/packages/types/src/clusters/device-energy-management-mode.ts
+++ b/packages/types/src/clusters/device-energy-management-mode.ts
@@ -15,10 +15,14 @@ import {
     Command,
     TlvNoResponse
 } from "../cluster/Cluster.js";
-import { TlvUInt8 } from "../tlv/TlvNumber.js";
+import { TlvUInt8, TlvEnum } from "../tlv/TlvNumber.js";
 import { TlvNullable } from "../tlv/TlvNullable.js";
 import { BitFlag } from "../schema/BitmapSchema.js";
 import { TlvArray } from "../tlv/TlvArray.js";
+import { TlvField, TlvOptionalField, TlvObject } from "../tlv/TlvObject.js";
+import { TlvString } from "../tlv/TlvString.js";
+import { TlvVendorId } from "../datatype/VendorId.js";
+import { TypeFromSchema } from "../tlv/TlvSchema.js";
 import { ModeBase } from "./mode-base.js";
 import { Identity } from "#general";
 import { ClusterRegistry } from "../cluster/ClusterRegistry.js";
@@ -70,8 +74,185 @@ export namespace DeviceEnergyManagementMode {
          *
          * @see {@link MatterSpecification.v13.Cluster} § 9.6.5.1.4
          */
-        GridOptimization = 16387
+        GridOptimization = 16387,
+
+        /**
+         * The device decides which options, features and setting values to use.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        Auto = 0,
+
+        /**
+         * The mode of the device is optimizing for faster completion.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        Quick = 1,
+
+        /**
+         * The device is silent or barely audible while in this mode.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        Quiet = 2,
+
+        /**
+         * Either the mode is inherently low noise or the device optimizes for that.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        LowNoise = 3,
+
+        /**
+         * The device is optimizing for lower energy usage in this mode. Sometimes called "Eco mode".
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        LowEnergy = 4,
+
+        /**
+         * A mode suitable for use during vacations or other extended absences.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        Vacation = 5,
+
+        /**
+         * The mode uses the lowest available setting value.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        Min = 6,
+
+        /**
+         * The mode uses the highest available setting value.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        Max = 7,
+
+        /**
+         * The mode is recommended or suitable for use during night time.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        Night = 8,
+
+        /**
+         * The mode is recommended or suitable for use during day time.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        Day = 9
     }
+
+    /**
+     * A Mode Tag is meant to be interpreted by the client for the purpose the cluster serves.
+     *
+     * @see {@link MatterSpecification.v13.Cluster} § 1.10.5.1
+     */
+    export const TlvModeTagStruct = TlvObject({
+        /**
+         * If the MfgCode field exists, the Value field shall be in the manufacturer-specific value range (see Section
+         * 1.10.8, “Mode Namespace”).
+         *
+         * This field shall indicate the manufacturer’s VendorID and it shall determine the meaning of the Value field.
+         *
+         * The same manufacturer code and mode tag value in separate cluster instances are part of the same namespace
+         * and have the same meaning. For example: a manufacturer tag meaning "pinch" can be used both in a cluster
+         * whose purpose is to choose the amount of sugar, or in a cluster whose purpose is to choose the amount of
+         * salt.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.5.1.1
+         */
+        mfgCode: TlvOptionalField(0, TlvVendorId),
+
+        /**
+         * This field shall indicate the mode tag within a mode tag namespace which is either manufacturer specific or
+         * standard.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.5.1.2
+         */
+        value: TlvField(1, TlvEnum<ModeTag>())
+    });
+
+    /**
+     * A Mode Tag is meant to be interpreted by the client for the purpose the cluster serves.
+     *
+     * @see {@link MatterSpecification.v13.Cluster} § 1.10.5.1
+     */
+    export interface ModeTagStruct extends TypeFromSchema<typeof TlvModeTagStruct> {}
+
+    /**
+     * The table below lists the changes relative to the Mode Base cluster for the fields of the ModeOptionStruct type.
+     * A blank field indicates no change.
+     *
+     * @see {@link MatterSpecification.v13.Cluster} § 9.6.4.1
+     */
+    export const TlvModeOption = TlvObject({
+        /**
+         * This field shall indicate readable text that describes the mode option, so that a client can provide it to
+         * the user to indicate what this option means. This field is meant to be readable and understandable by the
+         * user.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.5.2.1
+         */
+        label: TlvField(0, TlvString.bound({ maxLength: 64 })),
+
+        /**
+         * This field is used to identify the mode option.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.5.2.2
+         */
+        mode: TlvField(1, TlvUInt8),
+
+        /**
+         * This field shall contain a list of tags that are associated with the mode option. This may be used by
+         * clients to determine the full or the partial semantics of a certain mode, depending on which tags they
+         * understand, using standard definitions and/or manufacturer specific namespace definitions.
+         *
+         * The standard mode tags are defined in this cluster specification. For the derived cluster instances, if the
+         * specification of the derived cluster defines a namespace, the set of standard mode tags also includes the
+         * mode tag values from that namespace.
+         *
+         * Mode tags can help clients look for options that meet certain criteria, render the user interface, use
+         *
+         * the mode in an automation, or to craft help text their voice-driven interfaces. A mode tag shall be either a
+         * standard tag or a manufacturer specific tag, as defined in each ModeTagStruct list entry.
+         *
+         * A mode option may have more than one mode tag. A mode option may be associated with a mixture of standard
+         * and manufacturer specific mode tags. A mode option shall be associated with at least one standard mode tag.
+         *
+         * A few examples are provided below.
+         *
+         *   • A mode named "100%" can have both the High (manufacturer specific) and Max (standard) mode tag. Clients
+         *     seeking the mode for either High or Max will find the same mode in this case.
+         *
+         *   • A mode that includes a LowEnergy tag can be displayed by the client using a widget icon that shows a
+         *     green leaf.
+         *
+         *   • A mode that includes a LowNoise tag may be used by the client when the user wishes for a lower level of
+         *     audible sound, less likely to disturb the household’s activities.
+         *
+         *   • A mode that includes a LowEnergy tag (standard, defined in this cluster specification) and also a
+         *     Delicate tag (standard, defined in the namespace of a Laundry Mode derived cluster).
+         *
+         *   • A mode that includes both a generic Quick tag (defined here), and Vacuum and Mop tags, (defined in the
+         *     RVC Clean cluster that is a derivation of this cluster).
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.5.2.3
+         */
+        modeTags: TlvField(2, TlvArray(TlvModeTagStruct, { maxLength: 8 }))
+    });
+
+    /**
+     * The table below lists the changes relative to the Mode Base cluster for the fields of the ModeOptionStruct type.
+     * A blank field indicates no change.
+     *
+     * @see {@link MatterSpecification.v13.Cluster} § 9.6.4.1
+     */
+    export interface ModeOption extends TypeFromSchema<typeof TlvModeOption> {}
 
     /**
      * A DeviceEnergyManagementModeCluster supports these elements if it supports feature OnOff.
@@ -122,7 +303,7 @@ export namespace DeviceEnergyManagementMode {
              *
              * @see {@link MatterSpecification.v13.Cluster} § 1.10.6.2
              */
-            supportedModes: FixedAttribute(0x0, TlvArray(ModeBase.TlvModeOption, { minLength: 2, maxLength: 255 })),
+            supportedModes: FixedAttribute(0x0, TlvArray(TlvModeOption, { minLength: 2, maxLength: 255 })),
 
             /**
              * Indicates the current mode of the server.

--- a/packages/types/src/clusters/dishwasher-mode.ts
+++ b/packages/types/src/clusters/dishwasher-mode.ts
@@ -10,8 +10,12 @@ import { MutableCluster } from "../cluster/mutation/MutableCluster.js";
 import { BitFlag } from "../schema/BitmapSchema.js";
 import { FixedAttribute, Attribute, WritableAttribute, Command, TlvNoResponse } from "../cluster/Cluster.js";
 import { TlvArray } from "../tlv/TlvArray.js";
+import { TlvField, TlvOptionalField, TlvObject } from "../tlv/TlvObject.js";
+import { TlvString } from "../tlv/TlvString.js";
+import { TlvUInt8, TlvEnum } from "../tlv/TlvNumber.js";
+import { TlvVendorId } from "../datatype/VendorId.js";
+import { TypeFromSchema } from "../tlv/TlvSchema.js";
 import { ModeBase } from "./mode-base.js";
-import { TlvUInt8 } from "../tlv/TlvNumber.js";
 import { Identity } from "#general";
 import { ClusterRegistry } from "../cluster/ClusterRegistry.js";
 
@@ -53,8 +57,189 @@ export namespace DishwasherMode {
          *
          * @see {@link MatterSpecification.v13.Cluster} § 8.3.6.1.3
          */
-        Light = 16386
+        Light = 16386,
+
+        /**
+         * The device decides which options, features and setting values to use.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        Auto = 0,
+
+        /**
+         * The mode of the device is optimizing for faster completion.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        Quick = 1,
+
+        /**
+         * The device is silent or barely audible while in this mode.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        Quiet = 2,
+
+        /**
+         * Either the mode is inherently low noise or the device optimizes for that.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        LowNoise = 3,
+
+        /**
+         * The device is optimizing for lower energy usage in this mode. Sometimes called "Eco mode".
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        LowEnergy = 4,
+
+        /**
+         * A mode suitable for use during vacations or other extended absences.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        Vacation = 5,
+
+        /**
+         * The mode uses the lowest available setting value.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        Min = 6,
+
+        /**
+         * The mode uses the highest available setting value.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        Max = 7,
+
+        /**
+         * The mode is recommended or suitable for use during night time.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        Night = 8,
+
+        /**
+         * The mode is recommended or suitable for use during day time.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        Day = 9
     }
+
+    /**
+     * A Mode Tag is meant to be interpreted by the client for the purpose the cluster serves.
+     *
+     * @see {@link MatterSpecification.v13.Cluster} § 1.10.5.1
+     */
+    export const TlvModeTagStruct = TlvObject({
+        /**
+         * If the MfgCode field exists, the Value field shall be in the manufacturer-specific value range (see Section
+         * 1.10.8, “Mode Namespace”).
+         *
+         * This field shall indicate the manufacturer’s VendorID and it shall determine the meaning of the Value field.
+         *
+         * The same manufacturer code and mode tag value in separate cluster instances are part of the same namespace
+         * and have the same meaning. For example: a manufacturer tag meaning "pinch" can be used both in a cluster
+         * whose purpose is to choose the amount of sugar, or in a cluster whose purpose is to choose the amount of
+         * salt.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.5.1.1
+         */
+        mfgCode: TlvOptionalField(0, TlvVendorId),
+
+        /**
+         * This field shall indicate the mode tag within a mode tag namespace which is either manufacturer specific or
+         * standard.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.5.1.2
+         */
+        value: TlvField(1, TlvEnum<ModeTag>())
+    });
+
+    /**
+     * A Mode Tag is meant to be interpreted by the client for the purpose the cluster serves.
+     *
+     * @see {@link MatterSpecification.v13.Cluster} § 1.10.5.1
+     */
+    export interface ModeTagStruct extends TypeFromSchema<typeof TlvModeTagStruct> {}
+
+    /**
+     * The table below lists the changes relative to the Mode Base cluster for the fields of the ModeOptionStruct type.
+     * A blank field indicates no change.
+     *
+     * At least one entry in the SupportedModes attribute shall include the Normal mode tag in the ModeTags field list.
+     *
+     * @see {@link MatterSpecification.v13.Cluster} § 8.3.4.1
+     */
+    export const TlvModeOption = TlvObject({
+        /**
+         * This field shall indicate readable text that describes the mode option, so that a client can provide it to
+         * the user to indicate what this option means. This field is meant to be readable and understandable by the
+         * user.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.5.2.1
+         */
+        label: TlvField(0, TlvString.bound({ maxLength: 64 })),
+
+        /**
+         * This field is used to identify the mode option.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.5.2.2
+         */
+        mode: TlvField(1, TlvUInt8),
+
+        /**
+         * This field shall contain a list of tags that are associated with the mode option. This may be used by
+         * clients to determine the full or the partial semantics of a certain mode, depending on which tags they
+         * understand, using standard definitions and/or manufacturer specific namespace definitions.
+         *
+         * The standard mode tags are defined in this cluster specification. For the derived cluster instances, if the
+         * specification of the derived cluster defines a namespace, the set of standard mode tags also includes the
+         * mode tag values from that namespace.
+         *
+         * Mode tags can help clients look for options that meet certain criteria, render the user interface, use
+         *
+         * the mode in an automation, or to craft help text their voice-driven interfaces. A mode tag shall be either a
+         * standard tag or a manufacturer specific tag, as defined in each ModeTagStruct list entry.
+         *
+         * A mode option may have more than one mode tag. A mode option may be associated with a mixture of standard
+         * and manufacturer specific mode tags. A mode option shall be associated with at least one standard mode tag.
+         *
+         * A few examples are provided below.
+         *
+         *   • A mode named "100%" can have both the High (manufacturer specific) and Max (standard) mode tag. Clients
+         *     seeking the mode for either High or Max will find the same mode in this case.
+         *
+         *   • A mode that includes a LowEnergy tag can be displayed by the client using a widget icon that shows a
+         *     green leaf.
+         *
+         *   • A mode that includes a LowNoise tag may be used by the client when the user wishes for a lower level of
+         *     audible sound, less likely to disturb the household’s activities.
+         *
+         *   • A mode that includes a LowEnergy tag (standard, defined in this cluster specification) and also a
+         *     Delicate tag (standard, defined in the namespace of a Laundry Mode derived cluster).
+         *
+         *   • A mode that includes both a generic Quick tag (defined here), and Vacuum and Mop tags, (defined in the
+         *     RVC Clean cluster that is a derivation of this cluster).
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.5.2.3
+         */
+        modeTags: TlvField(2, TlvArray(TlvModeTagStruct, { maxLength: 8 }))
+    });
+
+    /**
+     * The table below lists the changes relative to the Mode Base cluster for the fields of the ModeOptionStruct type.
+     * A blank field indicates no change.
+     *
+     * At least one entry in the SupportedModes attribute shall include the Normal mode tag in the ModeTags field list.
+     *
+     * @see {@link MatterSpecification.v13.Cluster} § 8.3.4.1
+     */
+    export interface ModeOption extends TypeFromSchema<typeof TlvModeOption> {}
 
     /**
      * These elements and properties are present in all DishwasherMode clusters.
@@ -82,7 +267,7 @@ export namespace DishwasherMode {
              */
             supportedModes: FixedAttribute(
                 0x0,
-                TlvArray(ModeBase.TlvModeOption, { minLength: 2, maxLength: 255 }),
+                TlvArray(TlvModeOption, { minLength: 2, maxLength: 255 }),
                 { default: [] }
             ),
 

--- a/packages/types/src/clusters/door-lock.ts
+++ b/packages/types/src/clusters/door-lock.ts
@@ -2124,7 +2124,87 @@ export namespace DoorLock {
         pinCodeChanged: BitFlag(1),
         pinAdded: BitFlag(2),
         pinCleared: BitFlag(3),
-        pinChanged: BitFlag(4)
+        pinChanged: BitFlag(4),
+
+        /**
+         * State of bit 0
+         */
+        bit0: BitFlag(0),
+
+        /**
+         * State of bit 1
+         */
+        bit1: BitFlag(1),
+
+        /**
+         * State of bit 2
+         */
+        bit2: BitFlag(2),
+
+        /**
+         * State of bit 3
+         */
+        bit3: BitFlag(3),
+
+        /**
+         * State of bit 4
+         */
+        bit4: BitFlag(4),
+
+        /**
+         * State of bit 5
+         */
+        bit5: BitFlag(5),
+
+        /**
+         * State of bit 6
+         */
+        bit6: BitFlag(6),
+
+        /**
+         * State of bit 7
+         */
+        bit7: BitFlag(7),
+
+        /**
+         * State of bit 8
+         */
+        bit8: BitFlag(8),
+
+        /**
+         * State of bit 9
+         */
+        bit9: BitFlag(9),
+
+        /**
+         * State of bit 10
+         */
+        bit10: BitFlag(10),
+
+        /**
+         * State of bit 11
+         */
+        bit11: BitFlag(11),
+
+        /**
+         * State of bit 12
+         */
+        bit12: BitFlag(12),
+
+        /**
+         * State of bit 13
+         */
+        bit13: BitFlag(13),
+
+        /**
+         * State of bit 14
+         */
+        bit14: BitFlag(14),
+
+        /**
+         * State of bit 15
+         */
+        bit15: BitFlag(15)
     };
 
     /**
@@ -2138,7 +2218,87 @@ export namespace DoorLock {
         pinCleared: BitFlag(3),
         pinChanged: BitFlag(4),
         rfidCodeAdded: BitFlag(5),
-        rfidCodeCleared: BitFlag(6)
+        rfidCodeCleared: BitFlag(6),
+
+        /**
+         * State of bit 0
+         */
+        bit0: BitFlag(0),
+
+        /**
+         * State of bit 1
+         */
+        bit1: BitFlag(1),
+
+        /**
+         * State of bit 2
+         */
+        bit2: BitFlag(2),
+
+        /**
+         * State of bit 3
+         */
+        bit3: BitFlag(3),
+
+        /**
+         * State of bit 4
+         */
+        bit4: BitFlag(4),
+
+        /**
+         * State of bit 5
+         */
+        bit5: BitFlag(5),
+
+        /**
+         * State of bit 6
+         */
+        bit6: BitFlag(6),
+
+        /**
+         * State of bit 7
+         */
+        bit7: BitFlag(7),
+
+        /**
+         * State of bit 8
+         */
+        bit8: BitFlag(8),
+
+        /**
+         * State of bit 9
+         */
+        bit9: BitFlag(9),
+
+        /**
+         * State of bit 10
+         */
+        bit10: BitFlag(10),
+
+        /**
+         * State of bit 11
+         */
+        bit11: BitFlag(11),
+
+        /**
+         * State of bit 12
+         */
+        bit12: BitFlag(12),
+
+        /**
+         * State of bit 13
+         */
+        bit13: BitFlag(13),
+
+        /**
+         * State of bit 14
+         */
+        bit14: BitFlag(14),
+
+        /**
+         * State of bit 15
+         */
+        bit15: BitFlag(15)
     };
 
     /**
@@ -2146,7 +2306,91 @@ export namespace DoorLock {
      *
      * @see {@link MatterSpecification.v13.Cluster} § 5.2.9.47
      */
-    export const RfidProgrammingEventMask = { unknown: BitFlag(0), idAdded: BitFlag(5), idCleared: BitFlag(6) };
+    export const RfidProgrammingEventMask = {
+        unknown: BitFlag(0),
+        idAdded: BitFlag(5),
+        idCleared: BitFlag(6),
+
+        /**
+         * State of bit 0
+         */
+        bit0: BitFlag(0),
+
+        /**
+         * State of bit 1
+         */
+        bit1: BitFlag(1),
+
+        /**
+         * State of bit 2
+         */
+        bit2: BitFlag(2),
+
+        /**
+         * State of bit 3
+         */
+        bit3: BitFlag(3),
+
+        /**
+         * State of bit 4
+         */
+        bit4: BitFlag(4),
+
+        /**
+         * State of bit 5
+         */
+        bit5: BitFlag(5),
+
+        /**
+         * State of bit 6
+         */
+        bit6: BitFlag(6),
+
+        /**
+         * State of bit 7
+         */
+        bit7: BitFlag(7),
+
+        /**
+         * State of bit 8
+         */
+        bit8: BitFlag(8),
+
+        /**
+         * State of bit 9
+         */
+        bit9: BitFlag(9),
+
+        /**
+         * State of bit 10
+         */
+        bit10: BitFlag(10),
+
+        /**
+         * State of bit 11
+         */
+        bit11: BitFlag(11),
+
+        /**
+         * State of bit 12
+         */
+        bit12: BitFlag(12),
+
+        /**
+         * State of bit 13
+         */
+        bit13: BitFlag(13),
+
+        /**
+         * State of bit 14
+         */
+        bit14: BitFlag(14),
+
+        /**
+         * State of bit 15
+         */
+        bit15: BitFlag(15)
+    };
 
     /**
      * Input to the DoorLock setUserStatus command

--- a/packages/types/src/clusters/energy-evse-mode.ts
+++ b/packages/types/src/clusters/energy-evse-mode.ts
@@ -15,10 +15,14 @@ import {
     Command,
     TlvNoResponse
 } from "../cluster/Cluster.js";
-import { TlvUInt8 } from "../tlv/TlvNumber.js";
+import { TlvUInt8, TlvEnum } from "../tlv/TlvNumber.js";
 import { TlvNullable } from "../tlv/TlvNullable.js";
 import { BitFlag } from "../schema/BitmapSchema.js";
 import { TlvArray } from "../tlv/TlvArray.js";
+import { TlvField, TlvOptionalField, TlvObject } from "../tlv/TlvObject.js";
+import { TlvString } from "../tlv/TlvString.js";
+import { TlvVendorId } from "../datatype/VendorId.js";
+import { TypeFromSchema } from "../tlv/TlvSchema.js";
 import { ModeBase } from "./mode-base.js";
 import { Identity } from "#general";
 import { ClusterRegistry } from "../cluster/ClusterRegistry.js";
@@ -64,8 +68,183 @@ export namespace EnergyEvseMode {
          *
          * @see {@link MatterSpecification.v13.Cluster} § 9.4.4.1.3
          */
-        SolarCharging = 16386
+        SolarCharging = 16386,
+
+        /**
+         * The device decides which options, features and setting values to use.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        Auto = 0,
+
+        /**
+         * The mode of the device is optimizing for faster completion.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        Quick = 1,
+
+        /**
+         * The device is silent or barely audible while in this mode.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        Quiet = 2,
+
+        /**
+         * Either the mode is inherently low noise or the device optimizes for that.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        LowNoise = 3,
+
+        /**
+         * The device is optimizing for lower energy usage in this mode. Sometimes called "Eco mode".
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        LowEnergy = 4,
+
+        /**
+         * A mode suitable for use during vacations or other extended absences.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        Vacation = 5,
+
+        /**
+         * The mode uses the lowest available setting value.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        Min = 6,
+
+        /**
+         * The mode uses the highest available setting value.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        Max = 7,
+
+        /**
+         * The mode is recommended or suitable for use during night time.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        Night = 8,
+
+        /**
+         * The mode is recommended or suitable for use during day time.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        Day = 9
     }
+
+    /**
+     * A Mode Tag is meant to be interpreted by the client for the purpose the cluster serves.
+     *
+     * @see {@link MatterSpecification.v13.Cluster} § 1.10.5.1
+     */
+    export const TlvModeTagStruct = TlvObject({
+        /**
+         * If the MfgCode field exists, the Value field shall be in the manufacturer-specific value range (see Section
+         * 1.10.8, “Mode Namespace”).
+         *
+         * This field shall indicate the manufacturer’s VendorID and it shall determine the meaning of the Value field.
+         *
+         * The same manufacturer code and mode tag value in separate cluster instances are part of the same namespace
+         * and have the same meaning. For example: a manufacturer tag meaning "pinch" can be used both in a cluster
+         * whose purpose is to choose the amount of sugar, or in a cluster whose purpose is to choose the amount of
+         * salt.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.5.1.1
+         */
+        mfgCode: TlvOptionalField(0, TlvVendorId),
+
+        /**
+         * This field shall indicate the mode tag within a mode tag namespace which is either manufacturer specific or
+         * standard.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.5.1.2
+         */
+        value: TlvField(1, TlvEnum<ModeTag>())
+    });
+
+    /**
+     * A Mode Tag is meant to be interpreted by the client for the purpose the cluster serves.
+     *
+     * @see {@link MatterSpecification.v13.Cluster} § 1.10.5.1
+     */
+    export interface ModeTagStruct extends TypeFromSchema<typeof TlvModeTagStruct> {}
+
+    /**
+     * This is a struct representing a possible mode of the server.
+     *
+     * @see {@link MatterSpecification.v13.Cluster} § 1.10.5.2
+     */
+    export const TlvModeOption = TlvObject({
+        /**
+         * This field shall indicate readable text that describes the mode option, so that a client can provide it to
+         * the user to indicate what this option means. This field is meant to be readable and understandable by the
+         * user.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.5.2.1
+         */
+        label: TlvField(0, TlvString.bound({ maxLength: 64 })),
+
+        /**
+         * This field is used to identify the mode option.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.5.2.2
+         */
+        mode: TlvField(1, TlvUInt8),
+
+        /**
+         * This field shall contain a list of tags that are associated with the mode option. This may be used by
+         * clients to determine the full or the partial semantics of a certain mode, depending on which tags they
+         * understand, using standard definitions and/or manufacturer specific namespace definitions.
+         *
+         * The standard mode tags are defined in this cluster specification. For the derived cluster instances, if the
+         * specification of the derived cluster defines a namespace, the set of standard mode tags also includes the
+         * mode tag values from that namespace.
+         *
+         * Mode tags can help clients look for options that meet certain criteria, render the user interface, use
+         *
+         * the mode in an automation, or to craft help text their voice-driven interfaces. A mode tag shall be either a
+         * standard tag or a manufacturer specific tag, as defined in each ModeTagStruct list entry.
+         *
+         * A mode option may have more than one mode tag. A mode option may be associated with a mixture of standard
+         * and manufacturer specific mode tags. A mode option shall be associated with at least one standard mode tag.
+         *
+         * A few examples are provided below.
+         *
+         *   • A mode named "100%" can have both the High (manufacturer specific) and Max (standard) mode tag. Clients
+         *     seeking the mode for either High or Max will find the same mode in this case.
+         *
+         *   • A mode that includes a LowEnergy tag can be displayed by the client using a widget icon that shows a
+         *     green leaf.
+         *
+         *   • A mode that includes a LowNoise tag may be used by the client when the user wishes for a lower level of
+         *     audible sound, less likely to disturb the household’s activities.
+         *
+         *   • A mode that includes a LowEnergy tag (standard, defined in this cluster specification) and also a
+         *     Delicate tag (standard, defined in the namespace of a Laundry Mode derived cluster).
+         *
+         *   • A mode that includes both a generic Quick tag (defined here), and Vacuum and Mop tags, (defined in the
+         *     RVC Clean cluster that is a derivation of this cluster).
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.5.2.3
+         */
+        modeTags: TlvField(2, TlvArray(TlvModeTagStruct, { maxLength: 8 }))
+    });
+
+    /**
+     * This is a struct representing a possible mode of the server.
+     *
+     * @see {@link MatterSpecification.v13.Cluster} § 1.10.5.2
+     */
+    export interface ModeOption extends TypeFromSchema<typeof TlvModeOption> {}
 
     /**
      * A EnergyEvseModeCluster supports these elements if it supports feature OnOff.
@@ -116,7 +295,7 @@ export namespace EnergyEvseMode {
              *
              * @see {@link MatterSpecification.v13.Cluster} § 1.10.6.2
              */
-            supportedModes: FixedAttribute(0x0, TlvArray(ModeBase.TlvModeOption, { minLength: 2, maxLength: 255 })),
+            supportedModes: FixedAttribute(0x0, TlvArray(TlvModeOption, { minLength: 2, maxLength: 255 })),
 
             /**
              * Indicates the current mode of the server.

--- a/packages/types/src/clusters/groups.ts
+++ b/packages/types/src/clusters/groups.ts
@@ -44,7 +44,14 @@ export namespace Groups {
      *
      * @see {@link MatterSpecification.v13.Cluster} § 1.3.6.1
      */
-    export const NameSupportAttribute = { nameSupport: BitFlag(7) };
+    export const NameSupportAttribute = {
+        nameSupport: BitFlag(7),
+
+        /**
+         * The ability to store a name for a group.
+         */
+        groupNames: BitFlag(7)
+    };
 
     /**
      * Input to the Groups addGroup command

--- a/packages/types/src/clusters/laundry-washer-mode.ts
+++ b/packages/types/src/clusters/laundry-washer-mode.ts
@@ -10,8 +10,12 @@ import { MutableCluster } from "../cluster/mutation/MutableCluster.js";
 import { BitFlag } from "../schema/BitmapSchema.js";
 import { FixedAttribute, Attribute, WritableAttribute, Command, TlvNoResponse } from "../cluster/Cluster.js";
 import { TlvArray } from "../tlv/TlvArray.js";
+import { TlvField, TlvOptionalField, TlvObject } from "../tlv/TlvObject.js";
+import { TlvString } from "../tlv/TlvString.js";
+import { TlvUInt8, TlvEnum } from "../tlv/TlvNumber.js";
+import { TlvVendorId } from "../datatype/VendorId.js";
+import { TypeFromSchema } from "../tlv/TlvSchema.js";
 import { ModeBase } from "./mode-base.js";
-import { TlvUInt8 } from "../tlv/TlvNumber.js";
 import { Identity } from "#general";
 import { ClusterRegistry } from "../cluster/ClusterRegistry.js";
 
@@ -60,8 +64,189 @@ export namespace LaundryWasherMode {
          *
          * @see {@link MatterSpecification.v13.Cluster} § 8.5.6.1.4
          */
-        Whites = 16387
+        Whites = 16387,
+
+        /**
+         * The device decides which options, features and setting values to use.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        Auto = 0,
+
+        /**
+         * The mode of the device is optimizing for faster completion.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        Quick = 1,
+
+        /**
+         * The device is silent or barely audible while in this mode.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        Quiet = 2,
+
+        /**
+         * Either the mode is inherently low noise or the device optimizes for that.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        LowNoise = 3,
+
+        /**
+         * The device is optimizing for lower energy usage in this mode. Sometimes called "Eco mode".
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        LowEnergy = 4,
+
+        /**
+         * A mode suitable for use during vacations or other extended absences.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        Vacation = 5,
+
+        /**
+         * The mode uses the lowest available setting value.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        Min = 6,
+
+        /**
+         * The mode uses the highest available setting value.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        Max = 7,
+
+        /**
+         * The mode is recommended or suitable for use during night time.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        Night = 8,
+
+        /**
+         * The mode is recommended or suitable for use during day time.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        Day = 9
     }
+
+    /**
+     * A Mode Tag is meant to be interpreted by the client for the purpose the cluster serves.
+     *
+     * @see {@link MatterSpecification.v13.Cluster} § 1.10.5.1
+     */
+    export const TlvModeTagStruct = TlvObject({
+        /**
+         * If the MfgCode field exists, the Value field shall be in the manufacturer-specific value range (see Section
+         * 1.10.8, “Mode Namespace”).
+         *
+         * This field shall indicate the manufacturer’s VendorID and it shall determine the meaning of the Value field.
+         *
+         * The same manufacturer code and mode tag value in separate cluster instances are part of the same namespace
+         * and have the same meaning. For example: a manufacturer tag meaning "pinch" can be used both in a cluster
+         * whose purpose is to choose the amount of sugar, or in a cluster whose purpose is to choose the amount of
+         * salt.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.5.1.1
+         */
+        mfgCode: TlvOptionalField(0, TlvVendorId),
+
+        /**
+         * This field shall indicate the mode tag within a mode tag namespace which is either manufacturer specific or
+         * standard.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.5.1.2
+         */
+        value: TlvField(1, TlvEnum<ModeTag>())
+    });
+
+    /**
+     * A Mode Tag is meant to be interpreted by the client for the purpose the cluster serves.
+     *
+     * @see {@link MatterSpecification.v13.Cluster} § 1.10.5.1
+     */
+    export interface ModeTagStruct extends TypeFromSchema<typeof TlvModeTagStruct> {}
+
+    /**
+     * The table below lists the changes relative to the Mode Base cluster for the fields of the ModeOptionStruct type.
+     * A blank field indicates no change.
+     *
+     * At least one entry in the SupportedModes attribute shall include the Normal mode tag in the ModeTags field list.
+     *
+     * @see {@link MatterSpecification.v13.Cluster} § 8.5.4.1
+     */
+    export const TlvModeOption = TlvObject({
+        /**
+         * This field shall indicate readable text that describes the mode option, so that a client can provide it to
+         * the user to indicate what this option means. This field is meant to be readable and understandable by the
+         * user.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.5.2.1
+         */
+        label: TlvField(0, TlvString.bound({ maxLength: 64 })),
+
+        /**
+         * This field is used to identify the mode option.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.5.2.2
+         */
+        mode: TlvField(1, TlvUInt8),
+
+        /**
+         * This field shall contain a list of tags that are associated with the mode option. This may be used by
+         * clients to determine the full or the partial semantics of a certain mode, depending on which tags they
+         * understand, using standard definitions and/or manufacturer specific namespace definitions.
+         *
+         * The standard mode tags are defined in this cluster specification. For the derived cluster instances, if the
+         * specification of the derived cluster defines a namespace, the set of standard mode tags also includes the
+         * mode tag values from that namespace.
+         *
+         * Mode tags can help clients look for options that meet certain criteria, render the user interface, use
+         *
+         * the mode in an automation, or to craft help text their voice-driven interfaces. A mode tag shall be either a
+         * standard tag or a manufacturer specific tag, as defined in each ModeTagStruct list entry.
+         *
+         * A mode option may have more than one mode tag. A mode option may be associated with a mixture of standard
+         * and manufacturer specific mode tags. A mode option shall be associated with at least one standard mode tag.
+         *
+         * A few examples are provided below.
+         *
+         *   • A mode named "100%" can have both the High (manufacturer specific) and Max (standard) mode tag. Clients
+         *     seeking the mode for either High or Max will find the same mode in this case.
+         *
+         *   • A mode that includes a LowEnergy tag can be displayed by the client using a widget icon that shows a
+         *     green leaf.
+         *
+         *   • A mode that includes a LowNoise tag may be used by the client when the user wishes for a lower level of
+         *     audible sound, less likely to disturb the household’s activities.
+         *
+         *   • A mode that includes a LowEnergy tag (standard, defined in this cluster specification) and also a
+         *     Delicate tag (standard, defined in the namespace of a Laundry Mode derived cluster).
+         *
+         *   • A mode that includes both a generic Quick tag (defined here), and Vacuum and Mop tags, (defined in the
+         *     RVC Clean cluster that is a derivation of this cluster).
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.5.2.3
+         */
+        modeTags: TlvField(2, TlvArray(TlvModeTagStruct, { maxLength: 8 }))
+    });
+
+    /**
+     * The table below lists the changes relative to the Mode Base cluster for the fields of the ModeOptionStruct type.
+     * A blank field indicates no change.
+     *
+     * At least one entry in the SupportedModes attribute shall include the Normal mode tag in the ModeTags field list.
+     *
+     * @see {@link MatterSpecification.v13.Cluster} § 8.5.4.1
+     */
+    export interface ModeOption extends TypeFromSchema<typeof TlvModeOption> {}
 
     /**
      * These elements and properties are present in all LaundryWasherMode clusters.
@@ -89,7 +274,7 @@ export namespace LaundryWasherMode {
              */
             supportedModes: FixedAttribute(
                 0x0,
-                TlvArray(ModeBase.TlvModeOption, { minLength: 2, maxLength: 255 }),
+                TlvArray(TlvModeOption, { minLength: 2, maxLength: 255 }),
                 { default: [] }
             ),
 

--- a/packages/types/src/clusters/microwave-oven-mode.ts
+++ b/packages/types/src/clusters/microwave-oven-mode.ts
@@ -10,8 +10,11 @@ import { MutableCluster } from "../cluster/mutation/MutableCluster.js";
 import { BitFlag } from "../schema/BitmapSchema.js";
 import { FixedAttribute, Attribute } from "../cluster/Cluster.js";
 import { TlvArray } from "../tlv/TlvArray.js";
-import { ModeBase } from "./mode-base.js";
-import { TlvUInt8 } from "../tlv/TlvNumber.js";
+import { TlvField, TlvOptionalField, TlvObject } from "../tlv/TlvObject.js";
+import { TlvString } from "../tlv/TlvString.js";
+import { TlvUInt8, TlvEnum } from "../tlv/TlvNumber.js";
+import { TlvVendorId } from "../datatype/VendorId.js";
+import { TypeFromSchema } from "../tlv/TlvSchema.js";
 import { Identity } from "#general";
 import { ClusterRegistry } from "../cluster/ClusterRegistry.js";
 
@@ -46,8 +49,183 @@ export namespace MicrowaveOvenMode {
          *
          * @see {@link MatterSpecification.v13.Cluster} § 8.12.6.1
          */
-        Defrost = 16385
+        Defrost = 16385,
+
+        /**
+         * The device decides which options, features and setting values to use.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        Auto = 0,
+
+        /**
+         * The mode of the device is optimizing for faster completion.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        Quick = 1,
+
+        /**
+         * The device is silent or barely audible while in this mode.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        Quiet = 2,
+
+        /**
+         * Either the mode is inherently low noise or the device optimizes for that.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        LowNoise = 3,
+
+        /**
+         * The device is optimizing for lower energy usage in this mode. Sometimes called "Eco mode".
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        LowEnergy = 4,
+
+        /**
+         * A mode suitable for use during vacations or other extended absences.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        Vacation = 5,
+
+        /**
+         * The mode uses the lowest available setting value.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        Min = 6,
+
+        /**
+         * The mode uses the highest available setting value.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        Max = 7,
+
+        /**
+         * The mode is recommended or suitable for use during night time.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        Night = 8,
+
+        /**
+         * The mode is recommended or suitable for use during day time.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        Day = 9
     }
+
+    /**
+     * A Mode Tag is meant to be interpreted by the client for the purpose the cluster serves.
+     *
+     * @see {@link MatterSpecification.v13.Cluster} § 1.10.5.1
+     */
+    export const TlvModeTagStruct = TlvObject({
+        /**
+         * If the MfgCode field exists, the Value field shall be in the manufacturer-specific value range (see Section
+         * 1.10.8, “Mode Namespace”).
+         *
+         * This field shall indicate the manufacturer’s VendorID and it shall determine the meaning of the Value field.
+         *
+         * The same manufacturer code and mode tag value in separate cluster instances are part of the same namespace
+         * and have the same meaning. For example: a manufacturer tag meaning "pinch" can be used both in a cluster
+         * whose purpose is to choose the amount of sugar, or in a cluster whose purpose is to choose the amount of
+         * salt.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.5.1.1
+         */
+        mfgCode: TlvOptionalField(0, TlvVendorId),
+
+        /**
+         * This field shall indicate the mode tag within a mode tag namespace which is either manufacturer specific or
+         * standard.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.5.1.2
+         */
+        value: TlvField(1, TlvEnum<ModeTag>())
+    });
+
+    /**
+     * A Mode Tag is meant to be interpreted by the client for the purpose the cluster serves.
+     *
+     * @see {@link MatterSpecification.v13.Cluster} § 1.10.5.1
+     */
+    export interface ModeTagStruct extends TypeFromSchema<typeof TlvModeTagStruct> {}
+
+    /**
+     * This is a struct representing a possible mode of the server.
+     *
+     * @see {@link MatterSpecification.v13.Cluster} § 1.10.5.2
+     */
+    export const TlvModeOption = TlvObject({
+        /**
+         * This field shall indicate readable text that describes the mode option, so that a client can provide it to
+         * the user to indicate what this option means. This field is meant to be readable and understandable by the
+         * user.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.5.2.1
+         */
+        label: TlvField(0, TlvString.bound({ maxLength: 64 })),
+
+        /**
+         * This field is used to identify the mode option.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.5.2.2
+         */
+        mode: TlvField(1, TlvUInt8),
+
+        /**
+         * This field shall contain a list of tags that are associated with the mode option. This may be used by
+         * clients to determine the full or the partial semantics of a certain mode, depending on which tags they
+         * understand, using standard definitions and/or manufacturer specific namespace definitions.
+         *
+         * The standard mode tags are defined in this cluster specification. For the derived cluster instances, if the
+         * specification of the derived cluster defines a namespace, the set of standard mode tags also includes the
+         * mode tag values from that namespace.
+         *
+         * Mode tags can help clients look for options that meet certain criteria, render the user interface, use
+         *
+         * the mode in an automation, or to craft help text their voice-driven interfaces. A mode tag shall be either a
+         * standard tag or a manufacturer specific tag, as defined in each ModeTagStruct list entry.
+         *
+         * A mode option may have more than one mode tag. A mode option may be associated with a mixture of standard
+         * and manufacturer specific mode tags. A mode option shall be associated with at least one standard mode tag.
+         *
+         * A few examples are provided below.
+         *
+         *   • A mode named "100%" can have both the High (manufacturer specific) and Max (standard) mode tag. Clients
+         *     seeking the mode for either High or Max will find the same mode in this case.
+         *
+         *   • A mode that includes a LowEnergy tag can be displayed by the client using a widget icon that shows a
+         *     green leaf.
+         *
+         *   • A mode that includes a LowNoise tag may be used by the client when the user wishes for a lower level of
+         *     audible sound, less likely to disturb the household’s activities.
+         *
+         *   • A mode that includes a LowEnergy tag (standard, defined in this cluster specification) and also a
+         *     Delicate tag (standard, defined in the namespace of a Laundry Mode derived cluster).
+         *
+         *   • A mode that includes both a generic Quick tag (defined here), and Vacuum and Mop tags, (defined in the
+         *     RVC Clean cluster that is a derivation of this cluster).
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.5.2.3
+         */
+        modeTags: TlvField(2, TlvArray(TlvModeTagStruct, { maxLength: 8 }))
+    });
+
+    /**
+     * This is a struct representing a possible mode of the server.
+     *
+     * @see {@link MatterSpecification.v13.Cluster} § 1.10.5.2
+     */
+    export interface ModeOption extends TypeFromSchema<typeof TlvModeOption> {}
 
     /**
      * These elements and properties are present in all MicrowaveOvenMode clusters.
@@ -75,7 +253,7 @@ export namespace MicrowaveOvenMode {
              */
             supportedModes: FixedAttribute(
                 0x0,
-                TlvArray(ModeBase.TlvModeOption, { minLength: 2, maxLength: 255 }),
+                TlvArray(TlvModeOption, { minLength: 2, maxLength: 255 }),
                 { default: [] }
             ),
 

--- a/packages/types/src/clusters/mode-base.ts
+++ b/packages/types/src/clusters/mode-base.ts
@@ -14,7 +14,7 @@ import {
     OptionalWritableAttribute,
     Command
 } from "../cluster/Cluster.js";
-import { TlvUInt8, TlvUInt16, TlvEnum } from "../tlv/TlvNumber.js";
+import { TlvUInt8, TlvEnum } from "../tlv/TlvNumber.js";
 import { TlvNullable } from "../tlv/TlvNullable.js";
 import { BitFlag } from "../schema/BitmapSchema.js";
 import { TlvArray } from "../tlv/TlvArray.js";
@@ -43,12 +43,84 @@ export namespace ModeBase {
         OnOff = "OnOff"
     }
 
+    export enum ModeTag {
+        /**
+         * The device decides which options, features and setting values to use.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        Auto = 0,
+
+        /**
+         * The mode of the device is optimizing for faster completion.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        Quick = 1,
+
+        /**
+         * The device is silent or barely audible while in this mode.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        Quiet = 2,
+
+        /**
+         * Either the mode is inherently low noise or the device optimizes for that.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        LowNoise = 3,
+
+        /**
+         * The device is optimizing for lower energy usage in this mode. Sometimes called "Eco mode".
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        LowEnergy = 4,
+
+        /**
+         * A mode suitable for use during vacations or other extended absences.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        Vacation = 5,
+
+        /**
+         * The mode uses the lowest available setting value.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        Min = 6,
+
+        /**
+         * The mode uses the highest available setting value.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        Max = 7,
+
+        /**
+         * The mode is recommended or suitable for use during night time.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        Night = 8,
+
+        /**
+         * The mode is recommended or suitable for use during day time.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        Day = 9
+    }
+
     /**
      * A Mode Tag is meant to be interpreted by the client for the purpose the cluster serves.
      *
      * @see {@link MatterSpecification.v13.Cluster} § 1.10.5.1
      */
-    export const TlvModeTag = TlvObject({
+    export const TlvModeTagStruct = TlvObject({
         /**
          * If the MfgCode field exists, the Value field shall be in the manufacturer-specific value range (see Section
          * 1.10.8, “Mode Namespace”).
@@ -70,7 +142,7 @@ export namespace ModeBase {
          *
          * @see {@link MatterSpecification.v13.Cluster} § 1.10.5.1.2
          */
-        value: TlvField(1, TlvUInt16)
+        value: TlvField(1, TlvEnum<ModeTag>())
     });
 
     /**
@@ -78,7 +150,7 @@ export namespace ModeBase {
      *
      * @see {@link MatterSpecification.v13.Cluster} § 1.10.5.1
      */
-    export interface ModeTag extends TypeFromSchema<typeof TlvModeTag> {}
+    export interface ModeTagStruct extends TypeFromSchema<typeof TlvModeTagStruct> {}
 
     /**
      * This is a struct representing a possible mode of the server.
@@ -138,7 +210,7 @@ export namespace ModeBase {
          *
          * @see {@link MatterSpecification.v13.Cluster} § 1.10.5.2.3
          */
-        modeTags: TlvField(2, TlvArray(TlvModeTag, { maxLength: 8 }))
+        modeTags: TlvField(2, TlvArray(TlvModeTagStruct, { maxLength: 8 }))
     });
 
     /**
@@ -241,78 +313,6 @@ export namespace ModeBase {
          * @see {@link MatterSpecification.v13.Cluster} § 1.10.7.2.1.2
          */
         InvalidInMode = 3
-    }
-
-    export enum ModeTagEnum {
-        /**
-         * The device decides which options, features and setting values to use.
-         *
-         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
-         */
-        Auto = 0,
-
-        /**
-         * The mode of the device is optimizing for faster completion.
-         *
-         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
-         */
-        Quick = 1,
-
-        /**
-         * The device is silent or barely audible while in this mode.
-         *
-         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
-         */
-        Quiet = 2,
-
-        /**
-         * Either the mode is inherently low noise or the device optimizes for that.
-         *
-         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
-         */
-        LowNoise = 3,
-
-        /**
-         * The device is optimizing for lower energy usage in this mode. Sometimes called "Eco mode".
-         *
-         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
-         */
-        LowEnergy = 4,
-
-        /**
-         * A mode suitable for use during vacations or other extended absences.
-         *
-         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
-         */
-        Vacation = 5,
-
-        /**
-         * The mode uses the lowest available setting value.
-         *
-         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
-         */
-        Min = 6,
-
-        /**
-         * The mode uses the highest available setting value.
-         *
-         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
-         */
-        Max = 7,
-
-        /**
-         * The mode is recommended or suitable for use during night time.
-         *
-         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
-         */
-        Night = 8,
-
-        /**
-         * The mode is recommended or suitable for use during day time.
-         *
-         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
-         */
-        Day = 9
     }
 
     /**

--- a/packages/types/src/clusters/oven-mode.ts
+++ b/packages/types/src/clusters/oven-mode.ts
@@ -15,10 +15,14 @@ import {
     Command,
     TlvNoResponse
 } from "../cluster/Cluster.js";
-import { TlvUInt8 } from "../tlv/TlvNumber.js";
+import { TlvUInt8, TlvEnum } from "../tlv/TlvNumber.js";
 import { TlvNullable } from "../tlv/TlvNullable.js";
 import { BitFlag } from "../schema/BitmapSchema.js";
 import { TlvArray } from "../tlv/TlvArray.js";
+import { TlvField, TlvOptionalField, TlvObject } from "../tlv/TlvObject.js";
+import { TlvString } from "../tlv/TlvString.js";
+import { TlvVendorId } from "../datatype/VendorId.js";
+import { TypeFromSchema } from "../tlv/TlvSchema.js";
 import { ModeBase } from "./mode-base.js";
 import { Identity } from "#general";
 import { ClusterRegistry } from "../cluster/ClusterRegistry.js";
@@ -106,8 +110,183 @@ export namespace OvenMode {
         /**
          * @see {@link MatterSpecification.v13.Cluster} § 8.11.4.1
          */
-        Steam = 16393
+        Steam = 16393,
+
+        /**
+         * The device decides which options, features and setting values to use.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        Auto = 0,
+
+        /**
+         * The mode of the device is optimizing for faster completion.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        Quick = 1,
+
+        /**
+         * The device is silent or barely audible while in this mode.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        Quiet = 2,
+
+        /**
+         * Either the mode is inherently low noise or the device optimizes for that.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        LowNoise = 3,
+
+        /**
+         * The device is optimizing for lower energy usage in this mode. Sometimes called "Eco mode".
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        LowEnergy = 4,
+
+        /**
+         * A mode suitable for use during vacations or other extended absences.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        Vacation = 5,
+
+        /**
+         * The mode uses the lowest available setting value.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        Min = 6,
+
+        /**
+         * The mode uses the highest available setting value.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        Max = 7,
+
+        /**
+         * The mode is recommended or suitable for use during night time.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        Night = 8,
+
+        /**
+         * The mode is recommended or suitable for use during day time.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        Day = 9
     }
+
+    /**
+     * A Mode Tag is meant to be interpreted by the client for the purpose the cluster serves.
+     *
+     * @see {@link MatterSpecification.v13.Cluster} § 1.10.5.1
+     */
+    export const TlvModeTagStruct = TlvObject({
+        /**
+         * If the MfgCode field exists, the Value field shall be in the manufacturer-specific value range (see Section
+         * 1.10.8, “Mode Namespace”).
+         *
+         * This field shall indicate the manufacturer’s VendorID and it shall determine the meaning of the Value field.
+         *
+         * The same manufacturer code and mode tag value in separate cluster instances are part of the same namespace
+         * and have the same meaning. For example: a manufacturer tag meaning "pinch" can be used both in a cluster
+         * whose purpose is to choose the amount of sugar, or in a cluster whose purpose is to choose the amount of
+         * salt.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.5.1.1
+         */
+        mfgCode: TlvOptionalField(0, TlvVendorId),
+
+        /**
+         * This field shall indicate the mode tag within a mode tag namespace which is either manufacturer specific or
+         * standard.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.5.1.2
+         */
+        value: TlvField(1, TlvEnum<ModeTag>())
+    });
+
+    /**
+     * A Mode Tag is meant to be interpreted by the client for the purpose the cluster serves.
+     *
+     * @see {@link MatterSpecification.v13.Cluster} § 1.10.5.1
+     */
+    export interface ModeTagStruct extends TypeFromSchema<typeof TlvModeTagStruct> {}
+
+    /**
+     * This is a struct representing a possible mode of the server.
+     *
+     * @see {@link MatterSpecification.v13.Cluster} § 1.10.5.2
+     */
+    export const TlvModeOption = TlvObject({
+        /**
+         * This field shall indicate readable text that describes the mode option, so that a client can provide it to
+         * the user to indicate what this option means. This field is meant to be readable and understandable by the
+         * user.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.5.2.1
+         */
+        label: TlvField(0, TlvString.bound({ maxLength: 64 })),
+
+        /**
+         * This field is used to identify the mode option.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.5.2.2
+         */
+        mode: TlvField(1, TlvUInt8),
+
+        /**
+         * This field shall contain a list of tags that are associated with the mode option. This may be used by
+         * clients to determine the full or the partial semantics of a certain mode, depending on which tags they
+         * understand, using standard definitions and/or manufacturer specific namespace definitions.
+         *
+         * The standard mode tags are defined in this cluster specification. For the derived cluster instances, if the
+         * specification of the derived cluster defines a namespace, the set of standard mode tags also includes the
+         * mode tag values from that namespace.
+         *
+         * Mode tags can help clients look for options that meet certain criteria, render the user interface, use
+         *
+         * the mode in an automation, or to craft help text their voice-driven interfaces. A mode tag shall be either a
+         * standard tag or a manufacturer specific tag, as defined in each ModeTagStruct list entry.
+         *
+         * A mode option may have more than one mode tag. A mode option may be associated with a mixture of standard
+         * and manufacturer specific mode tags. A mode option shall be associated with at least one standard mode tag.
+         *
+         * A few examples are provided below.
+         *
+         *   • A mode named "100%" can have both the High (manufacturer specific) and Max (standard) mode tag. Clients
+         *     seeking the mode for either High or Max will find the same mode in this case.
+         *
+         *   • A mode that includes a LowEnergy tag can be displayed by the client using a widget icon that shows a
+         *     green leaf.
+         *
+         *   • A mode that includes a LowNoise tag may be used by the client when the user wishes for a lower level of
+         *     audible sound, less likely to disturb the household’s activities.
+         *
+         *   • A mode that includes a LowEnergy tag (standard, defined in this cluster specification) and also a
+         *     Delicate tag (standard, defined in the namespace of a Laundry Mode derived cluster).
+         *
+         *   • A mode that includes both a generic Quick tag (defined here), and Vacuum and Mop tags, (defined in the
+         *     RVC Clean cluster that is a derivation of this cluster).
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.5.2.3
+         */
+        modeTags: TlvField(2, TlvArray(TlvModeTagStruct, { maxLength: 8 }))
+    });
+
+    /**
+     * This is a struct representing a possible mode of the server.
+     *
+     * @see {@link MatterSpecification.v13.Cluster} § 1.10.5.2
+     */
+    export interface ModeOption extends TypeFromSchema<typeof TlvModeOption> {}
 
     /**
      * A OvenModeCluster supports these elements if it supports feature OnOff.
@@ -158,7 +337,7 @@ export namespace OvenMode {
              *
              * @see {@link MatterSpecification.v13.Cluster} § 1.10.6.2
              */
-            supportedModes: FixedAttribute(0x0, TlvArray(ModeBase.TlvModeOption, { minLength: 2, maxLength: 255 })),
+            supportedModes: FixedAttribute(0x0, TlvArray(TlvModeOption, { minLength: 2, maxLength: 255 })),
 
             /**
              * Indicates the current mode of the server.

--- a/packages/types/src/clusters/refrigerator-and-temperature-controlled-cabinet-mode.ts
+++ b/packages/types/src/clusters/refrigerator-and-temperature-controlled-cabinet-mode.ts
@@ -10,8 +10,12 @@ import { MutableCluster } from "../cluster/mutation/MutableCluster.js";
 import { BitFlag } from "../schema/BitmapSchema.js";
 import { FixedAttribute, Attribute, WritableAttribute, Command, TlvNoResponse } from "../cluster/Cluster.js";
 import { TlvArray } from "../tlv/TlvArray.js";
+import { TlvField, TlvOptionalField, TlvObject } from "../tlv/TlvObject.js";
+import { TlvString } from "../tlv/TlvString.js";
+import { TlvUInt8, TlvEnum } from "../tlv/TlvNumber.js";
+import { TlvVendorId } from "../datatype/VendorId.js";
+import { TypeFromSchema } from "../tlv/TlvSchema.js";
 import { ModeBase } from "./mode-base.js";
-import { TlvUInt8 } from "../tlv/TlvNumber.js";
 import { Identity } from "#general";
 import { ClusterRegistry } from "../cluster/ClusterRegistry.js";
 
@@ -46,8 +50,189 @@ export namespace RefrigeratorAndTemperatureControlledCabinetMode {
          *
          * @see {@link MatterSpecification.v13.Cluster} § 8.7.6.1.2
          */
-        RapidFreeze = 16385
+        RapidFreeze = 16385,
+
+        /**
+         * The device decides which options, features and setting values to use.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        Auto = 0,
+
+        /**
+         * The mode of the device is optimizing for faster completion.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        Quick = 1,
+
+        /**
+         * The device is silent or barely audible while in this mode.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        Quiet = 2,
+
+        /**
+         * Either the mode is inherently low noise or the device optimizes for that.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        LowNoise = 3,
+
+        /**
+         * The device is optimizing for lower energy usage in this mode. Sometimes called "Eco mode".
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        LowEnergy = 4,
+
+        /**
+         * A mode suitable for use during vacations or other extended absences.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        Vacation = 5,
+
+        /**
+         * The mode uses the lowest available setting value.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        Min = 6,
+
+        /**
+         * The mode uses the highest available setting value.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        Max = 7,
+
+        /**
+         * The mode is recommended or suitable for use during night time.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        Night = 8,
+
+        /**
+         * The mode is recommended or suitable for use during day time.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        Day = 9
     }
+
+    /**
+     * A Mode Tag is meant to be interpreted by the client for the purpose the cluster serves.
+     *
+     * @see {@link MatterSpecification.v13.Cluster} § 1.10.5.1
+     */
+    export const TlvModeTagStruct = TlvObject({
+        /**
+         * If the MfgCode field exists, the Value field shall be in the manufacturer-specific value range (see Section
+         * 1.10.8, “Mode Namespace”).
+         *
+         * This field shall indicate the manufacturer’s VendorID and it shall determine the meaning of the Value field.
+         *
+         * The same manufacturer code and mode tag value in separate cluster instances are part of the same namespace
+         * and have the same meaning. For example: a manufacturer tag meaning "pinch" can be used both in a cluster
+         * whose purpose is to choose the amount of sugar, or in a cluster whose purpose is to choose the amount of
+         * salt.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.5.1.1
+         */
+        mfgCode: TlvOptionalField(0, TlvVendorId),
+
+        /**
+         * This field shall indicate the mode tag within a mode tag namespace which is either manufacturer specific or
+         * standard.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.5.1.2
+         */
+        value: TlvField(1, TlvEnum<ModeTag>())
+    });
+
+    /**
+     * A Mode Tag is meant to be interpreted by the client for the purpose the cluster serves.
+     *
+     * @see {@link MatterSpecification.v13.Cluster} § 1.10.5.1
+     */
+    export interface ModeTagStruct extends TypeFromSchema<typeof TlvModeTagStruct> {}
+
+    /**
+     * The table below lists the changes relative to the Mode Base cluster for the fields of the ModeOptionStruct type.
+     * A blank field indicates no change.
+     *
+     * At least one entry in the SupportedModes attribute shall include the Auto mode tag in the ModeTags field list.
+     *
+     * @see {@link MatterSpecification.v13.Cluster} § 8.7.4.1
+     */
+    export const TlvModeOption = TlvObject({
+        /**
+         * This field shall indicate readable text that describes the mode option, so that a client can provide it to
+         * the user to indicate what this option means. This field is meant to be readable and understandable by the
+         * user.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.5.2.1
+         */
+        label: TlvField(0, TlvString.bound({ maxLength: 64 })),
+
+        /**
+         * This field is used to identify the mode option.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.5.2.2
+         */
+        mode: TlvField(1, TlvUInt8),
+
+        /**
+         * This field shall contain a list of tags that are associated with the mode option. This may be used by
+         * clients to determine the full or the partial semantics of a certain mode, depending on which tags they
+         * understand, using standard definitions and/or manufacturer specific namespace definitions.
+         *
+         * The standard mode tags are defined in this cluster specification. For the derived cluster instances, if the
+         * specification of the derived cluster defines a namespace, the set of standard mode tags also includes the
+         * mode tag values from that namespace.
+         *
+         * Mode tags can help clients look for options that meet certain criteria, render the user interface, use
+         *
+         * the mode in an automation, or to craft help text their voice-driven interfaces. A mode tag shall be either a
+         * standard tag or a manufacturer specific tag, as defined in each ModeTagStruct list entry.
+         *
+         * A mode option may have more than one mode tag. A mode option may be associated with a mixture of standard
+         * and manufacturer specific mode tags. A mode option shall be associated with at least one standard mode tag.
+         *
+         * A few examples are provided below.
+         *
+         *   • A mode named "100%" can have both the High (manufacturer specific) and Max (standard) mode tag. Clients
+         *     seeking the mode for either High or Max will find the same mode in this case.
+         *
+         *   • A mode that includes a LowEnergy tag can be displayed by the client using a widget icon that shows a
+         *     green leaf.
+         *
+         *   • A mode that includes a LowNoise tag may be used by the client when the user wishes for a lower level of
+         *     audible sound, less likely to disturb the household’s activities.
+         *
+         *   • A mode that includes a LowEnergy tag (standard, defined in this cluster specification) and also a
+         *     Delicate tag (standard, defined in the namespace of a Laundry Mode derived cluster).
+         *
+         *   • A mode that includes both a generic Quick tag (defined here), and Vacuum and Mop tags, (defined in the
+         *     RVC Clean cluster that is a derivation of this cluster).
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.5.2.3
+         */
+        modeTags: TlvField(2, TlvArray(TlvModeTagStruct, { maxLength: 8 }))
+    });
+
+    /**
+     * The table below lists the changes relative to the Mode Base cluster for the fields of the ModeOptionStruct type.
+     * A blank field indicates no change.
+     *
+     * At least one entry in the SupportedModes attribute shall include the Auto mode tag in the ModeTags field list.
+     *
+     * @see {@link MatterSpecification.v13.Cluster} § 8.7.4.1
+     */
+    export interface ModeOption extends TypeFromSchema<typeof TlvModeOption> {}
 
     /**
      * These elements and properties are present in all RefrigeratorAndTemperatureControlledCabinetMode clusters.
@@ -75,7 +260,7 @@ export namespace RefrigeratorAndTemperatureControlledCabinetMode {
              */
             supportedModes: FixedAttribute(
                 0x0,
-                TlvArray(ModeBase.TlvModeOption, { minLength: 2, maxLength: 255 }),
+                TlvArray(TlvModeOption, { minLength: 2, maxLength: 255 }),
                 { default: [] }
             ),
 

--- a/packages/types/src/clusters/rvc-clean-mode.ts
+++ b/packages/types/src/clusters/rvc-clean-mode.ts
@@ -10,8 +10,12 @@ import { MutableCluster } from "../cluster/mutation/MutableCluster.js";
 import { BitFlag } from "../schema/BitmapSchema.js";
 import { FixedAttribute, Attribute, Command, TlvNoResponse } from "../cluster/Cluster.js";
 import { TlvArray } from "../tlv/TlvArray.js";
+import { TlvField, TlvOptionalField, TlvObject } from "../tlv/TlvObject.js";
+import { TlvString } from "../tlv/TlvString.js";
+import { TlvUInt8, TlvEnum } from "../tlv/TlvNumber.js";
+import { TlvVendorId } from "../datatype/VendorId.js";
+import { TypeFromSchema } from "../tlv/TlvSchema.js";
 import { ModeBase } from "./mode-base.js";
-import { TlvUInt8 } from "../tlv/TlvNumber.js";
 import { Identity } from "#general";
 import { ClusterRegistry } from "../cluster/ClusterRegistry.js";
 
@@ -33,13 +37,6 @@ export namespace RvcCleanMode {
         OnOff = "OnOff"
     }
 
-    export enum ModeChangeStatus {
-        /**
-         * @see {@link MatterSpecification.v13.Cluster} § 7.3.7.1
-         */
-        CleaningInProgress = 64
-    }
-
     export enum ModeTag {
         /**
          * @see {@link MatterSpecification.v13.Cluster} § 7.3.7.2
@@ -58,7 +55,227 @@ export namespace RvcCleanMode {
          *
          * @see {@link MatterSpecification.v13.Cluster} § 7.3.7.2.3
          */
-        Mop = 16386
+        Mop = 16386,
+
+        /**
+         * The device decides which options, features and setting values to use.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        Auto = 0,
+
+        /**
+         * The mode of the device is optimizing for faster completion.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        Quick = 1,
+
+        /**
+         * The device is silent or barely audible while in this mode.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        Quiet = 2,
+
+        /**
+         * Either the mode is inherently low noise or the device optimizes for that.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        LowNoise = 3,
+
+        /**
+         * The device is optimizing for lower energy usage in this mode. Sometimes called "Eco mode".
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        LowEnergy = 4,
+
+        /**
+         * A mode suitable for use during vacations or other extended absences.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        Vacation = 5,
+
+        /**
+         * The mode uses the lowest available setting value.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        Min = 6,
+
+        /**
+         * The mode uses the highest available setting value.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        Max = 7,
+
+        /**
+         * The mode is recommended or suitable for use during night time.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        Night = 8,
+
+        /**
+         * The mode is recommended or suitable for use during day time.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        Day = 9
+    }
+
+    /**
+     * A Mode Tag is meant to be interpreted by the client for the purpose the cluster serves.
+     *
+     * @see {@link MatterSpecification.v13.Cluster} § 1.10.5.1
+     */
+    export const TlvModeTagStruct = TlvObject({
+        /**
+         * If the MfgCode field exists, the Value field shall be in the manufacturer-specific value range (see Section
+         * 1.10.8, “Mode Namespace”).
+         *
+         * This field shall indicate the manufacturer’s VendorID and it shall determine the meaning of the Value field.
+         *
+         * The same manufacturer code and mode tag value in separate cluster instances are part of the same namespace
+         * and have the same meaning. For example: a manufacturer tag meaning "pinch" can be used both in a cluster
+         * whose purpose is to choose the amount of sugar, or in a cluster whose purpose is to choose the amount of
+         * salt.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.5.1.1
+         */
+        mfgCode: TlvOptionalField(0, TlvVendorId),
+
+        /**
+         * This field shall indicate the mode tag within a mode tag namespace which is either manufacturer specific or
+         * standard.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.5.1.2
+         */
+        value: TlvField(1, TlvEnum<ModeTag>())
+    });
+
+    /**
+     * A Mode Tag is meant to be interpreted by the client for the purpose the cluster serves.
+     *
+     * @see {@link MatterSpecification.v13.Cluster} § 1.10.5.1
+     */
+    export interface ModeTagStruct extends TypeFromSchema<typeof TlvModeTagStruct> {}
+
+    /**
+     * The table below lists the changes relative to the Mode Base cluster for the fields of the ModeOptionStruct type.
+     * A blank field indicates no change.
+     *
+     * At least one entry in the SupportedModes attribute shall include the Vacuum and/or the Mop mode tag in the
+     * ModeTags field list.
+     *
+     * @see {@link MatterSpecification.v13.Cluster} § 7.3.5.1
+     */
+    export const TlvModeOption = TlvObject({
+        /**
+         * This field shall indicate readable text that describes the mode option, so that a client can provide it to
+         * the user to indicate what this option means. This field is meant to be readable and understandable by the
+         * user.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.5.2.1
+         */
+        label: TlvField(0, TlvString.bound({ maxLength: 64 })),
+
+        /**
+         * This field is used to identify the mode option.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.5.2.2
+         */
+        mode: TlvField(1, TlvUInt8),
+
+        /**
+         * This field shall contain a list of tags that are associated with the mode option. This may be used by
+         * clients to determine the full or the partial semantics of a certain mode, depending on which tags they
+         * understand, using standard definitions and/or manufacturer specific namespace definitions.
+         *
+         * The standard mode tags are defined in this cluster specification. For the derived cluster instances, if the
+         * specification of the derived cluster defines a namespace, the set of standard mode tags also includes the
+         * mode tag values from that namespace.
+         *
+         * Mode tags can help clients look for options that meet certain criteria, render the user interface, use
+         *
+         * the mode in an automation, or to craft help text their voice-driven interfaces. A mode tag shall be either a
+         * standard tag or a manufacturer specific tag, as defined in each ModeTagStruct list entry.
+         *
+         * A mode option may have more than one mode tag. A mode option may be associated with a mixture of standard
+         * and manufacturer specific mode tags. A mode option shall be associated with at least one standard mode tag.
+         *
+         * A few examples are provided below.
+         *
+         *   • A mode named "100%" can have both the High (manufacturer specific) and Max (standard) mode tag. Clients
+         *     seeking the mode for either High or Max will find the same mode in this case.
+         *
+         *   • A mode that includes a LowEnergy tag can be displayed by the client using a widget icon that shows a
+         *     green leaf.
+         *
+         *   • A mode that includes a LowNoise tag may be used by the client when the user wishes for a lower level of
+         *     audible sound, less likely to disturb the household’s activities.
+         *
+         *   • A mode that includes a LowEnergy tag (standard, defined in this cluster specification) and also a
+         *     Delicate tag (standard, defined in the namespace of a Laundry Mode derived cluster).
+         *
+         *   • A mode that includes both a generic Quick tag (defined here), and Vacuum and Mop tags, (defined in the
+         *     RVC Clean cluster that is a derivation of this cluster).
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.5.2.3
+         */
+        modeTags: TlvField(2, TlvArray(TlvModeTagStruct, { maxLength: 8 }))
+    });
+
+    /**
+     * The table below lists the changes relative to the Mode Base cluster for the fields of the ModeOptionStruct type.
+     * A blank field indicates no change.
+     *
+     * At least one entry in the SupportedModes attribute shall include the Vacuum and/or the Mop mode tag in the
+     * ModeTags field list.
+     *
+     * @see {@link MatterSpecification.v13.Cluster} § 7.3.5.1
+     */
+    export interface ModeOption extends TypeFromSchema<typeof TlvModeOption> {}
+
+    export enum ModeChangeStatus {
+        /**
+         * @see {@link MatterSpecification.v13.Cluster} § 7.3.7.1
+         */
+        CleaningInProgress = 64,
+
+        /**
+         * Switching to the mode indicated by the NewMode field is allowed and possible. The CurrentMode attribute is
+         * set to the value of the NewMode field.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.7.2.1.2
+         */
+        Success = 0,
+
+        /**
+         * The value of the NewMode field doesn’t match any entries in the SupportedMode attribute.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.7.2.1.2
+         */
+        UnsupportedMode = 1,
+
+        /**
+         * Generic failure code, indicating that switching to the mode indicated by the NewMode field is not allowed or
+         * not possible.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.7.2.1.2
+         */
+        GenericFailure = 2,
+
+        /**
+         * The received request cannot be handled due to the current mode of the device
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.7.2.1.2
+         */
+        InvalidInMode = 3
     }
 
     /**
@@ -87,7 +304,7 @@ export namespace RvcCleanMode {
              */
             supportedModes: FixedAttribute(
                 0x0,
-                TlvArray(ModeBase.TlvModeOption, { minLength: 2, maxLength: 255 }),
+                TlvArray(TlvModeOption, { minLength: 2, maxLength: 255 }),
                 { default: [] }
             ),
 

--- a/packages/types/src/clusters/rvc-run-mode.ts
+++ b/packages/types/src/clusters/rvc-run-mode.ts
@@ -10,8 +10,12 @@ import { MutableCluster } from "../cluster/mutation/MutableCluster.js";
 import { BitFlag } from "../schema/BitmapSchema.js";
 import { FixedAttribute, Attribute, Command, TlvNoResponse } from "../cluster/Cluster.js";
 import { TlvArray } from "../tlv/TlvArray.js";
+import { TlvField, TlvOptionalField, TlvObject } from "../tlv/TlvObject.js";
+import { TlvString } from "../tlv/TlvString.js";
+import { TlvUInt8, TlvEnum } from "../tlv/TlvNumber.js";
+import { TlvVendorId } from "../datatype/VendorId.js";
+import { TypeFromSchema } from "../tlv/TlvSchema.js";
 import { ModeBase } from "./mode-base.js";
-import { TlvUInt8 } from "../tlv/TlvNumber.js";
 import { Identity } from "#general";
 import { ClusterRegistry } from "../cluster/ClusterRegistry.js";
 
@@ -32,6 +36,235 @@ export namespace RvcRunMode {
          */
         OnOff = "OnOff"
     }
+
+    export enum ModeTag {
+        /**
+         * The device is not performing any of the main operations of the other modes. However, auxiliary actions, such
+         * as seeking the charger or charging, may occur.
+         *
+         * For example, the device has completed cleaning, successfully or not, on its own or due to a command, or has
+         * not been asked to clean after a restart.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 7.2.7.2.1
+         */
+        Idle = 16384,
+
+        /**
+         * The device was asked to clean so it may be actively running, or paused due to an error, due to a pause
+         * command, or for recharging etc. If currently paused and the device can resume it will continue to clean.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 7.2.7.2.2
+         */
+        Cleaning = 16385,
+
+        /**
+         * The device was asked to create a map of the space it is located in, so it may be actively running, or paused
+         * due to an error, due to a pause command, or for recharging etc. If currently paused and the device can
+         * resume, it will continue to map.
+         *
+         * NOTE
+         *
+         * this mode is intended to be used so the current space can be mapped by the device if the robot has not
+         * previously done that, or if the layout has substantially changed, for an optimal subsequent cleaning
+         * experience.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 7.2.7.2.3
+         */
+        Mapping = 16386,
+
+        /**
+         * The device decides which options, features and setting values to use.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        Auto = 0,
+
+        /**
+         * The mode of the device is optimizing for faster completion.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        Quick = 1,
+
+        /**
+         * The device is silent or barely audible while in this mode.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        Quiet = 2,
+
+        /**
+         * Either the mode is inherently low noise or the device optimizes for that.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        LowNoise = 3,
+
+        /**
+         * The device is optimizing for lower energy usage in this mode. Sometimes called "Eco mode".
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        LowEnergy = 4,
+
+        /**
+         * A mode suitable for use during vacations or other extended absences.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        Vacation = 5,
+
+        /**
+         * The mode uses the lowest available setting value.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        Min = 6,
+
+        /**
+         * The mode uses the highest available setting value.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        Max = 7,
+
+        /**
+         * The mode is recommended or suitable for use during night time.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        Night = 8,
+
+        /**
+         * The mode is recommended or suitable for use during day time.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.8
+         */
+        Day = 9
+    }
+
+    /**
+     * A Mode Tag is meant to be interpreted by the client for the purpose the cluster serves.
+     *
+     * @see {@link MatterSpecification.v13.Cluster} § 1.10.5.1
+     */
+    export const TlvModeTagStruct = TlvObject({
+        /**
+         * If the MfgCode field exists, the Value field shall be in the manufacturer-specific value range (see Section
+         * 1.10.8, “Mode Namespace”).
+         *
+         * This field shall indicate the manufacturer’s VendorID and it shall determine the meaning of the Value field.
+         *
+         * The same manufacturer code and mode tag value in separate cluster instances are part of the same namespace
+         * and have the same meaning. For example: a manufacturer tag meaning "pinch" can be used both in a cluster
+         * whose purpose is to choose the amount of sugar, or in a cluster whose purpose is to choose the amount of
+         * salt.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.5.1.1
+         */
+        mfgCode: TlvOptionalField(0, TlvVendorId),
+
+        /**
+         * This field shall indicate the mode tag within a mode tag namespace which is either manufacturer specific or
+         * standard.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.5.1.2
+         */
+        value: TlvField(1, TlvEnum<ModeTag>())
+    });
+
+    /**
+     * A Mode Tag is meant to be interpreted by the client for the purpose the cluster serves.
+     *
+     * @see {@link MatterSpecification.v13.Cluster} § 1.10.5.1
+     */
+    export interface ModeTagStruct extends TypeFromSchema<typeof TlvModeTagStruct> {}
+
+    /**
+     * The table below lists the changes relative to the Mode Base cluster for the fields of the ModeOptionStruct type.
+     * A blank field indicates no change.
+     *
+     * At least one entry in the SupportedModes attribute shall include the Idle mode tag in the ModeTags field.
+     *
+     * At least one entry in the SupportedModes attribute (different from the one above) shall include the Cleaning
+     * mode tag in the ModeTags field.
+     *
+     * The Mapping, Cleaning, and Idle mode tags are mutually exclusive and shall NOT be used together in a mode’s
+     * ModeTags.
+     *
+     * @see {@link MatterSpecification.v13.Cluster} § 7.2.5.1
+     */
+    export const TlvModeOption = TlvObject({
+        /**
+         * This field shall indicate readable text that describes the mode option, so that a client can provide it to
+         * the user to indicate what this option means. This field is meant to be readable and understandable by the
+         * user.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.5.2.1
+         */
+        label: TlvField(0, TlvString.bound({ maxLength: 64 })),
+
+        /**
+         * This field is used to identify the mode option.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.5.2.2
+         */
+        mode: TlvField(1, TlvUInt8),
+
+        /**
+         * This field shall contain a list of tags that are associated with the mode option. This may be used by
+         * clients to determine the full or the partial semantics of a certain mode, depending on which tags they
+         * understand, using standard definitions and/or manufacturer specific namespace definitions.
+         *
+         * The standard mode tags are defined in this cluster specification. For the derived cluster instances, if the
+         * specification of the derived cluster defines a namespace, the set of standard mode tags also includes the
+         * mode tag values from that namespace.
+         *
+         * Mode tags can help clients look for options that meet certain criteria, render the user interface, use
+         *
+         * the mode in an automation, or to craft help text their voice-driven interfaces. A mode tag shall be either a
+         * standard tag or a manufacturer specific tag, as defined in each ModeTagStruct list entry.
+         *
+         * A mode option may have more than one mode tag. A mode option may be associated with a mixture of standard
+         * and manufacturer specific mode tags. A mode option shall be associated with at least one standard mode tag.
+         *
+         * A few examples are provided below.
+         *
+         *   • A mode named "100%" can have both the High (manufacturer specific) and Max (standard) mode tag. Clients
+         *     seeking the mode for either High or Max will find the same mode in this case.
+         *
+         *   • A mode that includes a LowEnergy tag can be displayed by the client using a widget icon that shows a
+         *     green leaf.
+         *
+         *   • A mode that includes a LowNoise tag may be used by the client when the user wishes for a lower level of
+         *     audible sound, less likely to disturb the household’s activities.
+         *
+         *   • A mode that includes a LowEnergy tag (standard, defined in this cluster specification) and also a
+         *     Delicate tag (standard, defined in the namespace of a Laundry Mode derived cluster).
+         *
+         *   • A mode that includes both a generic Quick tag (defined here), and Vacuum and Mop tags, (defined in the
+         *     RVC Clean cluster that is a derivation of this cluster).
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.5.2.3
+         */
+        modeTags: TlvField(2, TlvArray(TlvModeTagStruct, { maxLength: 8 }))
+    });
+
+    /**
+     * The table below lists the changes relative to the Mode Base cluster for the fields of the ModeOptionStruct type.
+     * A blank field indicates no change.
+     *
+     * At least one entry in the SupportedModes attribute shall include the Idle mode tag in the ModeTags field.
+     *
+     * At least one entry in the SupportedModes attribute (different from the one above) shall include the Cleaning
+     * mode tag in the ModeTags field.
+     *
+     * The Mapping, Cleaning, and Idle mode tags are mutually exclusive and shall NOT be used together in a mode’s
+     * ModeTags.
+     *
+     * @see {@link MatterSpecification.v13.Cluster} § 7.2.5.1
+     */
+    export interface ModeOption extends TypeFromSchema<typeof TlvModeOption> {}
 
     export enum ModeChangeStatus {
         /**
@@ -72,43 +305,37 @@ export namespace RvcRunMode {
         /**
          * @see {@link MatterSpecification.v13.Cluster} § 7.2.7.1
          */
-        BatteryLow = 72
-    }
-
-    export enum ModeTag {
-        /**
-         * The device is not performing any of the main operations of the other modes. However, auxiliary actions, such
-         * as seeking the charger or charging, may occur.
-         *
-         * For example, the device has completed cleaning, successfully or not, on its own or due to a command, or has
-         * not been asked to clean after a restart.
-         *
-         * @see {@link MatterSpecification.v13.Cluster} § 7.2.7.2.1
-         */
-        Idle = 16384,
+        BatteryLow = 72,
 
         /**
-         * The device was asked to clean so it may be actively running, or paused due to an error, due to a pause
-         * command, or for recharging etc. If currently paused and the device can resume it will continue to clean.
+         * Switching to the mode indicated by the NewMode field is allowed and possible. The CurrentMode attribute is
+         * set to the value of the NewMode field.
          *
-         * @see {@link MatterSpecification.v13.Cluster} § 7.2.7.2.2
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.7.2.1.2
          */
-        Cleaning = 16385,
+        Success = 0,
 
         /**
-         * The device was asked to create a map of the space it is located in, so it may be actively running, or paused
-         * due to an error, due to a pause command, or for recharging etc. If currently paused and the device can
-         * resume, it will continue to map.
+         * The value of the NewMode field doesn’t match any entries in the SupportedMode attribute.
          *
-         * NOTE
-         *
-         * this mode is intended to be used so the current space can be mapped by the device if the robot has not
-         * previously done that, or if the layout has substantially changed, for an optimal subsequent cleaning
-         * experience.
-         *
-         * @see {@link MatterSpecification.v13.Cluster} § 7.2.7.2.3
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.7.2.1.2
          */
-        Mapping = 16386
+        UnsupportedMode = 1,
+
+        /**
+         * Generic failure code, indicating that switching to the mode indicated by the NewMode field is not allowed or
+         * not possible.
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.7.2.1.2
+         */
+        GenericFailure = 2,
+
+        /**
+         * The received request cannot be handled due to the current mode of the device
+         *
+         * @see {@link MatterSpecification.v13.Cluster} § 1.10.7.2.1.2
+         */
+        InvalidInMode = 3
     }
 
     /**
@@ -137,7 +364,7 @@ export namespace RvcRunMode {
              */
             supportedModes: FixedAttribute(
                 0x0,
-                TlvArray(ModeBase.TlvModeOption, { minLength: 2, maxLength: 255 }),
+                TlvArray(TlvModeOption, { minLength: 2, maxLength: 255 }),
                 { default: [] }
             ),
 

--- a/packages/types/src/globals/WildcardPathFlags.ts
+++ b/packages/types/src/globals/WildcardPathFlags.ts
@@ -58,5 +58,5 @@ export const WildcardPathFlags = {
     /**
      * Skip all clusters with the Diagnostics (K) quality during wildcard expansion.
      */
-    wildcardSkipDiagnosticsClusters: BitFlag(8),
+    wildcardSkipDiagnosticsClusters: BitFlag(8)
 };


### PR DESCRIPTION
Previously we identified implicit base models of datatypes and other model children, but we only did this from the perspective of the child (the "extension"), not from the perspective of the base.  This worked fine until Matter 1.3 when the specification began relying more heavily on the "extended cluster" construct.

This commit adds the notion of a "scope" to the model.  Instead of querying a model for applicable members, you now query the scope.  The scope is aware of extensions, so this allows you to retrieve the correct set of members in contexts (such as datatype fields defined in the base cluster) where there is otherwise no explicit reference to the extension.

CHANGELOG.md contains additional details.

Fixes #1455

@Apollon77 - this one is a somewhat large and has a couple of breaking changes, up to you whether we put in a dot release