### PR TITLE
Logging Optimization and Restructuring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The main work (all changes without a GitHub username in brackets in the below li
 -   @matter/protocol
     - Feature: Reworks Event server handling and optionally allow Non-Volatile event storage (currently mainly used in tests)
     - Enhancement: Adds a too-fast-resubmission guard for Unicast MDNS messages
+    - Enhancement: Optimized Logging for messages in various places
     - Fix: Corrects some Batch invoke checks and logic
     - Fix: Fixes MDNS discovery duration for retransmission cases to be 5s
     - Fix: Processes all TXT/SRV records in MDNS messages and optimized the processing

--- a/packages/general/src/log/Diagnostic.ts
+++ b/packages/general/src/log/Diagnostic.ts
@@ -365,6 +365,17 @@ export namespace Diagnostic {
     export function hex(value: number | bigint) {
         return `0x${value.toString(16)}`;
     }
+
+    export function keylikeFlags(flags: Record<string, unknown>) {
+        return Diagnostic.keylike(Diagnostic.flags(flags));
+    }
+
+    export function flags(flags: Record<string, unknown>) {
+        return Object.entries(flags)
+            .filter(([, value]) => !!value)
+            .map(([key]) => key)
+            .join(" ");
+    }
 }
 
 function formatError(error: any, options: { messagePrefix?: string; parentStack?: string[] } = {}) {

--- a/packages/general/src/log/Diagnostic.ts
+++ b/packages/general/src/log/Diagnostic.ts
@@ -249,11 +249,19 @@ export namespace Diagnostic {
     /**
      * Create a K/V map that presents with formatted keys.
      */
-    export function dict(entries: object): Record<string, unknown> & Diagnostic {
-        return {
+    export function dict(entries: object, suppressUndefinedValues = false): Record<string, unknown> & Diagnostic {
+        const result: any = {
             ...entries,
             [presentation]: Diagnostic.Presentation.Dictionary,
         };
+        if (suppressUndefinedValues) {
+            for (const key in result) {
+                if (result[key] === undefined) {
+                    delete result[key];
+                }
+            }
+        }
+        return result;
     }
 
     /**

--- a/packages/general/src/log/Diagnostic.ts
+++ b/packages/general/src/log/Diagnostic.ts
@@ -61,6 +61,11 @@ export namespace Diagnostic {
         Weak = "weak",
 
         /**
+         * A keylike diagnostic.  The key gets suppressed and the value is rendered as a key.
+         */
+        Keylike = "keylike",
+
+        /**
          * An error message diagnostic.
          */
         Error = "error",
@@ -177,6 +182,13 @@ export namespace Diagnostic {
      */
     export function weak(value: unknown) {
         return Diagnostic(Diagnostic.Presentation.Weak, value);
+    }
+
+    /**
+     * Create a value presented as key
+     */
+    export function keylike(value: string) {
+        return Diagnostic(Diagnostic.Presentation.Keylike, value);
     }
 
     /**

--- a/packages/general/src/log/LogFormat.ts
+++ b/packages/general/src/log/LogFormat.ts
@@ -8,6 +8,7 @@ import { ImplementationError, InternalError, MatterError } from "../MatterError.
 import { Bytes } from "../util/Bytes.js";
 import { Lifecycle } from "../util/Lifecycle.js";
 import { serialize } from "../util/String.js";
+import { isObject } from "../util/Type.js";
 import { Diagnostic } from "./Diagnostic.js";
 import { LogLevel } from "./LogLevel.js";
 

--- a/packages/general/src/log/LogFormat.ts
+++ b/packages/general/src/log/LogFormat.ts
@@ -67,6 +67,7 @@ interface Formatter {
     indent(producer: DiagnosticProducer): string;
     break(): string;
     key(text: string): string;
+    keylike(text: string): string;
     value(producer: DiagnosticProducer): string;
     strong(producer: DiagnosticProducer): string;
     weak(producer: DiagnosticProducer): string;
@@ -133,6 +134,7 @@ function formatPlain(diagnostic: unknown, indents = 0) {
             } ${message.facility} ${message.prefix}${formattedValues}`;
         },
         key: text => creator.text(`${text}: `),
+        keylike: text => creator.text(`${text}`),
         value: producer => creator.text(producer()),
         strong: producer => creator.text(`*${producer()}*`),
         weak: producer => creator.text(producer()),
@@ -269,6 +271,8 @@ function formatAnsi(diagnostic: unknown, indents = 0) {
         },
 
         key: text => creator.text(style("key", `${text}: `)),
+
+        keylike: text => creator.text(style("key", `${text}`)),
 
         value: producer => {
             styles.push("value");
@@ -433,6 +437,7 @@ function formatHtml(diagnostic: unknown) {
         break: () => "<br/>",
         indent: producer => htmlSpan("indent", producer()),
         key: text => htmlSpan("key", `${escape(text)}:`) + " ",
+        keylike: text => htmlSpan("key", `${escape(text)}`),
         value: producer => htmlSpan("value", producer()),
         strong: producer => `<em>${producer()}</em>`,
         weak: producer => htmlSpan("weak", producer()),
@@ -523,8 +528,20 @@ function renderDictionary(value: object, formatter: Formatter) {
         if (parts.length) {
             parts.push(" ");
         }
-        parts.push(formatter.key(k));
-        parts.push(formatter.value(() => renderDiagnostic(v, formatter)));
+        const suppressKey =
+            isObject(v) && (v as Diagnostic)[Diagnostic.presentation] === Diagnostic.Presentation.Keylike;
+        if (!suppressKey) {
+            parts.push(formatter.key(k));
+        }
+        const formattedValue = formatter.value(() => renderDiagnostic(v, formatter));
+        if (!suppressKey || formattedValue.length) {
+            parts.push(formattedValue);
+        } else {
+            // if keylike but the value is empty we need to remove the last  space if added above
+            if (parts.length && parts[parts.length - 1] === " ") {
+                parts.pop();
+            }
+        }
     }
 
     return parts.join("");
@@ -597,6 +614,9 @@ function renderDiagnostic(value: unknown, formatter: Formatter): string {
 
         case Diagnostic.Presentation.Deleted:
             return formatter.deleted(() => renderDiagnostic(value, formatter));
+
+        case Diagnostic.Presentation.Keylike:
+            return (value as string).length ? formatter.keylike(value as string) : "";
 
         case Diagnostic.Presentation.Error:
             return formatter.error(() => renderDiagnostic(value, formatter));

--- a/packages/protocol/src/interaction/InteractionClient.ts
+++ b/packages/protocol/src/interaction/InteractionClient.ts
@@ -621,7 +621,6 @@ export class InteractionClient {
             updateReceived?.();
 
             if (!Array.isArray(dataReport.attributeReports) || !dataReport.attributeReports.length) {
-                logger.debug(`Subscription result empty for subscription ID ${dataReport.subscriptionId}`);
                 return;
             }
 
@@ -715,7 +714,6 @@ export class InteractionClient {
             updateReceived?.();
 
             if (!Array.isArray(dataReport.eventReports) || !dataReport.eventReports.length) {
-                logger.debug(`Subscription result empty for subscription ID ${dataReport.subscriptionId}`);
                 return;
             }
 
@@ -889,7 +887,6 @@ export class InteractionClient {
                 (!Array.isArray(dataReport.attributeReports) || !dataReport.attributeReports.length) &&
                 (!Array.isArray(dataReport.eventReports) || !dataReport.eventReports.length)
             ) {
-                logger.debug(`Subscription result empty for subscription ID ${dataReport.subscriptionId}`);
                 return;
             }
             const { attributeReports, eventReports } = dataReport;

--- a/packages/protocol/src/interaction/InteractionServer.ts
+++ b/packages/protocol/src/interaction/InteractionServer.ts
@@ -1072,7 +1072,11 @@ export class InteractionServer implements ProtocolHandler, InteractionRecipient 
             await subscription.close(); // Cleanup
             if (error instanceof StatusResponseError) {
                 logger.info(`Sending status response ${error.code} for interaction error: ${error.message}`);
-                await messenger.sendStatus(error.code);
+                await messenger.sendStatus(error.code, {
+                    logContext: {
+                        for: "I/SubscriptionSeed-Status",
+                    },
+                });
             }
             await messenger.close();
             return; // Make sure to not bubble up the exception
@@ -1092,6 +1096,12 @@ export class InteractionServer implements ProtocolHandler, InteractionRecipient 
                 maxInterval,
                 interactionModelRevision: Specification.INTERACTION_MODEL_REVISION,
             }),
+            {
+                logContext: {
+                    subId: subscriptionId,
+                    maxInterval,
+                },
+            },
         );
 
         // When an error occurs while sending the response, the subscription is not yet active and will be cleaned up by GC
@@ -1230,12 +1240,21 @@ export class InteractionServer implements ProtocolHandler, InteractionRecipient 
                             `Send ${lastMessageProcessed ? "final " : ""}invoke response for ${invokeResponseMessage.invokeResponses} commands`,
                         );
                     }
+                    const moreChunkedMessages = lastMessageProcessed ? undefined : true;
                     await messenger.send(
                         MessageType.InvokeResponse,
                         TlvInvokeResponseForSend.encode({
                             ...invokeResponseMessage,
-                            moreChunkedMessages: lastMessageProcessed ? undefined : true,
+                            moreChunkedMessages,
                         }),
+                        {
+                            logContext: {
+                                invokeMsgFlags: Diagnostic.keylikeFlags({
+                                    suppressResponse,
+                                    moreChunkedMessages,
+                                }),
+                            },
+                        },
                     );
                     invokeResponseMessage.invokeResponses = [];
                     messageSize = emptyInvokeResponseBytes.length;

--- a/packages/protocol/src/interaction/ServerSubscription.ts
+++ b/packages/protocol/src/interaction/ServerSubscription.ts
@@ -896,6 +896,7 @@ export class ServerSubscription extends Subscription {
                         interactionModelRevision: Specification.INTERACTION_MODEL_REVISION,
                     },
                     this.criteria.isFabricFiltered,
+                    !this.isClosed, // Do not wait for ack when closed
                 );
             } else {
                 await messenger.sendDataReport(
@@ -928,6 +929,7 @@ export class ServerSubscription extends Subscription {
                         }),
                     },
                     this.criteria.isFabricFiltered,
+                    !this.isClosed, // Do not wait for ack when closed
                 );
             }
         } catch (error) {

--- a/packages/protocol/src/mdns/MdnsScanner.ts
+++ b/packages/protocol/src/mdns/MdnsScanner.ts
@@ -1206,27 +1206,30 @@ export class MdnsScanner implements Scanner {
     }
 
     static discoveryDataDiagnostics(data: DiscoveryData) {
-        return Diagnostic.dict({
-            SII: data.SII,
-            SAI: data.SAI,
-            SAT: data.SAT,
-            T: data.T,
-            DT: data.DT,
-            PH: data.PH,
-            ICD: data.ICD,
-            VP: data.VP,
-            DN: data.DN,
-            RI: data.RI,
-            PI: data.PI,
-        });
+        return Diagnostic.dict(
+            {
+                SII: data.SII,
+                SAI: data.SAI,
+                SAT: data.SAT,
+                T: data.T,
+                DT: data.DT,
+                PH: data.PH,
+                ICD: data.ICD,
+                VP: data.VP,
+                DN: data.DN,
+                RI: data.RI,
+                PI: data.PI,
+            },
+            true,
+        );
     }
 
     static deviceAddressDiagnostics(addresses: Map<string, MatterServerRecordWithExpire>) {
         return Array.from(addresses.values()).map(address =>
             Diagnostic.dict({
+                type: address.type,
                 ip: address.ip,
                 port: address.port,
-                type: address.type,
             }),
         );
     }

--- a/packages/protocol/src/protocol/ExchangeManager.ts
+++ b/packages/protocol/src/protocol/ExchangeManager.ts
@@ -27,7 +27,7 @@ import { SecureSession } from "../session/SecureSession.js";
 import { Session } from "../session/Session.js";
 import { SessionManager, UNICAST_UNSECURE_SESSION_ID } from "../session/SessionManager.js";
 import { ChannelManager } from "./ChannelManager.js";
-import { MessageExchange, MessageExchangeContext } from "./MessageExchange.js";
+import { ExchangeLogContext, MessageExchange, MessageExchangeContext } from "./MessageExchange.js";
 import { DuplicateMessageError } from "./MessageReceptionState.js";
 import { ProtocolHandler } from "./ProtocolHandler.js";
 
@@ -70,8 +70,8 @@ export class MessageChannel implements Channel<Message> {
         return this.channel.maxPayloadSize;
     }
 
-    send(message: Message): Promise<void> {
-        logger.debug("Message »", MessageCodec.messageDiagnostics(message));
+    send(message: Message, logContext?: ExchangeLogContext): Promise<void> {
+        logger.debug("Message »", MessageCodec.messageDiagnostics(message, logContext));
         const packet = this.session.encode(message);
         const bytes = MessageCodec.encodePacket(packet);
         if (bytes.length > this.maxPayloadSize) {

--- a/packages/protocol/src/securechannel/SecureChannelMessenger.ts
+++ b/packages/protocol/src/securechannel/SecureChannelMessenger.ts
@@ -43,17 +43,35 @@ export class SecureChannelMessenger {
         this.#defaultExpectedProcessingTimeMs = defaultExpectedProcessingTimeMs;
     }
 
+    async nextMessage(
+        expectedMessageType: number,
+        expectedProcessingTimeMs = this.#defaultExpectedProcessingTimeMs,
+        expectedMessageInfo?: string,
+    ) {
+        return this.#nextMessage(expectedMessageType, expectedProcessingTimeMs, expectedMessageInfo);
+    }
+
+    async anyNextMessage(
+        expectedMessageInfo: string,
+        expectedProcessingTimeMs = this.#defaultExpectedProcessingTimeMs,
+    ) {
+        return this.#nextMessage(undefined, expectedProcessingTimeMs, expectedMessageInfo);
+    }
+
     /**
      * Waits for the next message and returns it.
      * When no expectedProcessingTimeMs is provided, the default value of EXPECTED_CRYPTO_PROCESSING_TIME_MS is used.
      */
-    async nextMessage(
-        expectedMessageInfo: string,
+    async #nextMessage(
         expectedMessageType?: number,
         expectedProcessingTimeMs = this.#defaultExpectedProcessingTimeMs,
+        expectedMessageInfo?: string,
     ) {
-        const message = await this.exchange.nextMessage(expectedProcessingTimeMs);
+        const message = await this.exchange.nextMessage({ expectedProcessingTimeMs });
         const messageType = message.payloadHeader.messageType;
+        if (expectedMessageType !== undefined && expectedMessageInfo === undefined) {
+            expectedMessageInfo = SecureMessageType[expectedMessageType];
+        }
         this.throwIfErrorStatusReport(message, expectedMessageInfo);
         if (expectedMessageType !== undefined && messageType !== expectedMessageType)
             throw new UnexpectedDataError(
@@ -69,12 +87,9 @@ export class SecureChannelMessenger {
     async nextMessageDecoded<T>(
         expectedMessageType: number,
         schema: TlvSchema<T>,
-        expectedMessageInfo: string,
         expectedProcessingTimeMs = this.#defaultExpectedProcessingTimeMs,
     ) {
-        return schema.decode(
-            (await this.nextMessage(expectedMessageInfo, expectedMessageType, expectedProcessingTimeMs)).payload,
-        );
+        return schema.decode((await this.nextMessage(expectedMessageType, expectedProcessingTimeMs)).payload);
     }
 
     /**
@@ -86,7 +101,7 @@ export class SecureChannelMessenger {
         expectedProcessingTimeMs = this.#defaultExpectedProcessingTimeMs,
     ) {
         // If the status is not Success, this would throw an Error.
-        await this.nextMessage(expectedMessageInfo, SecureMessageType.StatusReport, expectedProcessingTimeMs);
+        await this.nextMessage(SecureMessageType.StatusReport, expectedProcessingTimeMs, expectedMessageInfo);
     }
 
     /**

--- a/packages/protocol/src/securechannel/SecureChannelMessenger.ts
+++ b/packages/protocol/src/securechannel/SecureChannelMessenger.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { MatterError, UnexpectedDataError } from "#general";
+import { Diagnostic, MatterError, UnexpectedDataError } from "#general";
 import {
     GeneralStatusCode,
     ProtocolStatusCode,
@@ -136,7 +136,13 @@ export class SecureChannelMessenger {
                 protocolId: SECURE_CHANNEL_PROTOCOL_ID,
                 protocolStatus,
             }),
-            { requiresAck },
+            {
+                requiresAck,
+                logContext: {
+                    generalStatus: GeneralStatusCode[generalStatus] ?? Diagnostic.hex(generalStatus),
+                    protocolStatus: ProtocolStatusCode[protocolStatus] ?? Diagnostic.hex(protocolStatus),
+                },
+            },
         );
     }
 

--- a/packages/protocol/src/session/SecureSession.ts
+++ b/packages/protocol/src/session/SecureSession.ts
@@ -156,16 +156,23 @@ export class SecureSession extends Session {
         logger.debug(
             `Created secure ${this.isPase ? "PASE" : "CASE"} session for fabric index ${fabric?.fabricIndex}`,
             this.name,
-            Diagnostic.dict({
-                idleIntervalMs: this.idleIntervalMs,
-                activeIntervalMs: this.activeIntervalMs,
-                activeThresholdMs: this.activeThresholdMs,
-                dataModelRevision: this.dataModelRevision,
-                interactionModelRevision: this.interactionModelRevision,
-                specificationVersion: this.specificationVersion,
-                maxPathsPerInvoke: this.maxPathsPerInvoke,
-                caseAuthenticatedTags: this.#caseAuthenticatedTags,
-            }),
+            this.parameterDiagnostics(),
+        );
+    }
+
+    parameterDiagnostics() {
+        return Diagnostic.dict(
+            {
+                SII: this.idleIntervalMs,
+                SAI: this.activeIntervalMs,
+                SAT: this.activeThresholdMs,
+                DMRev: this.dataModelRevision,
+                IMRev: this.interactionModelRevision,
+                spec: Diagnostic.hex(this.specificationVersion),
+                maxPaths: this.maxPathsPerInvoke,
+                CATs: this.#caseAuthenticatedTags,
+            },
+            true,
         );
     }
 

--- a/packages/protocol/src/session/case/CaseClient.ts
+++ b/packages/protocol/src/session/case/CaseClient.ts
@@ -106,8 +106,8 @@ export class CaseClient {
             });
             await messenger.sendSuccess();
             logger.info(
-                `Case client: session resumed with ${messenger.getChannelName()} and parameters`,
-                Diagnostic.dict(secureSession.parameters),
+                `Case client: Session resumed with ${messenger.getChannelName()} and parameters`,
+                secureSession.parameterDiagnostics(),
             );
 
             resumptionRecord.resumptionId = resumptionId; /* update resumptionId */
@@ -216,7 +216,7 @@ export class CaseClient {
             });
             logger.info(
                 `Case client: Paired successfully with ${messenger.getChannelName()} and parameters`,
-                Diagnostic.dict(secureSession.parameters),
+                secureSession.parameterDiagnostics(),
             );
             resumptionRecord = {
                 fabric,

--- a/packages/protocol/src/session/case/CaseClient.ts
+++ b/packages/protocol/src/session/case/CaseClient.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Bytes, Crypto, Diagnostic, Logger, PublicKey, UnexpectedDataError } from "#general";
+import { Bytes, Crypto, Logger, PublicKey, UnexpectedDataError } from "#general";
 import { SessionManager } from "#session/SessionManager.js";
 import { NodeId } from "#types";
 import { TlvIntermediateCertificate, TlvOperationalCertificate } from "../../certificate/CertificateManager.js";
@@ -196,7 +196,7 @@ export class CaseClient {
             const encryptedData = TlvEncryptedDataSigma3.encode({ nodeOpCert, intermediateCACert, signature });
             const encrypted = Crypto.encrypt(sigma3Key, encryptedData, TBE_DATA3_NONCE);
             const sigma3Bytes = await messenger.sendSigma3({ encrypted });
-            await messenger.waitForSuccess("Success after CASE Sigma3");
+            await messenger.waitForSuccess("Sigma3-Success");
 
             // All good! Create secure session
             const secureSessionSalt = Bytes.concat(

--- a/packages/protocol/src/session/case/CaseMessenger.ts
+++ b/packages/protocol/src/session/case/CaseMessenger.ts
@@ -11,7 +11,7 @@ import { TlvCaseSigma1, TlvCaseSigma2, TlvCaseSigma2Resume, TlvCaseSigma3 } from
 
 export class CaseServerMessenger extends SecureChannelMessenger {
     async readSigma1() {
-        const { payload } = await this.nextMessage("CASE Sigma1", SecureMessageType.Sigma1);
+        const { payload } = await this.nextMessage(SecureMessageType.Sigma1);
         return { sigma1Bytes: payload, sigma1: TlvCaseSigma1.decode(payload) };
     }
 
@@ -24,7 +24,7 @@ export class CaseServerMessenger extends SecureChannelMessenger {
     }
 
     async readSigma3() {
-        const { payload } = await this.nextMessage("CASE Sigma3", SecureMessageType.Sigma3);
+        const { payload } = await this.nextMessage(SecureMessageType.Sigma3);
         return { sigma3Bytes: payload, sigma3: TlvCaseSigma3.decode(payload) };
     }
 }
@@ -38,7 +38,7 @@ export class CaseClientMessenger extends SecureChannelMessenger {
         const {
             payload,
             payloadHeader: { messageType },
-        } = await this.nextMessage("CASE Sigma2 or Sigma2Resume");
+        } = await this.anyNextMessage("Sigma2(Resume)");
         switch (messageType) {
             case SecureMessageType.Sigma2:
                 return { sigma2Bytes: payload, sigma2: TlvCaseSigma2.decode(payload) };

--- a/packages/protocol/src/session/case/CaseServer.ts
+++ b/packages/protocol/src/session/case/CaseServer.ts
@@ -130,7 +130,7 @@ export class CaseServer implements ProtocolHandler {
             }
 
             logger.info(
-                `session ${secureSession.id} resumed with ${messenger.getChannelName()} for Fabric ${NodeId.toHexString(
+                `Session ${secureSession.id} resumed with ${messenger.getChannelName()} for Fabric ${NodeId.toHexString(
                     fabric.nodeId,
                 )}(index ${fabric.fabricIndex}) and PeerNode ${NodeId.toHexString(peerNodeId)}`,
                 "with CATs",
@@ -139,7 +139,7 @@ export class CaseServer implements ProtocolHandler {
             resumptionRecord.resumptionId = resumptionId; /* Update the ID */
 
             // Wait for success on the peer side
-            await messenger.waitForSuccess("Success after CASE Sigma2Resume");
+            await messenger.waitForSuccess("Sigma2Resume-Success");
 
             await messenger.close();
             await this.#sessions.saveResumptionRecord(resumptionRecord);

--- a/packages/protocol/src/session/pase/PaseClient.ts
+++ b/packages/protocol/src/session/pase/PaseClient.ts
@@ -80,7 +80,7 @@ export class PaseClient {
         await messenger.sendPasePake3({ verifier: hAY });
 
         // All good! Creating the secure session
-        await messenger.waitForSuccess("Success after PASE Pake3");
+        await messenger.waitForSuccess("PasePake3-Success");
         const secureSession = await this.#sessions.createSecureSession({
             sessionId: initiatorSessionId,
             fabric: undefined,

--- a/packages/protocol/src/session/pase/PaseMessenger.ts
+++ b/packages/protocol/src/session/pase/PaseMessenger.ts
@@ -30,7 +30,6 @@ type PasePake3 = TypeFromSchema<typeof TlvPasePake3>;
 export class PaseServerMessenger extends SecureChannelMessenger {
     async readPbkdfParamRequest() {
         const { payload } = await this.nextMessage(
-            "PASE PbkdfParamRequest",
             SecureMessageType.PbkdfParamRequest,
             DEFAULT_NORMAL_PROCESSING_TIME_MS,
         );
@@ -44,7 +43,7 @@ export class PaseServerMessenger extends SecureChannelMessenger {
     }
 
     readPasePake1() {
-        return this.nextMessageDecoded(SecureMessageType.PasePake1, TlvPasePake1, "PASE Pake1");
+        return this.nextMessageDecoded(SecureMessageType.PasePake1, TlvPasePake1);
     }
 
     sendPasePake2(pasePake2: PasePake2) {
@@ -52,7 +51,7 @@ export class PaseServerMessenger extends SecureChannelMessenger {
     }
 
     readPasePake3() {
-        return this.nextMessageDecoded(SecureMessageType.PasePake3, TlvPasePake3, "PASE Pake3");
+        return this.nextMessageDecoded(SecureMessageType.PasePake3, TlvPasePake3);
     }
 }
 
@@ -65,7 +64,6 @@ export class PaseClientMessenger extends SecureChannelMessenger {
 
     async readPbkdfParamResponse() {
         const { payload } = await this.nextMessage(
-            "PASE PbkdfParamResponse",
             SecureMessageType.PbkdfParamResponse,
             DEFAULT_NORMAL_PROCESSING_TIME_MS,
         );
@@ -77,7 +75,7 @@ export class PaseClientMessenger extends SecureChannelMessenger {
     }
 
     readPasePake2() {
-        return this.nextMessageDecoded(SecureMessageType.PasePake2, TlvPasePake2, "PASE Pake2");
+        return this.nextMessageDecoded(SecureMessageType.PasePake2, TlvPasePake2);
     }
 
     sendPasePake3(pasePake3: PasePake3) {

--- a/packages/react-native/src/net/UdpChannelReactNative.ts
+++ b/packages/react-native/src/net/UdpChannelReactNative.ts
@@ -122,9 +122,9 @@ export class UdpChannelReactNative implements UdpChannel {
             logger.debug(
                 "Initialize multicast",
                 Diagnostic.dict({
+                    type: type,
                     address: `${multicastInterface}:${listeningPort}`,
                     interface: netInterface,
-                    type: type,
                 }),
             );
             socket.setMulticastInterface(multicastInterface);


### PR DESCRIPTION
This PR changes the logging and combines some loglines into one. This mainly means that we have more information in the exchange message logs. 

It also adds one Shutdown optimization already because of code-overlappings: It allows to disable Exchange MRP logic which means that the message is sent but the ack is not awaited and returned directly. With this we can use a shorter timeout when waiting for the answer in case of node shutdowns where last subscription information are pushed before going offline.

Rest see commit comments