### PR TITLE
Test tweaks & fixes

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,9 +16,6 @@
                 "${workspaceFolder}/**/dist/esm/**/*.js",
                 "${workspaceFolder}/**/build/esm/**/*.js"
             ],
-            "presentation": {
-                "clear": true
-            },
             "name": "All tests",
             "args": [
                 "--clear"
@@ -40,9 +37,6 @@
                 "${workspaceFolder}/**/dist/esm/**/*.js",
                 "${workspaceFolder}/**/build/esm/**/*.js"
             ],
-            "presentation": {
-                "clear": true
-            },
             "name": "Test current file",
             "args": [
                 "--clear",
@@ -68,9 +62,6 @@
                 "${workspaceFolder}/**/dist/esm/**/*.js",
                 "${workspaceFolder}/**/build/esm/**/*.js"
             ],
-            "presentation": {
-                "clear": true
-            },
             "name": "Run current file",
             "args": [
                 "--clear",
@@ -93,9 +84,6 @@
                 "${workspaceFolder}/**/dist/esm/**/*.js",
                 "${workspaceFolder}/**/build/esm/**/*.js"
             ],
-            "presentation": {
-                "clear": true
-            },
             "name": "Run shell",
             "cwd": "${workspaceFolder}/packages/nodejs-shell",
             "args": [
@@ -119,9 +107,6 @@
                 "${workspaceFolder}/**/dist/esm/**/*.js",
                 "${workspaceFolder}/**/build/esm/**/*.js"
             ],
-            "presentation": {
-                "clear": true
-            },
             "name": "Run CLI tool",
             "cwd": "${workspaceFolder}/packages/cli-tool",
             "args": [
@@ -145,9 +130,6 @@
                 "${workspaceFolder}/**/dist/esm/**/*.js",
                 "${workspaceFolder}/**/build/esm/**/*.js"
             ],
-            "presentation": {
-                "clear": true
-            },
             "name": "Test @matter/testing",
             "cwd": "${workspaceFolder}/packages/testing",
             "args": [
@@ -170,9 +152,6 @@
                 "${workspaceFolder}/**/dist/esm/**/*.js",
                 "${workspaceFolder}/**/build/esm/**/*.js"
             ],
-            "presentation": {
-                "clear": true
-            },
             "name": "Test @matter/general",
             "cwd": "${workspaceFolder}/packages/general",
             "args": [
@@ -195,9 +174,6 @@
                 "${workspaceFolder}/**/dist/esm/**/*.js",
                 "${workspaceFolder}/**/build/esm/**/*.js"
             ],
-            "presentation": {
-                "clear": true
-            },
             "name": "Test @matter/model",
             "cwd": "${workspaceFolder}/packages/model",
             "args": [
@@ -220,9 +196,6 @@
                 "${workspaceFolder}/**/dist/esm/**/*.js",
                 "${workspaceFolder}/**/build/esm/**/*.js"
             ],
-            "presentation": {
-                "clear": true
-            },
             "name": "Test @matter/types",
             "cwd": "${workspaceFolder}/packages/types",
             "args": [
@@ -245,9 +218,6 @@
                 "${workspaceFolder}/**/dist/esm/**/*.js",
                 "${workspaceFolder}/**/build/esm/**/*.js"
             ],
-            "presentation": {
-                "clear": true
-            },
             "name": "Test @matter/protocol",
             "cwd": "${workspaceFolder}/packages/protocol",
             "args": [
@@ -270,9 +240,6 @@
                 "${workspaceFolder}/**/dist/esm/**/*.js",
                 "${workspaceFolder}/**/build/esm/**/*.js"
             ],
-            "presentation": {
-                "clear": true
-            },
             "name": "Test @matter/node",
             "cwd": "${workspaceFolder}/packages/node",
             "args": [
@@ -295,9 +262,6 @@
                 "${workspaceFolder}/**/dist/esm/**/*.js",
                 "${workspaceFolder}/**/build/esm/**/*.js"
             ],
-            "presentation": {
-                "clear": true
-            },
             "name": "Test @matter/nodejs",
             "cwd": "${workspaceFolder}/packages/nodejs",
             "args": [
@@ -320,9 +284,6 @@
                 "${workspaceFolder}/**/dist/esm/**/*.js",
                 "${workspaceFolder}/**/build/esm/**/*.js"
             ],
-            "presentation": {
-                "clear": true
-            },
             "name": "Test @matter/chip-testing",
             "cwd": "${workspaceFolder}/chip-testing",
             "args": [
@@ -345,9 +306,6 @@
                 "${workspaceFolder}/**/dist/esm/**/*.js",
                 "${workspaceFolder}/**/build/esm/**/*.js"
             ],
