### PR TITLE
PairedNode: ReadAll before subscribe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Breaking: The handling of the `requestFromRemote` parameter (first parameter) in get*Attribute methods in ClusterClients changed behavior! providing "false" will now never try to read from remote, "true" will always try to read from remote and "undefined" will use the default behavior (read from remote if not available locally or fabric scoped read). Only relevant if you used this parameter with value "false". Other use cases stay unchanged.
     - Feature: Allows to use a custom Root-NodeId, CertificateAuthority or CommissioningFlow implementation in the Controller
     - Feature: Allows to establish a secure PASE session to a device and use this to interact with the device in special pre-commissioning cases.
+    - Enhancement: Adjusted the initial Deice connection to Read-All before subscribing to also have initial values for not-changed attributes
 
 -   @project-chip/* packages (beside above)
     - Breaking: Packages are removed! Please use the new packages under @matter/* if needed

--- a/packages/matter.js/src/device/PairedNode.ts
+++ b/packages/matter.js/src/device/PairedNode.ts
@@ -831,6 +831,16 @@ export class PairedNode {
         this.#currentSubscriptionHandler = subscriptionHandler;
 
         const maxKnownEventNumber = this.#interactionClient.maxKnownEventNumber;
+
+        // We first update all values by doing a read all on the device
+        // We do not enrich existing data because we just want to store updated data
+        const attributeData = await this.#interactionClient.getAllAttributes({
+            dataVersionFilters: this.#interactionClient.getCachedClusterDataVersions(),
+            executeQueued: !!threadConnected, // We queue subscriptions for thread devices
+        });
+        await this.#interactionClient.addAttributesToCache(attributeData);
+        attributeData.length = 0; // Clear the array to save memory
+
         // If we subscribe anything we use these data to create the endpoint structure, so we do not need to fetch again
         const initialSubscriptionData = await this.#interactionClient.subscribeAllAttributesAndEvents({
             isUrgent: true,

--- a/packages/protocol/src/interaction/InteractionClient.ts
+++ b/packages/protocol/src/interaction/InteractionClient.ts
@@ -1305,6 +1305,24 @@ export class InteractionClient {
     }
 
     /**
+     * Allows to add the data received by e.g. a Read request to the cache
+     */
+    async addAttributesToCache(attributeReports: DecodedAttributeReportValue<any>[]) {
+        for (const data of attributeReports) {
+            const {
+                path: { endpointId, clusterId, attributeId },
+                value,
+            } = data;
+            if (value === undefined) continue;
+            const { value: oldValue } = this.#nodeStore?.retrieveAttribute(endpointId, clusterId, attributeId) ?? {};
+            const changed = oldValue !== undefined ? !isDeepEqual(oldValue, value) : undefined;
+            if (changed !== false) {
+                await this.#nodeStore?.persistAttributes([data]);
+            }
+        }
+    }
+
+    /**
      * Returns the list (optionally filtered by endpointId and/or clusterId) of the dataVersions of the currently cached
      * values to use them as knownDataVersion for read or subscription requests.
      */


### PR DESCRIPTION
This adds a read-all call before subscribing to the device to ensure that we have all attributes - also those not reported in a subscription in cache at least once.