### PR TITLE
Remove commissionedNode on recommissions in controller tests

### DIFF
--- a/chip-testing/src/handler/LegacyControllerCommandHandler.ts
+++ b/chip-testing/src/handler/LegacyControllerCommandHandler.ts
@@ -443,6 +443,12 @@ export class LegacyControllerCommandHandler extends CommandHandler {
     }
 
     async handleInitialPairing(data: InitialPairingRequest): Promise<void> {
+        const { nodeId } = data;
+        if (nodeId !== undefined) {
+            if (this.#controllerInstance.isNodeCommissioned(nodeId)) {
+                await this.#controllerInstance.removeNode(nodeId, false);
+            }
+        }
         await this.#controllerInstance.commissionNode(this.#determineCommissionOptions(data), {
             connectNodeAfterCommissioning: false,
             commissioningFlowImpl: CustomCommissioningFlow,


### PR DESCRIPTION
The latest addition to check already commissioned nodes has the side effect that now the controller tests do not work in a special case. This fixes this.