### PR TITLE
Add utility method `IndexedSet#mapOf`

### DIFF
--- a/packages/general/src/util/Set.ts
+++ b/packages/general/src/util/Set.ts
@@ -36,9 +36,20 @@ export interface ObservableSet<T> {
 
 /**
  * An interface for index set lookup.
+ *
+ * Note that this interface only supports a single item for each key.  If multiple items associate with a key only the
+ * first is returned.
  */
 export interface IndexedSet<T> {
+    /**
+     * Retrieve an item with the named {@link field} set to {@link value}.
+     */
     get<F extends keyof T>(field: F, value: T[F]): T | undefined;
+
+    /**
+     * Obtain a {@link Map} of values in {@link field} to the associated item in the set.
+     */
+    mapOf<F extends keyof T>(field: F): Map<T[F], T>;
 }
 
 /**
@@ -51,7 +62,10 @@ export class BasicSet<T, AddT = T> implements ImmutableSet<T>, MutableSet<T, Add
     #added?: Observable<[T]>;
     #deleted?: Observable<[T]>;
     #indices?: {
-        [field in keyof T]?: Map<any, T>;
+        [field in keyof T]?: Map<T[field], T>;
+    };
+    #maps?: {
+        [field in keyof T]?: Map<T[field], T>;
     };
 
     constructor(...initialItems: AddT[]) {
@@ -122,7 +136,16 @@ export class BasicSet<T, AddT = T> implements ImmutableSet<T>, MutableSet<T, Add
         this.#added?.emit(created);
     }
 
+    /**
+     * Retrieve entry with field {@link field} set to {@link value}.
+     *
+     * This assumes {@link field} is
+     */
     get<F extends keyof T>(field: F, value: T[F]) {
+        return this.#indexOf(field)?.get(value);
+    }
+
+    #indexOf<F extends keyof T>(field: F) {
         if (!this.#indices) {
             this.#indices = {};
         }
@@ -138,7 +161,19 @@ export class BasicSet<T, AddT = T> implements ImmutableSet<T>, MutableSet<T, Add
             }
             this.#indices[field] = index;
         }
-        return index?.get(value);
+        return index;
+    }
+
+    mapOf<This extends BasicSet<T, T>, F extends keyof T>(this: This, field: F): Map<T[F], T> {
+        if (!this.#maps) {
+            this.#maps = {};
+        }
+        let map = this.#maps[field];
+        if (map === undefined) {
+            map = new MapOfIndexedSet(this, field, this.#indexOf(field));
+            this.#maps[field] = map;
+        }
+        return map;
     }
 
     delete(item: T) {
@@ -186,4 +221,110 @@ export class BasicSet<T, AddT = T> implements ImmutableSet<T>, MutableSet<T, Add
     protected create(definition: AddT) {
         return definition as unknown as T;
     }
+}
+
+/**
+ * A {@link Map} backed by an {@link IndexedSet}.
+ *
+ * This supports the common case where sets must be looked up by key.  Implementations like {@link BasicSet} offer
+ * efficient lookup by key using {@link IndexedSet#get}, but usage like a {@link Map} is still cumbersome.  This class
+ * works as an adapter to make key/value access patterns more natural.
+ */
+export class MapOfIndexedSet<T, S extends ImmutableSet<T> & MutableSet<T> & IndexedSet<T>, K extends keyof T>
+    implements Map<T[K], T>
+{
+    #set: S;
+    #key: K;
+
+    // This is an optimization for lookup
+    #index?: Map<T[K], T>;
+
+    /**
+     * Create a new map.
+     *
+     * @param set the backing data
+     * @param key a property of {@link T} used as the key
+     * @param index optional index that optimizes lookup by bypassing {@link IndexedSet#get}
+     */
+    constructor(set: S, key: K, index?: Map<T[K], T>) {
+        this.#set = set;
+        this.#key = key;
+        this.#index = index;
+    }
+
+    clear(): void {
+        this.#set.clear();
+    }
+
+    delete(key: T[K]): boolean {
+        const item = this.get(key);
+        if (item) {
+            return this.#set.delete(item);
+        }
+        return false;
+    }
+
+    forEach(callbackfn: (value: T, key: T[K], map: Map<T[K], T>) => void, thisArg?: any): void {
+        if (thisArg) {
+            callbackfn = callbackfn.bind(thisArg);
+        }
+        for (const [k, v] of this) {
+            callbackfn(v, k, this);
+        }
+    }
+
+    get(key: T[K]): T | undefined {
+        if (this.#index) {
+            return this.#index.get(key);
+        }
+        return this.#set.get(this.#key, key);
+    }
+
+    has(key: T[K]): boolean {
+        return this.#index ? this.#index.has(key) : this.#set.get(this.#key, key) !== undefined;
+    }
+
+    set(key: T[K], value: T): this {
+        if (this.has(key)) {
+            this.#set.delete((this.#index ? this.#index.get(key) : this.#set.get(this.#key, key)) as T);
+        }
+        this.#set.add(value);
+        return this;
+    }
+
+    get size() {
+        return this.#set.size;
+    }
+
+    entries(): MapIterator<[T[K], T]> {
+        return this[Symbol.iterator]();
+    }
+
+    keys(): MapIterator<T[K]> {
+        if (this.#index) {
+            return this.#index.keys();
+        }
+        const keys = [...this.#set].map(item => item[this.#key]).filter(key => key !== undefined);
+        return keys[Symbol.iterator]();
+    }
+
+    values(): MapIterator<T> {
+        if (this.#index) {
+            return this.#index.values();
+        }
+        const values = [...this.#set].map(item => item);
+        return values[Symbol.iterator]();
+    }
+
+    *[Symbol.iterator](): MapIterator<[T[K], T]> {
+        for (const item of this.#set) {
+            const k = item[this.#key];
+            if (k === undefined) {
+                continue;
+            }
+            yield [k, item];
+        }
+    }
+
+    [Symbol.toStringTag] = "Map";
 }


### PR DESCRIPTION
Oftentimes we have sets of things that have a primary lookup key.  We have the choice of storing them in a `Map<key, Thing>` or in a `BasicSet<Thing>`.

In simple cases `Map` is fine, but if we need to lookup based on other fields we either need to maintain a second index or we need to do a slow O(n) search.  And niceties such as `BasicSet`'s events are unavailable.

`BasicSet` OTOH supports the same lookup patterns, plus observation, plus arbitrary secondary indices.  But it does not offer the same level of convenience as does a standard JS `Map` for key/value access.

The `mapOf` utility method in this commit removes this dilemma.  It allows you to obtain a `Map` view of a `BasicSet`.

For example, in `FabricManager` we have:

```ts
    readonly #fabrics = new Map<FabricIndex, Fabric>();
```

But then we manually implement things like `added`/`deleted` events.  And have awkward access patterns like this.#fabrics.values() and where, given a `Fabric`, we must use `Fabric#fabricIndex` to find the entry in the map.

Instead, with this new method we can do something like:

```ts
    const FabricManager extends BasicSet<Fabric> {
        #fabricsByIndex = this.mapFor("fabricIndex");
        /* ...other code here... */
    }
```

This gives us the benefit of both `Map` and `BasicSet` interfaces with no further effort or performance penalty.