### PR TITLE
Subscription and Exchange edge case fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ The main work (all changes without a GitHub username in brackets in the below li
 	## __WORK IN PROGRESS__
 -->
 
+## __WORK IN PROGRESS__
+
+-   @matter/protocol
+    - Fix: Prevented issues where closing subscriptions could block the session closing or establishing new subscriptions
+    - Fix: Prevented to establish new exchanges while shutting down Exchange Manager
+
+
 ## 0.12.2 (2025-02-01)
 
 -   @matter/node

--- a/packages/node/src/node/server/TransactionalInteractionServer.ts
+++ b/packages/node/src/node/server/TransactionalInteractionServer.ts
@@ -156,6 +156,11 @@ export class TransactionalInteractionServer extends InteractionServer {
         return (this.#aclServer = aclServer);
     }
 
+    /**
+     * Gets the context information from an endpoint needed for ACL checks. It prefills a cache if needed.
+     * The cache is cleared on structural changes and initialized again on next need.
+     * TODO Remove with the legacy API
+     */
     #getAclEndpointContext(endpointId: EndpointNumber) {
         if (!this.#endpointContexts.has(endpointId)) {
             this.#endpoint.visit(({ number, state }) => {

--- a/packages/protocol/src/interaction/Subscription.ts
+++ b/packages/protocol/src/interaction/Subscription.ts
@@ -23,7 +23,7 @@ export interface SubscriptionCriteria {
 /**
  * A single active subscription.
  */
-export class Subscription {
+export abstract class Subscription {
     #session: SecureSession;
     #id: SubscriptionId;
     #isClosed?: boolean;
@@ -61,7 +61,7 @@ export class Subscription {
     }
 
     /**
-     * Update session state.  This probably is meaniningless except in a server context.
+     * Update session state.  This probably is meaningless except in a server context.
      */
     async update() {}
 
@@ -76,13 +76,13 @@ export class Subscription {
         this.#isClosed = value;
     }
 
+    /** Close the subscription with the option to gracefully flush outstanding data. */
+    abstract close(graceful: boolean): Promise<void>;
+
     /**
-     * Close the session.
-     *
-     * @param _graceful in a server context this means flush pending updates.  Not sure if applies to client
-     * subscriptions
+     * Destroy the subscription. Unsubscribe from all attributes and events and stop all timers.
      */
-    async close(_graceful = true): Promise<void> {
+    protected async destroy(): Promise<void> {
         this.#isClosed = true;
         this.#session.subscriptions.delete(this);
         logger.debug(`Removed subscription ${this.id} from ${this.#session.name}`);


### PR DESCRIPTION
This PR refactors the subscription closing/destroy to prevent cyclic awaits for completing sending a message. Also it is not needed to close the session, we can just remove the subscription.

Additionally we prevent new exchanges to be accepted when ExchangeManager already is closing.

addresses https://github.com/t0bst4r/home-assistant-matter-hub/issues/485 and others