### PR TITLE
Remove workspace dependency from CHIP testing

### DIFF
--- a/packages/testing/src/chip/config.ts
+++ b/packages/testing/src/chip/config.ts
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Package } from "#tools";
-import { resolve } from "path";
 import { env } from "process";
 
 /**
@@ -54,8 +52,7 @@ export namespace Constants {
     export const initTimeout = 60_000;
     export const defaultTimeoutMs = 60_000;
 
-    export const matterJsRoot = Package.workspace.path;
-    export const localPicsOverrideFile = resolve(matterJsRoot, "packages/testing/src/chip/matter-js-pics.properties");
+    export const localPicsOverrideFile = "src/chip/matter-js-pics.properties";
 
     /**
      * We set the commissioning timeout value very low because this timeout is tested and waiting the default 180s.

--- a/packages/testing/src/chip/state.ts
+++ b/packages/testing/src/chip/state.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { Package } from "#tools";
 import { BackchannelCommand } from "../device/backchannel.js";
 import { Subject } from "../device/subject.js";
 import { Test } from "../device/test.js";
@@ -408,7 +409,8 @@ async function configurePics() {
     const ciPics = await State.container.read(ContainerPaths.chipPics);
     const pics = new PicsFile(ciPics, true);
 
-    const overrides = new PicsFile(Constants.localPicsOverrideFile);
+    const testing = Package.tools.findPackage("@matter/testing");
+    const overrides = new PicsFile(testing.resolve(Constants.localPicsOverrideFile));
     pics.patch(overrides);
 
     Values.maybePics = pics;


### PR DESCRIPTION
Previously CHIP testing would only work when run from within the a matter.js git clone.  Now it should work from installed packages as well.