### PR TITLE
Forced match for models

### DIFF
--- a/.github/workflows/chip-matterjs-tests.yml
+++ b/.github/workflows/chip-matterjs-tests.yml
@@ -102,7 +102,7 @@ jobs:
               --chip-tool ../chip-testing/dist/esm/ControllerWebSocketTestApp.js \
               --log-level info \
               --target-glob "{Test_*,}" \
-              --target-skip-glob "{Test_TC_BDX_*,Test_TC_DGTHREAD*,Test_TC_DGWIFI*,Test_TC_DRLK_2_7,Test_TC_ACE_1_6,Test_TC_SC_5_2,Test_TC_S_2_3}" \
+              --target-skip-glob "{Test_TC_BDX_*,Test_TC_DGTHREAD*,Test_TC_DGWIFI*,Test_TC_ACE_1_6,Test_TC_SC_5_2,Test_TC_S_2_3}" \
               run \
               --all-clusters-app ../bin/chip-all-clusters-app \
               --lock-app ../bin/chip-lock-app \

--- a/codegen/src/mom/common/generate-element.ts
+++ b/codegen/src/mom/common/generate-element.ts
@@ -35,6 +35,9 @@ export function generateElement(target: Block, importFrom: string, element: Mode
         delete fields.type;
     }
 
+    // This is for codegen only
+    delete fields.matchTo;
+
     // Next: Other fields
     properties.push(
         ...Object.entries(fields)

--- a/models/src/local/AlarmBaseOverrides.ts
+++ b/models/src/local/AlarmBaseOverrides.ts
@@ -11,61 +11,42 @@ LocalMatter.children.push({
     name: "AlarmBase",
 
     children: [
-        // Event ID Numbers of Fields were changed
-        // InitialTimeEstimate -> EstimatedTime
-        /*
-        TODO: This generates duplicate errors. YOu also need to add the import in index.ts!
+        /**
+         * The IDs in the "specification" for Notify fields are one off from defacto spec.
+         */
         {
             tag: "event",
             name: "Notify",
-            id: 0x0,
+            id: 0,
             children: [
                 {
                     tag: "field",
                     name: "Active",
-                    id: 0x0,
-                    type: "AlarmBitmap",
-                    conformance: "M",
-                    default: 0,
-                    details: "This field shall indicate those alarms that have become active.",
-                    xref: { document: "cluster", section: "1.15.8.1.1" },
+                    id: 0,
+                    matchTo: { name: "Active" },
                 },
+
                 {
                     tag: "field",
                     name: "Inactive",
-                    id: 0x1,
-                    type: "AlarmBitmap",
-                    conformance: "M",
-                    default: 0,
-                    details: "This field shall indicate those alarms that have become inactive.",
-                    xref: { document: "cluster", section: "1.15.8.1.2" },
+                    id: 1,
+                    matchTo: { name: "Inactive" },
                 },
 
                 {
                     tag: "field",
                     name: "State",
-                    id: 0x2,
-                    type: "AlarmBitmap",
-                    conformance: "M",
-                    default: 0,
-                    details:
-                        "This field shall be a copy of the new State attribute value that resulted in the event being " +
-                        "generated. That is, this field shall have all the bits in Active set and shall NOT have any of the " +
-                        "bits in Inactive set.",
-                    xref: { document: "cluster", section: "1.15.8.1.4" },
+                    id: 2,
+                    matchTo: { name: "State" },
                 },
 
                 {
                     tag: "field",
                     name: "Mask",
-                    id: 0x3,
-                    type: "AlarmBitmap",
-                    conformance: "M",
-                    default: 0,
-                    details: "This field shall be a copy of the Mask attribute when this event was generated.",
-                    xref: { document: "cluster", section: "1.15.8.1.3" },
+                    id: 3,
+                    matchTo: { name: "Mask" },
                 },
             ],
-        },*/
+        },
     ],
 });

