### PR TITLE
Only register outgoing commands in protocol

### DIFF
--- a/packages/node/src/node/server/ProtocolService.ts
+++ b/packages/node/src/node/server/ProtocolService.ts
@@ -521,7 +521,10 @@ function clusterTypeProtocolOf(backing: BehaviorBacking): ClusterTypeProtocol | 
                 break;
             }
             case "command": {
-                if (!member.effectiveConformance.isMandatory && !supportedElements.commands.has(name)) {
+                if (
+                    (!member.effectiveConformance.isMandatory && !supportedElements.commands.has(name)) ||
+                    !member.isRequest
+                ) {
                     continue;
                 }
 


### PR DESCRIPTION
... else responses with same ID might override requests.

(Happend in Groups cluster)