### PR TITLE
Model diff tool

### DIFF
--- a/packages/cli-tool/src/cli.ts
+++ b/packages/cli-tool/src/cli.ts
@@ -4,8 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { Domain, DomainContext } from "#domain.js";
+import { CommandInput } from "#parser.js";
 import { repl } from "#repl.js";
-import { commander } from "#tools";
+import { Environment, LogFormat, MatterError } from "@matter/general";
 import "@matter/nodejs";
 import colors from "ansi-colors";
 import { stdout } from "process";
@@ -13,9 +15,74 @@ import { stdout } from "process";
 export async function main(argv: string[]) {
     colors.enabled = stdout.isTTY;
 
-    commander("matter", "Interact with the local Matter environment.").parse(argv);
+    let args = argv.slice(2);
+    if (!args.length) {
+        await repl();
+        return;
+    }
 
-    // TODO - REPL is enough for testing but need proper CLI
+    for (const arg of args) {
+        if (arg.startsWith("-")) {
+            if (arg === "--help") {
+                args = ["help"];
+            } else {
+                throw new MatterError(`Unknown command line argument ${arg}`);
+            }
+        } else {
+            // Identified command
+            break;
+        }
+    }
 
-    await repl();
+    const command: CommandInput = {
+        kind: "command",
+        name: args[0],
+        args: args.slice(1).map(arg => {
+            let js;
+            if (arg.startsWith("(")) {
+                js = arg;
+            } else {
+                js = JSON.stringify(arg);
+            }
+            return {
+                line: 0,
+                column: 0,
+                js,
+            };
+        }),
+    };
+
+    const cx: DomainContext = {
+        description: "matter.js",
+        env: Environment.default,
+
+        out(...text) {
+            stdout.write(text.join(""));
+        },
+
+        err(...text) {
+            let str = text.join("");
+            if (str.indexOf("\x1b") === -1) {
+                str = colors.red(str);
+            }
+            stdout.write(str);
+        },
+
+        get terminalWidth() {
+            return process.stdout.columns;
+        },
+
+        colorize: true,
+    };
+
+    const domain = await Domain(cx);
+    try {
+        const result = await domain.execute(command);
+        if (result !== undefined) {
+            domain.out(domain.inspect(result), "\n");
+        }
+    } catch (e) {
+        domain.err(LogFormat.ansi(e), "\n");
+        process.exitCode = 1;
+    }
 }

