### PR TITLE
Resurrect web tests with `npm test` at root

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "version": "node packages/tools/bin/version.js",
     "build-clean": "node packages/tools/bin/build.js --clean",
     "build-doc": "node packages/tools/bin/build.js docs",
-    "test": "matter-test",
+    "test": "matter-test -w",
     "lint": "eslint \"**/*.ts\"",
     "lint-fix": "eslint --fix \"**/*.ts\"",
     "format": "prettier --write 'packages/**/*.ts' 'codegen/**/*.ts' 'chip-testing/**/*.ts' 'compat/**/*.ts'",

--- a/packages/tools/src/util/package.ts
+++ b/packages/tools/src/util/package.ts
@@ -387,6 +387,7 @@ export type PackageJson = {
     matter?: {
         test?: boolean;
     };
+    scripts?: Record<string, string>;
     [key: string]: any;
 };
 


### PR DESCRIPTION
These were lost when we converted cross-workspace builds to use the graph instead of NPM.