### PR TITLE
Remove AbsolutePosition in WC because forbidden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ The main work (all changes without a GitHub username in brackets in the below li
 -   @matter/node
     - Breaking: The Default `OnOffServer` implementation no longer has the "Lighting" feature enabled by default! Please enable manually when the relevant device type where the cluster is used in requires it or use the Requirement-classes like `OnOffLightRequirements.OnOffServer` to get the correct features enabled automatically.
     - Breaking: `LevelControlServer` API has a few small changes that may affect device implementors.  Most notably the `setLevel` method is replaced with `transition` which handles both immediate and gradual level shifts
+    - Breaking: Removed Implementation Logic for the "AbsolutePosition" Feature in WindowCOvering default implementation because this is a forbidden (Zigbee) Feature anyway that no-one should use!
     - Feature: `Transitions` utility class offers a flexible API for implementing Matter attributes that change gradually at a constant rate
     - Feature: Attributes marked as `Q` (quieter) quality now support an extended `quiet` property that controls how often and when they emit.  By default `Q` attributes emit once per second
     - Feature: `LevelControlServer` performs smoother transitions with configurable transition step sizes and Matter 1.4-compliant event emitting.  It offers several new extension points for integrating with hardware and bridged devices

--- a/packages/examples/src/device-composed-wc-light/IlluminatedRollerShade.ts
+++ b/packages/examples/src/device-composed-wc-light/IlluminatedRollerShade.ts
@@ -16,7 +16,7 @@ import { WindowCoveringDevice } from "@matter/main/devices/window-covering";
  * Our example device, the Excelsior 1000 EZ-Nite™, is a roller shade with an illuminated valance.
  */
 
-const LiftingWindowCoveringServer = WindowCoveringServer.with("Lift", "AbsolutePosition", "PositionAwareLift");
+const LiftingWindowCoveringServer = WindowCoveringServer.with("Lift", "PositionAwareLift");
 
 /**
  * Implementation of the Matter WindowCovering cluster for the shade motor.


### PR DESCRIPTION
The AbsolutePosition Feature of WindowCovering is defined in the Devce library as "Zigbee only", so we simply remove it too from Example (cough) and also from default implementation