### PR TITLE
Matter 1.4 constraint support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ The main work (all changes without a GitHub username in brackets in the below li
 
 -   @matter/model
     - Feature: The constraint evaluator now supports simple mathematical expressions
+    - Feature: The constraint evaluator now supports limits on the number of Unicode codepoints in a string
 
 -   @project-chip/matter.js
     - Feature: (Breaking) Added Fabric Label for Controller as required property to initialize the Controller

--- a/packages/model/src/parser/Token.ts
+++ b/packages/model/src/parser/Token.ts
@@ -43,6 +43,8 @@ export namespace BasicToken {
         | "]"
         | "("
         | ")"
+        | "{"
+        | "}"
         | "-"
         | "+"
         | "*"

--- a/packages/model/test/aspects/ConstraintTest.ts
+++ b/packages/model/test/aspects/ConstraintTest.ts
@@ -10,6 +10,8 @@ const TEST_CONSTRAINTS: [text: string, ast: Constraint.Ast, expectedText?: strin
     ["0", { value: 0 }],
     ["desc", { desc: true }],
     ["4", { value: 4 }],
+    ["-4", { value: -4 }],
+    ["+4", { value: 4 }, "4"],
     ["4%", { value: { type: "percent", value: 4 } }],
     ["4°C", { value: { type: "celsius", value: 4 } }],
     ["3.141592", { value: 3.141592 }],
@@ -19,8 +21,15 @@ const TEST_CONSTRAINTS: [text: string, ast: Constraint.Ast, expectedText?: strin
     ["0x4 to 0x44", { min: 4, max: 68 }, "4 to 68"],
     ["0xff to 0xffff", { min: 255, max: 65535 }, "255 to 65535"],
     ["4[44]", { value: 4, entry: { value: 44 } }],
+    ["4{44}", { value: 4, cpMax: 44 }],
     ["4, 44", { parts: [{ value: 4 }, { value: 44 }] }],
     ["in foo", { in: { type: "reference", name: "foo" } }],
+    ["-2.5°C to 2.5°C", { min: { type: "celsius", value: -2.5 }, max: { type: "celsius", value: 2.5 } }],
+    [
+        "0 to NumberOfPositions-1",
+        { min: 0, max: { type: "-", lhs: { type: "reference", name: "numberOfPositions" }, rhs: 1 } },
+        "0 to numberOfPositions - 1",
+    ],
     [
         "4[44, 444], 5[max 55, min 555]",
         {
@@ -41,7 +50,7 @@ const TEST_CONSTRAINTS: [text: string, ast: Constraint.Ast, expectedText?: strin
         },
     ],
     [
-        "(foo - 2)",
+        "foo - 2",
         {
             value: {
                 type: "-",
@@ -54,7 +63,7 @@ const TEST_CONSTRAINTS: [text: string, ast: Constraint.Ast, expectedText?: strin
         },
     ],
     [
-        "4 to (foo + 2)",
+        "4 to foo + 2",
         {
             min: 4,
 

--- a/packages/node/test/behavior/state/validation/constraintTest.ts
+++ b/packages/node/test/behavior/state/validation/constraintTest.ts
@@ -41,7 +41,7 @@ const AllTests = Tests({
             error: {
                 type: ConstraintError,
                 message:
-                    'Validating Test.test: Constraint "min (minVal + 1)": Value 4 is not within bounds defined by constraint',
+                    'Validating Test.test: Constraint "min minVal + 1": Value 4 is not within bounds defined by constraint',
             },
         },
         "accepts if reference value is missing": { record: { test: 3 } },
@@ -111,6 +111,50 @@ const AllTests = Tests({
                 type: ConstraintError,
                 message:
                     'Validating Test.test: Constraint "3 to 4, 6 to 7": Value 8 is not within bounds defined by constraint',
+            },
+        },
+    }),
+
+    "range with expression": Tests(Fields({ constraint: "0 to NumberOfPositions-1" }, { name: "NumberOfPositions" }), {
+        "accepts if under": {
+            record: { test: 1, numberOfPositions: 2 },
+        },
+        "rejects if over": {
+            record: { test: 2, numberOfPositions: 2 },
+            error: {
+                type: ConstraintError,
+                message:
+                    'Validating Test.test: Constraint "0 to numberOfPositions - 1": Value 2 is not within bounds defined by constraint',
+            },
+        },
+    }),
+
+    "string length": Tests(Fields({ type: "string", constraint: "max 2" }), {
+        "accepts if under": {
+            record: { test: "ab" },
+        },
+
+        "rejects if over": {
+            record: { test: "abc" },
+            error: {
+                type: ConstraintError,
+                message:
+                    'Validating Test.test: Constraint "max 2": String length of 3 is not within bounds defined by constraint',
+            },
+        },
+    }),
+
+    "string length with codepoints": Tests(Fields({ type: "string", constraint: "max 8{1}" }), {
+        "accepts if under": {
+            record: { test: "𩸽" },
+        },
+
+        "rejects if over": {
+            record: { test: "𩸽定" },
+            error: {
+                type: ConstraintError,
+                message:
+                    'Validating Test.test: Constraint "max 8{1}": Codepoint count of 2 is not within bounds defined by constraint',
             },
         },
     }),


### PR DESCRIPTION
Moves sign handling from lexer to parser which I would consider a bug fix although it didn't affect any expressions prior to 1.4.

Adds support for codepoint limits on strings.  This is a new feature for 1.4.

Adds additional tests.