### PR TITLE
Inform Device when controller cancels pairing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,8 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Enhancement: Allows to access attributes, events and commands in CLusterClient instances also by their ID.
     - Fix: Makes sure to not Forward StatusResponseError cases that we generate locally to the device when not wanted
     - Fix: Enhances checks for Wi-Fi/Thread credentials in config for CommissioningFlow
+    - Fix: Ensures that PASE establishments are guarded as defined by specification to prevent passcode brute force attacks
+    - Fix: Informs the device when Controller cancels pairing because of a wrong passcode to allow direct retries
 
 -   @project-chip/matter.js
     - Breaking: Reduced exports to the relevant one for Controller usage. Please move for @matter/main for the rest.

--- a/packages/protocol/src/session/pase/PaseClient.ts
+++ b/packages/protocol/src/session/pase/PaseClient.ts
@@ -7,6 +7,7 @@
 import { Bytes, Crypto, ec, Logger, PbkdfParameters, Spake2p, UnexpectedDataError } from "#general";
 import { SessionManager } from "#session/SessionManager.js";
 import { CommissioningOptions, NodeId } from "#types";
+import { ProtocolStatusCode } from "@matter/types";
 import { MessageExchange } from "../../protocol/MessageExchange.js";
 import { SessionParameters } from "../Session.js";
 import { DEFAULT_PASSCODE_ID, PaseClientMessenger, SPAKE_CONTEXT } from "./PaseMessenger.js";
@@ -66,8 +67,12 @@ export class PaseClient {
             responsePayload,
             response: { pbkdfParameters, responderSessionId, responderSessionParams },
         } = await messenger.readPbkdfParamResponse();
-        if (pbkdfParameters === undefined)
-            throw new UnexpectedDataError("Missing requested PbkdfParameters in the response.");
+        if (pbkdfParameters === undefined) {
+            // Sending this error is not defined in the specs and should normally never happen, but better inform device
+            // that we cancel the pairing
+            await messenger.sendError(ProtocolStatusCode.InvalidParam);
+            throw new UnexpectedDataError("Missing requested PbkdfParameters in the response. Commissioning failed.");
+        }
 
         // This includes the Fallbacks for the session parameters overridden by what was sent by the device in PbkdfResponse
         sessionParameters = {
@@ -84,8 +89,12 @@ export class PaseClient {
         // Process pack2 and send pake3
         const { y: Y, verifier } = await messenger.readPasePake2();
         const { Ke, hAY, hBX } = await spake2p.computeSecretAndVerifiersFromY(w1, X, Y);
-        if (!Bytes.areEqual(verifier, hBX))
-            throw new UnexpectedDataError("Received incorrect key confirmation from the receiver.");
+        if (!Bytes.areEqual(verifier, hBX)) {
+            await messenger.sendError(ProtocolStatusCode.InvalidParam);
+            throw new UnexpectedDataError(
+                "Received incorrect key confirmation from the receiver. Commissioning failed.",
+            );
+        }
         await messenger.sendPasePake3({ verifier: hAY });
 
         // All good! Creating the secure session


### PR DESCRIPTION
Spec defines that the device needs to be informed when PASE initiator cancels the pairing process to free the device up from the 60s block timer.

fixes #1898