### PR TITLE
Added Noble Windows discovery workaround

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The main work (all changes without a GitHub username in brackets in the below li
 -   @matter/nodejs-ble
     - Enhancement: Restructures BLE connection handling to improve reliability and eliminate hanging commissioning processes
     - Fix: Adds support for advanced manufacturer data on Windows (Noble update)
+    - Fix: Added workaround for Noble on Windows to prevent discovery issues
     
 -   @matter/protocol
     - Feature: Reworks Event server handling and optionally allow Non-Volatile event storage (currently mainly used in tests)

--- a/packages/nodejs-ble/src/NobleBleClient.ts
+++ b/packages/nodejs-ble/src/NobleBleClient.ts
@@ -85,7 +85,9 @@ export class NobleBleClient {
         this.shouldScan = true;
         if (this.nobleState === "poweredOn") {
             logger.debug("Start BLE scanning for Matter Services ...");
-            await noble.startScanningAsync([BLE_MATTER_SERVICE_UUID], true);
+            // TODO Remove this Windows hack once Noble Windows issue is fixed
+            //  see https://github.com/stoprocent/noble/issues/20
+            await noble.startScanningAsync(process.platform !== "win32" ? [BLE_MATTER_SERVICE_UUID] : undefined, true);
         } else {
             logger.debug("noble state is not poweredOn ... delay scanning till poweredOn");
         }
@@ -103,6 +105,16 @@ export class NobleBleClient {
         // The advertisement data contains a name, power level (if available), certain advertised service uuids,
         // as well as manufacturer data.
         // {"localName":"MATTER-3840","serviceData":[{"uuid":"fff6","data":{"type":"Buffer","data":[0,0,15,241,255,1,128,0]}}],"serviceUuids":["fff6"],"solicitationServiceUuids":[],"serviceSolicitationUuids":[]}
+
+        // TODO Remove this Windows hack once Noble Windows issue is fixed
+        //  see https://github.com/stoprocent/noble/issues/20
+        if (
+            process.platform === "win32" &&
+            !peripheral.advertisement.serviceData.some(({ uuid }) => uuid === BLE_MATTER_SERVICE_UUID)
+        ) {
+            return;
+        }
+
         const address = peripheral.address;
         logger.debug(
             `Found peripheral ${address} (${peripheral.advertisement.localName}): ${Logger.toJSON(
@@ -115,7 +127,7 @@ export class NobleBleClient {
             return;
         }
         const matterServiceData = peripheral.advertisement.serviceData.find(
-            serviceData => serviceData.uuid === BLE_MATTER_SERVICE_UUID,
+            ({ uuid }) => uuid === BLE_MATTER_SERVICE_UUID,
         );
         if (matterServiceData === undefined || matterServiceData.data.length !== 8) {
             logger.info(`Peripheral ${address} does not advertise Matter Service ... ignoring`);


### PR DESCRIPTION
This PR adds a workaround for a Noble issue where discovery behavior is different on Windows as it is on Linux. So for Windows we need to discover all devices and then check the servicedata field.

addresses https://github.com/stoprocent/noble/issues/20

PS: Yes for windows mow the one check for Service data is done twice but this should not be too problematic and so it is easier to revert this workaround again when issue is fixed.