### PR TITLE
Retry next address also open channel establishment error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,13 +13,16 @@ The main work (all changes without a GitHub username in brackets in the below li
 
 -   @matter/node
     - Enhancement: Enhances the number assertations to only allow finite numbers
+    - Fix: ColorControl: Do not try to convert color mode details if they are not defined
+
+-   @matter/protocol
+    - Fix: Also retry next discovered address when a Channel establishment error for PASE occurs
+
+-   @matter/types
+    - Enhancement: Removes default value from attribute ColorMode of ColorControl cluster because feature specific enum value was used
 
 -   @project-chip/matter.js
     - Enhancement: Considers a node in reconnection state that should be decommissioned as already factory reset
-
--   Matter cluster definitions and implementations
-    - Enhancement: Removes default value from attribute ColorMode of ColorControl cluster because feature specific enum value was used
-    - Fix: Do not try to convert color mode details if they are not defined
 
 ## 0.11.8 (2024-11-29)
 


### PR DESCRIPTION
When a channel establishment error occurs when trying addresses for client also retry next address on this error. Reason is that the discovery could have just searched e-g. for product+vendorid and so PASE could fail because of invalid pin and such