### PR TITLE
Improve version information for CHIP image

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -93,7 +93,7 @@ jobs:
           username: Automator77
           password: ${{ secrets.MATTERJS_DOCKER_TOKEN }}
 
-      - name: Rebuild docker image
+      - name: Publish docker image
         if: ${{ github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
         run: |
           cd chip

--- a/chip/Dockerfile
+++ b/chip/Dockerfile
@@ -44,13 +44,16 @@ RUN --mount=type=cache,sharing=locked,target=/var/cache/apt \
 FROM --platform=$BUILDPLATFORM base AS build
 
 ARG TARGETPLATFORM
+ARG CHIP_COMMIT
 
 # Validate platform (must be amd64 or arm64)
-RUN case "${TARGETPLATFORM}" in \
-    "linux/amd64"|"linux/arm64") echo "Targeting ${TARGETPLATFORM}";; \
-    "") echo "TARGETPLATFORM not set, please build with buildx";; \
-    *) echo "Unsupported platform ${TARGETPLATFORM}";; \
+RUN <<EOF
+    case "${TARGETPLATFORM}" in
+        "linux/amd64"|"linux/arm64") echo "Targeting ${TARGETPLATFORM}";;
+        "") echo "TARGETPLATFORM not set, please build with buildx";;
+        *) echo "Unsupported platform ${TARGETPLATFORM}";;
     esac
+EOF
 
 # Configure for cross compilation
 #RUN dpkg --add-architecture arm64
@@ -59,16 +62,34 @@ RUN case "${TARGETPLATFORM}" in \
 # Install system packages required for build
 RUN --mount=type=cache,sharing=locked,target=/var/cache/apt \
     --mount=type=cache,sharing=locked,target=/var/lib/apt \
-    apt-get -qq update && \
+<<EOF
+    set -e
+    apt-get -qq update
     apt-get -qq -y install git gcc g++ clang pkg-config libssl-dev libdbus-1-dev libglib2.0-dev libavahi-client-dev \
         ninja-build python3-venv python3-dev unzip libgirepository1.0-dev libcairo2-dev libreadline-dev python3-pip
+EOF
 
 # Install x86->arm cross compilers.  Not useful because requires installation of lib dependencies which we've not
 # implemented
 # RUN apt-get -qq -y install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu binutils-aarch64-linux-gnu
 
 # Pull CHIP source code
-RUN git clone --depth=1 https://github.com/project-chip/connectedhomeip.git
+RUN <<EOF
+    set -e
+    if [ -e "$CHIP_COMMIT" ]; then
+        CHIP_COMMIT="$(git ls-remote https://github.com/project-chip/connectedhomeip -t master | cut -f 1)"
+    fi
+    mkdir connectedhomeip
+    cd connectedhomeip
+    git config --global init.defaultBranch main
+    git config --global advice.detachedHead false
+    git init
+    git remote add origin https://github.com/project-chip/connectedhomeip.git
+    git fetch --depth 1 origin "$CHIP_COMMIT"
+    git checkout FETCH_HEAD
+    echo "$CHIP_COMMIT" > /etc/chip-version
+EOF
+
 WORKDIR /connectedhomeip
 RUN ./scripts/checkout_submodules.py --shallow --platform linux
 
@@ -144,8 +165,11 @@ FROM base AS final
 # Install some runtime-only packages
 RUN --mount=type=cache,sharing=locked,target=/var/cache/apt \
     --mount=type=cache,sharing=locked,target=/var/lib/apt \
-    apt-get -qq update && \
+<<EOF \
+    set -e
+    apt-get -qq update
     apt-get -qq -y install avahi-daemon avahi-utils iproute2 less vim wget
+EOF
 
 LABEL org.opencontainers.image.title="matter.js CHIP tooling build"
 LABEL org.opencontainers.image.url=https://github.com/matter-js/matter.js-chip
@@ -207,7 +231,7 @@ RUN generate-test-descriptor > /lib/test-descriptor.json
 COPY support/mdns-* /bin
 
 # Include CHIP SHA for diagnostic purposes
-COPY --from=build /connectedhomeip/.git/refs/heads/master /etc/chip-version
+COPY --from=build /etc/chip-version /etc
 
 # Configure avahi
 RUN echo allow-interfaces

--- a/chip/bin/build
+++ b/chip/bin/build
@@ -10,10 +10,23 @@ if ! docker buildx inspect matter.js-chip > /dev/null 2>&1; then
     docker buildx create --name matter.js-chip
 fi
 
