### PR TITLE
Enhance CommissioningFlow config checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Feature: Added `getMultipleAttributesAndStatus()` and `getMultipleEventsAndStatus()` to InteractionClient to allow to also returned attribute and event errors from the read interaction
     - Enhancement: Allows to access attributes, events and commands in CLusterClient instances also by their ID.
     - Fix: Makes sure to not Forward StatusResponseError cases that we generate locally to the device when not wanted
+    - Fix: Enhances checks for Wi-Fi/Thread credentials in config for CommissioningFlow
 
 -   @project-chip/matter.js
     - Breaking: Reduced exports to the relevant one for Controller usage. Please move for @matter/main for the rest.

--- a/packages/protocol/src/peer/ControllerCommissioningFlow.ts
+++ b/packages/protocol/src/peer/ControllerCommissioningFlow.ts
@@ -861,8 +861,12 @@ export class ControllerCommissioningFlow {
             throw new CommissioningError("No network features or status collected. This should never happen.");
         }
         if (
-            this.commissioningOptions.wifiNetwork === undefined &&
-            this.commissioningOptions.threadNetwork === undefined
+            (this.commissioningOptions.wifiNetwork === undefined ||
+                !this.commissioningOptions.wifiNetwork.wifiSsid ||
+                !this.commissioningOptions.wifiNetwork.wifiCredentials) &&
+            (this.commissioningOptions.threadNetwork === undefined ||
+                !this.commissioningOptions.threadNetwork.networkName ||
+                !this.commissioningOptions.threadNetwork.operationalDataset)
         ) {
             // Check if we have no networkCommissioning cluster or an Ethernet one
             const anyEthernetInterface =
@@ -1019,7 +1023,7 @@ export class ControllerCommissioningFlow {
 
     async #configureNetworkThread() {
         if (this.collectedCommissioningData.successfullyConnectedToNetwork) {
-            logger.debug("Node is already connected to a network. Skipping Thread configuration.");
+            logger.info("Node is already connected to a network. Skipping Thread configuration.");
             return {
                 code: CommissioningStepResultCode.Skipped,
                 breadcrumb: this.lastBreadcrumb,


### PR DESCRIPTION
If someone provides the fields for WiFi/Thread commissioning but empty they should still be ignored