### PR TITLE
Make MDNS aware of what the nodes are interested in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Breaking: `logEndpoint()` was removed. The Endpoints support logging directly via Diagnostics
     - Breaking: All legacy used *Server classes (AttributeServer, EventServer, CommandServer) are moved to the matter.js legacy package
     - Feature: Added `getLocal()` to AttributeClient to retrieve the currently stored/cached value 
+    - Enhancement: Optimized the usage of the MDNSScanner to prevent holding data in memory that are not needed (e.g. from other fabrics or such)
     - Adjustment: ACL writes are not sent chunked by default from now on like also in chip SDK
     - Fix: Handles messages only that are secured as required for the relevant protocol
 

--- a/packages/matter.js/src/device/PairedNode.ts
+++ b/packages/matter.js/src/device/PairedNode.ts
@@ -526,7 +526,7 @@ export class PairedNode {
         }
         if (this.#reconnectionInProgress || this.#remoteInitializationInProgress) {
             logger.debug(
-                `Node ${this.nodeId}: Ignoring reconnect request because ${this.#remoteInitializationInProgress ? "init" : "reconnect"} already underway.`,
+                `Node ${this.nodeId}: Ignoring reconnect request because ${this.#remoteInitializationInProgress ? "initialization" : "reconnect"} already underway.`,
             );
             return;
         }

--- a/packages/node/src/behavior/system/network/ServerNetworkRuntime.ts
+++ b/packages/node/src/behavior/system/network/ServerNetworkRuntime.ts
@@ -347,7 +347,9 @@ export class ServerNetworkRuntime extends NetworkRuntime {
 
         this.#observers.close();
 
-        await this.owner.env.close(DeviceCommissioner);
+        const { env } = this.owner;
+
+        await env.close(DeviceCommissioner);
         // Shutdown the Broadcaster if DeviceAdvertiser is not initialized
         // We kick-off the Advertiser shutdown to prevent re-announces when removing sessions and wait a bit later
         const advertisementShutdown = this.owner.env.has(DeviceAdvertiser)
@@ -360,10 +362,10 @@ export class ServerNetworkRuntime extends NetworkRuntime {
         // Now all sessions are closed, so we wait for Advertiser to be gone
         await advertisementShutdown;
 
-        await this.owner.env.close(ExchangeManager);
-        await this.owner.env.close(SecureChannelProtocol);
-        await this.owner.env.close(TransportInterfaceSet);
-        await this.owner.env.close(InteractionServer);
+        await env.close(ExchangeManager);
+        await env.close(SecureChannelProtocol);
+        await env.close(TransportInterfaceSet);
+        await env.close(InteractionServer);
     }
 
     protected override blockNewActivity() {


### PR DESCRIPTION
The nodes in the system can tell the MDNS scanner criteria they are interested in, so that scanning and storing data can be more focussed on them.

Server nodes basically do not need anything, unless they search for actively.
Client nodes are likely interested in all commissionable devices and the operational devices of their own fabric. So limit to that.

If no criteria is active then all MDNS traffic is skipped.