### PR TITLE
Node delayed connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,9 @@ The main work (all changes without a GitHub username in brackets in the below li
 -   @project-chip/matter.js
     - Feature: (Breaking) Added Fabric Label for Controller as required property to initialize the Controller
         including setting the Fabric Label when commissioning and validating and updating the Fabric Label on
-        connection 
+        connection
+    - Feature: Added autoConnect property to node connection options to allow to not automatically connect to a node when PairedNode instance is created. Also introduces a non-blocking PairedNode.connect() method to connect to a node
+    - Feature: Added CommissioningController.getNode() method to get a PairedNode instance for a node by its node ID without a direct connection
     - Feature: Allows to update the Fabric Label during controller runtime using `updateFabricLabel()` on CommissioningController
     - Enhancement: Improves Reconnection Handling for devices that use persisted subscriptions
     - Enhancement: Use data type definitions from Model for Controller Device type definitions

--- a/packages/matter.js/src/CommissioningController.ts
+++ b/packages/matter.js/src/CommissioningController.ts
@@ -319,9 +319,19 @@ export class CommissioningController extends MatterNode {
         await this.controllerInstance?.disconnect(nodeId);
     }
 
+    async getNode(nodeId: NodeId) {
+        const existingNode = this.initializedNodes.get(nodeId);
+        if (existingNode !== undefined) {
+            return existingNode;
+        }
+        return await this.connectNode(nodeId, { autoConnect: false });
+    }
+
     /**
      * Connect to an already paired Node.
      * After connection the endpoint data of the device is analyzed and an object structure is created.
+     * This call is not blocking and returns an initialized PairedNode instance. The connection or reconnection
+     * happens in the background. Please monitor the state of the node to see if the connection was successful.
      */
     async connectNode(nodeId: NodeId, connectOptions?: CommissioningControllerNodeOptions) {
         const controller = this.assertControllerIsStarted();
@@ -333,7 +343,7 @@ export class CommissioningController extends MatterNode {
         const existingNode = this.initializedNodes.get(nodeId);
         if (existingNode !== undefined) {
             if (!existingNode.initialized) {
-                await existingNode.reconnect(connectOptions);
+                existingNode.connect(connectOptions);
             }
             return existingNode;
         }

--- a/packages/matter.js/src/device/PairedNode.ts
+++ b/packages/matter.js/src/device/PairedNode.ts
@@ -156,6 +156,12 @@ export enum NodeStateInformation {
 
 export type CommissioningControllerNodeOptions = {
     /**
+     * Unless set to false the node will be automatically connected when initialized. When set to false use
+     * connect() to connect to the node at a later timepoint.
+     */
+    readonly autoConnect?: boolean;
+
+    /**
      * Unless set to false all events and attributes are subscribed and value changes are reflected in the ClusterClient
      * instances. With this reading attributes values is mostly looked up in the locally cached data.
      * Additionally more features like reaction on shutdown event or endpoint structure changes (for bridges) are done
@@ -453,6 +459,18 @@ export class PairedNode {
     }
 
     /**
+     * Schedule a connection to the device. This method is non-blocking and will return immediately.
+     * The connection happens in the background. Please monitor the state of the node to see if the
+     * connection was successful.
+     */
+    connect(connectOptions?: CommissioningControllerNodeOptions) {
+        if (connectOptions !== undefined) {
+            this.options = connectOptions;
+        }
+        this.triggerReconnect();
+    }
+
+    /**
      * Trigger a reconnection to the device. This method is non-blocking and will return immediately.
      * The reconnection happens in the background. Please monitor the state of the node to see if the
      * reconnection was successful.
@@ -460,7 +478,7 @@ export class PairedNode {
     triggerReconnect() {
         if (this.#reconnectionInProgress || this.#remoteInitializationInProgress) {
             logger.info(
-                `Node ${this.nodeId}: Ignoring reconnect request because ${this.#remoteInitializationInProgress ? "init" : "reconnect"} already underway.`,
+                `Node ${this.nodeId}: Ignoring reconnect request because ${this.#remoteInitializationInProgress ? "initialization" : "reconnect"} already in progress.`,
             );
             return;
         }

--- a/packages/protocol/src/protocol/ExchangeManager.ts
+++ b/packages/protocol/src/protocol/ExchangeManager.ts
@@ -352,8 +352,8 @@ export class ExchangeManager {
             logger.debug(`Channel for session ${session.name} is ${channel?.name}`);
             if (channel !== undefined) {
                 const exchange = this.initiateExchangeWithChannel(channel, SECURE_CHANNEL_PROTOCOL_ID);
-                logger.debug(`Initiated exchange ${!!exchange} to close session ${sessionName}`);
                 if (exchange !== undefined) {
+                    logger.debug(`Initiated exchange ${exchange.id} to close session ${sessionName}`);
                     try {
                         const messenger = new SecureChannelMessenger(exchange);
                         await messenger.sendCloseSession();


### PR DESCRIPTION
In cases where a pairedNode should be initialized but not yet connected this PR adds new methods and properties to allow this.