--- a/models/src/local/DoorLockOverrides.ts
+++ b/models/src/local/DoorLockOverrides.ts
@@ -65,7 +65,7 @@ LocalMatter.children.push({
         { tag: "attribute", id: 0x33, name: "RequirePinForRemoteOperation" },
 
         // Because of the special definition of this BitMap (being inverse as usual) we enhance the descriptions
-        // and add the other bits as an own entry to set the in a convenient way.
+        // and add the other bits as an own entry to set in a convenient way.
         {
             tag: "datatype",
             name: "OperatingModesBitmap",
@@ -114,67 +114,40 @@ LocalMatter.children.push({
             ],
         },
 
-        /*
-        TODO: This override is needed to correctly assign the field IDs to the fields in the command. But it does not work
+        // In 1.4 the IDS in GetYearDayScheduleResponse are borked so we force match and override
         {
             tag: "command",
             id: 0xf,
             name: "GetYearDayScheduleResponse",
+
             children: [
                 {
                     tag: "field",
                     name: "Status",
                     id: 0x2,
-                    type: "status",
-                    conformance: "M",
-                    constraint: "desc",
-                    default: 0,
-
-                    details:
-                        "Status shall be one of the following values:" +
-                        "\n" +
-                        "  • SUCCESS if both YearDayIndex and UserIndex are valid and there is a corresponding schedule " +
-                        "    entry." +
-                        "\n" +
-                        "  • INVALID_COMMAND if either YearDayIndex and/or UserIndex values are not within valid range" +
-                        "\n" +
-                        "  • NOT_FOUND if no corresponding schedule entry found for YearDayIndex." +
-                        "\n" +
-                        "  • NOT_FOUND if no corresponding user entry found for UserIndex." +
-                        "\n" +
-                        "If this field is SUCCESS, the optional fields for this command shall be present. For other (error) " +
-                        "status values, only the fields up to the status field shall be present.",
-
-                    xref: { document: "cluster", section: "5.2.10.18.3" },
+                    matchTo: {
+                        name: "Status",
+                    },
                 },
 
                 {
                     tag: "field",
                     name: "LocalStartTime",
                     id: 0x3,
-                    type: "epoch-s",
-                    conformance: "O",
-                    details:
-                        "This field shall indicate the starting time for the Year Day schedule in Epoch Time in Seconds with " +
-                        "local time offset based on the local timezone and DST offset on the day represented by the value. " +
-                        "This shall be null if the schedule is not set for the YearDayIndex and UserIndex provided.",
-                    xref: { document: "cluster", section: "5.2.10.18.4" },
+                    matchTo: {
+                        name: "LocalStartTime",
+                    },
                 },
 
                 {
                     tag: "field",
                     name: "LocalEndTime",
                     id: 0x4,
-                    type: "epoch-s",
-                    conformance: "O",
-                    details:
-                        "This field shall indicate the ending time for the Year Day schedule in Epoch Time in Seconds with " +
-                        "local time offset based on the local timezone and DST offset on the day represented by the value. " +
-                        "LocalEndTime shall be greater than LocalStartTime. This shall be null if the schedule is not set " +
-                        "for the YearDayIndex and UserIndex provided.",
-                    xref: { document: "cluster", section: "5.2.10.18.5" },
+                    matchTo: {
+                        name: "LocalEndTime",
+                    },
                 },
             ],
-        },*/
+        },
     ],
 });

--- a/models/src/local/index.ts
+++ b/models/src/local/index.ts
@@ -13,6 +13,7 @@
 // matching.
 
 import "./AdministratorCommissioningOverrides.js";
+import "./AlarmBaseOverrides.js";
 import "./any.js";
 import "./BasicInformationOverrides.js";
 import "./ColorControlOverrides.js";

