### PR TITLE
Full scope search for named references

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -30,8 +30,6 @@
                 "extendDefaults": true
             }
         ],
-        // turn on errors for missing imports
-        "import/no-unresolved": "error",
 
         "@typescript-eslint/require-await": "off",
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The main work (all changes without a GitHub username in brackets in the below li
 ## __WORK IN PROGRESS__
 
 -   @matter/node
+    - Feature: Constraint and conformance expressions may now reference values by name in any owner of a constrained value
     - Enhancement: Each new PASE session now automatically arms the failsafe timer for 60s as required by specs
     - Enhancement: Optimizes Node shutdown logic to close sessions and subscriptions before shutting down the network
     - Fix: Fixes withBehaviors() method on endpoints
@@ -34,6 +35,7 @@ The main work (all changes without a GitHub username in brackets in the below li
 -   @matter/model
     - Feature: The constraint evaluator now supports simple mathematical expressions
     - Feature: The constraint evaluator now supports limits on the number of Unicode codepoints in a string
+    - Feature: Default values may now be a reference to another field
 
 -   @project-chip/matter.js
     - Feature: (Breaking) Added Fabric Label for Controller as required property to initialize the Controller

--- a/packages/model/src/aspects/Constraint.ts
+++ b/packages/model/src/aspects/Constraint.ts
@@ -91,8 +91,8 @@ export class Constraint extends Aspect<Constraint.Definition> implements Constra
     /**
      * Test a value against a constraint.  Does not recurse into arrays.
      */
-    test(value: FieldValue, properties?: Record<string, any>): boolean {
-        // Helper that looks up "reference" field values in properties.  This is for constraints such as "min FieldName"
+    test(value: FieldValue, nameResolver?: (name: string) => unknown): boolean {
+        // Expression evaluator.  This is for constraints such as "min FieldName"
         function valueOf(value: Constraint.Expression | undefined, raw = false): FieldValue | undefined {
             if (!raw && (typeof value === "string" || Array.isArray(value))) {
                 return value.length;
@@ -102,7 +102,7 @@ export class Constraint extends Aspect<Constraint.Definition> implements Constra
                 switch (type) {
                     case FieldValue.reference:
                         if (typeof value.name === "string") {
-                            value = valueOf(properties?.[camelize(value.name)], raw);
+                            value = FieldValue(nameResolver?.(camelize(value.name)));
                         }
                         break;
 
@@ -168,7 +168,7 @@ export class Constraint extends Aspect<Constraint.Definition> implements Constra
             }
         }
 
-        if (this.parts?.every(part => part.test(value, properties) === false)) {
+        if (this.parts?.every(part => part.test(value, nameResolver) === false)) {
             return false;
         }
 

--- a/packages/model/src/common/FieldValue.ts
+++ b/packages/model/src/common/FieldValue.ts
@@ -26,6 +26,31 @@ export type FieldValue =
     | FieldValue.Bytes
     | FieldValue.None;
 
+/**
+ * Create a FieldValue (or undefined) from a naked JavaScript value.
+ *
+ * Assumes that objects and arrays already contain valid FieldValues.
+ */
+export function FieldValue(value: unknown): FieldValue | undefined {
+    if (typeof value === "function") {
+        throw new UnexpectedDataError("Cannot cast function to FieldValue");
+    }
+
+    if (typeof value === "object" && value !== null) {
+        if (Array.isArray(value)) {
+            return value as FieldValue[];
+        }
+
+        if (value instanceof Date) {
+            return value;
+        }
+
+        return value as FieldValue.Properties;
+    }
+
+    return value as FieldValue;
+}
+
 export namespace FieldValue {
     // Typing with constants should be just as type safe as using an enum but simplifies type definitions
 

--- a/packages/model/src/logic/definition-validation/ValueValidator.ts
+++ b/packages/model/src/logic/definition-validation/ValueValidator.ts
@@ -30,10 +30,15 @@ export class ValueValidator<T extends ValueModel> extends ModelValidator<T> {
                 // Feature lookup
                 const cluster = this.model.owner(ClusterModel);
                 return !!cluster?.features.find(f => f.name === name);
-            } else {
-                // Field lookup
-                return !!this.model.parent?.member(name);
             }
+
+            // Field lookup
+            for (let model = this.model.parent; model; model = model.parent) {
+                if (model.member(name) !== undefined) {
+                    return true;
+                }
+            }
+            return false;
         });
 
         this.validateAspect("constraint");
@@ -98,7 +103,7 @@ export class ValueValidator<T extends ValueModel> extends ModelValidator<T> {
             return;
         }
 
-        // Convert value to proper type if possible
+        // Special case for string "empty"
         if (metatype === Metatype.string && defaultValue === "empty") {
             // Metatype doesn't handle this case because otherwise you'd never be able to have a string called "empty".
             // In this case though the data likely comes from the spec so we're going to take a flyer and say you can
@@ -106,7 +111,25 @@ export class ValueValidator<T extends ValueModel> extends ModelValidator<T> {
             delete this.model.default;
             return;
         }
+
+        // Attempt to cast to correct value
         const cast = FieldValue.cast(metatype, defaultValue);
+
+        // Special case for field names
+        if (typeof defaultValue === "string") {
+            // Here we are converting any exact match of a default value to a field name to be a dynamic default
+            // referencing the named field.  If we ever have a default value that is the same as a field name then this
+            // will be incorrect but likely we never will as string defaults are uncommon
+            let referenced = this.model?.member(defaultValue);
+            if (referenced === undefined) {
+                referenced = this.model.owner(ClusterModel)?.member(defaultValue);
+            }
+            if (referenced instanceof ValueModel && referenced.effectiveType === this.model.effectiveType) {
+                this.model.default = FieldValue.Reference(referenced.name);
+                return;
+            }
+        }
+
         if (cast === FieldValue.Invalid) {
             this.error("INVALID_VALUE", `Value "${defaultValue}" is not a ${metatype}`);
             return;

--- a/packages/model/src/models/ScopeModel.ts
+++ b/packages/model/src/models/ScopeModel.ts
@@ -20,6 +20,9 @@ export abstract class ScopeModel<T extends BaseElement = BaseElement> extends Mo
 
     readonly isScope = true;
 
+    /**
+     * Obtain the {@link Scope} for this model.
+     */
     get scope() {
         if (this.#operationalScope !== undefined) {
             return this.#operationalScope;

--- a/packages/model/src/models/ValueModel.ts
+++ b/packages/model/src/models/ValueModel.ts
@@ -10,7 +10,7 @@ import { BaseElement, ValueElement } from "../elements/index.js";
 import { ModelTraversal } from "../logic/ModelTraversal.js";
 import { Aspects } from "./Aspects.js";
 import { Model } from "./Model.js";
-import { PropertyModel } from "./PropertyModel.js";
+import type { PropertyModel } from "./PropertyModel.js";
 
 // These are circular dependencies so just to be safe we only import the types.  We also need the class, though, at
 // runtime.  So we use the references in the Model.constructors factory pool.

--- a/packages/model/src/standard/elements/MicrowaveOvenControl.ts
+++ b/packages/model/src/standard/elements/MicrowaveOvenControl.ts
@@ -172,7 +172,7 @@ export const MicrowaveOvenControl = Cluster(
 
         Field({
             name: "PowerSetting", id: 0x2, type: "uint8", conformance: "[PWRNUM].a+",
-            constraint: "minPower to maxPower", default: "MaxPower",
+            constraint: "minPower to maxPower", default: { type: "reference", name: "MaxPower" },
 
             details: "This field shall indicate the PowerSetting associated with the operation of the device. The value " +
                 "of this field shall be subject to the constraints of the PowerSetting attribute of this cluster. If " +

--- a/packages/node/src/behavior/state/Val.ts
+++ b/packages/node/src/behavior/state/Val.ts
@@ -81,6 +81,11 @@ export namespace Val {
          * The object that owns the root managed value.
          */
         rootOwner?: any;
+
+        /**
+         * The parent of this reference, if any.
+         */
+        parent?: Reference;
     }
 
     export const properties = Symbol("properties");

--- a/packages/node/src/behavior/state/managed/ManagedReference.ts
+++ b/packages/node/src/behavior/state/managed/ManagedReference.ts
@@ -48,7 +48,13 @@ export function ManagedReference(
     };
 
     const reference: Val.Reference = {
-        owner: parent,
+        get rootOwner() {
+            return parent.rootOwner;
+        },
+
+        get parent() {
+            return parent;
+        },
 
         get value() {
             // Authorization is unnecessary here because the reference would not exist if access is unauthorized
@@ -67,10 +73,6 @@ export function ManagedReference(
 
         set location(loc: AccessControl.Location) {
             location = loc;
-        },
-
-        get rootOwner() {
-            return parent.rootOwner;
         },
 
         set value(newValue: Val) {

--- a/packages/node/src/behavior/state/managed/NameResolver.ts
+++ b/packages/node/src/behavior/state/managed/NameResolver.ts
@@ -1,0 +1,82 @@
+/**
+ * @license
+ * Copyright 2022-2024 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Val } from "#behavior/state/Val.js";
+import { RootSupervisor } from "#behavior/supervision/RootSupervisor.js";
+import { Schema } from "#behavior/supervision/Schema.js";
+import { camelize } from "@matter/general";
+import { ClusterModel, Model, ValueModel } from "@matter/model";
+import { Internal } from "./Internal.js";
+
+/**
+ * Obtain a function that returns a visible property by name from the ownership hierarchy of a managed value.
+ *
+ * This supports named lookup of a {@link FieldValue.Reference}.
+ */
+export function NameResolver(
+    supervisor: RootSupervisor,
+    model: Model | undefined,
+    name: string,
+): ((val: Val) => Val) | undefined {
+    if (model === undefined) {
+        return;
+    }
+
+    // Optimization for root schema
+    if (
+        model === supervisor.schema ||
+        (model.id !== undefined && supervisor.schema.tag === model.tag && supervisor.schema.id === model.id)
+    ) {
+        if (!supervisor.memberNames.has(name)) {
+            return;
+        }
+        return createDirectResolver();
+    }
+
+    // Only structs may provide named properties
+    if (!(model instanceof ValueModel) || model.effectiveMetatype !== "object") {
+        return createIndirectResolver();
+    }
+
+    // Read directly if the named property is supported by this schema.  This is not indexed which is fine because:
+    //   1. The spec uses this very lightly as of 1.4, and
+    //   2. We only do this once and only for schema that utilizes this feature
+    if (supervisor.membersOf(model as Schema).find(model => camelize(model.name, false) === name)) {
+        return createDirectResolver();
+    }
+
+    // Delegate to parent
+    return createIndirectResolver();
+
+    /**
+     * Create a reader that reads from this value.
+     */
+    function createDirectResolver() {
+        return (val: Val) => (val as Val.Struct)?.[name];
+    }
+
+    /**
+     * Create a reader that reads from parent.
+     */
+    function createIndirectResolver() {
+        const parentSchema = model!.parent;
+        if (!(parentSchema instanceof ValueModel) && !(parentSchema instanceof ClusterModel)) {
+            return;
+        }
+
+        const parentReader = NameResolver(supervisor, parentSchema, name);
+        if (!parentReader) {
+            return;
+        }
+
+        return (val: Val) => {
+            const parent = (val as Internal.Collection)?.[Internal.reference]?.parent?.owner;
+            if (parent) {
+                return parentReader(parent as Val.Collection);
+            }
+        };
+    }
+}

--- a/packages/node/src/behavior/state/validation/conformance-util.ts
+++ b/packages/node/src/behavior/state/validation/conformance-util.ts
@@ -97,6 +97,9 @@ export function asBoolean(node: StaticNode) {
         case Code.Optional:
             return true;
 
+        case Code.Value:
+            return !!node.value;
+
         default:
             return false;
     }

--- a/packages/node/src/behavior/supervision/RootSupervisor.ts
+++ b/packages/node/src/behavior/supervision/RootSupervisor.ts
@@ -46,6 +46,7 @@ export class RootSupervisor implements ValueSupervisor {
     #supportedFeatures: FeatureSet;
     #scope: Scope;
     #members: Set<ValueModel>;
+    #rootSchema: Schema;
     #root: ValueSupervisor;
     #memberNames?: Set<string>;
     #persistentNames?: Set<string>;
@@ -56,7 +57,7 @@ export class RootSupervisor implements ValueSupervisor {
      * @param schema the {@link Schema} for the supervised data
      */
     constructor(schema: Schema) {
-        schema.freeze();
+        this.#rootSchema = schema;
 
         this.#scope = Scope(schema, { forceCache: true, forceOwner: true });
 
@@ -89,7 +90,7 @@ export class RootSupervisor implements ValueSupervisor {
     }
 
     get schema() {
-        return this.#root.schema;
+        return this.#rootSchema;
     }
 
     get scope() {
@@ -186,8 +187,7 @@ export class RootSupervisor implements ValueSupervisor {
      * @returns the I/O implementation
      */
     get(schema: Schema): ValueSupervisor {
-        // #root isn't set while we generate root schema so guard against this.#root === undefined
-        if (schema === this.#root?.schema) {
+        if (schema === this.#rootSchema) {
             return this;
         }
 
@@ -216,7 +216,7 @@ export class RootSupervisor implements ValueSupervisor {
         // generated function for places where the function is held directly.
         const deferGeneration = (
             name: string,
-            generator: (schema: Schema, factory: RootSupervisor, base?: new () => Val) => any,
+            generator: (schema: Schema, supervisor: RootSupervisor, base?: new () => Val) => any,
         ) => {
             let generated = false;
 

--- a/packages/node/test/behavior/state/validation/conformanceTest.ts
+++ b/packages/node/test/behavior/state/validation/conformanceTest.ts
@@ -258,6 +258,7 @@ const AllTests = Tests({
                 Fields(
                     { name: "Value", type: "uint8" },
                     { name: "ValueIsSet", type: "bool", conformance: "F & Value" },
+                    { name: "UnsupportedValueIsSet", type: "bool", conformance: "F & UnsupportedValue" },
                 ),
                 {
                     "allows if present": {


### PR DESCRIPTION
Adds support for default values that are named references.  For any property with a default value that is a named reference, a managed struct will return the referenced value until set explicitly.

Adds logic that searches for properties by name in any owner of a managed value.  This allows conformance expressions, constraints and default values to reference values by name so long as they are visible in any object in the ownership hierarchy.  Previously we only supported referencing values that were siblings.

I believe this is the last feature we need to support 100% of the data model semantics used in the Matter specifications (as of Matter 1.4).