### PR TITLE
Fixes MDNS exception

### DIFF
--- a/packages/protocol/src/mdns/MdnsScanner.ts
+++ b/packages/protocol/src/mdns/MdnsScanner.ts
@@ -782,25 +782,28 @@ export class MdnsScanner implements Scanner {
             }
         }
 
-        return {
-            operational: combinedAnswers.operational
-                ? Object.fromEntries(
-                      Object.entries(combinedAnswers.operational).map(([recordType, records]) => [
-                          recordType,
-                          Array.from(records.values()),
-                      ]),
-                  )
-                : undefined,
-            commissionable: combinedAnswers.commissionable
-                ? Object.fromEntries(
-                      Object.entries(combinedAnswers.commissionable).map(([recordType, records]) => [
-                          recordType,
-                          Array.from(records.values()),
-                      ]),
-                  )
-                : undefined,
-            addresses: combinedAnswers.addresses,
-        };
+        const result: StructuredDnsAnswers = {};
+        if (combinedAnswers.operational) {
+            result.operational = Object.fromEntries(
+                Object.entries(combinedAnswers.operational).map(([recordType, records]) => [
+                    recordType,
+                    Array.from(records.values()),
+                ]),
+            );
+        }
+        if (combinedAnswers.commissionable) {
+            result.commissionable = Object.fromEntries(
+                Object.entries(combinedAnswers.commissionable).map(([recordType, records]) => [
+                    recordType,
+                    Array.from(records.values()),
+                ]),
+            );
+        }
+        if (combinedAnswers.addresses) {
+            result.addresses = combinedAnswers.addresses;
+        }
+
+        return result;
     }
 
     /**


### PR DESCRIPTION
fixes:

```
2024-12-20 21:23:37.548 - error: matter.0 (1814) Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch().
2024-12-20 21:23:37.549 - error: matter.0 (1814) unhandled promise rejection: Cannot convert undefined or null to object
2024-12-20 21:23:37.593 - error: matter.0 (1814) TypeError: Cannot convert undefined or null to object
at Function.values ()
at /opt/iobroker/node_modules/@matter/protocol/src/mdns/MdnsScanner.ts:152:61
at Array.flatMap ()
at /opt/iobroker/node_modules/@matter/protocol/src/mdns/MdnsScanner.ts:152:36
at Array.flatMap ()
at MdnsScanner.#sendQueries (/opt/iobroker/node_modules/@matter/protocol/src/mdns/MdnsScanner.ts:151:36)
at StandardTimer.callback (/opt/iobroker/node_modules/@matter/protocol/src/mdns/MdnsScanner.ts:249:74)
at Timeout. (/opt/iobroker/node_modules/@matter/general/src/time/Time.ts:180:18)
at listOnTimeout (node:internal/timers:581:17)
at processTimers (node:internal/timers:519:7)
2024-12-20 21:23:37.594 - error: matter.0 (1814) Cannot convert undefined or null to object
```