### PR TITLE
Partial arm64 support for CHIP container

### DIFF
--- a/chip/bin/build
+++ b/chip/bin/build
@@ -14,7 +14,7 @@
 #
 #   - Otherwise the argument should be a CHIP SHA or tag and triggers a full container build of that version
 
-set -e
+source "$(dirname "${BASH_SOURCE[0]}")/config.sh"
 
 if ! docker buildx inspect matter.js-chip > /dev/null 2>&1; then
     docker buildx create --name matter.js-chip
@@ -37,13 +37,12 @@ fi
 
 VERSION="$ACTOR-$(date -u +%Y%m%dT%H%M%S)-$(git rev-parse HEAD | cut -c 1-12)"
 
-docker buildx build . \
+docker buildx build "$CHIP_DIR" \
     --builder matter.js-chip \
     --load \
     -t ghcr.io/matter-js/chip \
     --label org.opencontainers.image.name=matter.js-chip \
     --label org.opencontainers.image.version="$VERSION" \
     --label org.opencontainers.image.revision="$CHIP_COMMIT" \
-    --platform linux/amd64 \
     --build-arg CHIP_COMMIT="$CHIP_COMMIT" \
     --build-arg SKIP_APPS="$SKIP_APPS"

--- a/chip/bin/config.sh
+++ b/chip/bin/config.sh
@@ -1,0 +1,9 @@
+# @license
+# Copyright 2022-2025 Matter.js Authors
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+export CHIP_ARCH=$(docker inspect --format '{{ .Architecture }}' ghcr.io/matter-js/chip)
+export CHIP_PLATFORM="linux/$CHIP_ARCH"
+export CHIP_DIR=$(dirname "$(realpath "$(dirname "${BASH_SOURCE[0]}")")")

--- a/chip/bin/info
+++ b/chip/bin/info
@@ -4,12 +4,17 @@
 # Copyright 2022-2025 Matter.js Authors
 # SPDX-License-Identifier: Apache-2.0
 
+# Display information about the current CHIP image
+
+source "$(dirname "${BASH_SOURCE[0]}")/config.sh"
+
 THISDIR=$(dirname -- "${BASH_SOURCE[0]}")
 GIT_ROOT=$(realpath "${THISDIR}/../../..")
 
 IMAGE_VERSION=$(docker inspect --format '{{ index .Config.Labels "org.opencontainers.image.version" }}' ghcr.io/matter-js/chip)
 IMAGE_CREATED=$(docker inspect --format '{{ .Created }}' ghcr.io/matter-js/chip)
 IMAGE_SIZE=$(docker inspect --format '{{ .Size }}' ghcr.io/matter-js/chip)
+IMAGE_ARCH=$(docker inspect --format '{{ .Architecture }}' ghcr.io/matter-js/chip)
 CHIP_COMMIT=$(docker inspect --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}' ghcr.io/matter-js/chip | cut -c 1-12)
 
 if [ -x /usr/bin/numfmt ]; then
@@ -21,7 +26,8 @@ cat <<-END
     "image": {
         "version": "$IMAGE_VERSION",
         "created": "$IMAGE_CREATED",
-        "size": "$IMAGE_SIZE"
+        "size": "$IMAGE_SIZE",
+        "arch": "$IMAGE_ARCH"
     },
     "chip": {
         "commit": "$CHIP_COMMIT"

--- a/chip/bin/load
+++ b/chip/bin/load
@@ -6,7 +6,7 @@
 
 # Loads build targets into a local image tagged "chip/<target>" and runs bash
 
-set -e
+source "$(dirname "${BASH_SOURCE[0]}")/config.sh"
 
 if ! docker buildx inspect matter.js-chip > /dev/null 2>&1; then
     docker buildx create --name matter.js-chip
@@ -25,7 +25,7 @@ docker buildx build . \
     -t "chip/${TARGET}" \
     --target "${TARGET}" \
     --label org.opencontainers.image.revision=$(git rev-parse HEAD) \
-    --platform linux/amd64 \
+    --platform "$CHIP_PLATFORM" \
     $*
 
 docker run -it --rm "chip/${TARGET}"

--- a/chip/bin/publish
+++ b/chip/bin/publish
@@ -12,4 +12,6 @@
 #
 # See also https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-with-a-personal-access-token-classic
 
+source "$(dirname "${BASH_SOURCE[0]}")/config.sh"
+
 docker push ghcr.io/matter-js/chip:latest

--- a/chip/bin/pull
+++ b/chip/bin/pull
@@ -4,4 +4,6 @@
 # Copyright 2022-2025 Matter.js Authors
 # SPDX-License-Identifier: Apache-2.0
 
+source "$(dirname "${BASH_SOURCE[0]}")/config.sh"
+
 docker pull ghcr.io/matter-js/chip:latest

--- a/chip/bin/rebuild
+++ b/chip/bin/rebuild
@@ -4,6 +4,8 @@
 # Copyright 2022-2025 Matter.js Authors
 # SPDX-License-Identifier: Apache-2.0
 
+source "$(dirname "${BASH_SOURCE[0]}")/config.sh"
+
 set -e
 
 if docker buildx inspect matter.js-chip > /dev/null 2>&1; then

--- a/chip/bin/shell
+++ b/chip/bin/shell
@@ -6,6 +6,8 @@
 
 # Run a shell in a new ephemeral container (if no args) or in a running container (1 arg)
 
+source "$(dirname "${BASH_SOURCE[0]}")/config.sh"
+
 THISDIR=$(dirname -- "${BASH_SOURCE[0]}")
 GIT_ROOT=$(realpath "${THISDIR}/../../..")
 
@@ -18,7 +20,7 @@ if [ -z "$CONTAINER" ]; then
         --workdir / \
         --security-opt apparmor:unconfined \
         -v matter.js-mdns:/run/dbus \
-        --platform linux/amd64 \
+        --platform "$CHIP_PLATFORM" \
         ghcr.io/matter-js/chip \
         "$@"
 else

--- a/chip/bin/tail-mdns
+++ b/chip/bin/tail-mdns
@@ -8,7 +8,7 @@
 #
 # Requires an active MDNS container
 
-set -e
+source "$(dirname "${BASH_SOURCE[0]}")/config.sh"
 
 if [ $# -gt 0 ]; then
     ARGS=("$@")

--- a/chip/bin/tool
+++ b/chip/bin/tool
@@ -4,4 +4,8 @@
 # Copyright 2022-2025 Matter.js Authors
 # SPDX-License-Identifier: Apache-2.0
 
+# Run chip-tool in a container
+
+source "$(dirname "${BASH_SOURCE[0]}")/config.sh"
+
 ./shell chip-tool "$@"

--- a/packages/testing/src/chip/config.ts
+++ b/packages/testing/src/chip/config.ts
@@ -36,10 +36,14 @@ export interface TestConflictResolutions {
  * Other misc configuration.
  */
 export namespace Constants {
+    export const selectedPlatform = env.MATTER_CHIP_PLATFORM;
+
     /**
      * We only publish for x86.  This is appropriate for GH CI and runs fine under emulation on MacOS
+     *
+     * TODO - if/when we do publish arm64 images, make the native architecture the default
      */
-    export const platform = env.MATTER_CHIP_PLATFORM || "linux/amd64";
+    export const platform = selectedPlatform || "linux/amd64";
 
     export const networkName = "matter.js-chip";
 


### PR DESCRIPTION
* Convert the "build" script to always build for the native platform

* Modify the test harness in "no pull" mode to use whatever architecture the current image is

* Updates the utility scripts to also use currently available architecture

* Also makes the build script select the correct directory so it's cwd independent