### PR TITLE
Metadata extractor for CHIP tests

### DIFF
--- a/chip/Dockerfile
+++ b/chip/Dockerfile
@@ -107,9 +107,6 @@ RUN --mount=type=cache,sharing=locked,target=/var/cache/apt \
     apt-get -qq update && \
     apt-get -qq -y install avahi-daemon avahi-utils iproute2 less vim wget
 
-RUN wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/bin/yq && \
-    chmod +x /usr/bin/yq
-
 LABEL org.opencontainers.image.title="matter.js CHIP tooling build"
 LABEL org.opencontainers.image.url=https://github.com/matter-js/matter.js-chip
 LABEL org.opencontainers.image.source=https://github.com/project-chip/matter.js/tree/main/packages/testing/chip
@@ -161,3 +158,7 @@ COPY --from=build /connectedhomeip/credentials/development/paa-root-certs /crede
 COPY --from=build /connectedhomeip/credentials/development/cd-certs /credentials/development/cd-certs
 
 RUN mkdir /run/dbus
+
+# Summarize tests for efficient metadata load at runtime
+COPY generate-test-descriptor /bin/generate-test-descriptor
+RUN generate-test-descriptor > /lib/test-descriptor.json

--- a/chip/generate-test-descriptor
+++ b/chip/generate-test-descriptor
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+
+# @license
+# Copyright 2022-2024 Matter.js Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Test Metadata Extractor
+
+Collects test metadata from various sources in CHIP and produces a normalized JSON summary.  The format of the JSON blob
+is defined in test-descriptor.ts in @matter/testing.
+
+During build, the Dockerfile stores this as /lib/test-descriptor.json.  The @matter/testing harness then loads it at
+runtime.
+"""
+
+import os
+import json
+import yaml
+import sys
+import glob
+import inspect
+import importlib
+import re
+import shutil
+from chip.testing.matter_testing import MatterBaseTest, MatterTestConfig, generate_mobly_test_config
+
+YAML_DIR = "/src/app/tests/suites"
+PYTHON_DIR = "/src/python_testing"
+
+# Somewhere in the code we run for test reflection CHIP decides to create a directory for the test name.  So execute in
+# /tmp/metadata-garbage and clean up when we're done
+os.mkdir("/tmp/metadata-garbage")
+os.chdir("/tmp/metadata-garbage")
+
+step_pattern = re.compile(r"Step ([^)]+):\s*(.*)", re.IGNORECASE)
+
+def read_yaml_file(path):
+    with open(path) as input:
+        return yaml.full_load(input)
+
+def read_json_file(path):
+    with open(path) as input:
+        return json.load(input)
+
+tests = []
+
+def load_yaml():
+    """Load metadata from YAML tests.
+
+    This is fairly straightforward as the tests are inherently declarative    
+    """
+    categories = {}
+    for category_name, members in read_json_file(f"{YAML_DIR}/manualTests.json").items():
+        for test_name in members:
+            categories[test_name] = category_name
+    
+    ci = set()
+    for members in read_json_file(f"{YAML_DIR}/ciTests.json").values():
+        for test_name in members:
+            ci.add(test_name)
+
+    for path in glob.glob(f"{YAML_DIR}/**/*.yaml", recursive = True):
+        if "/examples/" in path or path.endswith("/PICS.yaml"):
+            continue
+
+        definition = read_yaml_file(path)
+        basename = os.path.basename(path)
+        name = os.path.splitext(basename)[0]
+
+        props = {
+            "kind": "yaml",
+            "name": name.removeprefix("Test_").removeprefix("Test").removeprefix("TC_"),
+            "path": path
+        }
+
+        if "name" in definition:
+            props["description"] = definition["name"]
+
+        if basename in categories:
+            props["category"] = categories[basename]
+
+        if "config" in definition:
+            props["config"] = definition["config"]
+
+        if "PICS" in definition:
+            props["pics"] = " & ".join(map(lambda item: f"({item})" if " " in item else item, definition["PICS"]))
+
+        manual = True
+        if "tests" in definition:
+            members = []
+            for test in definition["tests"]:
+                step = {"kind": "step"}
+
+                name = test["label"]
+                match = step_pattern.match(name)
+                if match:
+                    step["name"] = match[1]
+                    step["description"] = match[2]
+                else:
+                    step["name"] = name
+            
+                if "disabled" in test and test["disabled"]:
+                    step["isDisabled"] = True
+                else:
+                    manual = False
+
+                if "PICS" in test and test["PICS"]:
+                    step["pics"] = test["PICS"].replace("&&", "&").replace("||", "|")
+
+                members.append(step)
+
+            if members:
+                props["members"] = members
+
+        if manual:
+                props["kind"] = "manual"
+
+        tests.append(props)
+
+def load_python():
+    """ Load metadata from Python tests.  This requires a bit more fiddling because:
+
+     * Most metadata is only available from instantiated Python classes
+
+     * We can't rely entirely on code convention due to errors.  Namely, the framework doesn't care if the test class is
+       named the same as the file.  It almost always is but some tests have the wrong class name
+
+     * Metadata fields have the test name in them.  So it's not just test.pics, but test.pics_NAME_1_2()
+
+     * Some metadata is embedded in YAML embedded in a comment at the head of the file
+
+     * Some metadata lives in a separate YAML file
+
+     * Some support logic is exposed as API so we can use it, but some is embedded in Mobly or slightly mismatched for
+       our purposes
+    """
+    sys.path.append(PYTHON_DIR)
+
+    test_metadata = read_yaml_file(f"{PYTHON_DIR}/test_metadata.yaml")
+    manual = { test["name"]: test["reason"] for test in test_metadata["not_automated"] }
+    slow = { test["name"]: test["duration"] for test in test_metadata["slow_tests"] }
+
+    matter_test_config = MatterTestConfig()
+    mobly_test_config = generate_mobly_test_config(matter_test_config)
+
+    for path in glob.glob(f"{PYTHON_DIR}/*.py"):
+        basename = os.path.basename(path)
+        name = os.path.splitext(basename)[0]
+        importlib.import_module(name)
+
+    for test in MatterBaseTest.__subclasses__():
+        path = inspect.getfile(test)
+        basename = os.path.basename(path)
+        name = os.path.splitext(basename)[0].removeprefix("test_")
+        instance = test(mobly_test_config)
+        props = {
+            "kind": "py",
+            "name": name.removeprefix("Test").removeprefix("TC_"),
+            "path": path
+        }
+
+        desc = instance.get_test_desc(name)
+        if desc != name:
+            props["description"] = desc
+
+        pics = instance.get_test_pics(name)
+        if pics:
+            props["pics"] = " & ".join(instance.get_test_pics(name))
+
+        steps = instance.get_defined_test_steps(name)
+        if steps:
+            props["members"] = list(map(lambda step: {
+                "name": step.test_plan_number,
+                "kind": "step",
+                "description": step.description,
+            }, steps))
+
+        if basename in slow:
+            props["isSlow"] = slow[basename]
+
+        if basename in manual:
+            props["isManual"] = manual[basename]
+
+        header = []
+        with open(path) as source:
+            in_yaml = False
+            
+            while True:
+                line = source.readline()
+                if not line:
+                    break
+
+                if "=== BEGIN CI TEST ARGUMENTS ===" in line:
+                    in_yaml = True
+                    break
+            
+            while in_yaml:
+                line = source.readline()
+                if not line:
+                    break
+
+                if "=== END CI TEST ARGUMENTS ===" in line:
+                    break
+
+                header.append(line.removeprefix("# "))
+
+        # Install a test for each run; suffix with run name if there are multiple runs
+        if header:
+            parsed = yaml.full_load("".join(header))
+            runs = parsed["test-runner-runs"]
+            if runs:
+                for run, config in runs.items():
+                    props["config"] = config
+                    if len(runs) == 1:
+                        tests.append(props)
+                    else:
+                        tests.append({**props, "name": f"{props["name"]}-{run}"})
+            else:
+                tests.append(props)
+        else:
+            tests.append(props)
+
+load_yaml()
+load_python()
+
+shutil.rmtree("/tmp/metadata-garbage")
+
+# Normalize/prettify names and create semantic version for sorting
+semantic_name_pattern = re.compile(r"(.*)_(\d+)_(\d+)(?:_(.*))?")
+for test in tests:
+    match = semantic_name_pattern.match(test["name"])
+    if match:
+        suffix = ".%s" % match[4] if match[4] != None else ""
+        test["parent"] = match[1]
+        test["name"] = "%s.%s%s" % (match[2], match[3], suffix)
+        test["semantic_name"] = "%s %04d.%04d%s" % (match[1].lower(), int(match[2]), int(match[3]), suffix)
+    else:
+        test["semantic_name"] = test["name"].lower()
+
+# Order by semantic name
+tests = sorted(tests, key = lambda test: test["semantic_name"])
+
+# Organize into buckets and strip out organizational fields
+parents = {}
+members = []
+for test in tests:
+    del test["semantic_name"]
+
+    if "parent" in test:
+        parent = None
+        if test["parent"] in parents:
+            parent = parents[test["parent"]]
+        else:
+            parent = parents[test["parent"]] = { "name": test["parent"], "kind": "suite", "members": [] }
+            members.append(parent)
+
+        parent["members"].append(test)
+
+        del test["parent"]
+    else:
+        members.append(test)
+
+# Write the result
+print(json.dumps({ "name": "chip", "kind": "suite", "members": members }))


### PR DESCRIPTION
I decided to collect metadata from CHIP tests as part of container build rather than at runtime.  This reduces test harness startup time and allows for more thorough extraction of metadata.

The included script extracts metadata that is currently scattered throughout the connectedhomeip repo, normalizes it and sticks it into a JSON file we can load.