### PR TITLE
Always close PASE server when ending commissioning

### DIFF
--- a/packages/protocol/src/protocol/DeviceCommissioner.ts
+++ b/packages/protocol/src/protocol/DeviceCommissioner.ts
@@ -259,13 +259,9 @@ export class DeviceCommissioner {
         }
 
         logger.debug("Commissioning mode ended, stop announcements.");
-        // Remove PASE responder when we close enhanced commissioning window or node is commissioned
-        if (
-            this.#windowStatus === AdministratorCommissioning.CommissioningWindowStatus.EnhancedWindowOpen ||
-            this.#context.fabrics.length > 0
-        ) {
-            this.#context.secureChannelProtocol.removePaseCommissioner();
-        }
+
+        this.#context.secureChannelProtocol.removePaseCommissioner();
+
         this.#windowStatus = AdministratorCommissioning.CommissioningWindowStatus.WindowNotOpen;
 
         if (this.#activeCommissioningEndCallback !== undefined) {
@@ -276,7 +272,7 @@ export class DeviceCommissioner {
 
         await this.#context.advertiser.exitCommissioningMode();
 
-        logger.info("All announcements stopped");
+        logger.info("All commissioning announcements stopped");
     }
 
     async close() {

--- a/packages/protocol/src/session/pase/PaseServer.ts
+++ b/packages/protocol/src/session/pase/PaseServer.ts
@@ -94,7 +94,7 @@ export class PaseServer implements ProtocolHandler {
                 );
             }
         } finally {
-            // Destroy the unsecure session used to establish the secure Case session
+            // Destroy the unsecure session used to establish the Pase session
             await exchange.session.destroy();
         }
     }

--- a/packages/protocol/src/session/pase/PaseServer.ts
+++ b/packages/protocol/src/session/pase/PaseServer.ts
@@ -63,7 +63,20 @@ export class PaseServer implements ProtocolHandler {
     async onNewExchange(exchange: MessageExchange) {
         const messenger = new PaseServerMessenger(exchange);
         try {
-            await this.handlePairingRequest(messenger);
+            // When a Commissioner is either in the process of establishing a PASE session with the Commissionee or has
+            // successfully established a session, the Commissionee SHALL NOT accept any more requests for new PASE
+            // sessions until session establishment fails or the successfully established PASE session is terminated on
+            // the commissioning channel.
+            if (this.sessions.getPaseSession()) {
+                logger.info("Pase server: Pairing already in progress (PASE session exists), ignoring new exchange.");
+            } else if (this.#pairingTimer?.isRunning) {
+                logger.info(
+                    "Pase server: Pairing already in progress (PASE establishment Timer running), ignoring new exchange.",
+                );
+            } else {
+                // Ok new pairing try, handle it
+                await this.handlePairingRequest(messenger);
+            }
         } catch (error) {
             this.#pairingErrors++;
             logger.error(
@@ -87,22 +100,6 @@ export class PaseServer implements ProtocolHandler {
     }
 
     private async handlePairingRequest(messenger: PaseServerMessenger) {
-        // When a Commissioner is either in the process of establishing a PASE session with the Commissionee or has
-        // successfully established a session, the Commissionee SHALL NOT accept any more requests for new PASE
-        // sessions until session establishment fails or the successfully established PASE session is terminated on
-        // the commissioning channel.
-        if (this.sessions.getPaseSession()) {
-            throw new MatterFlowError(
-                "Pase server: Pairing already in progress (PASE session exists), ignoring new exchange.",
-            );
-        }
-
-        if (this.#pairingTimer !== undefined && this.#pairingTimer.isRunning) {
-            throw new MatterFlowError(
-                "Pase server: Pairing already in progress (PASE establishment Timer running), ignoring new exchange.",
-            );
-        }
-
         logger.info(`Received pairing request from ${messenger.getChannelName()}.`);
 
         this.#pairingTimer = Time.getTimer("PASE pairing timeout", PASE_PAIRING_TIMEOUT_MS, () =>


### PR DESCRIPTION
This change always removes the PASE server when the commissioning mode ends. This is also to respect the requirement that PASE needs to be disabled when commissioning mode ends after 20 error tries within one window.

fixes #1894, fixes #1896