### PR TITLE
CHIP testing updates & fixes

### DIFF
--- a/chip-testing/test/core/Discovery.test.ts
+++ b/chip-testing/test/core/Discovery.test.ts
@@ -7,14 +7,17 @@
 import { edit } from "@matter/testing";
 
 describe("Discovery", () => {
-    before(() =>
-        chip.testFor("Discovery").edit(
-            edit.sed(
-                // We have our timeouts set artificially low (1 s.) so we need to reduce the timeout in the "discovery
-                // window too short" test to be zero
-                "s/value: 120/value: 0/",
-            ),
-        ),
-    );
+    before(async () => {
+        // We have our timeouts set artificially low (1 s.) so we need to reduce the timeout in the "discovery
+        // window too short" test to be zero
+        await chip.testFor("Discovery").edit(edit.sed("s/value: 120/value: 0/"));
+
+        // Avahi sometimes reports commissioning records from previous runs to CHIP even though we've expired the
+        // records.  The test is not discriminating and may fail due to these previous records
+        //
+        // We nuke Avahi to compensate
+        await chip.clearMdns();
+    });
+
     chip("Discovery");
 });

--- a/chip/Dockerfile
+++ b/chip/Dockerfile
@@ -203,5 +203,11 @@ RUN mkdir /run/dbus
 COPY support/generate-test-descriptor /bin/generate-test-descriptor
 RUN generate-test-descriptor > /lib/test-descriptor.json
 
+# Install MDNS scripts
+COPY support/mdns-* /bin
+
 # Include CHIP SHA for diagnostic purposes
 COPY --from=build /connectedhomeip/.git/refs/heads/master /etc/chip-version
+
+# Configure avahi
+RUN echo allow-interfaces

--- a/chip/bin/build
+++ b/chip/bin/build
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# @license
+# Copyright 2022-2025 Matter.js Authors
+# SPDX-License-Identifier: Apache-2.0
+
 set -e
 
 if ! docker buildx inspect matter.js-chip > /dev/null 2>&1; then

--- a/chip/bin/load
+++ b/chip/bin/load
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# @license
+# Copyright 2022-2025 Matter.js Authors
+# SPDX-License-Identifier: Apache-2.0
+
 # Loads build targets into a local image tagged "chip/<target>" and runs bash
 
 set -e

--- a/chip/bin/publish
+++ b/chip/bin/publish
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# @license
+# Copyright 2022-2025 Matter.js Authors
+# SPDX-License-Identifier: Apache-2.0
+
 # To push you must have write access to https://github.com/matter-js/matter.js-chip.
 #
 # Use "docker login" command with a "personal access token (classic)" with package:write scope.

--- a/chip/bin/pull
+++ b/chip/bin/pull
@@ -1,3 +1,7 @@
 #!/bin/bash
 
+# @license
+# Copyright 2022-2025 Matter.js Authors
+# SPDX-License-Identifier: Apache-2.0
+
 docker pull ghcr.io/matter-js/chip:latest

--- a/chip/bin/rebuild
+++ b/chip/bin/rebuild
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# @license
+# Copyright 2022-2025 Matter.js Authors
+# SPDX-License-Identifier: Apache-2.0
+
 set -e
 
 if docker buildx inspect matter.js-chip > /dev/null 2>&1; then

--- a/chip/bin/shell
+++ b/chip/bin/shell
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# @license
+# Copyright 2022-2025 Matter.js Authors
+# SPDX-License-Identifier: Apache-2.0
+
 THISDIR=$(dirname -- "${BASH_SOURCE[0]}")
 GIT_ROOT=$(realpath "${THISDIR}/../../..")
 