--- a/packages/cli-tool/src/commands/cat.ts
+++ b/packages/cli-tool/src/commands/cat.ts
@@ -12,7 +12,7 @@ Command({
     aliases: ["inspect"],
 
     invoke: async function cat(args) {
-        const locations = await Promise.all(args.map(path => this.location.at(`${path}`)));
+        const locations = await Promise.all(args._.map(path => this.location.at(`${path}`)));
         for (const location of locations) {
             this.out(this.inspect(location.definition), "\n");
         }

--- a/packages/cli-tool/src/commands/cd.ts
+++ b/packages/cli-tool/src/commands/cd.ts
@@ -11,8 +11,9 @@ Command({
     usage: "[PATH]",
     description: "Change current working directory.  If you omit PATH changes to the last node entered.",
     maxArgs: 1,
+    positionalArgs: [{ name: "path", description: "directory to enter", type: "string" }],
 
-    invoke: async function cd([path]) {
+    invoke: async function cd({ path }) {
         if (path === undefined) {
             path = this.env.vars.get("home", "/");
         } else {

--- a/packages/cli-tool/src/commands/command.ts
+++ b/packages/cli-tool/src/commands/command.ts
@@ -5,47 +5,117 @@
  */
 
 import { Domain } from "#domain.js";
-import { FormattedText, ImplementationError, MaybePromise } from "#general";
+import { decamelize, FormattedText, ImplementationError, MaybePromise } from "#general";
 import { bin } from "#globals.js";
+import { FieldValue, Metatype } from "#model";
 import colors from "ansi-colors";
 
-export interface CommandDefinition {
-    invoke: (this: Domain, args: unknown[], flags: Record<string, boolean>) => MaybePromise<unknown>;
+export interface CommandDefinition<
+    N extends CommandDefinition.ArgDescriptor[],
+    P extends CommandDefinition.ArgDescriptor[],
+    R extends CommandDefinition.ArgDescriptor,
+> {
+    invoke: (this: Domain, args: CommandDefinition.ArgValues<N, P, R>) => MaybePromise<unknown>;
     usage?: string | string[];
     description: string;
-    flagArgs?: Record<string, string>;
+    namedArgs?: N;
+    positionalArgs?: P;
+    restArgs?: R;
     minArgs?: number;
     maxArgs?: number;
     aliases?: string[];
 }
 
-export function Command({
+export namespace CommandDefinition {
+    export interface ArgDescriptor<T extends `${Metatype}` = any> {
+        name: string;
+        description: string;
+        type?: T;
+        default?: Metatype.Native<T>;
+    }
+
+    export type ArgValues<
+        N extends CommandDefinition.ArgDescriptor[],
+        P extends CommandDefinition.ArgDescriptor[],
+        R extends CommandDefinition.ArgDescriptor,
+    > = NamedArgValues<N> & NamedArgValues<P> & { _: ArgType<R>[] };
+
+    export type NamedArgValues<T extends CommandDefinition.ArgDescriptor[]> = {
+        [A in T[number] as A["name"]]: ArgType<A>;
+    };
+
+    export type ArgType<T extends CommandDefinition.ArgDescriptor> = T extends { type: string }
+        ? Metatype.Native<T["type"]>
+        : boolean;
+}
+
+export function Command<
+    const N extends CommandDefinition.ArgDescriptor[],
+    const P extends CommandDefinition.ArgDescriptor[],
+    const R extends CommandDefinition.ArgDescriptor,
+>({
     invoke: doInvoke,
     usage,
     description,
-    flagArgs,
+    namedArgs: namedArgDescriptors,
+    positionalArgs: positionalArgDescriptors,
+    restArgs: restArgDescriptor,
     minArgs,
     maxArgs,
     aliases,
-}: CommandDefinition) {
+}: CommandDefinition<N, P, R>) {
+    const args: Record<string, CommandDefinition.ArgDescriptor> = {
+        "--help": {
+            name: "help",
+            type: "boolean",
+            description: "Show this help",
+        },
+    };
+
+    const defaults = {} as Record<string, unknown>;
+
+    if (namedArgDescriptors) {
+        for (const arg of namedArgDescriptors) {
+            const long = arg.name.length > 1;
+            if (long) {
+                args[`--${arg.name}`] = { type: "boolean", ...arg };
+            } else {
+                args[`-${arg.name}`] = { type: "boolean", ...arg };
+            }
+            if (arg.default !== undefined) {
+                defaults[arg.name] = arg.default;
+            }
+        }
+    }
+
+    if (!positionalArgDescriptors) {
+        positionalArgDescriptors = [] as unknown as P;
+    }
+
     function help(domain: Domain) {
-        const flagDetails = [
-            ...Object.entries(flagArgs ?? {}).map(([k, v]) => [k.length > 1 ? `--${k}` : `-${k}`, v]),
+        const namedArgDetails = [
+            ...Object.entries(args ?? {}).map(([k, v]) => {
+                let description = v.description;
+                if (v.default !== undefined) {
+                    description = `${description} (default ${v.default})`;
+                }
+                return [k, description];
+            }),
             ["--help", "Show this help"],
         ];
 
-        const maxArgWidth = Math.max(...flagDetails.map(([arg]) => arg.length));
+        const maxArgWidth = Math.max(...namedArgDetails.map(([arg]) => arg.length));
         const argNameWidth = maxArgWidth + 4;
         const argDetailWidth = domain.terminalWidth - argNameWidth;
 
-        const argHelp = flagDetails.map(([arg, description]) => {
+        const argHelp = namedArgDetails.map(([arg, description]) => {
             arg = colors.blue(arg.padEnd(maxArgWidth));
             description = FormattedText(description, argDetailWidth).join("\n").replace(/\n/g, "".padEnd(maxArgWidth));
             return `  ${arg}  ${description}`;
         });
 
         let usageStr;
-        const name = colors.blue(doInvoke.name);
+        const name = colors.blue(decamelize(doInvoke.name));
         switch (typeof usage) {
             case "object":
                 usageStr = ["", ...usage.map(str => `${name}${str ? ` ${str}` : ""}`)].join("\n  ");
@@ -72,70 +142,101 @@ export function Command({
         );
     }
 
-    const { name } = doInvoke;
-    const command = function invoke(this: { domain: Domain }, ...args: unknown[]) {
+    const name = decamelize(doInvoke.name);
+    const command = function invoke(this: { domain: Domain }, ...argv: unknown[]) {
         const domain = this.domain;
         if (!domain?.isDomain) {
             throw new ImplementationError(`Domain command ${name} invoked without bin scope`);
         }
 
-        const otherArgs = Array<unknown>();
-        const flags = {} as Record<string, boolean>;
+        const positionalArgs = Array<unknown>();
+        const inputs = { ...defaults } as Record<string, unknown>;
 
-        for (const arg of args) {
+        for (let i = 0; i < argv.length; i++) {
+            let arg = argv[i] as string;
             if (typeof arg !== "string" || !arg.startsWith("-")) {
-                otherArgs.push(arg);
+                positionalArgs.push(arg);
                 continue;
             }
 
-            if (!flagArgs) {
-                domain.err(`Invalid argumetn: ${arg}\n`);
-                return;
+            const splitAt = arg.indexOf("=");
+            let name: string;
+            let param: unknown;
+            if (splitAt) {
+                param = arg.slice(splitAt + 1);
+                arg = arg.slice(0, splitAt);
             }
 
             if (arg[1] === "-") {
-                const name = arg.slice(2);
+                if (!(arg in args)) {
+                    domain.err(`Invalid argument: ${arg}\n`);
+                    return;
+                }
+
+                name = arg.slice(2);
 
                 if (name === "help") {
                     help(domain);
                     return;
                 }
+            } else {
+                for (let i = 0; i < arg.length; i++) {
+                    const subarg = `-${arg[i]}`;
+                    if (!(subarg in args)) {
+                        domain.err(`Invalid argument: ${subarg}\n`);
+                        return;
+                    }
 
-                if (!(name in flagArgs)) {
-                    domain.err(`Invalid argument: ${arg}\n`);
-                    return;
+                    if (i === arg.length - 1) {
+                        arg = subarg;
+                        name = arg[i];
+                    } else {
+                        if (args[subarg].type !== "boolean") {
+                            domain.err(`Argument "${subarg}" requires a parameter`);
+                            return;
+                        }
+                        inputs[subarg] = true;
+                        continue;
+                    }
                 }
-
-                flags[name] = true;
-                continue;
             }
 
-            for (const name of arg.slice(1).split("")) {
-                if (!(name in flagArgs)) {
-                    domain.err(`Invalid argument: ${arg}\n`);
-                    return;
+            const definition = args[arg];
+            if (param === undefined && definition.type !== "boolean") {
+                if (i === argv.length - 1) {
+                    domain.err(`Argument "${arg}" requires a parameter`);
                 }
-
-                if (!(name in flagArgs)) {
-                    domain.err(`Invalid argument: ${arg}\n`);
-                    return;
-                }
-
-                flags[name] = true;
+                param = argv[++i];
             }
+
+            inputs[name!] = FieldValue.cast((args[arg].type ?? "boolean") as Metatype, param);
         }
 
-        if (minArgs !== undefined && minArgs < args.length) {
+        if (minArgs !== undefined && minArgs < positionalArgs.length) {
             domain.err(`Too few arguments\n`);
             return;
         }
 
-        if (maxArgs !== undefined && maxArgs < args.length) {
+        if (maxArgs !== undefined && maxArgs < positionalArgs.length) {
             domain.err(`Too many arguments\n`);
             return;
         }
 
-        return doInvoke.call(domain, otherArgs, flags);
+        for (const arg of positionalArgDescriptors) {
+            if (!positionalArgs.length) {
+                break;
+            }
+            inputs[arg.name] =
+                arg.type === undefined ? positionalArgs.shift() : Metatype.cast(arg.type, positionalArgs.shift());
+        }
+
+        if (restArgDescriptor?.type === undefined) {
+            inputs._ = positionalArgs;
+        } else {
+            inputs._ = positionalArgs.map(arg => Metatype.cast(restArgDescriptor.type, arg));
+        }
+
+        return doInvoke.call(domain, inputs as CommandDefinition.ArgValues<N, P, R>);
     };
 
     command.help = help;

--- a/packages/cli-tool/src/commands/diff-spec.ts
+++ b/packages/cli-tool/src/commands/diff-spec.ts
@@ -1,0 +1,102 @@
+/**
+ * @license
+ * Copyright 2022-2024 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { AnyElement, ElementTag, Model, ModelDiff, Specification } from "#model";
+import { LogFormat, MatterError } from "@matter/general";
+import { Command } from "./command.js";
+
+Command({
+    usage: "[FROM] [TO]",
+    description: "Show differences between Matter versions.",
+    namedArgs: [
+        {
+            name: "d",
+            description: "maximum depth for details",
+            default: 2,
+            type: "integer",
+        },
+    ],
+    positionalArgs: [
+        {
+            name: "from",
+            description: "the baseline model",
+            type: "any",
+        },
+        {
+            name: "to",
+            description: "the target model",
+            type: "any",
+        },
+    ],
+    maxArgs: 2,
+
+    invoke: async function diffSpec({ d: depth, from, to }) {
+        if (to === undefined) {
+            to = Specification.REVISION;
+        }
+        const toModel = await loadModel(to);
+
+        if (from === undefined) {
+            let toRevision: string;
+            if ("revision" in toModel && typeof toModel.revision === "string") {
+                toRevision = toModel.revision;
+            } else {
+                toRevision = Specification.REVISION;
+            }
+            from = (Number.parseFloat(toRevision) - 0.1).toFixed(1);
+        }
+        const fromModel = await loadModel(from);
+
+        const diff = ModelDiff(fromModel, toModel, depth);
+        this.out(LogFormat.ansi(ModelDiff.diagnosticOf(diff)));
+    },
+});
+
+async function loadModel(source: unknown): Promise<Model> {
+    if (typeof source !== "string") {
+        const model = asModel(source);
+        if (model === undefined) {
+            throw new MatterError(`Input models must be Model, AnyElement, or a string import specifier`);
+        }
+        return model;
+    }
+
+    let importName;
+    if (source.match(/^\d+\.\d+$/)) {
+        importName = `@matter/intermediate-models/v${source}/spec`;
+    } else {
+        importName = source;
+    }
+    try {
+        const module = await import(importName);
+
+        for (const value of Object.values(module)) {
+            const model = asModel(value);
+            if (model) {
+                return model;
+            }
+        }
+
+        throw new MatterError(`Could not find an exported model in "${importName}"`);
+    } catch (cause) {
+        throw new MatterError(`Could not import "${importName}"`, { cause });
+    }
+}
+
+function asModel(value: unknown) {
+    if (value instanceof Model) {
+        return value;
+    }
+
+    if (
+        typeof value === "object" &&
+        value !== null &&
+        "tag" in value &&
+        Object.values(ElementTag).includes(value.tag as ElementTag)
+    ) {
+        return Model.create(value as AnyElement);
+    }
+}

--- a/packages/cli-tool/src/commands/help.ts
+++ b/packages/cli-tool/src/commands/help.ts
@@ -16,7 +16,7 @@ Command({
     description: "Display help",
     maxArgs: 1,
 
-    invoke: async function help([path]) {
+    invoke: async function help({ path }) {
         const quote = (text: string) => {
             if (this.colorize) {
                 return colors.blue(text);
@@ -26,7 +26,7 @@ Command({
 
         if (path === undefined) {
             const HELP = `This tool allows you to interact with matter.js and your local Matter environment.
-This tool understands both JavaScript and a shell-like syntax that maps "commands" to functions.  Type ${quote("ls /bin")} to see commands you can always use.  Type ${quote("help <name>")} for help with a specific command.
+This tool understands both JavaScript and a shell-like syntax that maps "commands" to functions.  Use ${quote("ls /bin")} to see commands you can always use.  Use ${quote("help <name>")} for help with a specific command.
 The current path appears in the prompt.  This points to the object this tool uses to find commands.  It is also the "global" object for any JavaScript statements you enter.
 You can change the current path using ${quote("cd <path>")}.  Paths work like you would expect, including ${quote("/")}, ${quote(".")} and ${quote("..")}.\n`;
 

--- a/packages/cli-tool/src/commands/index.ts
+++ b/packages/cli-tool/src/commands/index.ts
@@ -7,6 +7,7 @@
 import "./cat.js";
 import "./cd.js";
 import "./clear.js";
+import "./diff-spec.js";
 import "./exit.js";
 import "./help.js";
 import "./ls.js";

--- a/packages/cli-tool/src/commands/rm.ts
+++ b/packages/cli-tool/src/commands/rm.ts
@@ -10,11 +10,12 @@ import { Command } from "./command.js";
 Command({
     usage: "[PATH]...",
     description: "Deletes the properties at the paths you specify.",
+    restArgs: { name: "path", description: "path to remove", type: "string" },
 
-    invoke: async function rm(...args: unknown[]) {
+    invoke: async function rm(args) {
         const toDelete = Array<Location>();
 
-        for (const path of args) {
+        for (const path of args._) {
             const location = await this.location.at(`${path}`);
             if (!location.parent) {
                 this.err(`Invalid argument: Can't delete ${location.path}`);

--- a/packages/cli-tool/src/commands/set.ts
+++ b/packages/cli-tool/src/commands/set.ts
@@ -12,14 +12,15 @@ Command({
     description:
         'Set or display environment variables.  matter.js defines variables in a hierarchy with "." as a delimiter.  Variables persist across restarts.',
     maxArgs: 2,
+    restArgs: { name: "KV", description: "key and/or value", type: "string" },
 
     invoke: async function set(args) {
-        switch (args.length) {
+        switch (args._.length) {
             case 0:
                 return this.env.vars.vars;
 
             case 1:
-                const assignment = `${args[0]}`;
+                const assignment = `${args._[0]}`;
                 const equalPos = assignment.indexOf("=");
                 if (equalPos === -1) {
                     this.err("Invalid argument: parameter must be of the form key=value");
@@ -28,7 +29,7 @@ Command({
                 break;
 
             case 2:
-                await this.env.vars.persist(`${args[0]}`, args[1] as VariableService.Value);
+                await this.env.vars.persist(`${args._[0]}`, args._[1] as VariableService.Value);
                 break;
         }
     },

--- a/packages/cli-tool/src/parser.ts
+++ b/packages/cli-tool/src/parser.ts
@@ -232,11 +232,12 @@ export namespace isCommand {
     ];
 
     const IDENTIFIER = "[\\p{L}$_][\\p{L}$_0-9]*";
+    const PATH_SEGMENT = "[\\p{L}$_][\\p{L}$_\\-0-9]*";
     const EOW = "(?:\\s|$)";
 
     const statementStarts = [...STATEMENT_KEYWORDS.map(kw => `${kw}${EOW}`), `${IDENTIFIER}\\s*=`];
 
-    const commandStarts = ["\\.", "\\.\\.", `\\s*(?:\\.?\\.?/)?${IDENTIFIER}(?:\\/(?:\\.?\\.|${IDENTIFIER}))*`];
+    const commandStarts = ["\\.", "\\.\\.", `\\s*(?:\\.?\\.?/)?${PATH_SEGMENT}(?:\\/(?:\\.?\\.|${PATH_SEGMENT}))*`];
 
     // If this regexp matches, input is NOT a command
     export const STATEMENT_DETECTOR = new RegExp(`^\\s*(?:${statementStarts.join("|")})`, "u");

--- a/packages/general/src/log/Diagnostic.ts
+++ b/packages/general/src/log/Diagnostic.ts
@@ -74,6 +74,16 @@ export namespace Diagnostic {
          * Path, resource or session identifier.
          */
         Via = "via",
+
+        /**
+         * Resource that was added.
+         */
+        Added = "added",
+
+        /**
+         * Resource that was removed.
+         */
+        Deleted = "deleted",
     }
 
     export interface Context {
@@ -179,6 +189,20 @@ export namespace Diagnostic {
         const via = new String(value);
         Object.defineProperty(via, presentation, { value: Presentation.Via });
         return via as string;
+    }
+
+    /**
+     * Create a value identifying a resource that was added.
+     */
+    export function added(value: unknown) {
+        return Diagnostic(Diagnostic.Presentation.Added, value);
+    }
+
+    /**
+     * Create a value identifying a resource that was removed.
+     */
+    export function deleted(value: unknown) {
+        return Diagnostic(Diagnostic.Presentation.Deleted, value);
     }
 
     /**

--- a/packages/model/src/common/FieldValue.ts
+++ b/packages/model/src/common/FieldValue.ts
@@ -254,7 +254,7 @@ export namespace FieldValue {
      *
      * @returns the cast value or FieldValue.Invalid if cast is not possible
      */
-    export function cast(type: Metatype, value: any): FieldValue | FieldValue.Invalid | undefined {
+    export function cast<const T extends Metatype>(type: T, value: any): FieldValue | FieldValue.Invalid | undefined {
         if (value === undefined || value === null || type === "any") {
             return value;
         }

--- a/packages/model/src/common/Metatype.ts
+++ b/packages/model/src/common/Metatype.ts
@@ -75,6 +75,27 @@ export namespace Metatype {
     }
 
     /**
+     * Map metatype value to JS type.
+     */
+    export type Native<T> = T extends "boolean"
+        ? boolean
+        : T extends "integer" | "float"
+          ? number
+          : T extends "string"
+            ? string
+            : T extends "bitmap" | "object"
+              ? Record<string, unknown>
+              : T extends "array"
+                ? unknown[]
+                : T extends "bytes"
+                  ? Uint8Array
+                  : T extends "date"
+                    ? Date
+                    : T extends "any"
+                      ? unknown
+                      : never;
+
+    /**
      * Functions that perform conversion of arbitrary values to a metatype.
      *
      * This is a "best effort" that ensures the value is an appropriate JS type but cannot ensure semantic validity in
@@ -82,243 +103,241 @@ export namespace Metatype {
      *
      * @throws {@link UnsupportedCastError} if the cast is deemed impossible
      */
-    export const cast: Record<Metatype, (value: any) => any> = {
-        any(value: any) {
+    export function cast<const T extends `${Metatype}`>(type: T, value: unknown) {
+        const caster = cast[type];
+        return caster(value) as Native<T>;
+    }
+
+    cast.any = (value: unknown) => value;
+
+    cast.boolean = (value: unknown): boolean | null | undefined => {
+        if (typeof value === "boolean" || value === null || value === undefined) {
             return value;
-        },
+        }
 
-        boolean(value: any): boolean | null | undefined {
-            if (typeof value === "boolean" || value === null || value === undefined) {
-                return value;
+        if (typeof value === "string") {
+            const normalized = value.toLowerCase().trim();
+            switch (normalized) {
+                case "":
+                case "0":
+                case "off":
+                case "no":
+                case "false":
+                    return false;
+
+                case "1":
+                case "on":
+                case "yes":
+                case "true":
+                    return true;
             }
+        }
 
-            if (typeof value === "string") {
-                const normalized = value.toLowerCase().trim();
-                switch (normalized) {
-                    case "":
-                    case "0":
-                    case "off":
-                    case "no":
-                    case "false":
-                        return false;
+        if (typeof value === "number" || typeof value === "bigint") {
+            return !!value;
+        }
 
-                    case "1":
-                    case "on":
-                    case "yes":
-                    case "true":
-                        return true;
+        if (ArrayBuffer.isView(value)) {
+            for (const byte of new Uint8Array(value.buffer)) {
+                if (byte) {
+                    return true;
                 }
             }
+            return false;
+        }
 
-            if (typeof value === "number" || typeof value === "bigint") {
-                return !!value;
+        throw new UnsupportedCastError(`Cannot convert "${value}" to boolean`);
+    };
+
+    cast.bitmap = (value: any): number | bigint | Record<string, number> | null | undefined => {
+        if (value === null || value === undefined) {
+            return value;
+        }
+
+        if (typeof value === "string") {
+            value = cast.integer(value);
+        }
+
+        if (typeof value === "number") {
+            if (Number.isFinite(value)) {
+                return value;
             }
+        } else if (typeof value === "bigint") {
+            return value;
+        } else if (isObject(value)) {
+            return Object.fromEntries(Object.entries(value).map(([k, v]) => [k, cast.integer(v)])) as Record<
+                string,
+                number
+            >;
+        }
 
-            if (ArrayBuffer.isView(value)) {
-                for (const byte of new Uint8Array(value.buffer)) {
-                    if (byte) {
-                        return true;
-                    }
+        throw new UnsupportedCastError(`Cannot convert "${value}" to bitmap`);
+    };
+
+    cast.enum = (value: any): number | string | null | undefined => {
+        if (typeof value === "string") {
+            if (value.trim().match(/^(?:[0-9]+|0x[0-9a-f]+|0b[01]+)$/)) {
+                value = Number.parseInt(value);
+            } else {
+                return value;
+            }
+        }
+
+        if (typeof value === "number" && !Number.isNaN(value) && Number.isFinite(value)) {
+            return value;
+        }
+
+        throw new UnsupportedCastError(`Cannot convert "${value}" to an enum value`);
+    };
+
+    cast.integer = (value: any): number | bigint | null | undefined => {
+        if (value === null || value === undefined) {
+            return value;
+        }
+
+        switch (typeof value) {
+            case "number":
+                return Math.floor(value);
+
+            case "bigint":
+                return value;
+
+            case "boolean":
+                return value ? 1 : 0;
+        }
+
+        if (value instanceof Date) {
+            return value.getTime();
+        }
+
+        if (typeof value === "string") {
+            try {
+                const big = BigInt(value);
+                const little = Number.parseInt(value);
+                if (big === BigInt(little)) {
+                    return little;
                 }
-                return false;
-            }
-
-            throw new UnsupportedCastError(`Cannot convert "${value}" to boolean`);
-        },
-
-        bitmap(value: any): number | bigint | Record<string, number> | null | undefined {
-            if (value === null || value === undefined) {
-                return value;
-            }
-
-            if (typeof value === "string") {
-                value = cast.integer(value);
-            }
-
-            if (typeof value === "number") {
-                if (Number.isFinite(value)) {
-                    return value;
-                }
-            } else if (typeof value === "bigint") {
-                return value;
-            } else if (isObject(value)) {
-                return Object.fromEntries(Object.entries(value).map(([k, v]) => [k, cast.integer(v)])) as Record<
-                    string,
-                    number
-                >;
-            }
-
-            throw new UnsupportedCastError(`Cannot convert "${value}" to bitmap`);
-        },
-
-        enum(value: any): number | string | null | undefined {
-            if (typeof value === "string") {
-                if (value.trim().match(/^(?:[0-9]+|0x[0-9a-f]+|0b[01]+)$/)) {
-                    value = Number.parseInt(value);
-                } else {
-                    return value;
-                }
-            }
-
-            if (typeof value === "number" && !Number.isNaN(value) && Number.isFinite(value)) {
-                return value;
-            }
-
-            throw new UnsupportedCastError(`Cannot convert "${value}" to an enum value`);
-        },
-
-        integer(value: any): number | bigint | null | undefined {
-            if (value === null || value === undefined) {
-                return value;
-            }
-
-            switch (typeof value) {
-                case "number":
-                    return Math.floor(value);
-
-                case "bigint":
-                    return value;
-
-                case "boolean":
-                    return value ? 1 : 0;
-            }
-
-            if (value instanceof Date) {
-                return value.getTime();
-            }
-
-            if (typeof value === "string") {
-                try {
-                    const big = BigInt(value);
-                    const little = Number.parseInt(value);
-                    if (big === BigInt(little)) {
-                        return little;
-                    }
-                    return big;
-                } catch (e) {
-                    if (!(e instanceof SyntaxError)) {
-                        throw e;
-                    }
+                return big;
+            } catch (e) {
+                if (!(e instanceof SyntaxError)) {
+                    throw e;
                 }
             }
+        }
 
-            throw new UnsupportedCastError(`Cannot convert "${value}" to an integer`);
-        },
+        throw new UnsupportedCastError(`Cannot convert "${value}" to an integer`);
+    };
 
-        float(value: any): number | null | undefined {
-            if (typeof value === "number" || value === null || value === undefined) {
-                return value;
-            }
+    cast.float = (value: any): number | null | undefined => {
+        if (typeof value === "number" || value === null || value === undefined) {
+            return value;
+        }
 
-            if (value instanceof Date) {
-                return value.getTime();
-            }
+        if (value instanceof Date) {
+            return value.getTime();
+        }
 
-            const number = Number(value);
-            if (!Number.isNaN(number) && Number.isFinite(value)) {
-                return number;
-            }
+        const number = Number(value);
+        if (!Number.isNaN(number) && Number.isFinite(value)) {
+            return number;
+        }
 
-            throw new UnsupportedCastError(`Cannot convert "${value}" to a float`);
-        },
+        throw new UnsupportedCastError(`Cannot convert "${value}" to a float`);
+    };
 
-        bytes(value: any): Uint8Array | null | undefined {
-            if (value === undefined || value === null || value instanceof Uint8Array) {
-                return value;
-            }
+    cast.bytes = (value: any): Uint8Array | null | undefined => {
+        if (value === undefined || value === null || value instanceof Uint8Array) {
+            return value;
+        }
 
-            if (typeof value === "string") {
-                return Bytes.fromHex(value);
-            }
+        if (typeof value === "string") {
+            return Bytes.fromHex(value);
+        }
 
-            if (typeof value === "boolean") {
-                return new Uint8Array([value ? 1 : 0]);
-            }
+        if (typeof value === "boolean") {
+            return new Uint8Array([value ? 1 : 0]);
+        }
 
-            if (typeof value === "number" || typeof value === "bigint") {
-                return Bytes.fromHex(value.toString(16));
-            }
+        if (typeof value === "number" || typeof value === "bigint") {
+            return Bytes.fromHex(value.toString(16));
+        }
 
-            throw new UnsupportedCastError(`Cannot convert "${value}" to bytes`);
-        },
+        throw new UnsupportedCastError(`Cannot convert "${value}" to bytes`);
+    };
 
-        array(value: any): Array<unknown> | null | undefined {
-            if (value === undefined || value === null || Array.isArray(value)) {
-                return value;
-            }
+    cast.array = (value: any): Array<unknown> | null | undefined => {
+        if (value === undefined || value === null || Array.isArray(value)) {
+            return value;
+        }
 
-            if (typeof value === "string") {
-                try {
-                    const parsed = JSON.parse(value);
-                    if (Array.isArray(parsed)) {
-                        return parsed;
-                    }
-                } catch (e) {
-                    if (!(e instanceof SyntaxError)) {
-                        throw e;
-                    }
-                }
-            }
-
-            throw new UnsupportedCastError(`Cannot convert "${value}" to array`);
-        },
-
-        object(value: any): Record<string, unknown> | null | undefined {
-            if (
-                value === undefined ||
-                (typeof value === "object" && !Array.isArray(value) && !(value instanceof Date))
-            ) {
-                return value;
-            }
-
-            if (typeof value === "string") {
-                try {
-                    const parsed = JSON.parse(value);
+        if (typeof value === "string") {
+            try {
+                const parsed = JSON.parse(value);
+                if (Array.isArray(parsed)) {
                     return parsed;
-                } catch (e) {
-                    if (!(e instanceof SyntaxError)) {
-                        throw e;
-                    }
+                }
+            } catch (e) {
+                if (!(e instanceof SyntaxError)) {
+                    throw e;
                 }
             }
+        }
 
-            throw new UnsupportedCastError(`Cannot convert "${value}" to object`);
-        },
+        throw new UnsupportedCastError(`Cannot convert "${value}" to array`);
+    };
 
-        string(value: any): string | null | undefined {
-            if (value === undefined || value === null) {
-                return value;
-            }
+    cast.object = (value: any): Record<string, unknown> | null | undefined => {
+        if (value === undefined || (typeof value === "object" && !Array.isArray(value) && !(value instanceof Date))) {
+            return value;
+        }
 
-            if (typeof value === "string") {
-                return value;
-            }
-
-            if (value instanceof Date) {
-                return value.toISOString();
-            }
-
-            if (typeof value === "object" || Array.isArray(value)) {
-                return JSON.stringify(value);
-            }
-
-            return value.toString();
-        },
-
-        date(value: any): Date | null | undefined {
-            if (value === undefined || value === null || value instanceof Date) {
-                return value;
-            }
-
-            if (typeof value === "number" || typeof value === "string") {
-                const date = new Date(value);
-                if (!Number.isNaN(date.getTime())) {
-                    return date;
+        if (typeof value === "string") {
+            try {
+                const parsed = JSON.parse(value);
+                return parsed;
+            } catch (e) {
+                if (!(e instanceof SyntaxError)) {
+                    throw e;
                 }
             }
+        }
 
-            throw new UnexpectedDataError();
-        },
+        throw new UnsupportedCastError(`Cannot convert "${value}" to object`);
+    };
+
+    cast.string = (value: any): string | null | undefined => {
+        if (value === undefined || value === null) {
+            return value;
+        }
+
+        if (typeof value === "string") {
+            return value;
+        }
+
+        if (value instanceof Date) {
+            return value.toISOString();
+        }
+
+        if (typeof value === "object" || Array.isArray(value)) {
+            return JSON.stringify(value);
+        }
+
+        return value.toString();
+    };
+
+    cast.date = (value: any): Date | null | undefined => {
+        if (value === undefined || value === null || value instanceof Date) {
+            return value;
+        }
+
+        if (typeof value === "number" || typeof value === "string") {
+            const date = new Date(value);
+            if (!Number.isNaN(date.getTime())) {
+                return date;
+            }
+        }
+
+        throw new UnexpectedDataError();
     };
 
     /**

--- a/packages/model/src/common/Specification.ts
+++ b/packages/model/src/common/Specification.ts
@@ -44,7 +44,7 @@ export namespace Specification {
     /**
      * Matter specification version.
      */
-    export type Revision = `${number}.${number}`;
+    export type Revision = `${number}.${number}` | `${number}.${number}.${number}.${number}`;
 
     /**
      * The default specification revision for Matter.js.

--- a/packages/model/src/logic/ModelDiff.ts
+++ b/packages/model/src/logic/ModelDiff.ts
@@ -1,0 +1,150 @@
+/**
+ * @license
+ * Copyright 2022-2024 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ElementTag } from "#common/ElementTag.js";
+import { Specification } from "#index.js";
+import { Model } from "#models/Model.js";
+import { Diagnostic } from "@matter/general";
+import { ModelVariantTraversal, VariantDetail } from "./ModelVariantTraversal.js";
+
+/**
+ * A high level summary of changes between two models.
+ */
+export type ModelDiff = ModelDiff.Add | ModelDiff.Delete | ModelDiff.List | ModelDiff.Summary;
+
+/**
+ * Diff two models.
+ */
+export function ModelDiff(from: Model, to: Model, depth = 2) {
+    const traversal = new DiffTraversal(depth);
+    return traversal.traverse({ from, to });
+}
+
+class DiffTraversal extends ModelVariantTraversal<ModelDiff | undefined> {
+    #detailDepth: number;
+    #currentDepth = 0;
+
+    constructor(depth: number) {
+        super(Specification.REVISION, ["from", "to"]);
+        this.#detailDepth = depth;
+    }
+
+    protected override visit(variants: VariantDetail, recurse: () => (ModelDiff | undefined)[]): ModelDiff | undefined {
+        if (variants.map.to === undefined) {
+            if (variants.map.from === undefined) {
+                return;
+            }
+            return {
+                kind: "delete",
+                tag: variants.tag,
+                name: variants.name,
+            };
+        }
+
+        if (variants.map.from === undefined) {
+            return {
+                kind: "add",
+                tag: variants.tag,
+                name: variants.name,
+            };
+        }
+
+        if (this.#currentDepth >= this.#detailDepth) {
+            return;
+        }
+
+        this.#currentDepth++;
+        const children = recurse().filter(child => child !== undefined);
+        this.#currentDepth--;
+
+        if (!children.length) {
+            return;
+        }
+
+        if (this.#currentDepth < this.#detailDepth - 1) {
+            return {
+                kind: "list",
+                tag: variants.tag,
+                name: variants.name,
+                children,
+            };
+        }
+
+        const changes = {} as ModelDiff.Summary["changes"];
+        for (const child of children) {
+            changes[child.tag] = (changes[child.tag] ?? 0) + 1;
+        }
+
+        return {
+            kind: "summary",
+            tag: variants.tag,
+            name: variants.name,
+            changes,
+        };
+    }
+}
+
+export namespace ModelDiff {
+    /**
+     * Convert a diff to a diagnostic for serialization.
+     */
+    export function diagnosticOf(diff: ModelDiff | undefined): unknown {
+        const id = `${diff?.tag}#${diff?.name}`;
+        switch (diff?.kind) {
+            case "add":
+                return Diagnostic.added(id);
+
+            case "delete":
+                return Diagnostic.deleted(id);
+
+            case "list":
+                if (diff.children.length) {
+                    return [id, Diagnostic.list(diff.children.map(diagnosticOf))];
+                }
+                break;
+
+            case "summary":
+                const changes = Object.entries(diff.changes).map(([tag, count]) => {
+                    if (count < 0) {
+                        return Diagnostic.deleted(`${-count} ${tag}`);
+                    }
+
+                    if (count > 0) {
+                        return Diagnostic.added(`${count} ${tag}`);
+                    }
+
+                    return Diagnostic.weak(`${0} ${tag}`);
+                });
+
+                return [`${id}`, ...changes];
+        }
+
+        return Diagnostic.weak("(unchanged)");
+    }
+
+    export interface Identity {
+        name: string;
+        tag: ElementTag;
+    }
+
+    export interface Add extends Identity {
+        kind: "add";
+    }
+
+    export interface Delete extends Identity {
+        kind: "delete";
+    }
+
+    export interface List extends Identity {
+        kind: "list";
+        children: ModelDiff[];
+    }
+
+    export interface Summary extends Identity {
+        kind: "summary";
+        changes: Record<ElementTag, number>;
+    }
+}

--- a/packages/model/src/logic/index.ts
+++ b/packages/model/src/logic/index.ts
@@ -12,6 +12,7 @@ export * from "./cluster-variance/VarianceCondition.js";
 export * from "./ClusterVariance.js";
 export * from "./DefaultValue.js";
 export * from "./MergedModel.js";
+export * from "./ModelDiff.js";
 export * from "./ModelVariantTraversal.js";
 export * from "./Scope.js";
 export * from "./ValidateModel.js";

--- a/packages/node/src/behavior/state/managed/values/ValueCaster.ts
+++ b/packages/node/src/behavior/state/managed/values/ValueCaster.ts
@@ -78,5 +78,5 @@ function ListCaster(schema: ValueModel, owner: RootSupervisor) {
     const castToArray = Metatype.cast.array;
     const castEntry = owner.get(entry).cast;
 
-    return (value: any) => castToArray(value).map(castEntry);
+    return (value: any) => castToArray(value)?.map(castEntry);
 }


### PR DESCRIPTION
Adds "diff-spec" command that diffs any two models and summarizes changes between them.  Depth of details is configurable and output is a color-coded summary.  Without arguments, diffs the current model against the previous model.  With arguments you may specify the from/to models either as a spec version or specific model or element object.

Logic is also available as an API in the model package.

Upgrades CLI input parsing to support non-boolean arguments and typed argument access.  Converts other commands to use new API.

Adds support for running commands directly from command line so you can do e.g. `matter diff-spec`.

Implements general `FieldValue.cast` function that maps cast to proper type-specific implementation.

Adds "added" and "deleted" diagnostic display formats.