### PR TITLE
Conformance tweaks and fixes for Occupancy Sensing

### DIFF
--- a/packages/model/src/aspects/Conformance.ts
+++ b/packages/model/src/aspects/Conformance.ts
@@ -693,8 +693,13 @@ function computeApplicability(features: Set<string>, supportedFeatures: Set<stri
 
             case Conformance.Special.Group: {
                 let result = None;
-                for (const child of ast.param) {
-                    switch (processNode(child)) {
+                const { param } = ast;
+                let count = param.length;
+                if (param[count - 1]?.type === Conformance.Flag.Deprecated) {
+                    count--;
+                }
+                for (let i = 0; i < count; i++) {
+                    switch (processNode(param[i])) {
                         case Unconditional:
                             return Unconditional;
 

--- a/packages/node/src/behavior/cluster/ClusterBehaviorUtil.ts
+++ b/packages/node/src/behavior/cluster/ClusterBehaviorUtil.ts
@@ -8,7 +8,6 @@ import { Events, OfflineEvent, OnlineEvent, QuietEvent } from "#behavior/Events.
 import { AsyncObservable, camelize, EventEmitter, GeneratedClass, ImplementationError, Observable } from "#general";
 import {
     ClusterModel,
-    Conformance,
     DefaultValue,
     ElementTag,
     FeatureMap,
@@ -178,7 +177,6 @@ function createDerivedState(
         // value from previous configurations as otherwise conformance may not pass
         const attrs = props[name];
         let propSchema: ValueModel | undefined;
-        let isConditional = false;
 
         // Determine whether the attribute applies
         for (const attr of attrs) {
@@ -189,23 +187,13 @@ function createDerivedState(
                 continue;
             }
 
-            // Conditionally applicable; do not add default, do not remove default
-            if (applicability === Conformance.Applicability.Conditional) {
-                isConditional = true;
-            }
-
-            // Unconditionally applicable; add new default
+            // Applicable; add new default.  If conditional then cluster logic must modify
             propSchema = attr;
             break;
         }
 
         // If the attribute doesn't apply, erase any previous default unless conditionally applicable
         if (propSchema === undefined) {
-            // If conditional, retain incoming default
-            if (isConditional) {
-                return;
-            }
-
             // Inapplicable; ensure no default is present
             if (oldDefaults[name] !== undefined) {
                 // Save the default value so we can recreate it if a future derivative re-enables this element

--- a/packages/node/src/behavior/state/validation/conformance-compiler.ts
+++ b/packages/node/src/behavior/state/validation/conformance-compiler.ts
@@ -287,6 +287,9 @@ export function astToFunction(schema: ValueModel, supervisor: RootSupervisor): V
 
         // A "group" is a list of conformances; any success passes the entire group and subsequent tests are not
         // evaluated
+        if (param[param.length - 1]?.type === Conformance.Flag.Deprecated) {
+            param = param.slice(0, param.length - 1);
+        }
         const members = param.map(test => compile(test));
 
         // Reduce tests that must be evaluated at runtime vs. compile time

--- a/packages/node/src/behaviors/occupancy-sensing/OccupancySensingServer.ts
+++ b/packages/node/src/behaviors/occupancy-sensing/OccupancySensingServer.ts
@@ -6,9 +6,23 @@
 
 import { OccupancySensing } from "#clusters/occupancy-sensing";
 import { Logger, MaybePromise } from "#general";
+import { Val } from "#protocol";
 import { OccupancySensingBehavior } from "./OccupancySensingBehavior.js";
 
 const logger = Logger.get("OccupancySensingServer");
+
+const holdTimeDependencies = [
+    "holdTimeLimits",
+    "pirOccupiedToUnoccupiedDelay",
+    "pirUnoccupiedToOccupiedDelay",
+    "pirUnoccupiedToOccupiedThreshold",
+    "ultrasonicOccupiedToUnoccupiedDelay",
+    "ultrasonicUnoccupiedToOccupiedDelay",
+    "ultrasonicUnoccupiedToOccupiedThreshold",
+    "physicalContactOccupiedToUnoccupiedDelay",
+    "physicalContactUnoccupiedToOccupiedDelay",
+    "physicalContactUnoccupiedToOccupiedThreshold",
+];
 
 /**
  * This is the default server implementation of {@link OccupancySensingBehavior}.
@@ -59,6 +73,16 @@ export class OccupancySensingServer extends OccupancySensingBehavior {
                     "from features",
                     this.features,
                 );
+            }
+        }
+
+        // Clear attributes that are dependent on HoldTime if HoldTime is not set
+        // TODO - if we instead avoid defaults for attributes with field-conditional conformance, remove this
+        if (this.state.holdTime === undefined) {
+            for (const dep of holdTimeDependencies) {
+                if ((this.state as Val.Struct)[dep] !== undefined) {
+                    (this.state as Val.Struct)[dep] = undefined;
+                }
             }
         }
     }

--- a/packages/node/test/behavior/state/validation/conformanceTest.ts
+++ b/packages/node/test/behavior/state/validation/conformanceTest.ts
@@ -552,8 +552,21 @@ const AllTests = Tests({
                 },
             ),
             {
-                "OccupancySensing.PirUnoccupiedToOccupiedDelay": {
+                "disallows PirUnoccupiedToOccupiedDelay without HoldTime": {
                     record: { pirUnoccupiedToOccupiedDelay: 4 },
+                    error: {
+                        type: ConformanceError,
+                        message:
+                            'Validating Test.pirUnoccupiedToOccupiedDelay: Conformance "HoldTime & (PIR | !PIR & !US & !PHY) & PirUnoccupiedToOccupiedThreshold, [HoldTime & (PIR | !PIR & !US & !PHY)], D": Matter does not allow you to set this attribute',
+                    },
+                },
+
+                "allows PirUnoccupiedToOccupiedDelay without HoldTime": {
+                    record: { holdTime: 4, pirUnoccupiedToOccupiedDelay: 4 },
+                },
+
+                "allows neither PirUnoccupiedToOccupiedDelay nor HoldTime": {
+                    record: {},
                 },
             },
         ),

--- a/packages/node/test/behaviors/occupancy-sensing/OccupancySensingServerTest.ts
+++ b/packages/node/test/behaviors/occupancy-sensing/OccupancySensingServerTest.ts
@@ -6,12 +6,21 @@
 
 import { OccupancySensingServer } from "#behaviors/occupancy-sensing";
 import { OccupancySensing } from "#clusters/occupancy-sensing";
+import { Val } from "@matter/protocol";
 import { MockEndpoint } from "../../endpoint/mock-endpoint.js";
 
 describe("OccupancySensingServer", () => {
     it("instantiates", async () => {
         await MockEndpoint.createWith(
-            OccupancySensingServer.set({ occupancySensorType: OccupancySensing.OccupancySensorType.Pir }),
+            OccupancySensingServer.with("Radar").set({ occupancySensorType: OccupancySensing.OccupancySensorType.Pir }),
         );
+    });
+
+    it("chooses correct defaults", async () => {
+        const endpoint = await MockEndpoint.createWith(
+            OccupancySensingServer.with("Radar").set({ occupancySensorType: OccupancySensing.OccupancySensorType.Pir }),
+        );
+
+        expect((endpoint.state.occupancySensing as Val.Struct).pirUnoccupiedToOccupiedThreshold).undefined;
     });
 });


### PR DESCRIPTION
* On OccupancySensingServer initialization, clear fields related to HoldTime if HoldTime is not set

* Ignore "D" when it appears at the end of a conformance group.  This apparently means "not deprecated yet but will be deprecated in the future"

Fixes #2083