### PR TITLE
Ignore missing IPv4 addresses if enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,13 +19,14 @@ The main work (all changes without a GitHub username in brackets in the below li
 
 -   @matter/general
     - Breaking: `Logger.logger` is replaced with `Logger.destinations`.  Properties of individual destinations are slightly different.  A deprecated compability API should make this largely transparent
-    - Enhancement: Formalized concept of a logging "destination" and converted API for managing destinations to a simple object interface
     - Feature: Logging destinations may process `Diagnostic.Message` directly and bypass matter.js's formatting
     - Feature: Log formatting is now extensible with custom formats
-    - Enhancement: Modifying log levels and format using the `Logger` static interface now updates defaults and applies changes to all destinations
-    - Fix: Correctly handle MDNS records without QNames
     - Feature: `QuietObservable` is an extended event source that emits events at reduced frequency based on configuration
+    - Enhancement: Formalized concept of a logging "destination" and converted API for managing destinations to a simple object interface
+    - Enhancement: Modifying log levels and format using the `Logger` static interface now updates defaults and applies changes to all destinations
     - Enhancement: Transaction participants no longer need implement commit-related methods if they do not participate in persistence
+    - Enhancement: Missing IPv4 addresses on network interfaces are now ignored even if IPv4 is not disabled via configuration
+    - Fix: Correctly handle MDNS records without QNames
 
 -   @matter/main
     - Feature: Automatically handle basicInformation uniqueId Property as defined by specification if not set by the developer

--- a/packages/general/src/net/Network.ts
+++ b/packages/general/src/net/Network.ts
@@ -10,6 +10,8 @@ import { UdpChannel, UdpChannelOptions } from "./UdpChannel.js";
 
 export class NetworkError extends MatterError {}
 
+export class NoIPv4AddressAvailableError extends NetworkError {}
+
 /**
  * @see {@link MatterSpecification.v11.Core} § 11.11.4.4
  * Duplicated from the GeneralDiagnostics cluster to avoid circular dependencies.

--- a/packages/general/src/net/Network.ts
+++ b/packages/general/src/net/Network.ts
@@ -10,7 +10,7 @@ import { UdpChannel, UdpChannelOptions } from "./UdpChannel.js";
 
 export class NetworkError extends MatterError {}
 
-export class NoIPv4AddressAvailableError extends NetworkError {}
+export class NoAddressAvailableError extends NetworkError {}
 
 /**
  * @see {@link MatterSpecification.v11.Core} § 11.11.4.4

--- a/packages/general/src/net/UdpMulticastServer.ts
+++ b/packages/general/src/net/UdpMulticastServer.ts
@@ -9,7 +9,7 @@ import { Logger } from "../log/Logger.js";
 import { Cache } from "../util/Cache.js";
 import { asError } from "../util/Error.js";
 import { isIPv4 } from "../util/Ip.js";
-import { Network, NoIPv4AddressAvailableError } from "./Network.js";
+import { Network, NoAddressAvailableError } from "./Network.js";
 import { UdpChannel } from "./UdpChannel.js";
 
 const logger = Logger.get("UdpMulticastServer");
@@ -40,25 +40,31 @@ export class UdpMulticastServer {
                     membershipAddresses: [broadcastAddressIpv4],
                 });
             } catch (error) {
-                NoIPv4AddressAvailableError.accept(error);
+                NoAddressAvailableError.accept(error);
                 logger.info(`IPv4 UDP channel not created because IPv4 is not available: ${asError(error).message}`);
             }
         }
 
-        return new UdpMulticastServer(
-            network,
-            broadcastAddressIpv4,
-            broadcastAddressIpv6,
-            listeningPort,
-            ipv4UdpChannel,
-            await network.createUdpChannel({
-                type: "udp6",
-                netInterface,
+        try {
+            return new UdpMulticastServer(
+                network,
+                broadcastAddressIpv4,
+                broadcastAddressIpv6,
                 listeningPort,
-                membershipAddresses: [broadcastAddressIpv6],
-            }),
-            netInterface,
-        );
+                ipv4UdpChannel,
+                await network.createUdpChannel({
+                    type: "udp6",
+                    netInterface,
+                    listeningPort,
+                    membershipAddresses: [broadcastAddressIpv6],
+                }),
+                netInterface,
+            );
+        } catch (error) {
+            NoAddressAvailableError.accept(error);
+            logger.info(`IPv6 UDP interface not created because IPv6 is not available, but required my Matter.`);
+            throw error;
+        }
     }
 
     private readonly broadcastChannels = new Cache<Promise<UdpChannel>>(

--- a/packages/general/src/net/UdpMulticastServer.ts
+++ b/packages/general/src/net/UdpMulticastServer.ts
@@ -9,7 +9,7 @@ import { Logger } from "../log/Logger.js";
 import { Cache } from "../util/Cache.js";
 import { asError } from "../util/Error.js";
 import { isIPv4 } from "../util/Ip.js";
-import { Network } from "./Network.js";
+import { Network, NoIPv4AddressAvailableError } from "./Network.js";
 import { UdpChannel } from "./UdpChannel.js";
 
 const logger = Logger.get("UdpMulticastServer");
@@ -30,19 +30,27 @@ export class UdpMulticastServer {
         listeningPort,
         network,
     }: UdpMulticastServerOptions) {
+        let ipv4UdpChannel: UdpChannel | undefined = undefined;
+        if (broadcastAddressIpv4 !== undefined) {
+            try {
+                ipv4UdpChannel = await network.createUdpChannel({
+                    type: "udp4",
+                    netInterface,
+                    listeningPort,
+                    membershipAddresses: [broadcastAddressIpv4],
+                });
+            } catch (error) {
+                NoIPv4AddressAvailableError.accept(error);
+                logger.info(`IPv4 UDP channel not created because IPv4 is not available: ${asError(error).message}`);
+            }
+        }
+
         return new UdpMulticastServer(
             network,
             broadcastAddressIpv4,
             broadcastAddressIpv6,
             listeningPort,
-            broadcastAddressIpv4 === undefined
-                ? undefined
-                : await network.createUdpChannel({
-                      type: "udp4",
-                      netInterface,
-                      listeningPort,
-                      membershipAddresses: [broadcastAddressIpv4],
-                  }),
+            ipv4UdpChannel,
             await network.createUdpChannel({
                 type: "udp6",
                 netInterface,

--- a/packages/matter.js/src/CommissioningController.ts
+++ b/packages/matter.js/src/CommissioningController.ts
@@ -13,6 +13,7 @@ import {
     Logger,
     NetInterfaceSet,
     Network,
+    NoIPv4AddressAvailableError,
     NoProviderError,
     StorageContext,
     SyncStorage,
@@ -771,7 +772,14 @@ export async function configureNetwork(options: {
     netInterfaces.add(udpInterface);
     if (!ipv4Disabled) {
         // TODO: Add option to transport different ports to broadcaster
-        netInterfaces.add(await UdpInterface.create(Network.get(), "udp4", udpInterface.port, listeningAddressIpv4));
+        try {
+            netInterfaces.add(
+                await UdpInterface.create(Network.get(), "udp4", udpInterface.port, listeningAddressIpv4),
+            );
+        } catch (error) {
+            NoIPv4AddressAvailableError.accept(error);
+            logger.info(`IPv4 UDP interface not created because IPv4 is not available`);
+        }
     }
     if (mdnsScanner) {
         scanners.add(mdnsScanner);

--- a/packages/nodejs/src/net/NodeJsUdpChannel.ts
+++ b/packages/nodejs/src/net/NodeJsUdpChannel.ts
@@ -12,7 +12,7 @@ import {
     Logger,
     MAX_UDP_MESSAGE_SIZE,
     NetworkError,
-    NoIPv4AddressAvailableError,
+    NoAddressAvailableError,
     repackErrorAs,
     UdpChannel,
     UdpChannelOptions,
@@ -72,11 +72,11 @@ export class NodeJsUdpChannel implements UdpChannel {
             if (type === "udp4") {
                 multicastInterface = NodeJsNetwork.getMulticastInterfaceIpv4(netInterface);
                 if (multicastInterface === undefined) {
-                    throw new NoIPv4AddressAvailableError(`No IPv4 addresses on interface "${netInterface}"`);
+                    throw new NoAddressAvailableError(`No IPv4 addresses on interface "${netInterface}"`);
                 }
             } else {
                 if (netInterfaceZone === undefined) {
-                    throw new NetworkError(`No IPv6 addresses on interface "${netInterface}", but IPv6 is required`);
+                    throw new NoAddressAvailableError(`No IPv6 addresses on interface "${netInterface}"`);
                 }
                 multicastInterface = `::%${netInterfaceZone}`;
             }

--- a/packages/nodejs/src/net/NodeJsUdpChannel.ts
+++ b/packages/nodejs/src/net/NodeJsUdpChannel.ts
@@ -12,6 +12,7 @@ import {
     Logger,
     MAX_UDP_MESSAGE_SIZE,
     NetworkError,
+    NoIPv4AddressAvailableError,
     repackErrorAs,
     UdpChannel,
     UdpChannelOptions,
@@ -71,11 +72,11 @@ export class NodeJsUdpChannel implements UdpChannel {
             if (type === "udp4") {
                 multicastInterface = NodeJsNetwork.getMulticastInterfaceIpv4(netInterface);
                 if (multicastInterface === undefined) {
-                    throw new NetworkError(`No IPv4 addresses on interface: ${netInterface}`);
+                    throw new NoIPv4AddressAvailableError(`No IPv4 addresses on interface "${netInterface}"`);
                 }
             } else {
                 if (netInterfaceZone === undefined) {
-                    throw new NetworkError(`No IPv6 addresses on interface: ${netInterface}`);
+                    throw new NetworkError(`No IPv6 addresses on interface "${netInterface}", but IPv6 is required`);
                 }
                 multicastInterface = `::%${netInterfaceZone}`;
             }

--- a/packages/react-native/src/net/UdpChannelReactNative.ts
+++ b/packages/react-native/src/net/UdpChannelReactNative.ts
@@ -13,7 +13,7 @@ import {
     Logger,
     MAX_UDP_MESSAGE_SIZE,
     NetworkError,
-    NoIPv4AddressAvailableError,
+    NoAddressAvailableError,
     repackErrorAs,
     UdpChannel,
     UdpChannelOptions,
@@ -115,7 +115,7 @@ export class UdpChannelReactNative implements UdpChannel {
             if (type === "udp4") {
                 multicastInterface = await NetworkReactNative.getMulticastInterfaceIpv4(netInterface);
                 if (multicastInterface === undefined) {
-                    throw new NoIPv4AddressAvailableError(`No IPv4 addresses on interface "${netInterface}"`);
+                    throw new NoAddressAvailableError(`No IPv4 addresses on interface "${netInterface}"`);
                 }
             } else {
                 multicastInterface = `::%${netInterfaceZone}`;

--- a/packages/react-native/src/net/UdpChannelReactNative.ts
+++ b/packages/react-native/src/net/UdpChannelReactNative.ts
@@ -13,6 +13,7 @@ import {
     Logger,
     MAX_UDP_MESSAGE_SIZE,
     NetworkError,
+    NoIPv4AddressAvailableError,
     repackErrorAs,
     UdpChannel,
     UdpChannelOptions,
@@ -114,7 +115,7 @@ export class UdpChannelReactNative implements UdpChannel {
             if (type === "udp4") {
                 multicastInterface = await NetworkReactNative.getMulticastInterfaceIpv4(netInterface);
                 if (multicastInterface === undefined) {
-                    throw new NetworkError(`No IPv4 addresses on interface: ${netInterface}`);
+                    throw new NoIPv4AddressAvailableError(`No IPv4 addresses on interface "${netInterface}"`);
                 }
             } else {
                 multicastInterface = `::%${netInterfaceZone}`;


### PR DESCRIPTION
Missing IPv4 addresses on network interfaces are now ignored even if IPv4 is not disabled via configuration

addresses https://github.com/Luligu/matterbridge/issues/244