### PR TITLE
[rebuild-docker] Patch Docker PICS for removed LVL attributes

### DIFF
--- a/chip-testing/src/AllClustersTestInstance.ts
+++ b/chip-testing/src/AllClustersTestInstance.ts
@@ -156,7 +156,6 @@ export class AllClustersTestInstance extends NodeTestInstance {
                     events: { hardwareFaultChange: true, radioFaultChange: true, networkFaultChange: true },
                 }),
                 LocalizationConfigurationServer,
-
                 NetworkCommissioningServer.with("EthernetNetworkInterface"), // Set the correct Ethernet network Commissioning cluster
                 TimeFormatLocalizationServer.with("CalendarFormat"),
                 UnitLocalizationServer.with("TemperatureUnit"),

--- a/packages/testing/src/chip/matter-js-pics.properties
+++ b/packages/testing/src/chip/matter-js-pics.properties
@@ -95,3 +95,8 @@ ICDM.S.A0001..8=0
 
 # We do not enable GeneralCommissioning feature TermsAndConditions
 CGEN.S.F00=0
+
+# We disabled the Frequency attributes in LevelControl cluster
+LVL.S.A0004=0
+LVL.S.A0005=0
+LVL.S.A0006=0


### PR DESCRIPTION
... because Frequency is not really used