### PR TITLE
Adjust Mergify

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -17,6 +17,9 @@ pull_request_rules:
         - "check-skipped=pullapprove"
         - "check-neutral=pullapprove"
       - label!="automated pr"             # Don't auto merge automated PRs, other processes do this
+      - or:
+        - "author=dependabot[bot]"        # merge dependabot PRs automatically
+        - "label=automerge"               # merge PRs with the automerge label
     actions:
       merge:
         method: squash


### PR DESCRIPTION
as discussed Dependabot PRs will be automatically merged after approval or any PR that got the "automerge" label assigned. so we can still merge easily a queue of PRs by just setting the label