### PR TITLE
Fix for command handling in derived clusters

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -20,7 +20,10 @@
             "args": [
                 "--clear"
             ],
-            "program": "${workspaceFolder}/node_modules/.bin/matter-test"
+            "program": "${workspaceFolder}/node_modules/.bin/matter-test",
+            "presentation": {
+                "group": "00misc"
+            }
         },
         {
             "type": "node",
@@ -45,7 +48,10 @@
                 "--all-logs",
                 "esm"
             ],
-            "program": "${workspaceFolder}/node_modules/.bin/matter-test"
+            "program": "${workspaceFolder}/node_modules/.bin/matter-test",
+            "presentation": {
+                "group": "00misc"
+            }
         },
         {
             "type": "node",
@@ -67,7 +73,10 @@
                 "--clear",
                 "${file}"
             ],
-            "program": "${workspaceFolder}/node_modules/.bin/matter-run"
+            "program": "${workspaceFolder}/node_modules/.bin/matter-run",
+            "presentation": {
+                "group": "00misc"
+            }
         },
         {
             "type": "node",
@@ -90,7 +99,11 @@
                 "--clear",
                 "dist/cjs/app.js"
             ],
-            "program": "${workspaceFolder}/node_modules/.bin/matter-run"
+            "group": "tool",
+            "program": "${workspaceFolder}/node_modules/.bin/matter-run",
+            "presentation": {
+                "group": "01tool"
+            }
         },
         {
             "type": "node",
@@ -113,7 +126,11 @@
                 "--clear",
                 "bin/matter.js"
             ],
-            "program": "${workspaceFolder}/node_modules/.bin/matter-run"
+            "group": "tool",
+            "program": "${workspaceFolder}/node_modules/.bin/matter-run",
+            "presentation": {
+                "group": "01tool"
+            }
         },
         {
             "type": "node",
@@ -132,10 +149,14 @@
             ],
             "name": "Test @matter/testing",
             "cwd": "${workspaceFolder}/packages/testing",
+            "group": "test",
             "args": [
                 "--clear"
             ],
-            "program": "${workspaceFolder}/node_modules/.bin/matter-test"
+            "program": "${workspaceFolder}/node_modules/.bin/matter-test",
+            "presentation": {
+                "group": "02test"
+            }
         },
         {
             "type": "node",
@@ -154,10 +175,14 @@
             ],
             "name": "Test @matter/general",
             "cwd": "${workspaceFolder}/packages/general",
+            "group": "test",
             "args": [
                 "--clear"
             ],
-            "program": "${workspaceFolder}/node_modules/.bin/matter-test"
+            "program": "${workspaceFolder}/node_modules/.bin/matter-test",
+            "presentation": {
+                "group": "02test"
+            }
         },
         {
             "type": "node",
@@ -176,10 +201,14 @@
             ],
             "name": "Test @matter/model",
             "cwd": "${workspaceFolder}/packages/model",
+            "group": "test",
             "args": [
                 "--clear"
             ],
-            "program": "${workspaceFolder}/node_modules/.bin/matter-test"
+            "program": "${workspaceFolder}/node_modules/.bin/matter-test",
+            "presentation": {
+                "group": "02test"
+            }
         },
         {
             "type": "node",
@@ -198,10 +227,14 @@
             ],
             "name": "Test @matter/types",
             "cwd": "${workspaceFolder}/packages/types",
+            "group": "test",
             "args": [
                 "--clear"
             ],
-            "program": "${workspaceFolder}/node_modules/.bin/matter-test"
+            "program": "${workspaceFolder}/node_modules/.bin/matter-test",
+            "presentation": {
+                "group": "02test"
+            }
         },
         {
             "type": "node",
@@ -220,10 +253,14 @@
             ],
             "name": "Test @matter/protocol",
             "cwd": "${workspaceFolder}/packages/protocol",
+            "group": "test",
             "args": [
                 "--clear"
             ],
-            "program": "${workspaceFolder}/node_modules/.bin/matter-test"
+            "program": "${workspaceFolder}/node_modules/.bin/matter-test",
+            "presentation": {
+                "group": "02test"
+            }
         },
         {
             "type": "node",
@@ -242,10 +279,14 @@
             ],
             "name": "Test @matter/node",
             "cwd": "${workspaceFolder}/packages/node",
+            "group": "test",
             "args": [
                 "--clear"
             ],
-            "program": "${workspaceFolder}/node_modules/.bin/matter-test"
+            "program": "${workspaceFolder}/node_modules/.bin/matter-test",
+            "presentation": {
+                "group": "02test"
+            }
         },
         {
             "type": "node",
@@ -264,10 +305,14 @@
             ],
             "name": "Test @matter/nodejs",
             "cwd": "${workspaceFolder}/packages/nodejs",
+            "group": "test",
             "args": [
                 "--clear"
             ],
