### PR TITLE
New constraint parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: Fixes commissionable devices discovery with timeout
     - FIx: Restores the possibility to cancel a (continuous) discovery for commissionable devices
 
+-   @matter/model
+    - Feature: The constraint evaluator now supports simple mathematical expressions
+
 -   @project-chip/matter.js
     - Feature: (Breaking) Added Fabric Label for Controller as required property to initialize the Controller
         including setting the Fabric Label when commissioning and validating and updating the Fabric Label on

--- a/packages/model/src/common/FieldValue.ts
+++ b/packages/model/src/common/FieldValue.ts
@@ -155,7 +155,7 @@ export namespace FieldValue {
             return `${(value as Celsius).value}°C`;
         }
         if (is(value, percent)) {
-            return `${(value as Percent).value}%';`;
+            return `${(value as Percent).value}%`;
         }
         if (is(value, properties)) {
             return stringSerialize((value as Properties).properties) ?? "?";

--- a/packages/model/src/logic/definition-validation/ValueValidator.ts
+++ b/packages/model/src/logic/definition-validation/ValueValidator.ts
@@ -49,7 +49,7 @@ export class ValueValidator<T extends ValueModel> extends ModelValidator<T> {
     private validateAspect(name: string) {
         const aspect = (this.model as any)[name] as Aspect;
         if (aspect?.errors) {
-            aspect.errors.forEach((e: DefinitionError) => this.model.error(e.code, e.message));
+            aspect.errors.forEach((e: DefinitionError) => this.model.error(e.code, `${e.source}: ${e.message}`));
         }
     }
 

--- a/packages/model/src/parser/Token.ts
+++ b/packages/model/src/parser/Token.ts
@@ -18,7 +18,11 @@ export interface Token {
 /**
  * The base token produced by the tokenizer.
  */
-export type BasicToken = BasicToken.Special | BasicToken.Word | BasicToken.Number;
+export type BasicToken<KW extends string[] = []> =
+    | BasicToken.Special
+    | BasicToken.Word
+    | BasicToken.Number
+    | BasicToken.Keyword<KW>;
 
 /**
  * A {@link BasicToken} with additional keywords.
@@ -60,5 +64,9 @@ export namespace BasicToken {
     export interface Number extends Token {
         type: "value";
         value: FieldValue;
+    }
+
+    export interface Keyword<T extends string[]> extends Token {
+        type: T[number];
     }
 }

--- a/packages/model/src/parser/TokenStream.ts
+++ b/packages/model/src/parser/TokenStream.ts
@@ -50,10 +50,10 @@ export function TokenStream<T extends Token>(iterator: Iterator<T>): TokenStream
                     return "end of statement";
 
                 case "word":
-                    return `word "${(this.token as unknown as BasicToken.Word).value}`;
+                    return `word "${(this.token as unknown as BasicToken.Word).value}"`;
 
                 case "number":
-                    return `number "${(this.token as unknown as BasicToken.Number).value}`;
+                    return `number "${(this.token as unknown as BasicToken.Number).value}"`;
 
                 default:
                     if (this.token?.type.match(/[a-z]/i)) {

--- a/packages/model/test/MatterTest.ts
+++ b/packages/model/test/MatterTest.ts
@@ -22,7 +22,7 @@ describe("MatterDefinition", () => {
 
     it("has not increased in errors", () => {
         validate().report();
-        expect(validationResult?.errors.length).most(16);
+        expect(validationResult?.errors.length).most(2);
     });
 
     it("has not decreased in scope", () => {

--- a/packages/model/test/aspects/ConstraintTest.ts
+++ b/packages/model/test/aspects/ConstraintTest.ts
@@ -10,6 +10,9 @@ const TEST_CONSTRAINTS: [text: string, ast: Constraint.Ast, expectedText?: strin
     ["0", { value: 0 }],
     ["desc", { desc: true }],
     ["4", { value: 4 }],
+    ["4%", { value: { type: "percent", value: 4 } }],
+    ["4°C", { value: { type: "celsius", value: 4 } }],
+    ["3.141592", { value: 3.141592 }],
     ["min 4", { min: 4 }],
     ["max 4", { max: 4 }],
     ["4 to 44", { min: 4, max: 44 }],
@@ -17,6 +20,7 @@ const TEST_CONSTRAINTS: [text: string, ast: Constraint.Ast, expectedText?: strin
     ["0xff to 0xffff", { min: 255, max: 65535 }, "255 to 65535"],
     ["4[44]", { value: 4, entry: { value: 44 } }],
     ["4, 44", { parts: [{ value: 4 }, { value: 44 }] }],
+    ["in foo", { in: { type: "reference", name: "foo" } }],
     [
         "4[44, 444], 5[max 55, min 555]",
         {
@@ -34,6 +38,34 @@ const TEST_CONSTRAINTS: [text: string, ast: Constraint.Ast, expectedText?: strin
                     },
                 },
             ],
+        },
+    ],
+    [
+        "(foo - 2)",
+        {
+            value: {
+                type: "-",
+                lhs: {
+                    type: "reference",
+                    name: "foo",
+                },
+                rhs: 2,
+            },
+        },
+    ],
+    [
+        "4 to (foo + 2)",
+        {
+            min: 4,
+
+            max: {
+                type: "+",
+                lhs: {
+                    type: "reference",
+                    name: "foo",
+                },
+                rhs: 2,
+            },
         },
     ],
 ];

--- a/packages/node/test/behavior/state/validation/constraintTest.ts
+++ b/packages/node/test/behavior/state/validation/constraintTest.ts
@@ -34,6 +34,20 @@ const AllTests = Tests({
         "accepts if reference value is null": { record: { test: 3, minVal: null } },
     }),
 
+    "min with expression": Tests(Fields({ constraint: "min (MinVal + 1)" }, { name: "MinVal", quality: "X" }), {
+        "accepts if over": { record: { test: 6, minVal: 4 } },
+        "rejects if under": {
+            record: { test: 4, minVal: 4 },
+            error: {
+                type: ConstraintError,
+                message:
+                    'Validating Test.test: Constraint "min (minVal + 1)": Value 4 is not within bounds defined by constraint',
+            },
+        },
+        "accepts if reference value is missing": { record: { test: 3 } },
+        "accepts if reference value is null": { record: { test: 3, minVal: null } },
+    }),
+
     max: Tests(Fields({ constraint: "max 4" }), {
         "rejects if over": {
             record: { test: 5 },


### PR DESCRIPTION
* Replaces the constraint parser with less embarrassing implementation

* Adds basic expression support to the constraint parser and interpreter

* Fixes bugs in previously-unused portions of lexer

* Adds constraint tests

Depends on #1583
