### PR TITLE
Fix responses for commands with overrides

### DIFF
--- a/codegen/src/clusters/ClusterComponentGenerator.ts
+++ b/codegen/src/clusters/ClusterComponentGenerator.ts
@@ -7,7 +7,6 @@
 import {
     Access,
     AttributeModel,
-    ClusterModel,
     CommandModel,
     ElementTag,
     EventElement,
@@ -33,10 +32,7 @@ export class ClusterComponentGenerator {
     private defaults: DefaultValueGenerator;
     private file: ClusterFile;
 
-    constructor(
-        private target: Block,
-        private cluster: ClusterModel,
-    ) {
+    constructor(private target: Block) {
         this.file = target.file as ClusterFile;
         this.tlv = new TlvGenerator(this.file, this.file.types);
         this.defaults = new DefaultValueGenerator(this.tlv);
@@ -138,10 +134,7 @@ export class ClusterComponentGenerator {
             // Note - we end up mapping "status" response type to TlvNoResponse. Technically "no response" and "status
             // response" are different things but there's currently only a single place in the specification where it
             // makes a difference and neither we nor CHIP implement it yet
-            let responseModel;
-            if (model.response && model.response !== "status") {
-                responseModel = this.cluster.member(model.response, [ElementTag.Command]) as CommandModel | undefined;
-            }
+            const responseModel = model.responseModel;
             if (responseModel) {
                 block.atom(hex(responseModel.id));
                 block.atom(this.tlv.reference(responseModel));

--- a/codegen/src/clusters/generate-cluster.ts
+++ b/codegen/src/clusters/generate-cluster.ts
@@ -49,7 +49,7 @@ function generateDefinition(file: ClusterFile) {
     const features = cluster.features;
 
     // Generate components
-    const gen = new ClusterComponentGenerator(file.ns, cluster);
+    const gen = new ClusterComponentGenerator(file.ns);
     for (const component of variance.components) {
         gen.defineComponent(component);
     }

--- a/packages/model/src/logic/ModelTraversal.ts
+++ b/packages/model/src/logic/ModelTraversal.ts
@@ -612,9 +612,17 @@ export class ModelTraversal {
      * Find the response model for a command.
      */
     findResponse(command: CommandModel) {
-        if (command.response && command.response !== "status") {
-            return new ModelTraversal().findType(command, command.response, ElementTag.Command);
-        }
+        let response: undefined | CommandModel;
+
+        this.visitInheritance(command, model => {
+            const command = model as CommandModel;
+            if (command.response && command.response !== "status") {
+                response = this.findType(model, command.response, ElementTag.Command) as CommandModel;
+                return false;
+            }
+        });
+
+        return response;
     }
 
     /**

--- a/packages/model/src/models/CommandModel.ts
+++ b/packages/model/src/models/CommandModel.ts
@@ -28,7 +28,7 @@ export class CommandModel extends ValueModel<CommandElement> implements CommandE
     }
 
     get responseModel() {
-        return new ModelTraversal().findResponse(this) as ValueModel;
+        return new ModelTraversal().findResponse(this);
     }
 
     get effectiveDirection() {

--- a/packages/node/src/behaviors/oven-cavity-operational-state/OvenCavityOperationalStateInterface.ts
+++ b/packages/node/src/behaviors/oven-cavity-operational-state/OvenCavityOperationalStateInterface.ts
@@ -7,18 +7,19 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { MaybePromise } from "#general";
+import { OvenCavityOperationalState } from "#clusters/oven-cavity-operational-state";
 
 export namespace OvenCavityOperationalStateInterface {
     export interface Base {
         /**
          * @see {@link MatterSpecification.v14.Cluster} § 8.10.5
          */
-        stop(): MaybePromise;
+        stop(): MaybePromise<OvenCavityOperationalState.OperationalCommandResponse>;
 
         /**
          * @see {@link MatterSpecification.v14.Cluster} § 8.10.5
          */
-        start(): MaybePromise;
+        start(): MaybePromise<OvenCavityOperationalState.OperationalCommandResponse>;
     }
 }
 

--- a/packages/node/src/behaviors/rvc-operational-state/RvcOperationalStateInterface.ts
+++ b/packages/node/src/behaviors/rvc-operational-state/RvcOperationalStateInterface.ts
@@ -14,12 +14,12 @@ export namespace RvcOperationalStateInterface {
         /**
          * @see {@link MatterSpecification.v14.Cluster} § 7.4.5
          */
-        pause(): MaybePromise;
+        pause(): MaybePromise<RvcOperationalState.OperationalCommandResponse>;
 
         /**
          * @see {@link MatterSpecification.v14.Cluster} § 7.4.5
          */
-        resume(): MaybePromise;
+        resume(): MaybePromise<RvcOperationalState.OperationalCommandResponse>;
 
         /**
          * On receipt of this command, the device shall start seeking the charging dock, if possible in the current

--- a/packages/node/test/behaviors/rvc-operational-state/RvcOperationalStateServerTest.ts
+++ b/packages/node/test/behaviors/rvc-operational-state/RvcOperationalStateServerTest.ts
@@ -5,6 +5,7 @@
  */
 
 import { RvcOperationalStateServer } from "#behaviors/rvc-operational-state";
+import { RvcOperationalState } from "#clusters/rvc-operational-state";
 import { RoboticVacuumCleanerDevice } from "#devices/robotic-vacuum-cleaner";
 import { Endpoint } from "#endpoint/Endpoint.js";
 import { NotImplementedError } from "@matter/general";
@@ -46,7 +47,9 @@ describe("RvcOperationalState", () => {
     it("knows methods are methods", () => {
         // Type-only test to ensure override works
         class MyOperationalStateServer extends RvcOperationalStateServer {
-            override pause() {}
+            override pause() {
+                return {} as RvcOperationalState.OperationalCommandResponse;
+            }
         }
 
         MyOperationalStateServer satisfies {};

--- a/packages/types/src/clusters/oven-cavity-operational-state.ts
+++ b/packages/types/src/clusters/oven-cavity-operational-state.ts
@@ -7,25 +7,38 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { MutableCluster } from "../cluster/mutation/MutableCluster.js";
-import {
-    Attribute,
-    OptionalAttribute,
-    Command,
-    TlvNoResponse,
-    Event,
-    EventPriority,
-    OptionalEvent
-} from "../cluster/Cluster.js";
+import { Attribute, OptionalAttribute, Command, Event, EventPriority, OptionalEvent } from "../cluster/Cluster.js";
 import { TlvArray } from "../tlv/TlvArray.js";
 import { TlvString } from "../tlv/TlvString.js";
 import { TlvNullable } from "../tlv/TlvNullable.js";
 import { TlvUInt8, TlvUInt32, TlvEnum } from "../tlv/TlvNumber.js";
 import { OperationalState } from "./operational-state.js";
 import { TlvNoArguments } from "../tlv/TlvNoArguments.js";
+import { TlvField, TlvObject } from "../tlv/TlvObject.js";
+import { TypeFromSchema } from "../tlv/TlvSchema.js";
 import { Identity } from "#general";
 import { ClusterRegistry } from "../cluster/ClusterRegistry.js";
 
 export namespace OvenCavityOperationalState {
+    /**
+     * @see {@link MatterSpecification.v14.Cluster} § 8.10.5
+     */
+    export const TlvOperationalCommandResponse = TlvObject({
+        /**
+         * This shall indicate the success or otherwise of the attempted command invocation. On a successful invocation
+         * of the attempted command, the ErrorStateID shall be populated with NoError. Please see the individual command
+         * sections for additional specific requirements on population.
+         *
+         * @see {@link MatterSpecification.v14.Cluster} § 1.14.6.5.1
+         */
+        commandResponseState: TlvField(0, OperationalState.TlvErrorStateStruct)
+    });
+
+    /**
+     * @see {@link MatterSpecification.v14.Cluster} § 8.10.5
+     */
+    export interface OperationalCommandResponse extends TypeFromSchema<typeof TlvOperationalCommandResponse> {}
+
     /**
      * @see {@link Cluster}
      */
@@ -132,12 +145,12 @@ export namespace OvenCavityOperationalState {
             /**
              * @see {@link MatterSpecification.v14.Cluster} § 8.10.5
              */
-            stop: Command(0x1, TlvNoArguments, 0x1, TlvNoResponse),
+            stop: Command(0x1, TlvNoArguments, 0x4, TlvOperationalCommandResponse),
 
             /**
              * @see {@link MatterSpecification.v14.Cluster} § 8.10.5
              */
-            start: Command(0x2, TlvNoArguments, 0x2, TlvNoResponse)
+            start: Command(0x2, TlvNoArguments, 0x4, TlvOperationalCommandResponse)
         },
 
         events: {

--- a/packages/types/src/clusters/rvc-operational-state.ts
+++ b/packages/types/src/clusters/rvc-operational-state.ts
@@ -11,7 +11,6 @@ import {
     Attribute,
     OptionalAttribute,
     Command,
-    TlvNoResponse,
     OptionalCommand,
     Event,
     EventPriority,
@@ -362,12 +361,12 @@ export namespace RvcOperationalState {
             /**
              * @see {@link MatterSpecification.v14.Cluster} § 7.4.5
              */
-            pause: Command(0x0, TlvNoArguments, 0x0, TlvNoResponse),
+            pause: Command(0x0, TlvNoArguments, 0x4, TlvOperationalCommandResponse),
 
             /**
              * @see {@link MatterSpecification.v14.Cluster} § 7.4.5
              */
-            resume: Command(0x3, TlvNoArguments, 0x3, TlvNoResponse),
+            resume: Command(0x3, TlvNoArguments, 0x4, TlvOperationalCommandResponse),
 
             /**
              * On receipt of this command, the device shall start seeking the charging dock, if possible in the current


### PR DESCRIPTION
When a command was overridden, we were not using the "response" field from the base command when generating clusters and interfaces.