-            "program": "${workspaceFolder}/node_modules/.bin/matter-test"
+            "program": "${workspaceFolder}/node_modules/.bin/matter-test",
+            "presentation": {
+                "group": "02test"
+            }
         },
         {
             "type": "node",
@@ -286,10 +331,14 @@
             ],
             "name": "Test @matter/chip-testing",
             "cwd": "${workspaceFolder}/chip-testing",
+            "group": "test",
             "args": [
                 "--clear"
             ],
-            "program": "${workspaceFolder}/node_modules/.bin/matter-test"
+            "program": "${workspaceFolder}/node_modules/.bin/matter-test",
+            "presentation": {
+                "group": "02test"
+            }
         },
         {
             "type": "node",
@@ -315,7 +364,11 @@
                 "--all-logs",
                 "esm"
             ],
-            "program": "${workspaceFolder}/node_modules/.bin/matter-test"
+            "group": "chip",
+            "program": "${workspaceFolder}/node_modules/.bin/matter-test",
+            "presentation": {
+                "group": "03chip"
+            }
         },
         {
             "type": "node",
@@ -341,7 +394,11 @@
                 "--all-logs",
                 "esm"
             ],
-            "program": "${workspaceFolder}/node_modules/.bin/matter-test"
+            "group": "chip",
+            "program": "${workspaceFolder}/node_modules/.bin/matter-test",
+            "presentation": {
+                "group": "03chip"
+            }
         },
         {
             "type": "node",
@@ -367,7 +424,11 @@
                 "--all-logs",
                 "esm"
             ],
-            "program": "${workspaceFolder}/node_modules/.bin/matter-test"
+            "group": "chip",
+            "program": "${workspaceFolder}/node_modules/.bin/matter-test",
+            "presentation": {
+                "group": "03chip"
+            }
         },
         {
             "type": "node",
@@ -389,7 +450,11 @@
                 "--clear",
                 "packages/examples/src/controller/ControllerNode.ts"
             ],
-            "program": "${workspaceFolder}/node_modules/.bin/matter-run"
+            "group": "example",
+            "program": "${workspaceFolder}/node_modules/.bin/matter-run",
+            "presentation": {
+                "group": "04example"
+            }
         },
         {
             "type": "node",
@@ -411,7 +476,11 @@
                 "--clear",
                 "packages/examples/src/device-bridge-onoff/BridgedDevicesNode.ts"
             ],
-            "program": "${workspaceFolder}/node_modules/.bin/matter-run"
+            "group": "example",
+            "program": "${workspaceFolder}/node_modules/.bin/matter-run",
+            "presentation": {
+                "group": "04example"
+            }
         },
         {
             "type": "node",
@@ -433,7 +502,11 @@
                 "--clear",
                 "packages/examples/src/device-composed-onoff/ComposedDeviceNode.ts"
             ],
-            "program": "${workspaceFolder}/node_modules/.bin/matter-run"
+            "group": "example",
+            "program": "${workspaceFolder}/node_modules/.bin/matter-run",
+            "presentation": {
+                "group": "04example"
+            }
         },
         {
             "type": "node",
@@ -455,7 +528,11 @@
                 "--clear",
                 "packages/examples/src/device-composed-wc-light/IlluminatedRollerShade.ts"
             ],
-            "program": "${workspaceFolder}/node_modules/.bin/matter-run"
+            "group": "example",
+            "program": "${workspaceFolder}/node_modules/.bin/matter-run",
+            "presentation": {
+                "group": "04example"
+            }
         },
         {
             "type": "node",
@@ -477,7 +554,11 @@
                 "--clear",
                 "packages/examples/src/device-measuring-socket/MeasuredSocketDevice.ts"
             ],
-            "program": "${workspaceFolder}/node_modules/.bin/matter-run"
+            "group": "example",
+            "program": "${workspaceFolder}/node_modules/.bin/matter-run",
+            "presentation": {
+                "group": "04example"
+            }
         },
         {
             "type": "node",
@@ -499,7 +580,11 @@
                 "--clear",
                 "packages/examples/src/device-multiple-onoff/MultiDeviceNode.ts"
             ],
-            "program": "${workspaceFolder}/node_modules/.bin/matter-run"
+            "group": "example",
+            "program": "${workspaceFolder}/node_modules/.bin/matter-run",
+            "presentation": {
+                "group": "04example"
+            }
         },
         {
             "type": "node",
@@ -521,7 +606,11 @@
                 "--clear",
                 "packages/examples/src/device-onoff/DeviceNode.ts"
             ],
-            "program": "${workspaceFolder}/node_modules/.bin/matter-run"
+            "group": "example",
+            "program": "${workspaceFolder}/node_modules/.bin/matter-run",
+            "presentation": {
+                "group": "04example"
+            }
         },
         {
             "type": "node",
@@ -543,7 +632,11 @@
                 "--clear",
                 "packages/examples/src/device-onoff-advanced/DeviceNodeFull.ts"
             ],
