### PR TITLE
Fix upper bound when parsing bit ranges

### DIFF
--- a/codegen/src/mom/spec/html-translators.ts
+++ b/codegen/src/mom/spec/html-translators.ts
@@ -212,7 +212,6 @@ export const Bits = (el: HTMLElement) => {
             max = min;
             min = tmp;
         }
-        max++;
         return { min, max };
     }
 };

--- a/models/src/local/ThermostatOverrides.ts
+++ b/models/src/local/ThermostatOverrides.ts
@@ -27,19 +27,5 @@ LocalMatter.children.push({
             name: "ControlSequenceOfOperation",
             default: FieldValue.None,
         },
-
-        // Correct the ranges of two bitmaps  because scraping error
-        {
-            tag: "datatype",
-            name: "HVACSystemTypeBitmap",
-
-            // The type is correct but need to set here so model logic knows to use the constraint for matching
-            type: "map8",
-
-            children: [
-                { tag: "field", name: "CoolingStage", constraint: "0 to 1" },
-                { tag: "field", name: "HeatingStage", constraint: "2 to 3" },
-            ],
-        },
     ],
 });

--- a/models/src/local/WindowCoveringOverrides.ts
+++ b/models/src/local/WindowCoveringOverrides.ts
@@ -184,21 +184,21 @@ LocalMatter.children.push(
                         tag: "field",
                         name: "Global",
                         type: "MovementStatus",
-                        constraint: "0 to 2",
+                        constraint: "0 to 1",
                         description: "Movement status of the cover",
                     },
                     {
                         tag: "field",
                         name: "Lift",
                         type: "MovementStatus",
-                        constraint: "2 to 4",
+                        constraint: "2 to 3",
                         description: "Movement status of the cover's lift function",
                     },
                     {
                         tag: "field",
                         name: "Tilt",
                         type: "MovementStatus",
-                        constraint: "4 to 6",
+                        constraint: "4 to 5",
                         description: "Movement status of the cover's tilt function",
                     },
                 ],
@@ -213,6 +213,7 @@ LocalMatter.children.push(
                 type: "map8",
 
                 children: [
+                    // Note constraint is correct but we need to include for matching
                     { tag: "field", name: "Global", type: "MovementStatus", constraint: "0 to 1" },
                     { tag: "field", name: "Lift", type: "MovementStatus", constraint: "2 to 3" },
                     { tag: "field", name: "Tilt", type: "MovementStatus", constraint: "4 to 5" },

--- a/models/src/v1.4/spec.ts
+++ b/models/src/v1.4/spec.ts
@@ -11014,7 +11014,7 @@ export const SpecMatter = Matter(
 
             Field(
                 {
-                    name: "CoolingStage", constraint: "0 to 2",
+                    name: "CoolingStage", constraint: "0 to 1",
                     description: "Stage of cooling the HVAC system is using.",
 
                     details: "These bits shall indicate what stage of cooling the HVAC system is using." +
@@ -11033,7 +11033,7 @@ export const SpecMatter = Matter(
 
             Field(
                 {
-                    name: "HeatingStage", constraint: "2 to 4",
+                    name: "HeatingStage", constraint: "2 to 3",
                     description: "Stage of heating the HVAC system is using.",
 
                     details: "These bits shall indicate what stage of heating the HVAC system is using." +
@@ -16034,21 +16034,21 @@ export const SpecMatter = Matter(
             },
 
             Field({
-                name: "Global", constraint: "0 to 2", description: "Global operational state.",
+                name: "Global", constraint: "0 to 1", description: "Global operational state.",
                 details: "These bits shall indicate in which direction the covering is currently moving or if it has stopped. " +
                     "Global operational state shall always reflect the overall motion of the device.",
                 xref: { document: "cluster", section: "5.3.5.3.1" }
             }),
 
             Field({
-                name: "Lift", constraint: "2 to 4", description: "Lift operational state.",
+                name: "Lift", constraint: "2 to 3", description: "Lift operational state.",
                 details: "These bits shall indicate in which direction the covering’s lift is currently moving or if it has " +
                     "stopped.",
                 xref: { document: "cluster", section: "5.3.5.3.2" }
             }),
 
             Field({
-                name: "Tilt", constraint: "4 to 6", description: "Tilt operational state.",
+                name: "Tilt", constraint: "4 to 5", description: "Tilt operational state.",
                 details: "These bits shall indicate in which direction the covering’s tilt is currently moving or if it has " +
                     "stopped.",
                 xref: { document: "cluster", section: "5.3.5.3.3" }


### PR DESCRIPTION
Needed to keep 3 of five overrides to facilitate matching.  So glad I implemented bitfield parsing to avoid two whole overrides.