### PR TITLE
Improve async storage reliability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Feature: Automatically handle basicInformation uniqueId Property as defined by specification if not set by the developer
 
 -   @matter/nodejs
-    - Fix: Improves async storage reliability and error handling to prevent empty storage files in crashing edge cases
+    - Fix: Improves async storage reliability and error handling to prevent empty storage files in crashing edge cases. With this change write actions need a bit longer but are more reliable, which mainly effects controller use cases when persisting the device attribute data on first subscribe
 
 -   @matter/protocol
     - Breaking: `updateReceived()` callback on subscriptions is triggered after all updated data event are sent out.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ The main work (all changes without a GitHub username in brackets in the below li
 -   @matter/main
     - Feature: Automatically handle basicInformation uniqueId Property as defined by specification if not set by the developer
 
+-   @matter/nodejs
+    - Fix: Improves async storage reliability and error handling to prevent empty storage files in crashing edge cases
+
 -   @matter/protocol
     - Breaking: `updateReceived()` callback on subscriptions is triggered after all updated data event are sent out.
     - Feature: Enhanced `getMultipleAttributesAndEvents()` to also return attributeStatus and eventStatus properties with errors returned from the read interaction 

--- a/packages/nodejs/src/storage/StorageBackendDiskAsync.ts
+++ b/packages/nodejs/src/storage/StorageBackendDiskAsync.ts
@@ -163,6 +163,8 @@ export class StorageBackendDiskAsync extends MaybeAsyncStorage {
         const fd = await open(this.#path, "r");
         try {
             await fd.sync();
+        } catch (error) {
+            logger.warn(`Failed to fsync storage directory ${this.#path}`, error);
         } finally {
             await fd.close();
         }

--- a/packages/nodejs/src/storage/StorageBackendDiskAsync.ts
+++ b/packages/nodejs/src/storage/StorageBackendDiskAsync.ts
@@ -53,12 +53,12 @@ export class StorageBackendDiskAsync extends MaybeAsyncStorage {
                 return;
             }
         }
+        await this.#fsyncStorageDir();
     }
 
     async close() {
         this.isInitialized = false;
         await this.#finishAllWrites();
-        await this.#fsyncStorageDir();
     }
 
     filePath(fileName: string) {
@@ -67,7 +67,6 @@ export class StorageBackendDiskAsync extends MaybeAsyncStorage {
 
     async clear() {
         await this.#finishAllWrites();
-        await this.#fsyncStorageDir();
         await rm(this.#path, { recursive: true, force: true });
         await mkdir(this.#path, { recursive: true });
     }

--- a/packages/nodejs/src/storage/StorageBackendDiskAsync.ts
+++ b/packages/nodejs/src/storage/StorageBackendDiskAsync.ts
@@ -155,15 +155,14 @@ export class StorageBackendDiskAsync extends MaybeAsyncStorage {
      * We do this as best effort to ensure that all writes are persisted to disk.
      */
     async #fsyncStorageDir() {
+        if (process.platform === "win32") {
+            // Windows will cause `EPERM: operation not permitted, fsync`
+            // for directories, so lets catch this generically
+            return;
+        }
         const fd = await open(this.#path, "r");
         try {
             await fd.sync();
-        } catch (error) {
-            // Windows will cause `EPERM: operation not permitted, fsync`
-            // for directories, so lets catch this generically
-            if ((error as any).code !== "EPERM") {
-                throw error;
-            }
         } finally {
             await fd.close();
         }


### PR DESCRIPTION
This PR adjusts writing the storage files as temp file first and then do a rename. It also makes sure that all renames are finished when closing or clearing the storage.

I do this as Draft PR to get early review comments, but need to finish testing this in detail tomorrow