--- a/chip/bin/tail-mdns
+++ b/chip/bin/tail-mdns
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# @license
+# Copyright 2022-2025 Matter.js Authors
+# SPDX-License-Identifier: Apache-2.0
+
+# Browse MDNS records in the test MDNS instance using Avahi
+#
+# Requires an active MDNS container
+
+set -e
+
+if [ $# -gt 0 ]; then
+    ARGS=("$@")
+else
+    ARGS=(--all)
+fi
+
+docker run \
+    -it \
+    --rm \
+    --security-opt apparmor:unconfined \
+    -v matter.js-mdns:/run/dbus ghcr.io/matter-js/chip avahi-browse \
+    "${ARGS[@]}"

--- a/chip/bin/tool
+++ b/chip/bin/tool
@@ -1,3 +1,7 @@
 #!/bin/bash
 
+# @license
+# Copyright 2022-2025 Matter.js Authors
+# SPDX-License-Identifier: Apache-2.0
+
 ./shell chip-tool "$@"

--- a/chip/support/mdns-clear
+++ b/chip/support/mdns-clear
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+# @license
+# Copyright 2022-2025 Matter.js Authors
+# SPDX-License-Identifier: Apache-2.0
+
+# Clear MDNS cache.  This involves killing the Avahi daemon and assumes the daemon runs in a loop
+
+avahi-daemon --kill

--- a/chip/support/mdns-run
+++ b/chip/support/mdns-run
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+# @license
+# Copyright 2022-2025 Matter.js Authors
+# SPDX-License-Identifier: Apache-2.0
+
+# Run Avahi in a loop.  This allows us to exec a kill command to clear the DNS cache
+
+while true; do
+    avahi-daemon
+done

--- a/packages/node/src/node/NodeLifecycle.ts
+++ b/packages/node/src/node/NodeLifecycle.ts
@@ -19,7 +19,7 @@ export class NodeLifecycle extends EndpointLifecycle {
     #commissioned = Observable<[context: ActionContext]>();
     #decommissioned = Observable<[context: ActionContext]>();
     #initialized = Observable<[isCommissioned: boolean]>();
-    #isOnline = false;
+    #onlineAt?: Date;
     #isCommissioned = false;
     #mutex: Mutex;
 
@@ -29,10 +29,10 @@ export class NodeLifecycle extends EndpointLifecycle {
         this.#mutex = new Mutex(endpoint);
 
         this.#online.on(() => {
-            this.#isOnline = true;
+            this.#onlineAt = new Date();
         });
         this.#offline.on(() => {
-            this.#isOnline = false;
+            this.#onlineAt = undefined;
         });
         this.#commissioned.on(() => {
             this.#isCommissioned = true;
@@ -49,7 +49,14 @@ export class NodeLifecycle extends EndpointLifecycle {
      * True when the node is connected to the network.
      */
     get isOnline() {
-        return this.#isOnline;
+        return this.#onlineAt !== undefined;
+    }
+
+    /**
+     * The time the node went online.
+     */
+    get onlineAt() {
+        return this.#onlineAt;
     }
 
     /**

--- a/packages/testing/src/chip/chip.ts
+++ b/packages/testing/src/chip/chip.ts
@@ -71,6 +71,11 @@ export interface Chip extends chip.Builder {
     defaultSubject: Subject.Factory;
 
     /**
+     * Clear the MDNS cache.
+     */
+    clearMdns(): Promise<void>;
+
+    /**
      * The CHIP container.  Must be initialized before access.
      */
     container: Container;
@@ -338,6 +343,7 @@ Object.defineProperties(chipFn, {
     openPipe: { value: State.openPipe.bind(State) },
     onClose: { value: State.onClose.bind(State) },
     testFor: { value: State.testFor.bind(State) },
+    clearMdns: { value: State.clearMdns.bind(State) },
 });
 
 export const chip = chipFn as Chip;

--- a/packages/testing/src/global-declarations.ts
+++ b/packages/testing/src/global-declarations.ts
@@ -1,8 +1,7 @@
 /**
  * @license
  * Copyright 2022-2025 Matter.js Authors
- * SPDX-License-Identifier: Apa
- * e-2.0
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import type Chai from "chai";

--- a/packages/testing/src/global-declarations.ts
+++ b/packages/testing/src/global-declarations.ts
@@ -1,7 +1,8 @@
 /**
  * @license
  * Copyright 2022-2025 Matter.js Authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apa
+ * e-2.0
  */
 
 import type Chai from "chai";

--- a/packages/testing/src/mocha.ts
+++ b/packages/testing/src/mocha.ts
@@ -221,7 +221,7 @@ export function adaptReporter(
             });
 
             runner.on(RUNNER.EVENT_TEST_BEGIN, test => {
-                if (updateStats) {
+                if (updateStats && test.descriptor) {
                     test.descriptor.runAt = new Date();
                 }
                 logs = (test as any).logs = [];
@@ -230,13 +230,17 @@ export function adaptReporter(
 
             if (updateStats) {
                 runner.on(RUNNER.EVENT_TEST_PASS, test => {
+                    if (!test.descriptor) {
+                        return;
+                    }
+
                     test.descriptor.durationMs = test.duration;
                     test.descriptor.passed = true;
                 });
             }
 
             runner.on(RUNNER.EVENT_TEST_FAIL, (test, error) => {
-                if (updateStats) {
+                if (updateStats && test.descriptor) {
                     test.descriptor.durationMs = test.duration;
                     test.descriptor.passed = false;
                 }


### PR DESCRIPTION
* Implement MDNS reset to work around CHIP<->Avahi fragility, specifically apply to Discovery test

* Add "tail-mdns" command to track in-container mdns

* Switch "boot time" to be the time the node comes online instead of the time the OS started