-            "program": "${workspaceFolder}/node_modules/.bin/matter-run"
+            "group": "example",
+            "program": "${workspaceFolder}/node_modules/.bin/matter-run",
+            "presentation": {
+                "group": "04example"
+            }
         },
         {
             "type": "node",
@@ -565,7 +658,11 @@
                 "--clear",
                 "packages/examples/src/device-onoff-light/LightDevice.ts"
             ],
-            "program": "${workspaceFolder}/node_modules/.bin/matter-run"
+            "group": "example",
+            "program": "${workspaceFolder}/node_modules/.bin/matter-run",
+            "presentation": {
+                "group": "04example"
+            }
         },
         {
             "type": "node",
@@ -587,7 +684,11 @@
                 "--clear",
                 "packages/examples/src/device-sensor/SensorDeviceNode.ts"
             ],
-            "program": "${workspaceFolder}/node_modules/.bin/matter-run"
+            "group": "example",
+            "program": "${workspaceFolder}/node_modules/.bin/matter-run",
+            "presentation": {
+                "group": "04example"
+            }
         },
         {
             "type": "node",
@@ -609,7 +710,11 @@
                 "--clear",
                 "codegen/src/generate-chip.ts"
             ],
-            "program": "${workspaceFolder}/node_modules/.bin/matter-run"
+            "group": "codegen",
+            "program": "${workspaceFolder}/node_modules/.bin/matter-run",
+            "presentation": {
+                "group": "05codegen"
+            }
         },
         {
             "type": "node",
@@ -631,7 +736,11 @@
                 "--clear",
                 "codegen/src/generate-clusters.ts"
             ],
-            "program": "${workspaceFolder}/node_modules/.bin/matter-run"
+            "group": "codegen",
+            "program": "${workspaceFolder}/node_modules/.bin/matter-run",
+            "presentation": {
+                "group": "05codegen"
+            }
         },
         {
             "type": "node",
@@ -653,7 +762,11 @@
                 "--clear",
                 "codegen/src/generate-endpoints.ts"
             ],
-            "program": "${workspaceFolder}/node_modules/.bin/matter-run"
+            "group": "codegen",
+            "program": "${workspaceFolder}/node_modules/.bin/matter-run",
+            "presentation": {
+                "group": "05codegen"
+            }
         },
         {
             "type": "node",
@@ -675,7 +788,11 @@
                 "--clear",
                 "codegen/src/generate-forwards.ts"
             ],
-            "program": "${workspaceFolder}/node_modules/.bin/matter-run"
+            "group": "codegen",
+            "program": "${workspaceFolder}/node_modules/.bin/matter-run",
+            "presentation": {
+                "group": "05codegen"
+            }
         },
         {
             "type": "node",
@@ -697,7 +814,11 @@
                 "--clear",
                 "codegen/src/generate-model.ts"
             ],
-            "program": "${workspaceFolder}/node_modules/.bin/matter-run"
+            "group": "codegen",
+            "program": "${workspaceFolder}/node_modules/.bin/matter-run",
+            "presentation": {
+                "group": "05codegen"
+            }
         },
         {
             "type": "node",
@@ -719,10 +840,14 @@
                 "--clear",
                 "codegen/src/generate-spec.ts"
             ],
+            "group": "codegen",
             "env": {
                 "NODE_OPTIONS": "--max-old-space-size=6144"
             },
-            "program": "${workspaceFolder}/node_modules/.bin/matter-run"
+            "program": "${workspaceFolder}/node_modules/.bin/matter-run",
+            "presentation": {
+                "group": "05codegen"
+            }
         },
         {
             "type": "node",
@@ -744,7 +869,11 @@
                 "--clear",
                 "codegen/src/generate-vscode.ts"
             ],