-            "presentation": {
-                "clear": true
-            },
             "name": "Test chip:app-fast",
             "cwd": "${workspaceFolder}/chip-testing",
             "args": [
@@ -374,9 +332,6 @@
                 "${workspaceFolder}/**/dist/esm/**/*.js",
                 "${workspaceFolder}/**/build/esm/**/*.js"
             ],
-            "presentation": {
-                "clear": true
-            },
             "name": "Test chip:app-slow",
             "cwd": "${workspaceFolder}/chip-testing",
             "args": [
@@ -403,9 +358,6 @@
                 "${workspaceFolder}/**/dist/esm/**/*.js",
                 "${workspaceFolder}/**/build/esm/**/*.js"
             ],
-            "presentation": {
-                "clear": true
-            },
             "name": "Test chip:core",
             "cwd": "${workspaceFolder}/chip-testing",
             "args": [
@@ -432,38 +384,6 @@
                 "${workspaceFolder}/**/dist/esm/**/*.js",
                 "${workspaceFolder}/**/build/esm/**/*.js"
             ],
-            "presentation": {
-                "clear": true
-            },
-            "name": "Test chip:long",
-            "cwd": "${workspaceFolder}/chip-testing",
-            "args": [
-                "--clear",
-                "--spec",
-                "test/long/**/*.test.ts",
-                "--all-logs",
-                "esm"
-            ],
-            "program": "${workspaceFolder}/node_modules/.bin/matter-test"
-        },
-        {
-            "type": "node",
-            "request": "launch",
-            "skipFiles": [
-                "<node_internals>/**"
-            ],
-            "console": "integratedTerminal",
-            "internalConsoleOptions": "neverOpen",
-            "runtimeArgs": [
-                "--enable-source-maps"
-            ],
-            "outFiles": [
-                "${workspaceFolder}/**/dist/esm/**/*.js",
-                "${workspaceFolder}/**/build/esm/**/*.js"
-            ],
-            "presentation": {
-                "clear": true
-            },
             "name": "Run ControllerNode",
             "args": [
                 "--clear",
@@ -486,9 +406,6 @@
                 "${workspaceFolder}/**/dist/esm/**/*.js",
                 "${workspaceFolder}/**/build/esm/**/*.js"
             ],
-            "presentation": {
-                "clear": true
-            },
             "name": "Run BridgedDevicesNode",
             "args": [
                 "--clear",
@@ -511,9 +428,6 @@
                 "${workspaceFolder}/**/dist/esm/**/*.js",
                 "${workspaceFolder}/**/build/esm/**/*.js"
             ],
-            "presentation": {
-                "clear": true
-            },
             "name": "Run ComposedDeviceNode",
             "args": [
                 "--clear",
@@ -536,9 +450,6 @@
                 "${workspaceFolder}/**/dist/esm/**/*.js",
                 "${workspaceFolder}/**/build/esm/**/*.js"
             ],
-            "presentation": {
-                "clear": true
-            },
             "name": "Run IlluminatedRollerShade",
             "args": [
                 "--clear",
@@ -561,9 +472,6 @@
                 "${workspaceFolder}/**/dist/esm/**/*.js",
                 "${workspaceFolder}/**/build/esm/**/*.js"
             ],
-            "presentation": {
-                "clear": true
-            },
             "name": "Run MeasuredSocketDevice",
             "args": [
                 "--clear",
@@ -586,9 +494,6 @@
                 "${workspaceFolder}/**/dist/esm/**/*.js",
                 "${workspaceFolder}/**/build/esm/**/*.js"
             ],
-            "presentation": {
-                "clear": true
-            },
             "name": "Run MultiDeviceNode",
             "args": [
                 "--clear",
@@ -611,9 +516,6 @@
                 "${workspaceFolder}/**/dist/esm/**/*.js",
                 "${workspaceFolder}/**/build/esm/**/*.js"
             ],
-            "presentation": {
-                "clear": true
-            },
             "name": "Run DeviceNode",
             "args": [
                 "--clear",
@@ -636,9 +538,6 @@
                 "${workspaceFolder}/**/dist/esm/**/*.js",
                 "${workspaceFolder}/**/build/esm/**/*.js"
             ],
-            "presentation": {
-                "clear": true
-            },
             "name": "Run DeviceNodeFull",
             "args": [
                 "--clear",
@@ -661,9 +560,6 @@
                 "${workspaceFolder}/**/dist/esm/**/*.js",
                 "${workspaceFolder}/**/build/esm/**/*.js"
             ],
-            "presentation": {
-                "clear": true
-            },
             "name": "Run LightDevice",
             "args": [
                 "--clear",
@@ -686,9 +582,6 @@
                 "${workspaceFolder}/**/dist/esm/**/*.js",
                 "${workspaceFolder}/**/build/esm/**/*.js"
             ],
-            "presentation": {
-                "clear": true
-            },
             "name": "Run SensorDeviceNode",
             "args": [
                 "--clear",
@@ -711,9 +604,6 @@
                 "${workspaceFolder}/**/dist/esm/**/*.js",
                 "${workspaceFolder}/**/build/esm/**/*.js"
             ],
-            "presentation": {
-                "clear": true
-            },
             "name": "Generate chip",
             "args": [
                 "--clear",
@@ -736,9 +626,6 @@
                 "${workspaceFolder}/**/dist/esm/**/*.js",
                 "${workspaceFolder}/**/build/esm/**/*.js"
             ],
-            "presentation": {
-                "clear": true
-            },
             "name": "Generate clusters",
             "args": [
                 "--clear",
@@ -761,9 +648,6 @@
                 "${workspaceFolder}/**/dist/esm/**/*.js",
                 "${workspaceFolder}/**/build/esm/**/*.js"
             ],
-            "presentation": {
-                "clear": true
-            },
             "name": "Generate endpoints",
             "args": [
                 "--clear",
@@ -786,9 +670,6 @@
                 "${workspaceFolder}/**/dist/esm/**/*.js",
                 "${workspaceFolder}/**/build/esm/**/*.js"
             ],
-            "presentation": {
-                "clear": true
-            },
             "name": "Generate forwards",
             "args": [
                 "--clear",
@@ -811,9 +692,6 @@
                 "${workspaceFolder}/**/dist/esm/**/*.js",
                 "${workspaceFolder}/**/build/esm/**/*.js"
             ],
-            "presentation": {
-                "clear": true
-            },
             "name": "Generate model",
             "args": [
                 "--clear",
@@ -836,9 +714,6 @@
                 "${workspaceFolder}/**/dist/esm/**/*.js",
                 "${workspaceFolder}/**/build/esm/**/*.js"
             ],
-            "presentation": {
-                "clear": true
-            },
             "name": "Generate spec",
             "args": [
                 "--clear",
@@ -864,9 +739,6 @@
                 "${workspaceFolder}/**/dist/esm/**/*.js",
                 "${workspaceFolder}/**/build/esm/**/*.js"
             ],
-            "presentation": {
-                "clear": true
-            },
             "name": "Generate vscode",
             "args": [
                 "--clear",

--- a/chip-testing/package.json
+++ b/chip-testing/package.json
@@ -24,8 +24,7 @@
         "ci-test": "matter-test",
         "test-app-fast": "matter-test --spec=test/app-fast/**/*.test.ts",
         "test-app-slow": "matter-test --spec=test/app-slow/**/*.test.ts",
-        "test-core": "matter-test --spec=test/core/**/*.test.ts",
-        "test-long": "matter-test --spec=test/long/**/*.test.ts"
+        "test-core": "matter-test --spec=test/core/**/*.test.ts"
     },
     "dependencies": {
         "@matter/main": "*",

--- a/chip-testing/test/app-slow/CC.test.ts
+++ b/chip-testing/test/app-slow/CC.test.ts
@@ -5,5 +5,13 @@
  */
 
 describe("CC", () => {
-    chip("CC/*");
+    chip("CC/*").exclude(
+        // Pending full Q support for CC
+        "CC/2.2",
+        "CC/3.1",
+        "CC/9.1",
+
+        // Requires groups
+        "CC/10.1",
+    );
 });

--- a/chip-testing/test/core/CASERecovery.test.ts
+++ b/chip-testing/test/core/CASERecovery.test.ts
@@ -1,0 +1,9 @@
+/**
+ * @license
+ * Copyright 2022-2025 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+describe("CASERecovery", () => {
+    chip("CASERecovery");
+});

--- a/chip-testing/test/core/CommandsById.test.ts
+++ b/chip-testing/test/core/CommandsById.test.ts
@@ -1,0 +1,9 @@
+/**
+ * @license
+ * Copyright 2022-2025 Project CHIP Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+describe("CommandsById", () => {
+    chip("CommandsById");
+});

--- a/chip-testing/test/core/DeviceBasicComposition.test.ts
+++ b/chip-testing/test/core/DeviceBasicComposition.test.ts
@@ -1,0 +1,9 @@
+/**
+ * @license
+ * Copyright 2022-2025 Project CHIP Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+describe("DeviceBasicComposition", () => {
+    chip("DeviceBasicComposition-run1");
+});

--- a/chip-testing/test/core/Discovery.test.ts
+++ b/chip-testing/test/core/Discovery.test.ts
@@ -6,8 +6,7 @@
 
 import { edit } from "@matter/testing";
 
-describe("misc", () => {
-    // TODO - remove when we're on 1.4
+describe("Discovery", () => {
     before(() =>
         chip.testFor("Discovery").edit(
             edit.sed(
@@ -17,5 +16,5 @@ describe("misc", () => {
             ),
         ),
     );
-    chip("CASERecovery", "CommandsById", "DeviceBasicComposition-run1", "Discovery", "TestEventTrigger");
+    chip("Discovery");
 });

--- a/chip-testing/test/core/TestEventTrigger.test.ts
+++ b/chip-testing/test/core/TestEventTrigger.test.ts
@@ -1,0 +1,9 @@
+/**
+ * @license
+ * Copyright 2022-2025 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+describe("TestEventTrigger", () => {
+    chip("TestEventTrigger");
+});

--- a/chip/bin/rebuild
+++ b/chip/bin/rebuild
@@ -6,4 +6,4 @@ if docker buildx inspect matter.js-chip > /dev/null 2>&1; then
     docker buildx rm matter.js-chip
 fi
 
-source ./build
+source "$(dirname "$0")/build"

--- a/chip/support/generate-test-descriptor
+++ b/chip/support/generate-test-descriptor
@@ -169,6 +169,9 @@ def load_python():
 
         steps = instance.get_defined_test_steps(name)
         if steps:
+            if not steps[0].is_commissioning:
+                props["startUncommissioned"] = True
+                
             props["members"] = list(map(lambda step: {
                 "name": step.test_plan_number,
                 "kind": "step",

--- a/codegen/src/generate-vscode.ts
+++ b/codegen/src/generate-vscode.ts
@@ -40,7 +40,10 @@ const CONFIG_TEMPLATE = {
 
     runtimeArgs: ["--enable-source-maps"],
     outFiles: ["${workspaceFolder}/**/dist/esm/**/*.js", "${workspaceFolder}/**/build/esm/**/*.js"],
-    presentation: { clear: true },
+
+    // This is buggy as of VS Code 1.98.  Sometimes doesn't clear at all, sometimes clears after task completes which is
+    // really annoying.  We already clear manually with escape codes so just omit
+    //presentation: { clear: true },
 };
 
 export type LaunchOptions = {

--- a/packages/testing/src/chip/matter-js-pics.properties
+++ b/packages/testing/src/chip/matter-js-pics.properties
@@ -89,3 +89,9 @@ CC.C=0
 
 # FLW 2.2 requires user input to change flow; the test skips the user prompt so subsequent command fails.  This disables
 FLW.M.FlowChange=0
+
+# We do not support ICD management
+ICDM.S.A0001..8=0
+
+# We do not enable GeneralCommissioning feature TermsAndConditions
+CGEN.S.F00=0

--- a/packages/testing/src/test-descriptor.ts
+++ b/packages/testing/src/test-descriptor.ts
@@ -22,6 +22,7 @@ export interface TestDescriptor {
     description?: string;
     pics?: string;
     config?: Record<string, unknown>;
+    startUncommissioned?: boolean;
     runAt?: Date;
     passed?: boolean;
     durationMs?: number;

--- a/packages/tools/src/ansi-text/std.ts
+++ b/packages/tools/src/ansi-text/std.ts
@@ -16,13 +16,13 @@ export namespace std {
      * Writer that writes to Node's stdout.
      */
     export const out = Printer(new TextWriter(text => stdout.write(text), { terminalWidth: stdout.columns }), {
-        wrap: { wrapPrefix: DEFAULT_WRAP_PREFIX },
+        wrap: { wrapPrefix: DEFAULT_WRAP_PREFIX, preserveSpace: true },
     });
 
     /**
      * Writer that writes to Node's stdout.
      */
     export const err = Printer(new TextWriter(text => stderr.write(text), { terminalWidth: stderr.columns }), {
-        wrap: { wrapPrefix: DEFAULT_WRAP_PREFIX },
+        wrap: { wrapPrefix: DEFAULT_WRAP_PREFIX, preserveSpace: true },
     });
 }


### PR DESCRIPTION
Minor stuff...

* Remove broken vs code presentation clear that already has workarounds

* Fix whitespace handling in test reporter

* Add PICS to disable new CHIP tests

* Remove unused "test-long" from chip-testing

* Exclude CC tests that break pending Q updates

* Break CHIP "misc" test into tests tracking individual files

* Fix chip/bin/rebuild

* Tweak detection of CHIP python tests requiring uncommissioned startup; currently disabled due to CHIP inconsistencies