### PR TITLE
Adjust arming failsafe for new PASE sessions

### DIFF
--- a/packages/node/src/behaviors/general-commissioning/GeneralCommissioningServer.ts
+++ b/packages/node/src/behaviors/general-commissioning/GeneralCommissioningServer.ts
@@ -46,7 +46,10 @@ export class GeneralCommissioningServer extends GeneralCommissioningBehavior {
 
     /** As required by Commissioning Flows any new PASE session needs to arm the failsafe for 60s. */
     async #handleAddedPaseSessions(session: SecureSession) {
-        if (!session.isPase) {
+        if (
+            !session.isPase || // Only PASE sessions
+            session.fabric !== undefined // That does not have an assigned fabric (can never happen in real usecases)
+        ) {
             return;
         }
         logger.debug(`New PASE session added: ${session.id}. Arming Failsafe for 60s.`);


### PR DESCRIPTION
The case that a PASE session is opened with an associated fabric can not really happen in real life but in our testing, so adjust the logic here slightly.