-            "program": "${workspaceFolder}/node_modules/.bin/matter-run"
+            "group": "codegen",
+            "program": "${workspaceFolder}/node_modules/.bin/matter-run",
+            "presentation": {
+                "group": "05codegen"
+            }
         }
     ],
     "inputs": [

--- a/codegen/src/clusters/generate-cluster.ts
+++ b/codegen/src/clusters/generate-cluster.ts
@@ -12,6 +12,7 @@ import {
     CommandModel,
     conditionToBitmaps,
     Conformance,
+    DatatypeModel,
     DefaultValue,
     FeatureBitmap,
     translateBitmap,
@@ -76,7 +77,7 @@ function generateDefinition(file: ClusterFile) {
     gen.populateComponent(variance.base, base);
 
     // First generate all local compound datatypes
-    for (const datatype of cluster.datatypes) {
+    for (const datatype of cluster.all(DatatypeModel)) {
         if (!datatype.definesFields || !datatype.children.length) {
             continue;
         }

--- a/codegen/src/endpoints/InterfaceFile.ts
+++ b/codegen/src/endpoints/InterfaceFile.ts
@@ -18,17 +18,15 @@ export class InterfaceFile extends ScopeFile {
     readonly cluster: ClusterModel;
     readonly types: Block;
     readonly ns: Block;
+    readonly #variance: ClusterVariance;
 
-    constructor(
-        name: string,
-        cluster: ClusterModel,
-        private variance: ClusterVariance,
-    ) {
+    constructor(name: string, cluster: ClusterModel, variance: ClusterVariance) {
         super({ name, scope: cluster });
         this.definitionName = `${cluster.name}Interface`;
         this.cluster = cluster;
         this.types = this.section();
         this.ns = this.statements(`export namespace ${this.definitionName} {`, "}");
+        this.#variance = variance;
 
         this.generate();
     }
@@ -38,8 +36,8 @@ export class InterfaceFile extends ScopeFile {
 
         const gen = new InterfaceGenerator(this);
 
-        gen.generateComponent("Base", this.variance.base);
-        for (const component of this.variance.components) {
+        gen.generateComponent("Base", this.#variance.base);
+        for (const component of this.#variance.components) {
             gen.generateComponent(component.name, component);
         }
 

--- a/codegen/src/util/finalize-model.ts
+++ b/codegen/src/util/finalize-model.ts
@@ -121,7 +121,7 @@ function patchIllegalCrossClusterReferences(cluster: ClusterModel, scopedDatatyp
 function patchClusterTypes(cluster: ClusterModel) {
     // First gather existing datatypes so we treat them as canonical
     const datatypes = {} as { [name: string]: ValueModel };
-    cluster.datatypes.forEach(datatype => (datatypes[datatype.name] = datatype));
+    cluster.all(DatatypeModel).forEach(datatype => (datatypes[datatype.name] = datatype));
 
     // Now add any element that may be promoted to a datatype
     cluster.visit(model => {

--- a/packages/model/src/models/ClusterModel.ts
+++ b/packages/model/src/models/ClusterModel.ts
@@ -54,19 +54,19 @@ export class ClusterModel extends ScopeModel<ClusterElement> implements ClusterE
     }
 
     get attributes() {
-        return this.all(AttributeModel);
+        return this.scope.membersOf(this, { tags: [ElementTag.Attribute] }) as AttributeModel[];
     }
 
     get commands() {
-        return this.all(CommandModel);
+        return this.scope.membersOf(this, { tags: [ElementTag.Command] }) as CommandModel[];
     }
 
     get events() {
-        return this.all(EventModel);
+        return this.scope.membersOf(this, { tags: [ElementTag.Event] }) as EventModel[];
     }
 
     get datatypes() {
-        return this.all(DatatypeModel);
+        return this.scope.membersOf(this, { tags: [ElementTag.Datatype] }) as DatatypeModel[];
     }
 
     /**

--- a/packages/model/src/models/CommandModel.ts
+++ b/packages/model/src/models/CommandModel.ts
@@ -20,11 +20,11 @@ export class CommandModel extends ValueModel<CommandElement> implements CommandE
     }
 
     get isRequest() {
-        return this.direction === CommandElement.Direction.Request;
+        return this.effectiveDirection === CommandElement.Direction.Request;
     }
 
     get isResponse() {
-        return this.direction === CommandElement.Direction.Response;
+        return this.effectiveDirection === CommandElement.Direction.Response;
     }
 
     get responseModel() {
@@ -32,7 +32,7 @@ export class CommandModel extends ValueModel<CommandElement> implements CommandE
     }
 
     get effectiveDirection() {
-        return this.direction ?? (new ModelTraversal().findShadow(this) as CommandModel | undefined)?.direction;
+        return this.direction ?? (this.base as CommandModel | undefined)?.direction;
     }
 
     override get requiredFields() {

--- a/packages/node/src/behaviors/device-energy-management-mode/DeviceEnergyManagementModeInterface.ts
+++ b/packages/node/src/behaviors/device-energy-management-mode/DeviceEnergyManagementModeInterface.ts
@@ -1,0 +1,27 @@
+/**
+ * @license
+ * Copyright 2022-2025 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import { MaybePromise } from "#general";
+import { ModeBase } from "#clusters/mode-base";
+
+export namespace DeviceEnergyManagementModeInterface {
+    export interface Base {
+        /**
+         * This command is used to change device modes.
+         *
+         * On receipt of this command the device shall respond with a ChangeToModeResponse command.
+         *
+         * @see {@link MatterSpecification.v14.Cluster} § 1.10.7.1
+         */
+        changeToMode(request: ModeBase.ChangeToModeRequest): MaybePromise<ModeBase.ChangeToModeResponse>;
+    }
+}
+
+export type DeviceEnergyManagementModeInterface = {
+    components: [{ flags: {}, methods: DeviceEnergyManagementModeInterface.Base }]
+};

--- a/packages/node/src/behaviors/dishwasher-alarm/DishwasherAlarmInterface.ts
+++ b/packages/node/src/behaviors/dishwasher-alarm/DishwasherAlarmInterface.ts
@@ -1,0 +1,38 @@
+/**
+ * @license
+ * Copyright 2022-2025 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import { MaybePromise } from "#general";
+import { DishwasherAlarm } from "#clusters/dishwasher-alarm";
+
+export namespace DishwasherAlarmInterface {
+    export interface Base {
+        /**
+         * This command allows a client to request that an alarm be enabled or suppressed at the server.
+         *
+         * @see {@link MatterSpecification.v14.Cluster} § 1.15.7.2
+         */
+        modifyEnabledAlarms(request: DishwasherAlarm.ModifyEnabledAlarmsRequest): MaybePromise;
+    }
+
+    export interface Reset {
+        /**
+         * This command resets active and latched alarms (if possible). Any generated Notify event shall contain fields
+         * that represent the state of the server after the command has been processed.
+         *
+         * @see {@link MatterSpecification.v14.Cluster} § 1.15.7.1
+         */
+        reset(request: DishwasherAlarm.ResetRequest): MaybePromise;
+    }
+}
+
+export type DishwasherAlarmInterface = {
+    components: [
+        { flags: {}, methods: DishwasherAlarmInterface.Base },
+        { flags: { reset: true }, methods: DishwasherAlarmInterface.Reset }
+    ]
+};

--- a/packages/node/src/behaviors/dishwasher-mode/DishwasherModeInterface.ts
+++ b/packages/node/src/behaviors/dishwasher-mode/DishwasherModeInterface.ts
@@ -1,0 +1,25 @@
+/**
+ * @license
+ * Copyright 2022-2025 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import { MaybePromise } from "#general";
+import { ModeBase } from "#clusters/mode-base";
+
+export namespace DishwasherModeInterface {
+    export interface Base {
+        /**
+         * This command is used to change device modes.
+         *
+         * On receipt of this command the device shall respond with a ChangeToModeResponse command.
+         *
+         * @see {@link MatterSpecification.v14.Cluster} § 1.10.7.1
+         */
+        changeToMode(request: ModeBase.ChangeToModeRequest): MaybePromise<ModeBase.ChangeToModeResponse>;
+    }
+}
+
+export type DishwasherModeInterface = { components: [{ flags: {}, methods: DishwasherModeInterface.Base }] };

--- a/packages/node/src/behaviors/energy-evse-mode/EnergyEvseModeInterface.ts
+++ b/packages/node/src/behaviors/energy-evse-mode/EnergyEvseModeInterface.ts
@@ -1,0 +1,25 @@
+/**
+ * @license
+ * Copyright 2022-2025 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import { MaybePromise } from "#general";
+import { ModeBase } from "#clusters/mode-base";
+
+export namespace EnergyEvseModeInterface {
+    export interface Base {
+        /**
+         * This command is used to change device modes.
+         *
+         * On receipt of this command the device shall respond with a ChangeToModeResponse command.
+         *
+         * @see {@link MatterSpecification.v14.Cluster} § 1.10.7.1
+         */
+        changeToMode(request: ModeBase.ChangeToModeRequest): MaybePromise<ModeBase.ChangeToModeResponse>;
+    }
+}
+
+export type EnergyEvseModeInterface = { components: [{ flags: {}, methods: EnergyEvseModeInterface.Base }] };

--- a/packages/node/src/behaviors/laundry-washer-mode/LaundryWasherModeInterface.ts
+++ b/packages/node/src/behaviors/laundry-washer-mode/LaundryWasherModeInterface.ts
@@ -1,0 +1,25 @@
+/**
+ * @license
+ * Copyright 2022-2025 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import { MaybePromise } from "#general";
+import { ModeBase } from "#clusters/mode-base";
+
+export namespace LaundryWasherModeInterface {
+    export interface Base {
+        /**
+         * This command is used to change device modes.
+         *
+         * On receipt of this command the device shall respond with a ChangeToModeResponse command.
+         *
+         * @see {@link MatterSpecification.v14.Cluster} § 1.10.7.1
+         */
+        changeToMode(request: ModeBase.ChangeToModeRequest): MaybePromise<ModeBase.ChangeToModeResponse>;
+    }
+}
+
+export type LaundryWasherModeInterface = { components: [{ flags: {}, methods: LaundryWasherModeInterface.Base }] };

--- a/packages/node/src/behaviors/oven-cavity-operational-state/OvenCavityOperationalStateInterface.ts
+++ b/packages/node/src/behaviors/oven-cavity-operational-state/OvenCavityOperationalStateInterface.ts
@@ -6,5 +6,22 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-export namespace OvenCavityOperationalStateInterface {}
-export type OvenCavityOperationalStateInterface = { components: [] };
+import { MaybePromise } from "#general";
+
+export namespace OvenCavityOperationalStateInterface {
+    export interface Base {
+        /**
+         * @see {@link MatterSpecification.v14.Cluster} § 8.10.5
+         */
+        stop(): MaybePromise;
+
+        /**
+         * @see {@link MatterSpecification.v14.Cluster} § 8.10.5
+         */
+        start(): MaybePromise;
+    }
+}
+
+export type OvenCavityOperationalStateInterface = {
+    components: [{ flags: {}, methods: OvenCavityOperationalStateInterface.Base }]
+};

--- a/packages/node/src/behaviors/oven-mode/OvenModeInterface.ts
+++ b/packages/node/src/behaviors/oven-mode/OvenModeInterface.ts
@@ -1,0 +1,25 @@
+/**
+ * @license
+ * Copyright 2022-2025 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import { MaybePromise } from "#general";
+import { ModeBase } from "#clusters/mode-base";
+
+export namespace OvenModeInterface {
+    export interface Base {
+        /**
+         * This command is used to change device modes.
+         *
+         * On receipt of this command the device shall respond with a ChangeToModeResponse command.
+         *
+         * @see {@link MatterSpecification.v14.Cluster} § 1.10.7.1
+         */
+        changeToMode(request: ModeBase.ChangeToModeRequest): MaybePromise<ModeBase.ChangeToModeResponse>;
+    }
+}
+
+export type OvenModeInterface = { components: [{ flags: {}, methods: OvenModeInterface.Base }] };

--- a/packages/node/src/behaviors/refrigerator-and-temperature-controlled-cabinet-mode/RefrigeratorAndTemperatureControlledCabinetModeInterface.ts
+++ b/packages/node/src/behaviors/refrigerator-and-temperature-controlled-cabinet-mode/RefrigeratorAndTemperatureControlledCabinetModeInterface.ts
@@ -1,0 +1,27 @@
+/**
+ * @license
+ * Copyright 2022-2025 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import { MaybePromise } from "#general";
+import { ModeBase } from "#clusters/mode-base";
+
+export namespace RefrigeratorAndTemperatureControlledCabinetModeInterface {
+    export interface Base {
+        /**
+         * This command is used to change device modes.
+         *
+         * On receipt of this command the device shall respond with a ChangeToModeResponse command.
+         *
+         * @see {@link MatterSpecification.v14.Cluster} § 1.10.7.1
+         */
+        changeToMode(request: ModeBase.ChangeToModeRequest): MaybePromise<ModeBase.ChangeToModeResponse>;
+    }
+}
+
+export type RefrigeratorAndTemperatureControlledCabinetModeInterface = {
+    components: [{ flags: {}, methods: RefrigeratorAndTemperatureControlledCabinetModeInterface.Base }]
+};

