### PR TITLE
Fix edge case in new DataReport chunking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,21 @@ The main work (all changes without a GitHub username in brackets in the below li
 
 ### __WORK IN PROGRESS__
 
+-   @matter/general
+    - Adjustment: Do not accept listeners on read-only transactions
+    - Enhancement: Only report locks for slow async transactions in logs
+    - Enhancement: Do not report Read transactions anymore in logs
+
+-   @matter/node
+    - Enhancement: Added caching for generated ClusterType and ClusterBehavior classes
+    - Enhancement: Added preparations for optimized node read handling
+
 -   @matter/protocol
     - Enhancement: Optimized Report Data message chunking 
     - Fix: handles errors when setting fabric label during commissioning as non-critical for the commissioning flow
 
+-   @project-chip/matter.js
+    - Cleanup: Deprecated some methods fof the CommissioningController and pairedNode to better define the best practice interfaces to use
 
 ### 0.12.3 (2025-02-05)
 
@@ -22,9 +33,6 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: Reduced some over-exact certificate validation to unblock Aqara commissioning
     - Fix: Prevented issues where closing subscriptions could block the session closing or establishing new subscriptions
     - Fix: Prevented to establish new exchanges while shutting down Exchange Manager
-
--   @project-chip/matter.js
-    - Cleanup: Deprecated some methods fof the CommissioningController and pairedNode to better define the best practice interfaces to use
 
 ## 0.12.2 (2025-02-01)
 

--- a/packages/protocol/src/interaction/InteractionMessenger.ts
+++ b/packages/protocol/src/interaction/InteractionMessenger.ts
@@ -542,7 +542,6 @@ export class InteractionServerMessenger extends InteractionMessenger {
                                                 allowMissingFieldsForNonFabricFilteredRead,
                                             }),
                                         );
-
                                         break;
                                     }
                                     availableBytes -= encodedChunkDataSize;
@@ -581,6 +580,12 @@ export class InteractionServerMessenger extends InteractionMessenger {
                             // We did not send the message, means assumption is that there is more space in the message
                             // So we add the current attribute to the end of the queue
                             attributeReportsToSend.push(attributeToSend);
+                            continue;
+                        }
+                        if (encodedSize > this.exchange.maxPayloadSize - emptyDataReportBytes.length - 3) {
+                            // We sent the message but the current attribute is too big for a message alone so needs to
+                            // be chunked, so add it to the queue at the beginning
+                            attributeReportsToSend.unshift(attributeToSend);
                             continue;
                         }
                     }
@@ -626,7 +631,7 @@ export class InteractionServerMessenger extends InteractionMessenger {
         const encodedMessage = TlvDataReportForSend.encode(dataReportToSend);
         if (encodedMessage.length > this.exchange.maxPayloadSize) {
             throw new MatterFlowError(
-                `DataReport is too long to fit in a single chunk, This should not happen! Data: ${Logger.toJSON(
+                `DataReport with ${encodedMessage.length}bytes is too long to fit in a single chunk (${this.exchange.maxPayloadSize}bytes), This should not happen! Data: ${Logger.toJSON(
                     dataReportToSend,
                 )}`,
             );


### PR DESCRIPTION
In the edge case that a list did not matched in the current package and the list is too long for one message at all then this list was still added to the packet and so lead to an "message to big "error.