### PR TITLE
Workaround for node bug 56219

### DIFF
--- a/packages/general/src/codec/Base64Codec.ts
+++ b/packages/general/src/codec/Base64Codec.ts
@@ -77,7 +77,7 @@ export namespace Base64 {
             }
         }
 
-        return new TextDecoder("iso-8859-1").decode(out);
+        return new TextDecoder().decode(out);
     }
 
     /**


### PR DESCRIPTION
https://github.com/nodejs/node/issues/56219 breaks our base-64 encoder.  Node is off spec and should release fix quickly.  Normally I wouldn't patch but in this case workaround is innocuous.

Fixes #1516