### PR TITLE
Allow Clients to never read remote

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Breaking: Reduced exports to the relevant one for Controller usage. Please move for @matter/main for the rest.
     - Breaking: Remove the Legacy Device building API. Please use the new SeverNode based API which is more flexible and powerful.
     - Breaking: Changed signatures of `commissionNode()` and `createInteractionClient()` to provide options as object and not plain parameters
+    - Breaking: The handling of the `requestFromRemote` parameter (first parameter) in get*Attribute methods in ClusterClients changed behavior! providing "false" will now never try to read from remote, "true" will always try to read from remote and "undefined" will use the default behavior (read from remote if not available locally or fabric scoped read). Only relevant if you used this parameter with value "false". Other use cases stay unchanged.
     - Feature: Allows to use a custom Root-NodeId, CertificateAuthority or CommissioningFlow implementation in the Controller
     - Feature: Allows to establish a secure PASE session to a device and use this to interact with the device in special pre-commissioning cases.
 

--- a/packages/protocol/src/cluster/client/AttributeClient.ts
+++ b/packages/protocol/src/cluster/client/AttributeClient.ts
@@ -106,37 +106,47 @@ export class AttributeClient<T = any> {
         });
     }
 
-    /** Get the value of the attribute. Fabric scoped reads are always done with the remote. */
-    async get(alwaysRequestFromRemote?: boolean, isFabricFiltered = true) {
-        if (alwaysRequestFromRemote === undefined) {
-            alwaysRequestFromRemote = this.#isFabricScoped || !this.#updatedBySubscriptions;
-        } else if (!alwaysRequestFromRemote && this.#isFabricScoped) {
-            alwaysRequestFromRemote = true;
+    /**
+     * Get the value of the attribute. Fabric scoped reads are always done with the remote.
+     * The `requestFromRemote` parameter allowed to force or prevent remote reads:
+     * - `true` forces a remote read
+     * - `false` forces a local read, return undefined if no value is available
+     * - `undefined` returns local values if available or if the read is fabric filtered, otherwise remote read
+     */
+    async get(requestFromRemote?: boolean, isFabricFiltered = true) {
+        if (requestFromRemote === undefined) {
+            requestFromRemote = this.#isFabricScoped || !this.#updatedBySubscriptions ? true : undefined;
+        } else if (!requestFromRemote && this.#isFabricScoped) {
+            requestFromRemote = true;
         }
         return await this.#interactionClient.getAttribute({
             endpointId: this.endpointId,
             clusterId: this.clusterId,
             attribute: this.attribute,
             isFabricFiltered,
-            alwaysRequestFromRemote,
+            requestFromRemote,
         });
     }
 
     /**
      * Get the value with version of the attribute. Fabric scoped reads are always done with the remote.
-     * */
-    async getWithVersion(alwaysRequestFromRemote?: boolean, isFabricFiltered = true) {
-        if (alwaysRequestFromRemote === undefined) {
-            alwaysRequestFromRemote = this.#isFabricScoped;
-        } else if (!alwaysRequestFromRemote && this.#isFabricScoped) {
-            alwaysRequestFromRemote = true;
+     * The `requestFromRemote` parameter allowed to force or prevent remote reads:
+     * - `true` forces a remote read
+     * - `false` forces a local read, return undefined if no value is available
+     * - `undefined` returns local values if available or if the read is fabric filtered, otherwise remote read
+     */
+    async getWithVersion(requestFromRemote?: boolean, isFabricFiltered = true) {
+        if (requestFromRemote === undefined) {
+            requestFromRemote = this.#isFabricScoped || !this.#updatedBySubscriptions ? true : undefined;
+        } else if (!requestFromRemote && this.#isFabricScoped) {
+            requestFromRemote = true;
         }
         return await this.#interactionClient.getAttributeWithVersion({
             endpointId: this.endpointId,
             clusterId: this.clusterId,
             attribute: this.attribute,
             isFabricFiltered,
-            alwaysRequestFromRemote,
+            requestFromRemote,
         });
     }
 

--- a/packages/protocol/src/interaction/InteractionClient.ts
+++ b/packages/protocol/src/interaction/InteractionClient.ts
@@ -377,13 +377,13 @@ export class InteractionClient {
         clusterId: ClusterId;
         attribute: A;
         isFabricFiltered?: boolean;
-        alwaysRequestFromRemote?: boolean;
+        requestFromRemote?: boolean;
         executeQueued?: boolean;
     }): Promise<AttributeJsType<A> | undefined> {
-        const { alwaysRequestFromRemote = false } = options;
+        const { requestFromRemote } = options;
         const response = await this.getAttributeWithVersion({
             ...options,
-            alwaysRequestFromRemote,
+            requestFromRemote,
         });
         return response?.value;
     }
@@ -393,22 +393,20 @@ export class InteractionClient {
         clusterId: ClusterId;
         attribute: A;
         isFabricFiltered?: boolean;
-        alwaysRequestFromRemote?: boolean;
+        requestFromRemote?: boolean;
         executeQueued?: boolean;
     }): Promise<{ value: AttributeJsType<A>; version: number } | undefined> {
-        const {
-            endpointId,
-            clusterId,
-            attribute,
-            alwaysRequestFromRemote = false,
-            isFabricFiltered,
-            executeQueued,
-        } = options;
+        const { endpointId, clusterId, attribute, requestFromRemote, isFabricFiltered, executeQueued } = options;
         const { id: attributeId } = attribute;
-        if (!alwaysRequestFromRemote && this.#nodeStore !== undefined) {
-            const { value, version } = this.#nodeStore.retrieveAttribute(endpointId, clusterId, attributeId) ?? {};
-            if (value !== undefined && version !== undefined) {
-                return { value, version } as { value: AttributeJsType<A>; version: number };
+        if (this.#nodeStore !== undefined) {
+            if (!requestFromRemote) {
+                const { value, version } = this.#nodeStore.retrieveAttribute(endpointId, clusterId, attributeId) ?? {};
+                if (value !== undefined && version !== undefined) {
+                    return { value, version } as { value: AttributeJsType<A>; version: number };
+                }
+            }
+            if (requestFromRemote === false) {
+                return undefined;
             }
         }
 


### PR DESCRIPTION
The handling of the `requestFromRemote` parameter (first parameter) in get*Attribute methods in ClusterClients changed behavior! providing "false" will now never try to read from remote, "true" will always try to read from remote and "undefined" will use the default behavior (read from remote if not available locally or fabric scoped read). Only relevant if you used this parameter with value "false". Other use cases stay unchanged.