### PR TITLE
Stores MDNS host information for faster reuse with new SRV announcements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Enhancement: Optimized Logging for messages in various places
     - Enhancement: Added support for concurrent and non-concurrent commissioning flows
     - Enhancement: Re-arms the failsafe timer in commissioning flows before steps that could take longer and during operative reconnection
+    - Enhancement: Stores Matter relevant MDNS host information to faster reuse when new SRV announcements come in
     - Fix: Corrects some Batch invoke checks and logic
     - Fix: Fixes MDNS discovery duration for retransmission cases to be 5s
     - Fix: Processes all TXT/SRV records in MDNS messages and optimized the processing

--- a/packages/protocol/src/mdns/MdnsScanner.ts
+++ b/packages/protocol/src/mdns/MdnsScanner.ts
@@ -1411,11 +1411,6 @@ export class MdnsScanner implements Scanner {
                 }
             });
         }
-        console.log(
-            "After expire",
-            Object.keys(data.addressesV6 ?? {}).length,
-            Object.keys(data.addressesV4 ?? {}).length,
-        );
     }
 
     static discoveryDataDiagnostics(data: DiscoveryData) {


### PR DESCRIPTION
Host records were not persisted when they were used already or such, so we needed to re-ask them. in commissioning processes the hostname likely stays the same when the device switches from commissioning to operative mode, so we could reuse the host information easiely.

The PR also adds expiry logic for active query data and details and for these stored data.

it also adds a bit more logging to be likely removed before we publish 0.12 but allows better validation of the fix with the affected users.