### PR TITLE
Increase BLE connect timeout from 60s to 120s.

### DIFF
--- a/packages/nodejs-ble/src/NobleBleChannel.ts
+++ b/packages/nodejs-ble/src/NobleBleChannel.ts
@@ -153,7 +153,7 @@ export class NobleBleCentralInterface implements NetInterface {
                 // Timeout when trying to connect to the device because sometimes connect fails and noble does
                 // not emit an event. If device does not connect we do not try any longer and reject the promise
                 // because a re-discovery is the best option to get teh device into a good state again
-                connectTimeout: Time.getTimer("BLE connect timeout", 60_000, () => {
+                connectTimeout: Time.getTimer("BLE connect timeout", 120_000, () => {
                     logger.debug(`Timeout while connecting to peripheral ${peripheralAddress}`);
                     // eslint-disable-next-line @typescript-eslint/no-misused-promises
                     peripheral.removeListener("connect", connectHandler);


### PR DESCRIPTION
To workaround https://github.com/stoprocent/noble/issues/32, I have tested that increasing the BLE connect timeout to 120s, allow commissioning of my devices.