### PR TITLE
Ensure unique NodeIds on commissioning

### DIFF
--- a/packages/matter.js/src/MatterController.ts
+++ b/packages/matter.js/src/MatterController.ts
@@ -329,6 +329,7 @@ export class MatterController {
         this.clients = new InteractionClientProvider(this.peers);
 
         this.commissioner = new ControllerCommissioner({
+            peers: this.peers,
             clients: this.clients,
             scanners: this.scanners,
             netInterfaces: this.netInterfaces,


### PR DESCRIPTION
It seems we somehow missed the check if a node id is already commissioned over time. This gets readded.

We now first time also validate the random ID to be unique.