--- a/packages/node/src/behaviors/rvc-clean-mode/RvcCleanModeInterface.ts
+++ b/packages/node/src/behaviors/rvc-clean-mode/RvcCleanModeInterface.ts
@@ -1,0 +1,25 @@
+/**
+ * @license
+ * Copyright 2022-2025 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import { MaybePromise } from "#general";
+import { ModeBase } from "#clusters/mode-base";
+
+export namespace RvcCleanModeInterface {
+    export interface Base {
+        /**
+         * This command is used to change device modes.
+         *
+         * On receipt of this command the device shall respond with a ChangeToModeResponse command.
+         *
+         * @see {@link MatterSpecification.v14.Cluster} § 1.10.7.1
+         */
+        changeToMode(request: ModeBase.ChangeToModeRequest): MaybePromise<ModeBase.ChangeToModeResponse>;
+    }
+}
+
+export type RvcCleanModeInterface = { components: [{ flags: {}, methods: RvcCleanModeInterface.Base }] };

--- a/packages/node/src/behaviors/rvc-operational-state/RvcOperationalStateInterface.ts
+++ b/packages/node/src/behaviors/rvc-operational-state/RvcOperationalStateInterface.ts
@@ -12,6 +12,16 @@ import { RvcOperationalState } from "#clusters/rvc-operational-state";
 export namespace RvcOperationalStateInterface {
     export interface Base {
         /**
+         * @see {@link MatterSpecification.v14.Cluster} § 7.4.5
+         */
+        pause(): MaybePromise;
+
+        /**
+         * @see {@link MatterSpecification.v14.Cluster} § 7.4.5
+         */
+        resume(): MaybePromise;
+
+        /**
          * On receipt of this command, the device shall start seeking the charging dock, if possible in the current
          * state of the device.
          *

--- a/packages/node/src/behaviors/rvc-run-mode/RvcRunModeInterface.ts
+++ b/packages/node/src/behaviors/rvc-run-mode/RvcRunModeInterface.ts
@@ -1,0 +1,25 @@
+/**
+ * @license
+ * Copyright 2022-2025 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import { MaybePromise } from "#general";
+import { ModeBase } from "#clusters/mode-base";
+
+export namespace RvcRunModeInterface {
+    export interface Base {
+        /**
+         * This command is used to change device modes.
+         *
+         * On receipt of this command the device shall respond with a ChangeToModeResponse command.
+         *
+         * @see {@link MatterSpecification.v14.Cluster} § 1.10.7.1
+         */
+        changeToMode(request: ModeBase.ChangeToModeRequest): MaybePromise<ModeBase.ChangeToModeResponse>;
+    }
+}
+
+export type RvcRunModeInterface = { components: [{ flags: {}, methods: RvcRunModeInterface.Base }] };

