### PR TITLE
Fix level control with features disabled

### DIFF
--- a/packages/node/src/behaviors/level-control/LevelControlServer.ts
+++ b/packages/node/src/behaviors/level-control/LevelControlServer.ts
@@ -113,7 +113,11 @@ export class LevelControlBaseServer extends LevelControlLogicBase {
      */
     protected initializeTransitions() {
         const { endpoint } = this;
-        const readOnlyState = endpoint.stateOf(LevelControlBaseServer);
+
+        // Transitions read continuously from their configuration object so the values need to be dynamic.  To make
+        // this efficient we use the read-only view of our state provided by the endpoint as it is always available
+        const readOnlyState = (endpoint.state as Record<string, unknown>).levelControl as LevelControlBaseServer.State;
+
         return new Transitions(this.endpoint, {
             type: LevelControlBaseServer,
 
@@ -134,11 +138,11 @@ export class LevelControlBaseServer extends LevelControlLogicBase {
             properties: {
                 currentLevel: {
                     get min() {
-                        return endpoint.stateOf(LevelControlBaseServer).minLevel;
+                        return readOnlyState.minLevel;
                     },
 
                     get max() {
-                        return endpoint.stateOf(LevelControlBaseServer).maxLevel;
+                        return readOnlyState.maxLevel;
                     },
                 },
             },

--- a/packages/node/test/behaviors/level-control/LevelControlServerTest.ts
+++ b/packages/node/test/behaviors/level-control/LevelControlServerTest.ts
@@ -4,9 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { LevelControlServer } from "#behaviors/level-control";
 import { DimmableLightDevice } from "#devices/dimmable-light";
 import { Endpoint } from "#endpoint/Endpoint.js";
 import { Time } from "#general";
+import { LevelControl } from "@matter/types/clusters/level-control";
 import { MockServerNode } from "../../node/mock-server-node.js";
 
 describe("LevelControlServer", () => {
@@ -148,7 +150,21 @@ describe("LevelControlServer", () => {
         // To be on the safe side, advance time beyond when the timer would trigger.  If nothing blows up, timers were
         // correctly shut down
         await MockTime.advance(100_000);
-    }).timeout(200000);
+    });
+
+    it("works with anonymous class and downlevel features", async () => {
+        const endpoint = new Endpoint(
+            DimmableLightDevice.with(createLevelControlServer().with(LevelControl.Feature.Lighting)),
+        );
+
+        function createLevelControlServer() {
+            return class extends LevelControlServer {};
+        }
+
+        const node = await MockServerNode.createOnline({ device: endpoint });
+
+        await node.close();
+    });
 });
 
 function expectTimers(count: number) {


### PR DESCRIPTION
Previously was using `endpoint.stateOf` which does not work if there is a feature mismatch.  Switch to a cast instead.

Fixes #1837