### PR TITLE
Minor ServerSubscription.flush cleanup

### DIFF
--- a/packages/protocol/src/interaction/ServerSubscription.ts
+++ b/packages/protocol/src/interaction/ServerSubscription.ts
@@ -878,7 +878,7 @@ export class ServerSubscription extends Subscription {
         }
     }
 
-    async flush() {
+    async #flush() {
         this.#sendDelayTimer.stop();
         if (this.#outstandingAttributeUpdates.size > 0 || this.#outstandingEventUpdates.size > 0) {
             logger.debug(
@@ -906,7 +906,7 @@ export class ServerSubscription extends Subscription {
         this.#updateTimer.stop();
         this.#sendDelayTimer.stop();
         if (graceful) {
-            await this.flush();
+            await this.#flush();
         }
         if (this.currentUpdatePromise) {
             await this.currentUpdatePromise;

--- a/packages/protocol/src/interaction/ServerSubscription.ts
+++ b/packages/protocol/src/interaction/ServerSubscription.ts
@@ -878,16 +878,13 @@ export class ServerSubscription extends Subscription {
         }
     }
 
-    async #flush() {
+    #flush() {
         this.#sendDelayTimer.stop();
         if (this.#outstandingAttributeUpdates.size > 0 || this.#outstandingEventUpdates.size > 0) {
             logger.debug(
                 `Flushing subscription ${this.id} with ${this.#outstandingAttributeUpdates.size} attributes and ${this.#outstandingEventUpdates.size} events${this.isClosed ? " (for closing)" : ""}`,
             );
             this.#triggerSendUpdate();
-            if (this.currentUpdatePromise) {
-                await this.currentUpdatePromise;
-            }
         }
     }
 
@@ -906,7 +903,7 @@ export class ServerSubscription extends Subscription {
         this.#updateTimer.stop();
         this.#sendDelayTimer.stop();
         if (graceful) {
-            await this.#flush();
+            this.#flush();
         }
         if (this.currentUpdatePromise) {
             await this.currentUpdatePromise;


### PR DESCRIPTION
The caller of flush always awaits the `currentUpdatePromise` if one is set, so `flush` doesn't need to do this and does in turn not need to be async.