--- a/packages/node/src/behaviors/water-heater-mode/WaterHeaterModeInterface.ts
+++ b/packages/node/src/behaviors/water-heater-mode/WaterHeaterModeInterface.ts
@@ -1,0 +1,25 @@
+/**
+ * @license
+ * Copyright 2022-2025 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import { MaybePromise } from "#general";
+import { ModeBase } from "#clusters/mode-base";
+
+export namespace WaterHeaterModeInterface {
+    export interface Base {
+        /**
+         * This command is used to change device modes.
+         *
+         * On receipt of this command the device shall respond with a ChangeToModeResponse command.
+         *
+         * @see {@link MatterSpecification.v14.Cluster} § 1.10.7.1
+         */
+        changeToMode(request: ModeBase.ChangeToModeRequest): MaybePromise<ModeBase.ChangeToModeResponse>;
+    }
+}
+
+export type WaterHeaterModeInterface = { components: [{ flags: {}, methods: WaterHeaterModeInterface.Base }] };

--- a/packages/node/test/behaviors/energy-evse-mode/EnergyEvsModeServerTest.ts
+++ b/packages/node/test/behaviors/energy-evse-mode/EnergyEvsModeServerTest.ts
@@ -7,38 +7,64 @@
 import { EnergyEvseModeServer } from "#behaviors/energy-evse-mode";
 import { EnergyEvseMode } from "#clusters/energy-evse-mode";
 import { OnOffPlugInUnitDevice } from "#devices/on-off-plug-in-unit";
