### PR TITLE
Updates and fixes

### DIFF
--- a/packages/general/src/util/Mutex.ts
+++ b/packages/general/src/util/Mutex.ts
@@ -105,12 +105,12 @@ export class Mutex implements PromiseLike<unknown> {
     }
 
     /**
-     * Execute a task immediately if it is a function.
+     * Activate a task.
      */
     protected async initiateTask(task: PromiseLike<unknown> | (() => PromiseLike<unknown>)) {
         if (typeof task === "function") {
             task = task();
         }
-        return Promise.resolve(task).catch(cause => logger.error(`Error initializing ${this.#owner} worker:`, cause));
+        return Promise.resolve(task).catch(cause => logger.error(`Unhandled error in ${this.#owner} worker:`, cause));
     }
 }

--- a/packages/node/src/behavior/Events.ts
+++ b/packages/node/src/behavior/Events.ts
@@ -32,8 +32,7 @@ export class Events extends EventEmitter {
     #endpoint?: Endpoint;
     #behavior?: Behavior.Type;
 
-    constructor(endpoint?: Endpoint, behavior?: Behavior.Type) {
-        super();
+    setContext(endpoint: Endpoint, behavior: Behavior.Type) {
         this.#endpoint = endpoint;
         this.#behavior = behavior;
     }
@@ -57,7 +56,7 @@ export class Events extends EventEmitter {
     }
 
     override toString() {
-        return `${this.#endpoint ?? "endpoint"}.${this.#behavior?.id}.events`;
+        return `${this.#endpoint ?? "?"}.${this.#behavior?.id ?? "?"}.events`;
     }
 }
 

--- a/packages/node/src/endpoint/properties/Behaviors.ts
+++ b/packages/node/src/endpoint/properties/Behaviors.ts
@@ -10,6 +10,7 @@ import { ActionContext } from "#behavior/context/ActionContext.js";
 import { ActionTracer } from "#behavior/context/ActionTracer.js";
 import { NodeActivity } from "#behavior/context/NodeActivity.js";
 import { OfflineContext } from "#behavior/context/server/OfflineContext.js";
+import { Events } from "#behavior/Events.js";
 import { BehaviorBacking } from "#behavior/internal/BehaviorBacking.js";
 import { Datasource } from "#behavior/state/managed/Datasource.js";
 import {
@@ -622,6 +623,10 @@ export class Behaviors {
             get: () => {
                 if (!events) {
                     events = new type.Events();
+
+                    if (typeof (events as Events).setContext === "function") {
+                        (events as Events).setContext(this.#endpoint, type);
+                    }
                 }
                 return events;
             },

--- a/packages/testing/src/cli.ts
+++ b/packages/testing/src/cli.ts
@@ -18,6 +18,8 @@ import { defaultDescriptor, printReport } from "./print-report.js";
 import { TestRunner } from "./runner.js";
 import { TestDescriptor } from "./test-descriptor.js";
 
+const SHUTDOWN_TIMEOUT_MS = 5000;
+
 enum TestType {
     esm = "esm",
     cjs = "cjs",
@@ -174,6 +176,14 @@ export async function main(argv = process.argv) {
             console.log();
         }
     }
+
+    // Do not hang indefinitely if tests do not clean up after themselves properly.  Instead print error and exit with
+    // non-zero status code
+    const timeout = setTimeout(() => {
+        console.error(`Error: Tests passed but process did not exit cleanly after ${SHUTDOWN_TIMEOUT_MS / 1000}s.`);
+        process.exit(101);
+    }, SHUTDOWN_TIMEOUT_MS);
+    timeout.unref();
 }
 
 function supportsWebTests(pkg: Package) {

--- a/packages/testing/src/failure-reporter.ts
+++ b/packages/testing/src/failure-reporter.ts
@@ -4,24 +4,25 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ansi, Printer, screen } from "#tools";
+import { ansi, Printer, STATUS_ICON_FAILURE } from "#tools";
 import { FailureDetail } from "./failure-detail.js";
 import { TextDiff } from "./text-diff.js";
 
-const OUTER_PREFIX = `${ansi.red}▌ ${ansi.not.red}`;
-const INNER_PREFIX = `${ansi.dim}┆ ${ansi.not.dim}`;
+const BEGIN_ERROR = `${ansi.red}┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┅\n┃${ansi.not.red}`;
+const OUTER_PREFIX = `${ansi.red}┃  ${ansi.not.red}`;
+const INNER_PREFIX = `${ansi.dim}┆  ${ansi.not.dim}`;
+const END_ERROR = `${ansi.red}┃\n┗━┅${ansi.not.red}`;
 
 export namespace FailureReporter {
     export function report(out: Printer, failure: FailureDetail, title: string) {
-        out.state({ style: ansi.reset.white.bg.red }, () => {
-            out(screen.erase.toEol, "\n ", title, screen.erase.toEol, "\n", screen.erase.toEol, "\n");
-        });
-
-        out(screen.erase.toEol);
+        out(BEGIN_ERROR, "\n");
 
         out.state({ linePrefix: OUTER_PREFIX }, () => {
+            out(ansi.bold.red(STATUS_ICON_FAILURE), " ", title, "\n");
             dumpDetails(out, failure);
         });
+
+        out(END_ERROR, "\n");
     }
 }
 

--- a/packages/testing/src/nodejs-reporter.ts
+++ b/packages/testing/src/nodejs-reporter.ts
@@ -99,14 +99,11 @@ export abstract class NodejsReporter implements Reporter {
     }
 
     #dumpFailures() {
+        std.out("\n");
         for (let i = 0; i < this.#failures.length; i++) {
-            if (i !== 0) {
-                std.out("\n");
-            }
-
             const failure = this.#failures[i];
-            const index = `⚠ Failure ${ansi.bold((i + 1).toString())} of ${this.#failures.length}`;
-            const title = `${index} ${this.#formatName(failure.suite, failure.test, failure.step)}`;
+            const index = `Failure ${ansi.bold((i + 1).toString())} of ${this.#failures.length}: `;
+            const title = `${index}${this.#formatName(failure.suite, failure.test, failure.step)}`;
 
             FailureReporter.report(std.out, failure.detail, title);
         }

--- a/packages/tools/src/ansi-text/wrapper.ts
+++ b/packages/tools/src/ansi-text/wrapper.ts
@@ -86,8 +86,6 @@ export class Wrapper implements Consumer {
                 break;
 
             case "ansi":
-                this.#enqueue(token);
-
                 switch (token.sequence) {
                     case Wrapper.prefixStart:
                         this.#inputState = "prefix";
@@ -95,6 +93,11 @@ export class Wrapper implements Consumer {
 
                     case Wrapper.prefixStop:
                         this.#inputState = "indent";
+                        break;
+
+                    default:
+                        // Note that we don't enqueue above codes as GH CI doesn't format correctly
+                        this.#enqueue(token);
                         break;
                 }
                 break;


### PR DESCRIPTION
* Previously we were losing track of various advertisement promises either by leaving them with a non-async observable or by simply catching and logging errors.  We had a mutex to track promises but IIRC did not place all promises into it just to be conservative.  Now we do.  This should prevent spurious errors related to operating on closed advertisers that regularly cropped up in test logs.

* Changes how messages are logged when attribute reads fail.  Previously we logged all exceptions with a stack trace.  Now if it's a StatusResponseError we log the message but not the stack trace.  If it's any other type of error we do not log at all but rethrow (which we already did) an implementation error with the original error as the cause.

* Fix error messages and promise handling for async observers of non-async behavior events.  This was already implemented but the relevant context fields weren't set.

* The test suite now waits 5 seconds for the process to exit once testing is complete.  If the interval elapses and the process is still alive it exits with a message and error code.  This will make CI jobs fail faster when tests are unruly.

* Adjusted test failure formatting to suck less in GH CI