--- a/packages/model/src/elements/BaseElement.ts
+++ b/packages/model/src/elements/BaseElement.ts
@@ -73,6 +73,11 @@ export interface BaseElement {
      * The Matter specification revision in which this element was removed.
      */
     until?: Specification.Revision;
+
+    /**
+     * Force match to other elements with the specified name or ID.
+     */
+    matchTo?: BaseElement.MatchDirective;
 }
 
 export function BaseElement(tag: ElementTag, definition: BaseElement, children: BaseElement[]) {
@@ -101,4 +106,12 @@ export namespace BaseElement {
     export type Properties<T extends BaseElement> = T extends { tag: `${ElementTag}` }
         ? Omit<T, "tag"> & Partial<Pick<T, "tag">>
         : T;
+
+    /**
+     * An explicit ID and/or name that override normal matching heuristics.
+     */
+    export interface MatchDirective {
+        id?: string | number;
+        name?: string;
+    }
 }

--- a/packages/model/src/logic/ModelVariantTraversal.ts
+++ b/packages/model/src/logic/ModelVariantTraversal.ts
@@ -328,8 +328,24 @@ export abstract class ModelVariantTraversal<S = void> {
                 const mapping =
                     mappings[child.tag] || (mappings[child.tag] = { slots: [], idToSlot: {}, nameToSlot: {} });
 
-                const idKey = child.key;
-                let nameKey = this.getCanonicalName(child);
+                let idKey: string | undefined;
+                let nameKey: string | undefined;
+
+                // Determine matching keys.  These are based on ID and/or name unless explicitly overridden
+                if (child.matchTo !== undefined) {
+                    const { id, name } = child.matchTo;
+
+                    if (id !== undefined) {
+                        idKey = id.toString();
+                    }
+
+                    if (name !== undefined) {
+                        nameKey = name.toString();
+                    }
+                } else {
+                    idKey = child.key;
+                    nameKey = this.getCanonicalName(child) as string | undefined;
+                }
 
                 if (child.discriminator !== undefined) {
                     nameKey = `${nameKey}␜${child.discriminator}`;
@@ -343,7 +359,7 @@ export abstract class ModelVariantTraversal<S = void> {
                 }
 
                 // Find existing slot by name
-                if (slot === undefined) {
+                if (slot === undefined && nameKey !== undefined) {
                     slot = mapping.nameToSlot[nameKey];
                 }
 
@@ -354,14 +370,12 @@ export abstract class ModelVariantTraversal<S = void> {
                 }
 
                 // Map the child's ID to the slot
-                if (idKey !== undefined) {
-                    if (mapping.idToSlot[idKey] === undefined) {
-                        mapping.idToSlot[idKey] = slot;
-                    }
+                if (idKey !== undefined && mapping.idToSlot[idKey] === undefined) {
+                    mapping.idToSlot[idKey] = slot;
                 }
 
                 // Map the child's name to the slot
-                if (mapping.nameToSlot[nameKey] === undefined) {
+                if (nameKey !== undefined && mapping.nameToSlot[nameKey] === undefined) {
                     mapping.nameToSlot[nameKey] = slot;
                 }
 

--- a/packages/model/src/models/Model.ts
+++ b/packages/model/src/models/Model.ts
@@ -32,6 +32,10 @@ export abstract class Model<T extends BaseElement = BaseElement> {
     errors?: DefinitionError[];
     asOf?: Specification.Revision;
     until?: Specification.Revision;
+    matchTo?: {
+        id?: string | number;
+        name?: string;
+    };
     declare id?: number;
     declare name: string;
 

--- a/packages/model/src/standard/elements/AlarmBase.ts
+++ b/packages/model/src/standard/elements/AlarmBase.ts
@@ -76,18 +76,18 @@ export const AlarmBase = Cluster(
             xref: { document: "cluster", section: "1.15.8.1" }
         },
         Field({
-            name: "Active", id: 0x1, type: "AlarmBitmap", conformance: "M", default: 0,
+            name: "Active", id: 0x0, type: "AlarmBitmap", conformance: "M", default: 0,
             details: "This field shall indicate those alarms that have become active.",
             xref: { document: "cluster", section: "1.15.8.1.1" }
         }),
         Field({
-            name: "Inactive", id: 0x2, type: "AlarmBitmap", conformance: "M", default: 0,
+            name: "Inactive", id: 0x1, type: "AlarmBitmap", conformance: "M", default: 0,
             details: "This field shall indicate those alarms that have become inactive.",
             xref: { document: "cluster", section: "1.15.8.1.2" }
         }),
 
         Field({
-            name: "State", id: 0x3, type: "AlarmBitmap", conformance: "M", default: 0,
+            name: "State", id: 0x2, type: "AlarmBitmap", conformance: "M", default: 0,
             details: "This field shall be a copy of the new State attribute value that resulted in the event being " +
                 "generated. That is, this field shall have all the bits in Active set and shall NOT have any of the " +
                 "bits in Inactive set.",
@@ -95,7 +95,7 @@ export const AlarmBase = Cluster(
         }),
 
         Field({
-            name: "Mask", id: 0x4, type: "AlarmBitmap", conformance: "M", default: 0,
+            name: "Mask", id: 0x3, type: "AlarmBitmap", conformance: "M", default: 0,
             details: "This field shall be a copy of the Mask attribute when this event was generated.",
             xref: { document: "cluster", section: "1.15.8.1.3" }
         })

--- a/packages/model/src/standard/elements/DoorLock.ts
+++ b/packages/model/src/standard/elements/DoorLock.ts
@@ -1389,7 +1389,7 @@ export const DoorLock = Cluster(
         }),
 
         Field({
-            name: "LocalStartTime", id: 0x2, type: "epoch-s", conformance: "O",
+            name: "LocalStartTime", id: 0x3, type: "epoch-s", conformance: "O",
             details: "This field shall indicate the starting time for the Year Day schedule in Epoch Time in Seconds with " +
                 "local time offset based on the local timezone and DST offset on the day represented by the value. " +
                 "This shall be null if the schedule is not set for the YearDayIndex and UserIndex provided.",
@@ -1397,7 +1397,7 @@ export const DoorLock = Cluster(
         }),
 
         Field({
-            name: "LocalEndTime", id: 0x3, type: "epoch-s", conformance: "O",
+            name: "LocalEndTime", id: 0x4, type: "epoch-s", conformance: "O",
             details: "This field shall indicate the ending time for the Year Day schedule in Epoch Time in Seconds with " +
                 "local time offset based on the local timezone and DST offset on the day represented by the value. " +
                 "LocalEndTime shall be greater than LocalStartTime. This shall be null if the schedule is not set for " +

--- a/packages/types/src/clusters/alarm-base.ts
+++ b/packages/types/src/clusters/alarm-base.ts
@@ -111,14 +111,14 @@ export namespace AlarmBase {
          *
          * @see {@link MatterSpecification.v13.Cluster} § 1.15.8.1.1
          */
-        active: TlvField(1, TlvUInt32),
+        active: TlvField(0, TlvUInt32),
 
         /**
          * This field shall indicate those alarms that have become inactive.
          *
          * @see {@link MatterSpecification.v13.Cluster} § 1.15.8.1.2
          */
-        inactive: TlvField(2, TlvUInt32),
+        inactive: TlvField(1, TlvUInt32),
 
         /**
          * This field shall be a copy of the new State attribute value that resulted in the event being generated. That
@@ -126,14 +126,14 @@ export namespace AlarmBase {
          *
          * @see {@link MatterSpecification.v13.Cluster} § 1.15.8.1.4
          */
-        state: TlvField(3, TlvUInt32),
+        state: TlvField(2, TlvUInt32),
 
         /**
          * This field shall be a copy of the Mask attribute when this event was generated.
          *
          * @see {@link MatterSpecification.v13.Cluster} § 1.15.8.1.3
          */
-        mask: TlvField(4, TlvUInt32)
+        mask: TlvField(3, TlvUInt32)
     });
 
     /**

--- a/packages/types/src/clusters/dishwasher-alarm.ts
+++ b/packages/types/src/clusters/dishwasher-alarm.ts
@@ -147,14 +147,14 @@ export namespace DishwasherAlarm {
          *
          * @see {@link MatterSpecification.v13.Cluster} § 1.15.8.1.1
          */
-        active: TlvField(1, TlvBitmap(TlvUInt32, Alarm)),
+        active: TlvField(0, TlvBitmap(TlvUInt32, Alarm)),
 
         /**
          * This field shall indicate those alarms that have become inactive.
          *
          * @see {@link MatterSpecification.v13.Cluster} § 1.15.8.1.2
          */
-        inactive: TlvField(2, TlvBitmap(TlvUInt32, Alarm)),
+        inactive: TlvField(1, TlvBitmap(TlvUInt32, Alarm)),
 
         /**
          * This field shall be a copy of the new State attribute value that resulted in the event being generated. That
@@ -162,14 +162,14 @@ export namespace DishwasherAlarm {
          *
          * @see {@link MatterSpecification.v13.Cluster} § 1.15.8.1.4
          */
-        state: TlvField(3, TlvBitmap(TlvUInt32, Alarm)),
+        state: TlvField(2, TlvBitmap(TlvUInt32, Alarm)),
 
         /**
          * This field shall be a copy of the Mask attribute when this event was generated.
          *
          * @see {@link MatterSpecification.v13.Cluster} § 1.15.8.1.3
          */
-        mask: TlvField(4, TlvBitmap(TlvUInt32, Alarm))
+        mask: TlvField(3, TlvBitmap(TlvUInt32, Alarm))
     });
 
     /**

--- a/packages/types/src/clusters/door-lock.ts
+++ b/packages/types/src/clusters/door-lock.ts
@@ -1686,7 +1686,7 @@ export namespace DoorLock {
          *
          * @see {@link MatterSpecification.v13.Cluster} § 5.2.10.18.4
          */
-        localStartTime: TlvOptionalField(2, TlvEpochS),
+        localStartTime: TlvOptionalField(3, TlvEpochS),
 
         /**
          * This field shall indicate the ending time for the Year Day schedule in Epoch Time in Seconds with local time
@@ -1696,7 +1696,7 @@ export namespace DoorLock {
          *
          * @see {@link MatterSpecification.v13.Cluster} § 5.2.10.18.5
          */
-        localEndTime: TlvOptionalField(3, TlvEpochS)
+        localEndTime: TlvOptionalField(4, TlvEpochS)
     });
 
     /**

--- a/packages/types/src/clusters/refrigerator-alarm.ts
+++ b/packages/types/src/clusters/refrigerator-alarm.ts
@@ -75,14 +75,14 @@ export namespace RefrigeratorAlarm {
          *
          * @see {@link MatterSpecification.v13.Cluster} § 1.15.8.1.1
          */
-        active: TlvField(1, TlvBitmap(TlvUInt32, Alarm)),
+        active: TlvField(0, TlvBitmap(TlvUInt32, Alarm)),
 
         /**
          * This field shall indicate those alarms that have become inactive.
          *
          * @see {@link MatterSpecification.v13.Cluster} § 1.15.8.1.2
          */
-        inactive: TlvField(2, TlvBitmap(TlvUInt32, Alarm)),
+        inactive: TlvField(1, TlvBitmap(TlvUInt32, Alarm)),
 
         /**
          * This field shall be a copy of the new State attribute value that resulted in the event being generated. That
@@ -90,14 +90,14 @@ export namespace RefrigeratorAlarm {
          *
          * @see {@link MatterSpecification.v13.Cluster} § 1.15.8.1.4
          */
-        state: TlvField(3, TlvBitmap(TlvUInt32, Alarm)),
+        state: TlvField(2, TlvBitmap(TlvUInt32, Alarm)),
 
         /**
          * This field shall be a copy of the Mask attribute when this event was generated.
          *
          * @see {@link MatterSpecification.v13.Cluster} § 1.15.8.1.3
          */
-        mask: TlvField(4, TlvBitmap(TlvUInt32, Alarm))
+        mask: TlvField(3, TlvBitmap(TlvUInt32, Alarm))
     });
 
     /**


### PR DESCRIPTION
Adds a "match directive" that allows override of normal model matching heuristics.  Uses this to repair spec errors in DoorLock cluster.

fixes #1745, fixes #1746