### PR TITLE
Add explicit transaction isolation

### DIFF
--- a/packages/general/src/transaction/Transaction.ts
+++ b/packages/general/src/transaction/Transaction.ts
@@ -9,7 +9,7 @@ import { Participant } from "./Participant.js";
 import { Resource } from "./Resource.js";
 import { ResourceSet } from "./ResourceSet.js";
 import { Status } from "./Status.js";
-import { ReadOnlyTransaction, open } from "./Tx.js";
+import { open } from "./Tx.js";
 
 /**
  * Two-phase commit implementation.
@@ -32,6 +32,11 @@ export interface Transaction {
      * Diagnostic description of the transaction's source.
      */
     readonly via: string;
+
+    /**
+     * The {@link Transaction.IsolationLevel} of this transaction.
+     */
+    readonly isolation: Transaction.IsolationLevel;
 
     /**
      * The status of the transaction.
@@ -183,12 +188,10 @@ export const Transaction = {
      *
      * When closed the transaction commits automatically if exclusive.
      */
-    open(via: string) {
+    open(via: string, isolation: Transaction.IsolationLevel = "rw") {
         // This function is replaced below so do not edit
-        return open(via);
+        return open(via, isolation);
     },
-
-    ReadOnly: ReadOnlyTransaction,
 
     Status,
 
@@ -224,4 +227,20 @@ export namespace Transaction {
          */
         reject(cause: unknown): MaybePromise<never>;
     }
+
+    export type IsolationLevel =
+        /**
+         * Transaction reads only committed and may enter exclusive (write) mode.
+         */
+        | "rw"
+
+        /**
+         * Transaction is read-only but updates are visible after commit.
+         */
+        | "ro"
+
+        /**
+         * Transaction is read-only and data remains at version of first access.
+         */
+        | "snapshot";
 }

--- a/packages/general/test/transaction/TransactionTest.ts
+++ b/packages/general/test/transaction/TransactionTest.ts
@@ -622,7 +622,7 @@ describe("Transaction", () => {
     describe("read-only", () => {
         function readonlySync(description: string, fn: () => MaybePromise<void>) {
             it(description, () => {
-                transaction = Transaction.ReadOnly;
+                transaction = Transaction.open("test", "ro");
 
                 expect(() => {
                     const result = fn();
@@ -633,7 +633,7 @@ describe("Transaction", () => {
 
         function readonlyAsync(description: string, fn: () => Promise<void>) {
             it(description, async () => {
-                transaction = Transaction.ReadOnly;
+                transaction = Transaction.open("test", "ro");
 
                 await expect(fn()).rejectedWith("This view is read-only");
             });

--- a/packages/node/src/behavior/context/server/OfflineContext.ts
+++ b/packages/node/src/behavior/context/server/OfflineContext.ts
@@ -81,7 +81,7 @@ export const OfflineContext = {
      *
      * Write operations will throw an error with this context.
      */
-    ReadOnly: createOfflineContext(Transaction.ReadOnly),
+    ReadOnly: createOfflineContext(Transaction.open("read-only", "ro")),
 
     [Symbol.toStringTag]: "OfflineContext",
 };

--- a/packages/node/src/behavior/context/server/OnlineContext.ts
+++ b/packages/node/src/behavior/context/server/OnlineContext.ts
@@ -103,7 +103,7 @@ export function OnlineContext(options: OnlineContext.Options) {
         beginReadOnly() {
             const close = initialize();
 
-            return createContext(Transaction.ReadOnly, {
+            return createContext(Transaction.open(via, "snapshot"), {
                 [Symbol.dispose]: close,
             }) as OnlineContext.ReadOnly;
         },

--- a/packages/testing/src/util/heap.ts
+++ b/packages/testing/src/util/heap.ts
@@ -24,9 +24,12 @@ config.externalLeakFilter = {
         switch (edge.name_or_index) {
             case "MatterHooks":
             case "MockLogger":
+            case "MockTime":
             case "MochaReporter":
+            case "mocha":
             case "#wrapPrefix":
             case "#dumps":
+            case "_playwrightInstance":
                 // Skip stashed log messages, etc. from testing infrastructure
                 return false;
         }

--- a/support/tests/test/subscription-leaks.test.ts
+++ b/support/tests/test/subscription-leaks.test.ts
@@ -10,7 +10,8 @@ import { TemperatureSensorDevice } from "@matter/node/devices/temperature-sensor
 import { HeapDumpSet } from "@matter/testing";
 
 /**
- * This test currently does not actually
+ * We will need further filtering for heap analysis to function as a proper test.  Currently this just dumps leak report
+ * to logs and should pass.
  */
 describe("subscriptions", () => {
     it("do not leak", async () => {


### PR DESCRIPTION
* Fixes memory leak in reads that were registering read-only transactions with datasources

* Removes singleton "ReadOnly" transaction that would cause leaks if used improperly; replaces with singletons with clear ownership

* Adds "read-only snapshot" isolation mode that allows for use of transactions without registration with datasource

* Replaces use of singleton transactions for node reads; use of one-off snapshot transactions offers some perf benefits while also properly tracking diagnostic via