### PR TITLE
Accept UDP traffic from unknown interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The main work (all changes without a GitHub username in brackets in the below li
 
 -   @matter/nodejs
     - Fix: Improves async storage reliability and error handling to prevent empty storage files in crashing edge cases. With this change write actions need a bit longer but are more reliable, which mainly effects controller use cases when persisting the device attribute data on first subscribe
+    - Fix: Also accept incoming UDP traffic from unknown network interfaces for Matter messages
 
 -   @matter/nodejs-shell
     - Feature: Added parameters `--qrCode` and `--qrCodeIndex` to the `commission pair` command to also use QR Code strings for pairing

--- a/packages/general/src/net/UdpChannel.ts
+++ b/packages/general/src/net/UdpChannel.ts
@@ -21,7 +21,7 @@ export interface UdpChannelOptions {
 export interface UdpChannel {
     maxPayloadSize: number;
     onData(
-        listener: (netInterface: string, peerAddress: string, peerPort: number, data: Uint8Array) => void,
+        listener: (netInterface: string | undefined, peerAddress: string, peerPort: number, data: Uint8Array) => void,
     ): TransportInterface.Listener;
     send(host: string, port: number, data: Uint8Array): Promise<void>;
     close(): Promise<void>;

--- a/packages/general/src/net/UdpMulticastServer.ts
+++ b/packages/general/src/net/UdpMulticastServer.ts
@@ -85,12 +85,20 @@ export class UdpMulticastServer {
     ) {}
 
     onMessage(listener: (message: Uint8Array, peerAddress: string, netInterface: string) => void) {
-        this.serverIpv4?.onData((netInterface, peerAddress, _port, message) =>
-            listener(message, peerAddress, netInterface),
-        );
-        this.serverIpv6.onData((netInterface, peerAddress, _port, message) =>
-            listener(message, peerAddress, netInterface),
-        );
+        this.serverIpv4?.onData((netInterface, peerAddress, _port, message) => {
+            if (netInterface === undefined) {
+                // Ignore Network packages not coming over any known interface
+                return;
+            }
+            listener(message, peerAddress, netInterface);
+        });
+        this.serverIpv6.onData((netInterface, peerAddress, _port, message) => {
+            if (netInterface === undefined) {
+                // Ignore Network packages not coming over any known interface
+                return;
+            }
+            listener(message, peerAddress, netInterface);
+        });
     }
 
     async send(message: Uint8Array, netInterface?: string, uniCastTarget?: string) {

--- a/packages/nodejs/src/net/NodeJsUdpChannel.ts
+++ b/packages/nodejs/src/net/NodeJsUdpChannel.ts
@@ -117,10 +117,11 @@ export class NodeJsUdpChannel implements UdpChannel {
         private readonly netInterface?: string,
     ) {}
 
-    onData(listener: (netInterface: string, peerAddress: string, peerPort: number, data: Uint8Array) => void) {
+    onData(
+        listener: (netInterface: string | undefined, peerAddress: string, peerPort: number, data: Uint8Array) => void,
+    ) {
         const messageListener = (data: Uint8Array, { address, port }: dgram.RemoteInfo) => {
             const netInterface = this.netInterface ?? NodeJsNetwork.getNetInterfaceForIp(address);
-            if (netInterface === undefined) return;
             listener(netInterface, address, port, data);
         };
 

--- a/packages/react-native/src/net/UdpChannelReactNative.ts
+++ b/packages/react-native/src/net/UdpChannelReactNative.ts
@@ -160,10 +160,11 @@ export class UdpChannelReactNative implements UdpChannel {
         private readonly netInterface?: string,
     ) {}
 
-    onData(listener: (netInterface: string, peerAddress: string, peerPort: number, data: Uint8Array) => void) {
+    onData(
+        listener: (netInterface: string | undefined, peerAddress: string, peerPort: number, data: Uint8Array) => void,
+    ) {
         const messageListener = async (data: Uint8Array, { address, port }: RemoteInfo) => {
             const netInterface = this.netInterface ?? (await NetworkReactNative.getNetInterfaceForIp(address));
-            if (netInterface === undefined) return;
             listener(netInterface, address, port, data);
         };
 


### PR DESCRIPTION
for Matter messages. Move the check to also consider traffic from known network interfaces for MDNS.

@digitaldan Wanne try it? :-)

For me locally in one network zone all works. What about your multi zone setup?