### PR TITLE
Revert ScenesManagement Override

### DIFF
--- a/models/src/local/ScenesManagementOverrides.ts
+++ b/models/src/local/ScenesManagementOverrides.ts
@@ -11,6 +11,15 @@ LocalMatter.children.push({
     name: "ScenesManagement",
 
     children: [
+        /*
+        This Override is currently inactive till it is decided how names will be.
+
+        In https://github.com/project-chip/connectedhomeip/pull/38003 SDK was adjusted to be like spec why this
+        override is obsolete when it stays that way.
+
+        Discussion is still open in see https://github.com/CHIP-Specifications/connectedhomeip-spec/issues/11386
+        TODO Remove the override or not depending on outcome of above Issue in Spec.
+
         // Field name for AddScene and ViewSceneResponse needs to be adjusted to match the 1.4 spec
         // ExtensionFieldSetStruct -> ExtensionFieldSets
         {
@@ -25,5 +34,6 @@ LocalMatter.children.push({
             name: "ViewSceneResponse",
             children: [{ tag: "field", id: 0x5, name: "ExtensionFieldSets" }],
         },
+        */
     ],
 });

--- a/packages/model/src/standard/elements/ScenesManagement.ts
+++ b/packages/model/src/standard/elements/ScenesManagement.ts
@@ -116,7 +116,7 @@ export const ScenesManagement = Cluster(
 
         Field(
             {
-                name: "ExtensionFieldSets", id: 0x4, type: "list", conformance: "M", constraint: "desc",
+                name: "ExtensionFieldSetStructs", id: 0x4, type: "list", conformance: "M", constraint: "desc",
                 details: "This field shall contains the list of extension fields.",
                 xref: { document: "cluster", section: "1.4.9.2.5" }
             },
@@ -201,7 +201,7 @@ export const ScenesManagement = Cluster(
 
         Field(
             {
-                name: "ExtensionFieldSets", id: 0x5, type: "list", conformance: "desc",
+                name: "ExtensionFieldSetStructs", id: 0x5, type: "list", conformance: "desc",
                 details: "If the status is SUCCESS, this field shall be copied from the corresponding field in the Scene Table " +
                     "entry, otherwise it shall be omitted.",
                 xref: { document: "cluster", section: "1.4.9.5.6" }

--- a/packages/types/src/clusters/scenes-management.ts
+++ b/packages/types/src/clusters/scenes-management.ts
@@ -296,7 +296,7 @@ export namespace ScenesManagement {
          *
          * @see {@link MatterSpecification.v14.Cluster} § 1.4.9.2.5
          */
-        extensionFieldSets: TlvField(4, TlvArray(TlvExtensionFieldSet))
+        extensionFieldSetStructs: TlvField(4, TlvArray(TlvExtensionFieldSet))
     });
 
     /**
@@ -412,7 +412,7 @@ export namespace ScenesManagement {
          *
          * @see {@link MatterSpecification.v14.Cluster} § 1.4.9.5.6
          */
-        extensionFieldSets: TlvOptionalField(5, TlvArray(TlvExtensionFieldSet))
+        extensionFieldSetStructs: TlvOptionalField(5, TlvArray(TlvExtensionFieldSet))
     });
 
     /**


### PR DESCRIPTION
This Override is currently inactive till it is decided how names will be.

        In https://github.com/project-chip/connectedhomeip/pull/38003 SDK was adjusted to be like spec why this
        override is obsolete when it stays that way.

        Discussion is still open in see https://github.com/CHIP-Specifications/connectedhomeip-spec/issues/11386

So for now lets revertto "as chip does it" and see how it goes.

Reverting this fixes the daily interop tests