+import { Endpoint } from "#endpoint/Endpoint.js";
+import { NotImplementedError } from "#general";
 import { MockServerNode } from "../../node/mock-server-node.js";
 
-describe("EnergyEvseModeServer", () => {
-    it("accepts local mode tags", async () => {
-        const node = await MockServerNode.create();
-        const DeviceType = OnOffPlugInUnitDevice.with(EnergyEvseModeServer);
-        await node.add(DeviceType, {
-            energyEvseMode: {
-                currentMode: 0,
-                supportedModes: [
+const DeviceType = OnOffPlugInUnitDevice.with(EnergyEvseModeServer);
+
+async function createNode(options?: Endpoint.Options<typeof DeviceType>) {
+    const node = await MockServerNode.create();
+    if (!options) {
+        options = {};
+    }
+    const energyEvseMode = options.energyEvseMode ?? {};
+    options.energyEvseMode = {
+        currentMode: 0,
+        supportedModes: [
+            {
+                label: "Manual",
+                mode: 0,
+                modeTags: [
                     {
-                        label: "Manual",
-                        mode: 0,
-                        modeTags: [
-                            {
-                                value: EnergyEvseMode.ModeTag.Manual,
-                            },
-                        ],
-                    },
-                    {
-                        label: "Quick",
-                        mode: 1,
-                        modeTags: [
-                            {
-                                value: EnergyEvseMode.ModeTag.TimeOfUse,
-                            },
-                        ],
+                        value: EnergyEvseMode.ModeTag.Manual,
                     },
                 ],
             },
-        });
+            {
+                label: "Quick",
+                mode: 1,
+                modeTags: [
+                    {
+                        value: EnergyEvseMode.ModeTag.TimeOfUse,
+                    },
+                ],
+            },
+        ],
+
+        ...energyEvseMode,
+    };
+
+    const endpoint = await node.add(DeviceType, options);
+
+    return { node, endpoint };
+}
+
+describe("EnergyEvseModeServer", () => {
+    it("accepts local mode tags", async () => {
+        const { node } = await createNode();
         await node.start();
         await node.close();
+    });
+
+    it("supports inherited commands", async () => {
+        const { endpoint } = await createNode();
+        await endpoint.act(agent => {
+            const { energyEvseMode } = agent;
+            expect(typeof energyEvseMode.changeToMode === "function");
+            expect(() => energyEvseMode.changeToMode({ newMode: EnergyEvseMode.ModeTag.LowEnergy })).throws(
+                NotImplementedError,
+            );
+        });
     });
 });

--- a/packages/node/test/behaviors/rvc-operational-state/RvcOperationalStateServerTest.ts
+++ b/packages/node/test/behaviors/rvc-operational-state/RvcOperationalStateServerTest.ts
@@ -1,0 +1,54 @@
+/**
+ * @license
+ * Copyright 2022-2025 Project CHIP Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { RvcOperationalStateServer } from "#behaviors/rvc-operational-state";
+import { RoboticVacuumCleanerDevice } from "#devices/robotic-vacuum-cleaner";
+import { Endpoint } from "#endpoint/Endpoint.js";
+import { NotImplementedError } from "@matter/general";
+import { MockServerNode } from "../../node/mock-server-node.js";
+
+const DeviceType = RoboticVacuumCleanerDevice;
+
+async function createNode(options?: Endpoint.Options<typeof DeviceType>) {
+    const node = await MockServerNode.create();
+    if (!options) {
+        options = {};
+    }
+
+    const rvcRunMode = options.rvcRunMode ?? {};
+    options.rvcRunMode = {
+        ...rvcRunMode,
+    };
+
+    const rvcOperationalState = options.rvcOperationalState ?? {};
+    options.rvcOperationalState = {
+        operationalState: 0,
+        ...rvcOperationalState,
+    };
+
+    const endpoint = await node.add(DeviceType, options);
+
+    return { node, endpoint };
+}
+
+describe("RvcOperationalState", () => {
+    it("supports base commands", async () => {
+        const { endpoint } = await createNode();
+        await endpoint.act(agent => {
+            expect(typeof agent.rvcOperationalState.pause).equals("function");
+            expect(() => agent.rvcOperationalState.pause()).throws(NotImplementedError);
+        });
+    });
+
+    it("knows methods are methods", () => {
+        // Type-only test to ensure override works
+        class MyOperationalStateServer extends RvcOperationalStateServer {
+            override pause() {}
+        }
+
+        MyOperationalStateServer satisfies {};
+    });
+});

--- a/packages/types/src/clusters/oven-cavity-operational-state.ts
+++ b/packages/types/src/clusters/oven-cavity-operational-state.ts
@@ -7,12 +7,21 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { MutableCluster } from "../cluster/mutation/MutableCluster.js";
-import { Attribute, OptionalAttribute, Event, EventPriority, OptionalEvent } from "../cluster/Cluster.js";
+import {
+    Attribute,
+    OptionalAttribute,
+    Command,
+    TlvNoResponse,
+    Event,
+    EventPriority,
+    OptionalEvent
+} from "../cluster/Cluster.js";
 import { TlvArray } from "../tlv/TlvArray.js";
 import { TlvString } from "../tlv/TlvString.js";
 import { TlvNullable } from "../tlv/TlvNullable.js";
 import { TlvUInt8, TlvUInt32, TlvEnum } from "../tlv/TlvNumber.js";
 import { OperationalState } from "./operational-state.js";
+import { TlvNoArguments } from "../tlv/TlvNoArguments.js";
 import { Identity } from "#general";
 import { ClusterRegistry } from "../cluster/ClusterRegistry.js";
 
@@ -117,6 +126,18 @@ export namespace OvenCavityOperationalState {
              * @see {@link MatterSpecification.v14.Cluster} § 1.14.5.6
              */
             operationalError: Attribute(0x5, OperationalState.TlvErrorStateStruct)
+        },
+
+        commands: {
+            /**
+             * @see {@link MatterSpecification.v14.Cluster} § 8.10.5
+             */
+            stop: Command(0x1, TlvNoArguments, 0x1, TlvNoResponse),
+
+            /**
+             * @see {@link MatterSpecification.v14.Cluster} § 8.10.5
+             */
+            start: Command(0x2, TlvNoArguments, 0x2, TlvNoResponse)
         },
 
         events: {

--- a/packages/types/src/clusters/rvc-operational-state.ts
+++ b/packages/types/src/clusters/rvc-operational-state.ts
@@ -10,6 +10,8 @@ import { MutableCluster } from "../cluster/mutation/MutableCluster.js";
 import {
     Attribute,
     OptionalAttribute,
+    Command,
+    TlvNoResponse,
     OptionalCommand,
     Event,
     EventPriority,
@@ -219,8 +221,6 @@ export namespace RvcOperationalState {
     export interface ErrorStateStruct extends TypeFromSchema<typeof TlvErrorStateStruct> {}
 
     /**
-     * Input to the RvcOperationalState operationalCommandResponse command
-     *
      * @see {@link MatterSpecification.v14.Cluster} § 7.4.5
      */
     export const TlvOperationalCommandResponse = TlvObject({
@@ -235,8 +235,6 @@ export namespace RvcOperationalState {
     });
 
     /**
-     * Input to the RvcOperationalState operationalCommandResponse command
-     *
      * @see {@link MatterSpecification.v14.Cluster} § 7.4.5
      */
     export interface OperationalCommandResponse extends TypeFromSchema<typeof TlvOperationalCommandResponse> {}
@@ -361,6 +359,16 @@ export namespace RvcOperationalState {
         },
 
         commands: {
+            /**
+             * @see {@link MatterSpecification.v14.Cluster} § 7.4.5
+             */
+            pause: Command(0x0, TlvNoArguments, 0x0, TlvNoResponse),
+
+            /**
+             * @see {@link MatterSpecification.v14.Cluster} § 7.4.5
+             */
+            resume: Command(0x3, TlvNoArguments, 0x3, TlvNoResponse),
+
             /**
              * On receipt of this command, the device shall start seeking the charging dock, if possible in the current
              * state of the device.


### PR DESCRIPTION
* ClusterModel properties for attributes, commands, events and datatypes now include all members in scope

* CommandModel direction helpers isRequest and isResponse now use effective (scoped) direction

* Regenerate clusters and endpoints

* (unrelated) Group vscode launch configs