+CHIP_COMMIT=$(git ls-remote https://github.com/project-chip/connectedhomeip -t master | cut -f 1)
+
+if [ -e "$GITHUB_ACTION" ]; then
+    ACTOR=ci
+else
+    ACTOR=$(whoami)
+fi
+
+VERSION="$ACTOR-$(date -u +%Y%m%dT%H%M%S)-$(git rev-parse HEAD | cut -c 1-12)"
+
 docker buildx build . \
     --builder matter.js-chip \
     --load \
     -t ghcr.io/matter-js/chip \
-    --label org.opencontainers.image.revision=$(git rev-parse HEAD) \
+    --label org.opencontainers.image.name=matter.js-chip \
+    --label org.opencontainers.image.version="$VERSION" \
+    --label org.opencontainers.image.revision="$CHIP_COMMIT" \
     --platform linux/amd64 \
+    --build-arg CHIP_COMMIT="$CHIP_COMMIT" \
     $*

--- a/chip/bin/info
+++ b/chip/bin/info
@@ -7,31 +7,24 @@
 THISDIR=$(dirname -- "${BASH_SOURCE[0]}")
 GIT_ROOT=$(realpath "${THISDIR}/../../..")
 
-CONTAINER_ID=$(docker inspect --format '{{ .Id }}' ghcr.io/matter-js/chip)
-CONTAINER_CREATED=$(docker inspect --format '{{ .Created }}' ghcr.io/matter-js/chip)
-CONTAINER_SIZE=$(docker inspect --format '{{ .Size }}' ghcr.io/matter-js/chip)
-CHIP_VERSION=$(
-    docker run \
-        --rm \
-        --platform linux/amd64 \
-        --entrypoint /usr/bin/cat \
-        ghcr.io/matter-js/chip \
-        /etc/chip-version
-)
+IMAGE_VERSION=$(docker inspect --format '{{ index .Config.Labels "org.opencontainers.image.version" }}' ghcr.io/matter-js/chip)
+IMAGE_CREATED=$(docker inspect --format '{{ .Created }}' ghcr.io/matter-js/chip)
+IMAGE_SIZE=$(docker inspect --format '{{ .Size }}' ghcr.io/matter-js/chip)
+CHIP_COMMIT=$(docker inspect --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}' ghcr.io/matter-js/chip | cut -c 1-12)
 
 if [ -x /usr/bin/numfmt ]; then
-    CONTAINER_SIZE=$(numfmt --to=iec <<< "$CONTAINER_SIZE")
+    IMAGE_SIZE=$(numfmt --to=iec <<< "$IMAGE_SIZE")
 fi
 
 cat <<-END
 {
-    "container": {
-        "id": "$CONTAINER_ID",
-        "created": "$CONTAINER_CREATED",
-        "size": "$CONTAINER_SIZE"
+    "image": {
+        "version": "$IMAGE_VERSION",
+        "created": "$IMAGE_CREATED",
+        "size": "$IMAGE_SIZE"
     },
     "chip": {
-        "sha": "$CHIP_VERSION"
+        "commit": "$CHIP_COMMIT"
     }
 }
 END

--- a/packages/testing/src/chip/state.ts
+++ b/packages/testing/src/chip/state.ts
@@ -153,12 +153,12 @@ export const State = {
         try {
             const result = await initialize();
 
-            const imageVersion = formatSha(await State.container.imageId);
-            const chipVersion = formatSha(await State.container.read("/etc/chip-version"));
+            const image = await State.container.image;
+            const info = await image.inspect();
+            const chipCommit = formatSha(info.Config.Labels["org.opencontainers.image.revision"] ?? "(unknown)");
+            const imageVersion = info.Config.Labels["org.opencontainers.image.version"] ?? "(unknown)";
 
-            progress.success(
-                `Initialized containers from image ${ansi.bold(imageVersion)} for CHIP ${ansi.bold(chipVersion)}`,
-            );
+            progress.success(`Initialized CHIP ${ansi.bold(chipCommit)} image ${ansi.bold(imageVersion)}`);
 
             return result;
         } catch (e) {

--- a/packages/testing/src/docker/container.ts
+++ b/packages/testing/src/docker/container.ts
@@ -11,6 +11,7 @@ import { base64Of } from "../util/text.js";
 import type { Docker } from "./docker.js";
 import { edit } from "./edit.js";
 import { DockerError, NonZeroExitError } from "./errors.js";
+import { Image } from "./image.js";
 import { Network } from "./network.js";
 import { Terminal } from "./terminal.js";
 
@@ -20,7 +21,7 @@ import { Terminal } from "./terminal.js";
 export interface Container {
     docker: Docker;
 
-    imageId: Promise<string>;
+    image: Promise<Image>;
 
     start(): Promise<void>;
     kill(): Promise<void>;
@@ -229,8 +230,8 @@ function adaptContainer(docker: Docker, ct: Dockerode.Container): Container {
     return {
         docker,
 
-        get imageId() {
-            return ct.inspect().then(info => info.Image);
+        get image() {
+            return DockerError.adapt(ct.inspect().then(info => Image(docker, info.Image)));
         },
 
         async start() {

--- a/packages/testing/src/docker/image.ts
+++ b/packages/testing/src/docker/image.ts
@@ -1,0 +1,39 @@
+/**
+ * @license
+ * Copyright 2022-2025 Project CHIP Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import Dockerode from "dockerode";
+import { Docker } from "./docker.js";
+import { DockerError } from "./errors.js";
+
+export interface Image {
+    inspect(): Promise<Dockerode.ImageInspectInfo>;
+}
+
+/**
+ * Create an image by name.
+ */
+export function Image(docker: Docker, name: string): Image;
+
+/**
+ * Wrap a {@link Dockerode.Image}.
+ */
+export function Image(docker: Docker, image: Dockerode.Image): Image;
+
+export function Image(docker: Docker, definition: string | Dockerode.Image): Image {
+    let image;
+
+    if (typeof definition === "string") {
+        image = docker.intf.getImage(definition);
+    } else {
+        image = definition;
+    }
+
+    return {
+        inspect() {
+            return DockerError.adapt(image.inspect());
+        },
+    };
+}


### PR DESCRIPTION
* CHIP commit used for testing is now an argument to the Dockerfile

* The build script selects the latest version and uses that to label image

* We also generate a version using user+timestamp+matter.js commit and install as a label

* Updated tooling to report these new labels instead of the (useless) image ID and reading CHIP version from container

* Also fixes name of one of the gh workflow steps