### PR TITLE
Handle all updateFabricLabel error as non-critical

### DIFF
--- a/packages/general/src/util/DataReadQueue.ts
+++ b/packages/general/src/util/DataReadQueue.ts
@@ -28,7 +28,7 @@ export class DataReadQueue<T> implements Stream<T> {
             resolver,
             rejecter,
             timeoutTimer: Time.getTimer("Queue timeout", timeoutMs, () =>
-                rejecter(new NoResponseTimeoutError("No incoming data within the timeout period")),
+                rejecter(new NoResponseTimeoutError(`Expected response data missing within timeout of ${timeoutMs}ms`)),
             ).start(),
         };
         return promise;

--- a/packages/general/src/util/DataReadQueue.ts
+++ b/packages/general/src/util/DataReadQueue.ts
@@ -28,7 +28,7 @@ export class DataReadQueue<T> implements Stream<T> {
             resolver,
             rejecter,
             timeoutTimer: Time.getTimer("Queue timeout", timeoutMs, () =>
-                rejecter(new NoResponseTimeoutError()),
+                rejecter(new NoResponseTimeoutError("No incoming data within the timeout period")),
             ).start(),
         };
         return promise;

--- a/packages/protocol/src/peer/ControllerCommissioningFlow.ts
+++ b/packages/protocol/src/peer/ControllerCommissioningFlow.ts
@@ -811,11 +811,8 @@ export class ControllerCommissioningFlow {
                 }),
             );
         } catch (error) {
-            CommissioningError.accept(error);
-            return {
-                code: CommissioningStepResultCode.Failure,
-                breadcrumb: this.#lastBreadcrumb,
-            };
+            // convert error
+            throw repackErrorAs(error, RecoverableCommissioningError);
         }
 
         return {


### PR DESCRIPTION
... because it seems there are devices that have issues and we try on next connect anyway again to set/update the label. dditionally prevent an "emopty" error message for devs that only log the message.