### PR TITLE
Optimize Memory usage and Subscriptions/Read Handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ The main work (all changes without a GitHub username in brackets in the below li
 	## __WORK IN PROGRESS__
 -->
 
+## __WORK IN PROGRESS__
+
+-   @matter/node
+    - Enhancement: Added support to check all device types of an endpoint against ACL definition and not only primary one
+    - Enhancement: Optimized data handling for subscriptions by reading them endpoint wise to optimize memory usage and to reuse the used context
+    - Adjustment: Refactored ACL logic to just get relevant endpoint information instead a whole EndpointInterface
+
+-   @matter/protocol
+    - Enhancement: Optimized sending of DataReports to stream the read data to the encoder when needed to reduce memory usage
+
+
 ## 0.12.1 (2025-01-25)
 
 -   @matter/protocol

--- a/packages/matter.js/src/device/LegacyInteractionServer.ts
+++ b/packages/matter.js/src/device/LegacyInteractionServer.ts
@@ -92,7 +92,7 @@ export class LegacyInteractionServer extends InteractionServer {
         }
     }
 
-    protected override async readAttribute(
+    protected override readAttribute(
         path: AttributePath,
         attribute: AnyAttributeServer<any>,
         exchange: MessageExchange,
@@ -104,7 +104,7 @@ export class LegacyInteractionServer extends InteractionServer {
         if (!offline) {
             this.#assertAccess(path, exchange, attribute.readAcl);
         }
-        const data = await super.readAttribute(path, attribute, exchange, isFabricFiltered, message, endpoint);
+        const data = super.readAttribute(path, attribute, exchange, isFabricFiltered, message);
         if (attribute instanceof FabricScopedAttributeServer && !isFabricFiltered) {
             const { value, version } = data;
             return {

--- a/packages/node/src/behavior/context/server/OfflineContext.ts
+++ b/packages/node/src/behavior/context/server/OfflineContext.ts
@@ -24,6 +24,7 @@ export const OfflineContext = {
      *
      * {@link act} provides an {@link ActionContext} you can use to access agents for a {@link Endpoint}.
      * State changes and change events occur once {@link actor} returns.
+     * It can return a promise even if the actor method does not return a promise, so manual checks are needed.
      *
      * The {@link Transaction} is destroyed with {@link act} exits so you should not keep a reference to any agents
      * beyond the lifespan of {@link actor}.
@@ -33,9 +34,9 @@ export const OfflineContext = {
     act<T>(
         purpose: string,
         activity: NodeActivity | undefined,
-        actor: (context: ActionContext) => T,
+        actor: (context: ActionContext) => MaybePromise<T>,
         options?: OfflineContext.Options,
-    ): T {
+    ): MaybePromise<T> {
         const id = nextInternalId;
         nextInternalId = (nextInternalId + 1) % 65535;
         const via = Diagnostic.via(`${purpose}#${id.toString(16)}`);

--- a/packages/node/src/behavior/context/server/OfflineContext.ts
+++ b/packages/node/src/behavior/context/server/OfflineContext.ts
@@ -33,9 +33,9 @@ export const OfflineContext = {
     act<T>(
         purpose: string,
         activity: NodeActivity | undefined,
-        actor: (context: ActionContext) => MaybePromise<T>,
+        actor: (context: ActionContext) => T,
         options?: OfflineContext.Options,
-    ): MaybePromise<T> {
+    ): T {
         const id = nextInternalId;
         nextInternalId = (nextInternalId + 1) % 65535;
         const via = Diagnostic.via(`${purpose}#${id.toString(16)}`);

--- a/packages/node/src/behavior/context/server/OnlineContext.ts
+++ b/packages/node/src/behavior/context/server/OnlineContext.ts
@@ -27,7 +27,7 @@ import { ContextAgents } from "./ContextAgents.js";
  */
 export function OnlineContext(options: OnlineContext.Options) {
     return {
-        act<T>(actor: (context: ActionContext) => MaybePromise<T>): MaybePromise<T> {
+        act<T>(actor: (context: ActionContext) => T): T {
             let agents: undefined | ContextAgents;
 
             let fabric: FabricIndex | undefined;
@@ -152,7 +152,7 @@ export function OnlineContext(options: OnlineContext.Options) {
                 const result = Transaction.act(via, actOnline);
                 if (MaybePromise.is(result)) {
                     isAsync = true;
-                    return Promise.resolve(result).catch(traceError).finally(close);
+                    return Promise.resolve(result).catch(traceError).finally(close) as T;
                 }
                 return result;
             } catch (e) {

--- a/packages/node/src/behavior/context/server/OnlineContext.ts
+++ b/packages/node/src/behavior/context/server/OnlineContext.ts
@@ -10,7 +10,7 @@ import { EndpointType } from "#endpoint/type/EndpointType.js";
 import { Diagnostic, ImplementationError, InternalError, MaybePromise } from "#general";
 import { AccessLevel } from "#model";
 import type { Message } from "#protocol";
-import { assertSecureSession, EndpointInterface, MessageExchange } from "#protocol";
+import { AclEndpointContext, assertSecureSession, MessageExchange } from "#protocol";
 import { FabricIndex, NodeId, StatusResponseError, SubjectId } from "#types";
 import { AccessControlServer } from "../../../behaviors/access-control/AccessControlServer.js";
 import { RootEndpoint } from "../../../endpoints/root.js";
@@ -111,7 +111,7 @@ export function OnlineContext(options: OnlineContext.Options) {
                         const accessLevels = accessControl.accessLevelsFor(
                             context as ActionContext,
                             location,
-                            options.endpoint,
+                            options.endpointContext,
                         );
                         location.accessLevels = accessLevels;
                         return accessLevels.includes(desiredAccessLevel);
@@ -180,7 +180,7 @@ export namespace OnlineContext {
         message?: Message;
         tracer?: ActionTracer;
         actionType?: ActionTracer.ActionType;
-        endpoint?: EndpointInterface;
+        endpointContext?: AclEndpointContext;
         root?: Endpoint<RootEndpoint>;
     } & (
         | { exchange: MessageExchange; fabric?: undefined; subject?: undefined }

--- a/packages/node/src/behavior/context/server/OnlineContext.ts
+++ b/packages/node/src/behavior/context/server/OnlineContext.ts
@@ -27,7 +27,11 @@ import { ContextAgents } from "./ContextAgents.js";
  */
 export function OnlineContext(options: OnlineContext.Options) {
     return {
-        act<T>(actor: (context: ActionContext) => T): T {
+        /**
+         * It can return a promise even if the actor method does not return a promise, so manual checks
+         * are needed.
+         */
+        act<T>(actor: (context: ActionContext) => MaybePromise<T>): MaybePromise<T> {
             let agents: undefined | ContextAgents;
 
             let fabric: FabricIndex | undefined;
@@ -152,7 +156,7 @@ export function OnlineContext(options: OnlineContext.Options) {
                 const result = Transaction.act(via, actOnline);
                 if (MaybePromise.is(result)) {
                     isAsync = true;
-                    return Promise.resolve(result).catch(traceError).finally(close) as T;
+                    return Promise.resolve(result).catch(traceError).finally(close);
                 }
                 return result;
             } catch (e) {

--- a/packages/node/src/behaviors/access-control/AccessControlServer.ts
+++ b/packages/node/src/behaviors/access-control/AccessControlServer.ts
@@ -10,7 +10,7 @@ import { AccessControl as AccessControlTypes } from "#clusters/access-control";
 import { deepCopy, InternalError, isDeepEqual, Logger } from "#general";
 import { AccessLevel } from "#model";
 import { NodeLifecycle } from "#node/NodeLifecycle.js";
-import { AccessControlManager, EndpointInterface, FabricManager, IncomingSubjectDescriptor } from "#protocol";
+import { AccessControlManager, AclEndpointContext, FabricManager, IncomingSubjectDescriptor } from "#protocol";
 import {
     CaseAuthenticatedTag,
     ClusterId,
@@ -332,7 +332,7 @@ export class AccessControlServer extends AccessControlBehavior {
     accessLevelsFor(
         context: ActionContext,
         location: AccessControl.Location,
-        endpoint?: EndpointInterface,
+        endpoint?: AclEndpointContext,
     ): AccessLevel[] {
         if (location.cluster === undefined) {
             // Without a cluster, internal behaviors are only accessible internally so this is an irrelevant placeholder
@@ -385,7 +385,7 @@ export class AccessControlServer extends AccessControlBehavior {
         _aclList: AccessControlTypes.AccessControlEntry[],
         _aclEntry: AccessControlTypes.AccessControlEntry,
         _subjectDesc: IncomingSubjectDescriptor,
-        _endpoint: EndpointInterface,
+        _endpoint: AclEndpointContext,
         _clusterId: ClusterId,
     ) {
         return true;

--- a/packages/node/src/node/server/TransactionalInteractionServer.ts
+++ b/packages/node/src/node/server/TransactionalInteractionServer.ts
@@ -207,6 +207,10 @@ export class TransactionalInteractionServer extends InteractionServer {
         }).act(readAttribute);
     }
 
+    /**
+     * Reads the attributes for the given endpoint.
+     * This can currently only be used for subscriptions because errors are ignored!
+     */
     protected override readAttributesForEndpoint(
         endpointId: EndpointNumber,
         attributes: { path: AttributePath; attribute: AnyAttributeServer<any> }[],

--- a/packages/node/src/node/server/TransactionalInteractionServer.ts
+++ b/packages/node/src/node/server/TransactionalInteractionServer.ts
@@ -17,6 +17,7 @@ import { EndpointServer } from "#endpoint/server/EndpointServer.js";
 import { Diagnostic, InternalError, Logger, MaybePromise } from "#general";
 import {
     AccessDeniedError,
+    AclEndpointContext,
     AnyAttributeServer,
     AnyEventServer,
     AttributePath,
@@ -32,12 +33,11 @@ import {
     InteractionServerMessenger,
     Message,
     MessageExchange,
-    NumberedOccurrence,
     SessionManager,
     WriteRequest,
     WriteResponse,
 } from "#protocol";
-import { TlvEventFilter, TypeFromSchema } from "#types";
+import { EndpointNumber, StatusCode, StatusResponseError, TlvEventFilter, TypeFromSchema } from "#types";
 import { AccessControlServer } from "../../behaviors/access-control/AccessControlServer.js";
 import { ServerNode } from "../ServerNode.js";
 
@@ -72,6 +72,7 @@ export class TransactionalInteractionServer extends InteractionServer {
     #newActivityBlocked = false;
     #aclServer?: AccessControlServer;
     #aclUpdateIsDelayedInExchange = new Set<MessageExchange>();
+    #endpointContexts = new Map<number, AclEndpointContext>();
 
     static async create(endpoint: Endpoint<ServerNode.RootEndpoint>, sessions: SessionManager) {
         const structure = new InteractionEndpointStructure();
@@ -155,21 +156,43 @@ export class TransactionalInteractionServer extends InteractionServer {
         return (this.#aclServer = aclServer);
     }
 
-    protected override async readAttribute(
+    #getAclEndpointContext(endpointId: EndpointNumber) {
+        if (!this.#endpointContexts.has(endpointId)) {
+            this.#endpoint.visit(({ number, state }) => {
+                if (number !== undefined && !this.#endpointContexts.has(number)) {
+                    this.#endpointContexts.set(number, {
+                        number,
+                        deviceTypes: state.descriptor.deviceTypeList.map(({ deviceType }) => deviceType),
+                    });
+                }
+            });
+        }
+        const context = this.#endpointContexts.get(endpointId);
+        if (context) {
+            return context;
+        } else {
+            throw new InternalError("Endpoint not found for ACL check. This should never happen.");
+        }
+    }
+
+    protected override readAttribute(
         path: AttributePath,
         attribute: AnyAttributeServer<any>,
         exchange: MessageExchange,
         fabricFiltered: boolean,
         message: Message,
-        endpoint: EndpointInterface,
         offline = false,
     ) {
-        const readAttribute = () =>
-            super.readAttribute(path, attribute, exchange, fabricFiltered, message, endpoint, offline);
+        const readAttribute = () => super.readAttribute(path, attribute, exchange, fabricFiltered, message, offline);
 
         // Offline read do not require ACL checks
         if (offline) {
             return OfflineContext.act("offline-read", this.#activity, readAttribute);
+        }
+
+        const endpoint = this.#endpointStructure.getEndpoint(path.endpointId);
+        if (!endpoint) {
+            throw new InternalError("Endpoint not found for ACL check. This should never happen.");
         }
 
         return OnlineContext({
@@ -179,7 +202,7 @@ export class TransactionalInteractionServer extends InteractionServer {
             exchange,
             tracer: this.#tracer,
             actionType: ActionTracer.ActionType.Read,
-            endpoint,
+            endpointContext: this.#getAclEndpointContext(path.endpointId),
             root: this.#endpoint,
         }).act(readAttribute);
     }
@@ -191,15 +214,14 @@ export class TransactionalInteractionServer extends InteractionServer {
         exchange: MessageExchange,
         fabricFiltered: boolean,
         message: Message,
-        endpoint: EndpointInterface,
-    ): Promise<NumberedOccurrence[]> {
+    ) {
         const readEvent = (context: ActionContext) => {
             if (!context.authorizedFor(event.readAcl, { cluster: path.clusterId } as AccessControl.Location)) {
                 throw new AccessDeniedError(
-                    `Access to ${endpoint.number}/${Diagnostic.hex(path.clusterId)} denied on ${exchange.session.name}.`,
+                    `Access to ${path.endpointId}/${Diagnostic.hex(path.clusterId)} denied on ${exchange.session.name}.`,
                 );
             }
-            return super.readEvent(path, eventFilters, event, exchange, fabricFiltered, message, endpoint);
+            return super.readEvent(path, eventFilters, event, exchange, fabricFiltered, message);
         };
 
         return OnlineContext({
@@ -209,7 +231,7 @@ export class TransactionalInteractionServer extends InteractionServer {
             exchange,
             tracer: this.#tracer,
             actionType: ActionTracer.ActionType.Read,
-            endpoint,
+            endpointContext: this.#getAclEndpointContext(path.endpointId),
             root: this.#endpoint,
         }).act(readEvent);
     }
@@ -291,7 +313,8 @@ export class TransactionalInteractionServer extends InteractionServer {
             fabricFiltered: true,
             tracer: this.#tracer,
             actionType: ActionTracer.ActionType.Write,
-            endpoint,
+            endpointContext: this.#getAclEndpointContext(path.endpointId),
+
             root: this.#endpoint,
         }).act(writeAttribute);
     }
@@ -322,7 +345,7 @@ export class TransactionalInteractionServer extends InteractionServer {
             exchange,
             tracer: this.#tracer,
             actionType: ActionTracer.ActionType.Invoke,
-            endpoint,
+            endpointContext: this.#getAclEndpointContext(path.endpointId),
             root: this.#endpoint,
         }).act(invokeCommand);
     }
@@ -337,6 +360,8 @@ export class TransactionalInteractionServer extends InteractionServer {
         if (this.#endpoint.lifecycle.isPartsReady) {
             const server = EndpointServer.forEndpoint(this.#endpoint);
             this.#endpointStructure.initializeFromEndpoint(server);
+
+            this.#endpointContexts.clear();
         }
     }
 }

--- a/packages/node/test/behavior/state/managed/values/StructManagerTest.ts
+++ b/packages/node/test/behavior/state/managed/values/StructManagerTest.ts
@@ -79,7 +79,7 @@ async function testDuality(life: boolean, actor: (struct: { alive?: boolean }) =
 
     const datasource = Datasource({ type: SchrödingersCatsState, supervisor, path: DataModelPath(0) });
 
-    await OfflineContext.act("test", undefined, cx => {
+    OfflineContext.act("test", undefined, cx => {
         actor(datasource.reference(cx));
     });
 }

--- a/packages/node/test/behavior/state/managed/values/StructManagerTest.ts
+++ b/packages/node/test/behavior/state/managed/values/StructManagerTest.ts
@@ -79,7 +79,7 @@ async function testDuality(life: boolean, actor: (struct: { alive?: boolean }) =
 
     const datasource = Datasource({ type: SchrödingersCatsState, supervisor, path: DataModelPath(0) });
 
-    OfflineContext.act("test", undefined, cx => {
+    await OfflineContext.act("test", undefined, cx => {
         actor(datasource.reference(cx));
     });
 }

--- a/packages/nodejs/test/IntegrationTest.ts
+++ b/packages/nodejs/test/IntegrationTest.ts
@@ -971,7 +971,6 @@ describe("Integration Test", () => {
             let resolved = false;
             await onOffClient.subscribeOnOffAttribute(
                 value => {
-                    console.trace("onOffClient.subscribeOnOffAttribute", value);
                     pushedUpdates.push({ value, time: Time.nowMs() });
                     if (!resolved) updateResolver();
                     resolved = true;

--- a/packages/nodejs/test/interaction/InteractionProtocolTest.ts
+++ b/packages/nodejs/test/interaction/InteractionProtocolTest.ts
@@ -8,7 +8,7 @@ import { Crypto, StorageBackendMemory, StorageContext, StorageManager } from "#g
 import {
     BaseDataReport,
     DataReportPayload,
-    DataReportPayloadGenerator,
+    DataReportPayloadIterator,
     FabricManager,
     InteractionContext,
     InteractionEndpointStructure,
@@ -923,7 +923,7 @@ const wildcardTestCases: {
 
 function fillIterableDataReport(data: {
     dataReport: BaseDataReport;
-    payload: DataReportPayloadGenerator;
+    payload: DataReportPayloadIterator;
 }): DataReportPayload {
     const { dataReport: report, payload } = data;
     const dataReport: DataReportPayload = { ...report };

--- a/packages/protocol/src/interaction/AttributeDataEncoder.ts
+++ b/packages/protocol/src/interaction/AttributeDataEncoder.ts
@@ -54,11 +54,21 @@ export type EventDataPayload = Omit<TypeFromSchema<typeof TlvEventData>, "data">
     payload: any;
 };
 
+export type EventOrAttributeDataPayload = AttributeReportPayload | EventReportPayload;
+
+/** A base type for a DataReport which removes the fields of the actual attribute or event content */
+export type BaseDataReport = Omit<TypeFromSchema<typeof TlvDataReport>, "attributeReports" | "eventReports">;
+
 /** Type for TlvDataReport where the real data are represented with the schema and the JS value. */
-export type DataReportPayload = Omit<TypeFromSchema<typeof TlvDataReport>, "attributeReports" | "eventReports"> & {
+export type DataReportPayload = BaseDataReport & {
     attributeReportsPayload?: AttributeReportPayload[];
     eventReportsPayload?: EventReportPayload[];
 };
+
+/**
+ * Type for the DataReport Generator function to send all data
+ */
+export type DataReportPayloadGenerator = Generator<EventOrAttributeDataPayload, boolean>;
 
 /** Encodes an AttributeReportPayload into a TlvStream (used for TlvAny type). */
 export function encodeAttributePayload(

--- a/packages/protocol/src/interaction/AttributeDataEncoder.ts
+++ b/packages/protocol/src/interaction/AttributeDataEncoder.ts
@@ -68,7 +68,7 @@ export type DataReportPayload = BaseDataReport & {
 /**
  * Type for the DataReport Generator function to send all data
  */
-export type DataReportPayloadGenerator = Generator<EventOrAttributeDataPayload, boolean>;
+export type DataReportPayloadIterator = IterableIterator<EventOrAttributeDataPayload>;
 
 /** Encodes an AttributeReportPayload into a TlvStream (used for TlvAny type). */
 export function encodeAttributePayload(

--- a/packages/protocol/src/interaction/InteractionMessenger.ts
+++ b/packages/protocol/src/interaction/InteractionMessenger.ts
@@ -305,114 +305,105 @@ export class InteractionServerMessenger extends InteractionMessenger {
             eventReports: undefined,
         };
 
-        try {
-            if (payload !== undefined) {
-                // TODO Add tag compressing once https://github.com/project-chip/connectedhomeip/issues/29359 is solved
-                dataReport.moreChunkedMessages = true; // Assume we have multiple chunks, also for size calculation
-                const emptyDataReportBytes = TlvDataReportForSend.encode(dataReport);
+        if (payload !== undefined) {
+            // TODO Add tag compressing once https://github.com/project-chip/connectedhomeip/issues/29359 is solved
+            dataReport.moreChunkedMessages = true; // Assume we have multiple chunks, also for size calculation
+            const emptyDataReportBytes = TlvDataReportForSend.encode(dataReport);
 
-                const sendAndResetReport = async () => {
-                    await this.sendDataReportMessage(dataReport, waitForAck);
-                    delete dataReport.attributeReports;
-                    delete dataReport.eventReports;
-                    messageSize = emptyDataReportBytes.length + 3; // We add 3 bytes because either one of the both removed arrays will be added or it is the last message and we don't care
-                };
-                let messageSize = emptyDataReportBytes.length;
+            const sendAndResetReport = async () => {
+                await this.sendDataReportMessage(dataReport, waitForAck);
+                delete dataReport.attributeReports;
+                delete dataReport.eventReports;
+                messageSize = emptyDataReportBytes.length + 3; // We add 3 bytes because either one of the both removed arrays will be added or it is the last message and we don't care
+            };
+            let messageSize = emptyDataReportBytes.length;
 
-                let attributeReportsToSend = new Array<AttributeReportPayload>();
-                let eventReportsToSend = new Array<EventReportPayload>();
+            let attributeReportsToSend = new Array<AttributeReportPayload>();
+            let eventReportsToSend = new Array<EventReportPayload>();
 
-                while (true) {
-                    // If we have no data to process we need to get the next chunk
-                    // If no more data is available we cancel the while loop and send final message
-                    if (attributeReportsToSend.length === 0 && eventReportsToSend.length === 0) {
-                        const { done, value } = payload.next();
-                        if (done) {
-                            if (value !== true) {
-                                // A non-true response when generator is done is an error
-                                logger.debug("Cancel DataReport sending because of non-true finish signal", value);
-                                return;
-                            }
-                            // No more chunks to send
-                            delete dataReport.moreChunkedMessages;
-                            break;
+            while (true) {
+                // If we have no data to process we need to get the next chunk
+                // If no more data is available we cancel the while loop and send final message
+                if (attributeReportsToSend.length === 0 && eventReportsToSend.length === 0) {
+                    const { done, value } = payload.next();
+                    if (done) {
+                        if (value !== true) {
+                            // A non-true response when generator is done is an error
+                            logger.debug("Cancel DataReport sending because of non-true finish signal", value);
+                            return;
                         }
-                        if (value === undefined) {
-                            continue;
-                        }
-                        if ("attributeData" in value || "attributeStatus" in value) {
-                            attributeReportsToSend = [value];
-                        } else if ("eventData" in value || "eventStatus" in value) {
-                            eventReportsToSend = [value];
-                        } else {
-                            payload.throw(new InternalError(`Invalid report type: ${value}`));
-                        }
-                    }
-
-                    // If we have attribute data to send, we add them first
-                    if (attributeReportsToSend.length > 0) {
-                        const attributeReport = attributeReportsToSend.shift();
-                        if (attributeReport !== undefined) {
-                            if (dataReport.attributeReports === undefined) {
-                                messageSize += 3; // Array element is added now which needs 3 bytes
-                            }
-                            const allowMissingFieldsForNonFabricFilteredRead =
-                                !forFabricFilteredRead && attributeReport.hasFabricSensitiveData;
-                            const encodedAttribute = encodeAttributePayload(attributeReport, {
-                                allowMissingFieldsForNonFabricFilteredRead,
-                            });
-                            const attributeReportBytes = TlvAny.getEncodedByteLength(encodedAttribute);
-                            if (messageSize + attributeReportBytes > this.exchange.maxPayloadSize) {
-                                if (canAttributePayloadBeChunked(attributeReport)) {
-                                    // Attribute is a non-empty array: chunk it and add the chunks to the beginning of the queue
-                                    attributeReportsToSend.unshift(...chunkAttributePayload(attributeReport));
-                                    continue;
-                                }
-                                await sendAndResetReport();
-                            }
-                            messageSize += attributeReportBytes;
-                            if (dataReport.attributeReports === undefined) dataReport.attributeReports = [];
-                            dataReport.attributeReports.push(encodedAttribute);
-                        }
-                    } else if (eventReportsToSend.length > 0) {
-                        const eventReport = eventReportsToSend.shift();
-                        if (eventReport === undefined) {
-                            // No more chunks to send
-                            delete dataReport.moreChunkedMessages;
-                            break;
-                        }
-                        if (dataReport.eventReports === undefined) {
-                            messageSize += 3; // Array element is added now which needs 3 bytes
-                        }
-                        const allowMissingFieldsForNonFabricFilteredRead =
-                            !forFabricFilteredRead && eventReport.hasFabricSensitiveData;
-                        const encodedEvent = encodeEventPayload(eventReport, {
-                            allowMissingFieldsForNonFabricFilteredRead,
-                        });
-                        const eventReportBytes = TlvAny.getEncodedByteLength(encodedEvent);
-                        if (messageSize + eventReportBytes > this.exchange.maxPayloadSize) {
-                            await sendAndResetReport();
-                        }
-                        messageSize += eventReportBytes;
-                        if (dataReport.eventReports === undefined) dataReport.eventReports = [];
-                        dataReport.eventReports.push(encodedEvent);
-                    } else {
                         // No more chunks to send
                         delete dataReport.moreChunkedMessages;
                         break;
                     }
+                    if (value === undefined) {
+                        continue;
+                    }
+                    if ("attributeData" in value || "attributeStatus" in value) {
+                        attributeReportsToSend = [value];
+                    } else if ("eventData" in value || "eventStatus" in value) {
+                        eventReportsToSend = [value];
+                    } else {
+                        throw new InternalError(`Invalid report type: ${value}`);
+                    }
+                }
+
+                // If we have attribute data to send, we add them first
+                if (attributeReportsToSend.length > 0) {
+                    const attributeReport = attributeReportsToSend.shift();
+                    if (attributeReport !== undefined) {
+                        if (dataReport.attributeReports === undefined) {
+                            messageSize += 3; // Array element is added now which needs 3 bytes
+                        }
+                        const allowMissingFieldsForNonFabricFilteredRead =
+                            !forFabricFilteredRead && attributeReport.hasFabricSensitiveData;
+                        const encodedAttribute = encodeAttributePayload(attributeReport, {
+                            allowMissingFieldsForNonFabricFilteredRead,
+                        });
+                        const attributeReportBytes = TlvAny.getEncodedByteLength(encodedAttribute);
+                        if (messageSize + attributeReportBytes > this.exchange.maxPayloadSize) {
+                            if (canAttributePayloadBeChunked(attributeReport)) {
+                                // Attribute is a non-empty array: chunk it and add the chunks to the beginning of the queue
+                                attributeReportsToSend.unshift(...chunkAttributePayload(attributeReport));
+                                continue;
+                            }
+                            await sendAndResetReport();
+                        }
+                        messageSize += attributeReportBytes;
+                        if (dataReport.attributeReports === undefined) dataReport.attributeReports = [];
+                        dataReport.attributeReports.push(encodedAttribute);
+                    }
+                } else if (eventReportsToSend.length > 0) {
+                    const eventReport = eventReportsToSend.shift();
+                    if (eventReport === undefined) {
+                        // No more chunks to send
+                        delete dataReport.moreChunkedMessages;
+                        break;
+                    }
+                    if (dataReport.eventReports === undefined) {
+                        messageSize += 3; // Array element is added now which needs 3 bytes
+                    }
+                    const allowMissingFieldsForNonFabricFilteredRead =
+                        !forFabricFilteredRead && eventReport.hasFabricSensitiveData;
+                    const encodedEvent = encodeEventPayload(eventReport, {
+                        allowMissingFieldsForNonFabricFilteredRead,
+                    });
+                    const eventReportBytes = TlvAny.getEncodedByteLength(encodedEvent);
+                    if (messageSize + eventReportBytes > this.exchange.maxPayloadSize) {
+                        await sendAndResetReport();
+                    }
+                    messageSize += eventReportBytes;
+                    if (dataReport.eventReports === undefined) dataReport.eventReports = [];
+                    dataReport.eventReports.push(encodedEvent);
+                } else {
+                    // No more chunks to send
+                    delete dataReport.moreChunkedMessages;
+                    break;
                 }
             }
-
-            await this.sendDataReportMessage(dataReport, waitForAck);
-        } catch (e) {
-            // Rethrow any error that happens, either into the Generator or directly
-            if (payload !== undefined) {
-                payload.throw(e);
-            } else {
-                throw e;
-            }
         }
+
+        await this.sendDataReportMessage(dataReport, waitForAck);
     }
 
     async sendDataReportMessage(dataReport: TypeFromSchema<typeof TlvDataReportForSend>, waitForAck = true) {

--- a/packages/protocol/src/interaction/InteractionMessenger.ts
+++ b/packages/protocol/src/interaction/InteractionMessenger.ts
@@ -49,7 +49,7 @@ import {
     BaseDataReport,
     canAttributePayloadBeChunked,
     chunkAttributePayload,
-    DataReportPayloadGenerator,
+    DataReportPayloadIterator,
     encodeAttributePayload,
     encodeEventPayload,
     EventReportPayload,
@@ -184,7 +184,7 @@ export interface InteractionRecipient {
         exchange: MessageExchange,
         request: ReadRequest,
         message: Message,
-    ): Promise<{ dataReport: DataReport; payload: DataReportPayloadGenerator }>;
+    ): Promise<{ dataReport: DataReport; payload: DataReportPayloadIterator }>;
     handleWriteRequest(exchange: MessageExchange, request: WriteRequest, message: Message): Promise<WriteResponse>;
     handleSubscribeRequest(
         exchange: MessageExchange,
@@ -292,7 +292,7 @@ export class InteractionServerMessenger extends InteractionMessenger {
     async sendDataReport(
         baseDataReport: BaseDataReport,
         forFabricFilteredRead: boolean,
-        payload?: DataReportPayloadGenerator,
+        payload?: DataReportPayloadIterator,
         waitForAck = true,
     ) {
         const { subscriptionId, suppressResponse, interactionModelRevision } = baseDataReport;
@@ -327,11 +327,6 @@ export class InteractionServerMessenger extends InteractionMessenger {
                 if (attributeReportsToSend.length === 0 && eventReportsToSend.length === 0) {
                     const { done, value } = payload.next();
                     if (done) {
-                        if (value !== true) {
-                            // A non-true response when generator is done is an error
-                            logger.debug("Cancel DataReport sending because of non-true finish signal", value);
-                            return;
-                        }
                         // No more chunks to send
                         delete dataReport.moreChunkedMessages;
                         break;

--- a/packages/protocol/src/interaction/InteractionServer.ts
+++ b/packages/protocol/src/interaction/InteractionServer.ts
@@ -48,7 +48,7 @@ import {
     decodeListAttributeValueWithSchema,
     expandPathsInAttributeData,
 } from "./AttributeDataDecoder.js";
-import { DataReportPayloadGenerator, EventReportPayload } from "./AttributeDataEncoder.js";
+import { DataReportPayloadIterator, EventReportPayload } from "./AttributeDataEncoder.js";
 import { InteractionEndpointStructure } from "./InteractionEndpointStructure.js";
 import {
     DataReport,
@@ -379,7 +379,6 @@ export class InteractionServer implements ProtocolHandler, InteractionRecipient 
 
     /**
      * Returns an iterator that yields the data reports and events data for the given read request.
-     * It returns true on success. If an error is thrown the send is cancelled immediately.
      */
     *#iterateReadAttributesPaths(
         { attributeRequests, dataVersionFilters, isFabricFiltered }: ReadRequest,
@@ -525,15 +524,13 @@ export class InteractionServer implements ProtocolHandler, InteractionRecipient 
                 yield eventReport;
             }
         }
-
-        return true;
     }
 
     async handleReadRequest(
         exchange: MessageExchange,
         readRequest: ReadRequest,
         message: Message,
-    ): Promise<{ dataReport: DataReport; payload: DataReportPayloadGenerator }> {
+    ): Promise<{ dataReport: DataReport; payload: DataReportPayloadIterator }> {
         const { attributeRequests, eventRequests, isFabricFiltered, interactionModelRevision } = readRequest;
         logger.debug(
             `Received read request from ${exchange.channel.name}: attributes:${

--- a/packages/protocol/src/interaction/InteractionServer.ts
+++ b/packages/protocol/src/interaction/InteractionServer.ts
@@ -48,9 +48,10 @@ import {
     decodeListAttributeValueWithSchema,
     expandPathsInAttributeData,
 } from "./AttributeDataDecoder.js";
-import { AttributeReportPayload, DataReportPayload, EventReportPayload } from "./AttributeDataEncoder.js";
+import { DataReportPayloadGenerator, EventReportPayload } from "./AttributeDataEncoder.js";
 import { InteractionEndpointStructure } from "./InteractionEndpointStructure.js";
 import {
+    DataReport,
     InteractionRecipient,
     InteractionServerMessenger,
     InvokeRequest,
@@ -262,185 +263,11 @@ export class InteractionServer implements ProtocolHandler, InteractionRecipient 
         await new InteractionServerMessenger(exchange).handleRequest(this);
     }
 
-    async handleReadRequest(
+    async #collectEventDataForRead(
+        { eventRequests, eventFilters, isFabricFiltered }: ReadRequest,
         exchange: MessageExchange,
-        {
-            attributeRequests,
-            dataVersionFilters,
-            eventRequests,
-            eventFilters,
-            isFabricFiltered,
-            interactionModelRevision,
-        }: ReadRequest,
         message: Message,
-    ): Promise<DataReportPayload> {
-        logger.debug(
-            `Received read request from ${exchange.channel.name}: attributes:${
-                attributeRequests?.map(path => this.#endpointStructure.resolveAttributeName(path)).join(", ") ?? "none"
-            }, events:${
-                eventRequests?.map(path => this.#endpointStructure.resolveEventName(path)).join(", ") ?? "none"
-            } isFabricFiltered=${isFabricFiltered}`,
-        );
-
-        if (interactionModelRevision > Specification.INTERACTION_MODEL_REVISION) {
-            logger.debug(
-                `Interaction model revision of sender ${interactionModelRevision} is higher than supported ${Specification.INTERACTION_MODEL_REVISION}.`,
-            );
-        }
-        if (attributeRequests === undefined && eventRequests === undefined) {
-            throw new StatusResponseError(
-                "Only Read requests with attributeRequests or eventRequests are supported right now",
-                StatusCode.UnsupportedRead,
-            );
-        }
-
-        if (message.packetHeader.sessionType !== SessionType.Unicast) {
-            throw new StatusResponseError(
-                "Subscriptions are only allowed on unicast sessions",
-                StatusCode.InvalidAction,
-            );
-        }
-
-        const dataVersionFilterMap = new Map<string, number>(
-            dataVersionFilters?.map(({ path, dataVersion }) => [clusterPathToId(path), dataVersion]) ?? [],
-        );
-        if (dataVersionFilterMap.size > 0) {
-            logger.debug(
-                `DataVersionFilters: ${Array.from(dataVersionFilterMap.entries())
-                    .map(([path, version]) => `${path}=${version}`)
-                    .join(", ")}`,
-            );
-        }
-
-        const attributeReportsPayload = new Array<AttributeReportPayload>();
-        for (const requestPath of attributeRequests ?? []) {
-            validateReadAttributesPath(requestPath);
-
-            const attributes = this.#endpointStructure.getAttributes([requestPath]);
-
-            // Requested attribute path not found in any cluster server on any endpoint
-            if (attributes.length === 0) {
-                // TODO Add checks for nodeId -> UnknownNode
-                if (isConcreteAttributePath(requestPath)) {
-                    const { endpointId, clusterId, attributeId } = requestPath;
-                    // Concrete path, but still unknown for us, so generate the right error status
-                    try {
-                        this.#endpointStructure.validateConcreteAttributePath(endpointId, clusterId, attributeId);
-                        throw new InternalError(
-                            "validateConcreteAttributePath should throw StatusResponseError but did not.",
-                        );
-                    } catch (e) {
-                        StatusResponseError.accept(e);
-                        logger.debug(
-                            `Error reading attribute from ${
-                                exchange.channel.name
-                            }: ${this.#endpointStructure.resolveAttributeName(requestPath)}: unsupported path: Status=${
-                                e.code
-                            }`,
-                        );
-                        attributeReportsPayload.push({
-                            hasFabricSensitiveData: false,
-                            attributeStatus: { path: requestPath, status: { status: e.code } },
-                        });
-                    }
-                }
-
-                // Wildcard path and we do not know any of the attributes: Ignore the error
-                logger.debug(
-                    `Read from ${exchange.channel.name}: ${this.#endpointStructure.resolveAttributeName(
-                        requestPath,
-                    )}: ${this.#endpointStructure.resolveAttributeName(requestPath)}: ignore non-existing attribute`,
-                );
-                continue;
-            }
-
-            // Process all known attributes for the given path
-            for (const { path, attribute } of attributes) {
-                const { nodeId, endpointId, clusterId } = path;
-
-                try {
-                    // We accept attributes not in the model ans readable, because existence is checked already
-                    if (getMatterModelClusterAttribute(clusterId, attribute.id)?.readable === false) {
-                        throw new StatusResponseError(
-                            `Attribute ${attribute.id} is not readable.`,
-                            StatusCode.UnsupportedRead,
-                        );
-                    }
-
-                    let value, version;
-                    try {
-                        ({ value, version } = await this.readAttribute(
-                            path,
-                            attribute,
-                            exchange,
-                            isFabricFiltered,
-                            message,
-                            this.#endpointStructure.getEndpoint(endpointId)!,
-                        ));
-                    } catch (e) {
-                        NoAssociatedFabricError.accept(e);
-
-                        // TODO: Remove when we remove legacy API
-                        //  This is not fully correct but should be sufficient for now
-                        //  This is fixed in the new API already, so this error should never throw
-                        //  Fabric scoped attributes are access errors, fabric sensitive attributes are just filtered
-                        //  Assume for now that in this place we only need to handle fabric sensitive case
-                        if (endpointId === undefined || clusterId === undefined) {
-                            throw new MatterFlowError("Should never happen");
-                        }
-                        const cluster = this.#endpointStructure.getClusterServer(endpointId, clusterId);
-                        if (cluster === undefined || cluster.datasource == undefined) {
-                            throw new MatterFlowError("Should never happen");
-                        }
-                        version = cluster.datasource.version;
-                        value = [];
-                    }
-
-                    const versionFilterValue =
-                        endpointId !== undefined && clusterId !== undefined
-                            ? dataVersionFilterMap.get(clusterPathToId({ nodeId, endpointId, clusterId }))
-                            : undefined;
-                    if (versionFilterValue !== undefined && versionFilterValue === version) {
-                        logger.debug(
-                            `Read attribute from ${exchange.channel.name}: ${this.#endpointStructure.resolveAttributeName(
-                                path,
-                            )}=${Logger.toJSON(value)} (version=${version}) ignored because of dataVersionFilter`,
-                        );
-                        continue;
-                    }
-
-                    logger.debug(
-                        `Read attribute from ${exchange.channel.name}: ${this.#endpointStructure.resolveAttributeName(
-                            path,
-                        )}=${Logger.toJSON(value)} (version=${version})`,
-                    );
-
-                    const { schema } = attribute;
-                    attributeReportsPayload.push({
-                        hasFabricSensitiveData: attribute.hasFabricSensitiveData,
-                        attributeData: { path, dataVersion: version, payload: value, schema },
-                    });
-                } catch (error) {
-                    logger.error(
-                        `Error while reading attribute from ${
-                            exchange.channel.name
-                        } to ${this.#endpointStructure.resolveAttributeName(path)}:`,
-                        error,
-                    );
-
-                    StatusResponseError.accept(error);
-
-                    // Add StatusResponseErrors, but only when the initial path was concrete, else error are ignored
-                    if (isConcreteAttributePath(requestPath)) {
-                        attributeReportsPayload.push({
-                            hasFabricSensitiveData: false,
-                            attributeStatus: { path, status: { status: error.code } },
-                        });
-                    }
-                }
-            }
-        }
-
+    ) {
         let eventReportsPayload: undefined | EventReportPayload[];
         if (eventRequests) {
             eventReportsPayload = [];
@@ -486,7 +313,6 @@ export class InteractionServer implements ProtocolHandler, InteractionRecipient 
                 const reportsForPath = new Array<EventReportPayload>();
                 for (const { path, event } of events) {
                     try {
-                        const { endpointId } = path;
                         const matchingEvents = await this.readEvent(
                             path,
                             eventFilters,
@@ -494,7 +320,6 @@ export class InteractionServer implements ProtocolHandler, InteractionRecipient 
                             exchange,
                             isFabricFiltered,
                             message,
-                            this.#endpointStructure.getEndpoint(endpointId)!,
                         );
                         logger.debug(
                             `Read event from ${exchange.channel.name}: ${this.#endpointStructure.resolveEventName(
@@ -549,22 +374,214 @@ export class InteractionServer implements ProtocolHandler, InteractionRecipient 
                 );
             }
         }
+        return eventReportsPayload;
+    }
+
+    /**
+     * Returns an iterator that yields the data reports and events data for the given read request.
+     * It returns true on success. If an error is thrown the send is cancelled immediately.
+     */
+    *#iterateReadAttributesPaths(
+        { attributeRequests, dataVersionFilters, isFabricFiltered }: ReadRequest,
+        eventReportsPayload: EventReportPayload[] | undefined,
+        exchange: MessageExchange,
+        message: Message,
+    ) {
+        const dataVersionFilterMap = new Map<string, number>(
+            dataVersionFilters?.map(({ path, dataVersion }) => [clusterPathToId(path), dataVersion]) ?? [],
+        );
+        if (dataVersionFilterMap.size > 0) {
+            logger.debug(
+                `DataVersionFilters: ${Array.from(dataVersionFilterMap.entries())
+                    .map(([path, version]) => `${path}=${version}`)
+                    .join(", ")}`,
+            );
+        }
+
+        for (const requestPath of attributeRequests ?? []) {
+            validateReadAttributesPath(requestPath);
+
+            const attributes = this.#endpointStructure.getAttributes([requestPath]);
+
+            // Requested attribute path not found in any cluster server on any endpoint
+            if (attributes.length === 0) {
+                // TODO Add checks for nodeId -> UnknownNode
+                if (isConcreteAttributePath(requestPath)) {
+                    const { endpointId, clusterId, attributeId } = requestPath;
+                    // Concrete path, but still unknown for us, so generate the right error status
+                    try {
+                        this.#endpointStructure.validateConcreteAttributePath(endpointId, clusterId, attributeId);
+                        throw new InternalError(
+                            "validateConcreteAttributePath should throw StatusResponseError but did not.",
+                        );
+                    } catch (e) {
+                        StatusResponseError.accept(e);
+                        logger.debug(
+                            `Error reading attribute from ${
+                                exchange.channel.name
+                            }: ${this.#endpointStructure.resolveAttributeName(requestPath)}: unsupported path: Status=${
+                                e.code
+                            }`,
+                        );
+                        yield {
+                            hasFabricSensitiveData: false,
+                            attributeStatus: { path: requestPath, status: { status: e.code } },
+                        };
+                    }
+                }
+
+                // Wildcard path and we do not know any of the attributes: Ignore the error
+                logger.debug(
+                    `Read from ${exchange.channel.name}: ${this.#endpointStructure.resolveAttributeName(
+                        requestPath,
+                    )}: ${this.#endpointStructure.resolveAttributeName(requestPath)}: ignore non-existing attribute`,
+                );
+                continue;
+            }
+
+            // Process all known attributes for the given path
+            for (const { path, attribute } of attributes) {
+                const { nodeId, endpointId, clusterId } = path;
+
+                try {
+                    // We accept attributes not in the model ans readable, because existence is checked already
+                    if (getMatterModelClusterAttribute(clusterId, attribute.id)?.readable === false) {
+                        throw new StatusResponseError(
+                            `Attribute ${attribute.id} is not readable.`,
+                            StatusCode.UnsupportedRead,
+                        );
+                    }
+
+                    let value, version;
+                    try {
+                        // TODO Optimize read later here too to optimize context usage
+                        ({ value, version } = this.readAttribute(path, attribute, exchange, isFabricFiltered, message));
+                    } catch (e) {
+                        NoAssociatedFabricError.accept(e);
+
+                        // TODO: Remove when we remove legacy API
+                        //  This is not fully correct but should be sufficient for now
+                        //  This is fixed in the new API already, so this error should never throw
+                        //  Fabric scoped attributes are access errors, fabric sensitive attributes are just filtered
+                        //  Assume for now that in this place we only need to handle fabric sensitive case
+                        if (endpointId === undefined || clusterId === undefined) {
+                            throw new MatterFlowError("Should never happen");
+                        }
+                        const cluster = this.#endpointStructure.getClusterServer(endpointId, clusterId);
+                        if (cluster === undefined || cluster.datasource == undefined) {
+                            throw new MatterFlowError("Should never happen");
+                        }
+                        version = cluster.datasource.version;
+                        value = [];
+                    }
+
+                    const versionFilterValue =
+                        endpointId !== undefined && clusterId !== undefined
+                            ? dataVersionFilterMap.get(clusterPathToId({ nodeId, endpointId, clusterId }))
+                            : undefined;
+                    if (versionFilterValue !== undefined && versionFilterValue === version) {
+                        logger.debug(
+                            `Read attribute from ${exchange.channel.name}: ${this.#endpointStructure.resolveAttributeName(
+                                path,
+                            )}=${Logger.toJSON(value)} (version=${version}) ignored because of dataVersionFilter`,
+                        );
+                        continue;
+                    }
+
+                    logger.debug(
+                        `Read attribute from ${exchange.channel.name}: ${this.#endpointStructure.resolveAttributeName(
+                            path,
+                        )}=${Logger.toJSON(value)} (version=${version})`,
+                    );
+
+                    const { schema } = attribute;
+                    yield {
+                        hasFabricSensitiveData: attribute.hasFabricSensitiveData,
+                        attributeData: { path, dataVersion: version, payload: value, schema },
+                    };
+                } catch (error) {
+                    logger.error(
+                        `Error while reading attribute from ${
+                            exchange.channel.name
+                        } to ${this.#endpointStructure.resolveAttributeName(path)}:`,
+                        error,
+                    );
+
+                    StatusResponseError.accept(error);
+
+                    // Add StatusResponseErrors, but only when the initial path was concrete, else error are ignored
+                    if (isConcreteAttributePath(requestPath)) {
+                        yield {
+                            hasFabricSensitiveData: false,
+                            attributeStatus: { path, status: { status: error.code } },
+                        };
+                    }
+                }
+            }
+        }
+
+        if (eventReportsPayload !== undefined) {
+            for (const eventReport of eventReportsPayload) {
+                yield eventReport;
+            }
+        }
+
+        return true;
+    }
+
+    async handleReadRequest(
+        exchange: MessageExchange,
+        readRequest: ReadRequest,
+        message: Message,
+    ): Promise<{ dataReport: DataReport; payload: DataReportPayloadGenerator }> {
+        const { attributeRequests, eventRequests, isFabricFiltered, interactionModelRevision } = readRequest;
+        logger.debug(
+            `Received read request from ${exchange.channel.name}: attributes:${
+                attributeRequests?.map(path => this.#endpointStructure.resolveAttributeName(path)).join(", ") ?? "none"
+            }, events:${
+                eventRequests?.map(path => this.#endpointStructure.resolveEventName(path)).join(", ") ?? "none"
+            } isFabricFiltered=${isFabricFiltered}`,
+        );
+
+        if (interactionModelRevision > Specification.INTERACTION_MODEL_REVISION) {
+            logger.debug(
+                `Interaction model revision of sender ${interactionModelRevision} is higher than supported ${Specification.INTERACTION_MODEL_REVISION}.`,
+            );
+        }
+        if (attributeRequests === undefined && eventRequests === undefined) {
+            throw new StatusResponseError(
+                "Only Read requests with attributeRequests or eventRequests are supported right now",
+                StatusCode.UnsupportedRead,
+            );
+        }
+
+        if (message.packetHeader.sessionType !== SessionType.Unicast) {
+            throw new StatusResponseError(
+                "Subscriptions are only allowed on unicast sessions",
+                StatusCode.InvalidAction,
+            );
+        }
 
         return {
-            interactionModelRevision: Specification.INTERACTION_MODEL_REVISION,
-            suppressResponse: true,
-            attributeReportsPayload,
-            eventReportsPayload,
+            dataReport: {
+                interactionModelRevision: Specification.INTERACTION_MODEL_REVISION,
+                suppressResponse: true,
+            },
+            payload: this.#iterateReadAttributesPaths(
+                readRequest,
+                await this.#collectEventDataForRead(readRequest, exchange, message),
+                exchange,
+                message,
+            ),
         };
     }
 
-    protected async readAttribute(
+    protected readAttribute(
         _path: AttributePath,
         attribute: AnyAttributeServer<any>,
         exchange: MessageExchange,
         isFabricFiltered: boolean,
         message: Message,
-        _endpoint: EndpointInterface,
         offline = false,
     ) {
         return attribute.getWithVersion(exchange.session, isFabricFiltered, offline ? undefined : message);

--- a/packages/protocol/src/interaction/InteractionServer.ts
+++ b/packages/protocol/src/interaction/InteractionServer.ts
@@ -591,7 +591,7 @@ export class InteractionServer implements ProtocolHandler, InteractionRecipient 
      * Reads the attributes for the given endpoint.
      * This can currently only be used for subscriptions because errors are ignored!
      */
-    protected readAttributesForEndpoint(
+    protected readEndpointAttributesForSubscription(
         _endpointId: EndpointNumber,
         attributes: { path: AttributePath; attribute: AnyAttributeServer<any> }[],
         exchange: MessageExchange,
@@ -1082,8 +1082,8 @@ export class InteractionServer implements ProtocolHandler, InteractionRecipient 
             readAttribute: (path, attribute, offline) =>
                 this.readAttribute(path, attribute, exchange, isFabricFiltered, message, offline),
 
-            readAttributesForEndpoint: (endpointId, attributes) =>
-                this.readAttributesForEndpoint(endpointId, attributes, exchange, isFabricFiltered, message),
+            readEndpointAttributesForSubscription: (endpointId, attributes) =>
+                this.readEndpointAttributesForSubscription(endpointId, attributes, exchange, isFabricFiltered, message),
 
             readEvent: (path, event, eventFilters) =>
                 this.readEvent(path, eventFilters, event, exchange, isFabricFiltered, message),

--- a/packages/protocol/src/interaction/ServerSubscription.ts
+++ b/packages/protocol/src/interaction/ServerSubscription.ts
@@ -696,6 +696,7 @@ export class ServerSubscription extends Subscription {
      * The iterator will yield all attributes and events that match the subscription criteria.
      * It will return true when finished without an error which triggers the sending of the data.
      * A thrown exception will cancel the sending process immediately.
+     * TODO: Streamline all this with the normal Read flow to also handle Concrete Path subscriptions with errors correctly
      */
     *#iterateInitialSubscriptionData(
         attributesToSend: {

--- a/packages/protocol/src/interaction/ServerSubscription.ts
+++ b/packages/protocol/src/interaction/ServerSubscription.ts
@@ -22,6 +22,7 @@ import { PeerAddress } from "#peer/PeerAddress.js";
 import type { MessageExchange } from "#protocol/MessageExchange.js";
 import { SecureSession } from "#session/SecureSession.js";
 import {
+    EndpointNumber,
     EventNumber,
     INTERACTION_PROTOCOL_ID,
     StatusCode,
@@ -37,7 +38,7 @@ import {
 import { AnyAttributeServer, FabricScopedAttributeServer } from "../cluster/server/AttributeServer.js";
 import { AnyEventServer, FabricSensitiveEventServer } from "../cluster/server/EventServer.js";
 import { NoChannelError } from "../protocol/ChannelManager.js";
-import { AttributeReportPayload, EventReportPayload } from "./AttributeDataEncoder.js";
+import { EventReportPayload } from "./AttributeDataEncoder.js";
 import { InteractionEndpointStructure } from "./InteractionEndpointStructure.js";
 import { InteractionServerMessenger } from "./InteractionMessenger.js";
 import {
@@ -133,7 +134,11 @@ export interface ServerSubscriptionContext {
         path: AttributePath,
         attribute: AnyAttributeServer<unknown>,
         offline?: boolean,
-    ): Promise<{ version: number; value: unknown }>;
+    ): { version: number; value: unknown };
+    readAttributesForEndpoint(
+        endpointId: EndpointNumber,
+        attributes: { path: AttributePath; attribute: AnyAttributeServer<unknown>; offline?: boolean }[],
+    ): { path: AttributePath; attribute: AnyAttributeServer<unknown>; version: number; value: unknown }[];
     readEvent(
         path: EventPath,
         event: AnyEventServer<any, any>,
@@ -425,7 +430,7 @@ export class ServerSubscription extends Subscription {
         const { newAttributes } = this.registerNewAttributes();
 
         for (const { path, attribute } of newAttributes) {
-            const { version, value } = await this.#context.readAttribute(path, attribute);
+            const { version, value } = this.#context.readAttribute(path, attribute);
 
             // We do not do any version filtering for attributes that are newly added to make sure controller gets
             // most current state
@@ -639,69 +644,7 @@ export class ServerSubscription extends Subscription {
         }
     }
 
-    async sendInitialReport(messenger: InteractionServerMessenger) {
-        this.#updateTimer.stop();
-
-        const { newAttributes, attributeErrors } = this.registerNewAttributes();
-
-        const dataVersionFilterMap = new Map<string, number>(
-            this.criteria.dataVersionFilters?.map(({ path, dataVersion }) => [clusterPathToId(path), dataVersion]) ??
-                [],
-        );
-
-        let attributesFilteredWithVersion = false;
-        const attributes = new Array<{
-            path: TypeFromSchema<typeof TlvAttributePath>;
-            value: any;
-            version: number;
-            schema: TlvSchema<any>;
-            attribute: AnyAttributeServer<any>;
-        }>();
-        for (const { path, attribute } of newAttributes) {
-            try {
-                const { value, version } = await this.#context.readAttribute(path, attribute);
-                if (value === undefined) continue;
-
-                const { nodeId, endpointId, clusterId } = path;
-
-                const versionFilterValue =
-                    endpointId !== undefined && clusterId !== undefined
-                        ? dataVersionFilterMap.get(clusterPathToId({ nodeId, endpointId, clusterId }))
-                        : undefined;
-                if (versionFilterValue !== undefined && versionFilterValue === version) {
-                    attributesFilteredWithVersion = true;
-                    continue;
-                }
-
-                attributes.push({ path, value, version, schema: attribute.schema, attribute });
-            } catch (error) {
-                if (StatusResponseError.is(error, StatusCode.UnsupportedAccess)) {
-                    logger.warn(`Permission denied reading attribute ${this.#structure.resolveAttributeName(path)}`);
-                } else {
-                    logger.warn(`Error reading attribute ${this.#structure.resolveAttributeName(path)}:`, error);
-                }
-            }
-        }
-        const attributeReportsPayload: AttributeReportPayload[] = attributes.map(
-            ({ path, schema, value, version, attribute }) => ({
-                hasFabricSensitiveData: attribute.hasFabricSensitiveData,
-                attributeData: {
-                    path,
-                    dataVersion: version,
-                    payload: value,
-                    schema,
-                },
-            }),
-        );
-        attributeErrors.forEach(attributeStatus =>
-            attributeReportsPayload.push({
-                hasFabricSensitiveData: false,
-                attributeStatus,
-            }),
-        );
-
-        const { newEvents, eventErrors } = this.#registerNewEvents();
-
+    async #collectInitialEventReportPayloads(newEvents: EventWithPath[]) {
         let eventsFiltered = false;
         const eventReportsPayload = new Array<EventReportPayload>();
         for (const { path, event } of newEvents) {
@@ -745,8 +688,91 @@ export class ServerSubscription extends Subscription {
             }
         });
 
+        return { eventReportsPayload, eventsFiltered };
+    }
+
+    /**
+     * Returns an iterator that yields the initial subscription data to be sent to the controller.
+     * The iterator will yield all attributes and events that match the subscription criteria.
+     * It will return true when finished without an error which triggers the sending of the data.
+     * A thrown exception will cancel the sending process immediately.
+     */
+    *#iterateInitialSubscriptionData(
+        attributesToSend: {
+            newAttributes: AttributeWithPath[];
+            attributeErrors: TypeFromSchema<typeof TlvAttributeStatus>[];
+        },
+        eventsToSend: {
+            eventReportsPayload: EventReportPayload[];
+            eventsFiltered: boolean;
+            eventErrors: TypeFromSchema<typeof TlvEventStatus>[];
+        },
+    ) {
+        const dataVersionFilterMap = new Map<string, number>(
+            this.criteria.dataVersionFilters?.map(({ path, dataVersion }) => [clusterPathToId(path), dataVersion]) ??
+                [],
+        );
+
+        const { newAttributes, attributeErrors } = attributesToSend;
+        const { eventReportsPayload, eventsFiltered, eventErrors } = eventsToSend;
+
+        logger.debug(
+            `Initializes Subscription with ${newAttributes.length} attributes and ${eventReportsPayload.length} events.`,
+        );
+
+        let attributesFilteredWithVersion = false;
+
+        const attributesPerCluster = new Map<EndpointNumber, AttributeWithPath[]>();
+        for (const { path, attribute } of newAttributes) {
+            const { endpointId } = path;
+            const endpointAttributes = attributesPerCluster.get(endpointId) ?? new Array<AttributeWithPath>();
+            endpointAttributes.push({ path, attribute });
+            attributesPerCluster.set(endpointId, endpointAttributes);
+        }
+
+        let attributesCounter = 0;
+        for (const endpointId of attributesPerCluster.keys()) {
+            const endpointAttributes = attributesPerCluster.get(endpointId)!;
+            attributesPerCluster.delete(endpointId);
+            for (const { path, attribute, value, version } of this.#context.readAttributesForEndpoint(
+                endpointId,
+                endpointAttributes,
+            )) {
+                if (value === undefined) continue;
+
+                const { nodeId, endpointId, clusterId } = path;
+
+                const versionFilterValue =
+                    endpointId !== undefined && clusterId !== undefined
+                        ? dataVersionFilterMap.get(clusterPathToId({ nodeId, endpointId, clusterId }))
+                        : undefined;
+                if (versionFilterValue !== undefined && versionFilterValue === version) {
+                    attributesFilteredWithVersion = true;
+                    continue;
+                }
+
+                attributesCounter++;
+                yield {
+                    hasFabricSensitiveData: attribute.hasFabricSensitiveData,
+                    attributeData: {
+                        path,
+                        dataVersion: version,
+                        payload: value,
+                        schema: attribute.schema,
+                    },
+                };
+            }
+        }
+
+        for (const attributeStatus of attributeErrors) {
+            yield {
+                hasFabricSensitiveData: false,
+                attributeStatus,
+            };
+        }
+
         if (
-            attributes.length === 0 &&
+            attributesCounter === 0 &&
             !attributesFilteredWithVersion &&
             eventReportsPayload.length === 0 &&
             !eventsFiltered
@@ -757,27 +783,40 @@ export class ServerSubscription extends Subscription {
             );
         }
 
-        eventErrors.forEach(eventStatus =>
-            eventReportsPayload.push({
+        for (const eventReport of eventReportsPayload) {
+            yield eventReport;
+        }
+
+        for (const eventStatus of eventErrors) {
+            yield {
                 hasFabricSensitiveData: false,
                 eventStatus,
-            }),
-        );
+            };
+        }
 
-        logger.debug(
-            `Initialize Subscription with ${attributes.length} attributes and ${eventReportsPayload.length} events.`,
-        );
         this.#lastUpdateTimeMs = Time.nowMs();
+
+        return true;
+    }
+
+    async sendInitialReport(messenger: InteractionServerMessenger) {
+        this.#updateTimer.stop();
+
+        const { newAttributes, attributeErrors } = this.registerNewAttributes();
+        const { newEvents, eventErrors } = this.#registerNewEvents();
+        const { eventReportsPayload, eventsFiltered } = await this.#collectInitialEventReportPayloads(newEvents);
 
         await messenger.sendDataReport(
             {
                 suppressResponse: false, // we always need proper response for initial report
                 subscriptionId: this.id,
                 interactionModelRevision: Specification.INTERACTION_MODEL_REVISION,
-                attributeReportsPayload,
-                eventReportsPayload,
             },
             this.criteria.isFabricFiltered,
+            this.#iterateInitialSubscriptionData(
+                { newAttributes, attributeErrors },
+                { eventReportsPayload, eventsFiltered, eventErrors },
+            ),
         );
     }
 
@@ -805,16 +844,15 @@ export class ServerSubscription extends Subscription {
             // We cannot be sure what value we got for fabric filtered attributes (and from which fabric),
             // so get it again for this relevant fabric. This also makes sure that fabric sensitive fields are filtered
             // TODO: Remove this once we remove the legacy API and go away from using AttributeServers in the background
-            return this.#context.readAttribute(path, attribute, true).then(({ value }) => {
-                this.#outstandingAttributeUpdates.set(attributePathToId(path), {
-                    attribute,
-                    path,
-                    schema,
-                    version,
-                    value,
-                });
-                this.#prepareDataUpdate();
+            const { value } = this.#context.readAttribute(path, attribute, true);
+            this.#outstandingAttributeUpdates.set(attributePathToId(path), {
+                attribute,
+                path,
+                schema,
+                version,
+                value,
             });
+            this.#prepareDataUpdate();
         }
         this.#outstandingAttributeUpdates.set(attributePathToId(path), { attribute, path, schema, version, value });
         this.#prepareDataUpdate();
@@ -878,6 +916,40 @@ export class ServerSubscription extends Subscription {
         await super.close();
     }
 
+    /**
+     * Iterates over all attributes and events that have changed since the last update and sends them to
+     * the controller.
+     * It will return true when finished without an error which triggers the sending of the data.
+     * A thrown exception will cancel the sending process immediately.
+     */
+    *#iterateDataUpdate(attributes: AttributePathWithValueVersion<any>[], events: EventPathWithEventData<any>[]) {
+        for (const {
+            path,
+            schema,
+            value: payload,
+            version: dataVersion,
+            attribute: { hasFabricSensitiveData },
+        } of attributes) {
+            yield {
+                hasFabricSensitiveData,
+                attributeData: { path, dataVersion, schema, payload },
+            };
+        }
+
+        for (const {
+            path,
+            schema,
+            event,
+            data: { number: eventNumber, priority, epochTimestamp, payload },
+        } of events) {
+            yield {
+                hasFabricSensitiveData: event.hasFabricSensitiveData,
+                eventData: { path, eventNumber, priority, epochTimestamp, schema, payload },
+            };
+        }
+        return true;
+    }
+
     private async sendUpdateMessage(
         attributes: AttributePathWithValueVersion<any>[],
         events: EventPathWithEventData<any>[],
@@ -905,6 +977,7 @@ export class ServerSubscription extends Subscription {
                         interactionModelRevision: Specification.INTERACTION_MODEL_REVISION,
                     },
                     this.criteria.isFabricFiltered,
+                    undefined,
                     !this.isClosed, // Do not wait for ack when closed
                 );
             } else {
@@ -913,31 +986,9 @@ export class ServerSubscription extends Subscription {
                         suppressResponse: false, // Non-empty data reports always need to send response
                         subscriptionId: this.id,
                         interactionModelRevision: Specification.INTERACTION_MODEL_REVISION,
-                        attributeReportsPayload: attributes.map(({ path, schema, value, version, attribute }) => ({
-                            hasFabricSensitiveData: attribute.hasFabricSensitiveData,
-                            attributeData: {
-                                path,
-                                dataVersion: version,
-                                schema,
-                                payload: value,
-                            },
-                        })),
-                        eventReportsPayload: events.map(({ path, schema, event, data }) => {
-                            const { number, priority, epochTimestamp, payload } = data;
-                            return {
-                                hasFabricSensitiveData: event.hasFabricSensitiveData,
-                                eventData: {
-                                    path,
-                                    eventNumber: number,
-                                    priority,
-                                    epochTimestamp,
-                                    schema,
-                                    payload,
-                                },
-                            };
-                        }),
                     },
                     this.criteria.isFabricFiltered,
+                    this.#iterateDataUpdate(attributes, events),
                     !this.isClosed, // Do not wait for ack when closed
                 );
             }

--- a/packages/protocol/src/interaction/ServerSubscription.ts
+++ b/packages/protocol/src/interaction/ServerSubscription.ts
@@ -694,7 +694,6 @@ export class ServerSubscription extends Subscription {
     /**
      * Returns an iterator that yields the initial subscription data to be sent to the controller.
      * The iterator will yield all attributes and events that match the subscription criteria.
-     * It will return true when finished without an error which triggers the sending of the data.
      * A thrown exception will cancel the sending process immediately.
      * TODO: Streamline all this with the normal Read flow to also handle Concrete Path subscriptions with errors correctly
      */
@@ -796,8 +795,6 @@ export class ServerSubscription extends Subscription {
         }
 
         this.#lastUpdateTimeMs = Time.nowMs();
-
-        return true;
     }
 
     async sendInitialReport(messenger: InteractionServerMessenger) {
@@ -920,7 +917,6 @@ export class ServerSubscription extends Subscription {
     /**
      * Iterates over all attributes and events that have changed since the last update and sends them to
      * the controller.
-     * It will return true when finished without an error which triggers the sending of the data.
      * A thrown exception will cancel the sending process immediately.
      */
     *#iterateDataUpdate(attributes: AttributePathWithValueVersion<any>[], events: EventPathWithEventData<any>[]) {
@@ -948,7 +944,6 @@ export class ServerSubscription extends Subscription {
                 eventData: { path, eventNumber, priority, epochTimestamp, schema, payload },
             };
         }
-        return true;
     }
 
     private async sendUpdateMessage(

--- a/packages/protocol/src/interaction/ServerSubscription.ts
+++ b/packages/protocol/src/interaction/ServerSubscription.ts
@@ -135,7 +135,7 @@ export interface ServerSubscriptionContext {
         attribute: AnyAttributeServer<unknown>,
         offline?: boolean,
     ): { version: number; value: unknown };
-    readAttributesForEndpoint(
+    readEndpointAttributesForSubscription(
         endpointId: EndpointNumber,
         attributes: { path: AttributePath; attribute: AnyAttributeServer<unknown>; offline?: boolean }[],
     ): { path: AttributePath; attribute: AnyAttributeServer<unknown>; version: number; value: unknown }[];
@@ -735,7 +735,7 @@ export class ServerSubscription extends Subscription {
         for (const endpointId of attributesPerCluster.keys()) {
             const endpointAttributes = attributesPerCluster.get(endpointId)!;
             attributesPerCluster.delete(endpointId);
-            for (const { path, attribute, value, version } of this.#context.readAttributesForEndpoint(
+            for (const { path, attribute, value, version } of this.#context.readEndpointAttributesForSubscription(
                 endpointId,
                 endpointAttributes,
             )) {


### PR DESCRIPTION
This PR is mainly focussed on optimizations of resources (mainly RAM) usage on Data Reads and Subscriptions.

It:
* Makes data reads sync as they should have been all the time, so reducing some async overhead
* On Subscriptions it reuses the OnlineContext in new API code flows and reads the data for one endpoint together in the same Context
* DataReports are now sent in a streaming fashion using Generator functions and also new data are read when they are needed and not all at the beginning

addresses #1640 ... lets see how it is afterwards as first step