### PR TITLE
Remove OnOffServer "Lighting " feature enablement

### DIFF
--- a/.github/workflows/chip-tool-tests.yml
+++ b/.github/workflows/chip-tool-tests.yml
@@ -182,7 +182,7 @@ jobs:
               --chip-tool ../chip-testing/dist/esm/ControllerWebSocketTestApp.js \
               --log-level info \
               --target-glob "{Test_TC_ACE_*,Test_TC_ACL_*,Test_AddNewFabricFromExistingFabric,Test_TC_BINFO_*,Test_TC_BRBINFO_*,Test_TC_CADMIN_*,Test_TC_CGEN_*,Test_TC_CNET_*,Test_TC_DGGEN_*,Test_TC_DESC_*,Test_TC_OPCREDS_*,TestAccessControlC*,TestArmFailSafe,TestCASERecovery,TestCommandsById,TestCommissionerNodeId,TestCommissioningWindow,TestFabricRemovalWhileSubscribed,TestGeneralCommissioning,TestMultiAdmin,TestOperationalCredentialsCluster,TestSelfFabricRemoval,TestSubscribe_*,TestDiscovery}" \
-              --target-skip-glob "{TestCASERecovery,Test_TC_ACE_1_6}" \
+              --target-skip-glob "{TestCASERecovery,TestOperationalCredentialsCluster,Test_TC_ACE_1_6}" \
               run \
               --iterations 1 \
               --all-clusters-app ../chip-testing/dist/esm/AllClustersTestApp.js \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: Prevents crash on startup when having set a Fabric label in config
 
 -   @matter/node
+    - Breaking: The Default `OnOffServer` implementation no longer has the "Lighting" feature enabled by default! Please enable manually when the relevant device type where the cluster is used in requires it or use the Requirement-classes like `OnOffLightRequirements.OnOffServer` to get the correct features enabled automatically.
     - Breaking: `LevelControlServer` API has a few small changes that may affect device implementors.  Most notably the `setLevel` method is replaced with `transition` which handles both immediate and gradual level shifts
     - Feature: `Transitions` utility class offers a flexible API for implementing Matter attributes that change gradually at a constant rate
     - Feature: Attributes marked as `Q` (quieter) quality now support an extended `quiet` property that controls how often and when they emit.  By default `Q` attributes emit once per second

--- a/packages/examples/src/device-onoff-advanced/DeviceNodeFull.ts
+++ b/packages/examples/src/device-onoff-advanced/DeviceNodeFull.ts
@@ -36,7 +36,7 @@ import {
     singleton,
 } from "@matter/main";
 import { OnOffServer } from "@matter/main/behaviors";
-import { GeneralDiagnostics, NetworkCommissioning } from "@matter/main/clusters";
+import { GeneralDiagnostics, NetworkCommissioning, OnOff } from "@matter/main/clusters";
 import { OnOffLightDevice, OnOffPlugInUnitDevice } from "@matter/main/devices";
 import { RootRequirements } from "@matter/main/endpoints";
 import { Ble, FabricAction, logEndpoint } from "@matter/main/protocol";
@@ -139,7 +139,7 @@ await deviceStorage.set({
 
 // Matter exposes functionality in groups called "clusters".  For this example device we override the matter.js "On/Off"
 // cluster implementation to print status to the console.
-class OnOffShellExecServer extends OnOffServer {
+class OnOffShellExecServer extends OnOffServer.with(OnOff.Feature.Lighting) {
     // Intercept the "on" command to the Matter On/Off cluster to print a log message.
     override async on() {
         executeCommand("on");

--- a/packages/node/src/behaviors/mode-select/ModeSelectServer.ts
+++ b/packages/node/src/behaviors/mode-select/ModeSelectServer.ts
@@ -38,7 +38,11 @@ export class ModeSelectServerLogic extends ModeSelectServerBase {
         if (this.features.onOff && this.state.onMode !== undefined && this.state.onMode !== null) {
             const onOffServer = this.agent.get(OnOffServer);
             if (onOffServer !== undefined) {
-                if (onOffServer.features.lighting && onOffServer.state.startUpOnOff === OnOff.StartUpOnOff.On) {
+                if (
+                    onOffServer.features.lighting &&
+                    "startUpOnOff" in onOffServer.state &&
+                    onOffServer.state.startUpOnOff === OnOff.StartUpOnOff.On
+                ) {
                     this.state.currentMode = this.state.onMode;
                     currentModeOverridden = true;
                 }

--- a/packages/node/src/behaviors/on-off/OnOffServer.ts
+++ b/packages/node/src/behaviors/on-off/OnOffServer.ts
@@ -9,24 +9,24 @@ import { GeneralDiagnostics } from "#clusters/general-diagnostics";
 import { OnOff } from "#clusters/on-off";
 import { RootEndpoint } from "#endpoints/root";
 import { MaybePromise, Time, Timer } from "#general";
+import { ClusterType } from "#types";
 import { OnOffBehavior } from "./OnOffBehavior.js";
 
-const Base = OnOffBehavior.with(OnOff.Feature.Lighting);
+const OnOffLogicBase = OnOffBehavior.with(OnOff.Feature.Lighting);
 
 /**
  * This is the default server implementation of {@link OnOffBehavior}.
  *
- * This implementation includes all features of {@link OnOff.Cluster} and automatically enables the "Level Control
- * for Lighting" Feature. You should use {@link OnOffServer.with} to specialize the class for the features your
- * implementation supports. Alternatively you can extend this class and override the methods you need to change or add
- * mandatory commands.
+ * This implementation includes all features of {@link OnOff.Cluster}. You should use {@link OnOffServer.with} to
+ * specialize the class for the features your implementation supports. Alternatively you can extend this class and
+ * override the methods you need to change or add mandatory commands.
  *
- * The "OffOnly" feature is automatically supported because the commands are disabled by conformance.
+ * The "OffOnly" and "Lighting" features are automatically supported because the commands are disabled by conformance.
  * The default implementation do not contain any logic for the DeadFrontBehavior feature because this is very use case
  * specific, so this needs to be implemented by the device implementor as needed.
  */
-export class OnOffServer extends Base {
-    declare protected internal: OnOffServer.Internal;
+export class OnOffServerLogic extends OnOffLogicBase {
+    declare protected internal: OnOffServerLogic.Internal;
 
     override initialize() {
         if (this.features.lighting && this.#getBootReason() !== GeneralDiagnostics.BootReason.SoftwareUpdateCompleted) {
@@ -195,9 +195,13 @@ export class OnOffServer extends Base {
     }
 }
 
-export namespace OnOffServer {
+export namespace OnOffServerLogic {
     export class Internal {
         timedOnTimer?: Timer;
         delayedOffTimer?: Timer;
     }
 }
+
+// We had turned on some more features to provide a default implementation, but export the cluster with default
+// Features again.
+export class OnOffServer extends OnOffServerLogic.for(ClusterType(OnOff.Base)) {}


### PR DESCRIPTION
In fact the default enablement of Lighting makes issues with other device types where this cluster can be in. So better fix this special case now.