### PR TITLE
Add ClusterClient get*AttributeFromCache()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ The main work (all changes without a GitHub username in brackets in the below li
 -   @matter/*
     - Feature: Implement Matter Groups support in protocol, node and (partly) controller packages
 
+-   @matter/protocol
+    - Enhancement: Exposed reading cached ClusterClient attributes via `get*AttributeFromCache()` method
+
 ## 0.14.0 (2025-06-04)
 
 - NOTE: This version is compatible with Node.js 20.x, 22.x and 24.x. Node.js 18.x is also supported with the following exceptions:

--- a/packages/protocol/src/cluster/client/ClusterClient.ts
+++ b/packages/protocol/src/cluster/client/ClusterClient.ts
@@ -91,6 +91,20 @@ export function ClusterClient<const T extends ClusterType>(
                 throw e;
             }
         };
+        result[`get${capitalizedAttributeName}AttributeFromCache`] = async () => {
+            if (isGroupAddress) {
+                throw new ImplementationError("Group cluster clients do not support reading attributes");
+            }
+
+            try {
+                return await (attributes as any)[attributeName].getLocal();
+            } catch (e) {
+                if (StatusResponseError.is(e, StatusCode.UnsupportedAttribute)) {
+                    return undefined;
+                }
+                throw e;
+            }
+        };
         result[`set${capitalizedAttributeName}Attribute`] = async <T>(value: T, dataVersion?: number) =>
             (attributes as any)[attributeName].set(value, dataVersion);
         result[`subscribe${capitalizedAttributeName}Attribute`] = async <T>(

--- a/packages/protocol/src/cluster/client/ClusterClient.ts
+++ b/packages/protocol/src/cluster/client/ClusterClient.ts
@@ -91,19 +91,12 @@ export function ClusterClient<const T extends ClusterType>(
                 throw e;
             }
         };
-        result[`get${capitalizedAttributeName}AttributeFromCache`] = async () => {
+        result[`get${capitalizedAttributeName}AttributeFromCache`] = () => {
             if (isGroupAddress) {
                 throw new ImplementationError("Group cluster clients do not support reading attributes");
             }
 
-            try {
-                return await (attributes as any)[attributeName].getLocal();
-            } catch (e) {
-                if (StatusResponseError.is(e, StatusCode.UnsupportedAttribute)) {
-                    return undefined;
-                }
-                throw e;
-            }
+            return (attributes as any)[attributeName].getLocal();
         };
         result[`set${capitalizedAttributeName}Attribute`] = async <T>(value: T, dataVersion?: number) =>
             (attributes as any)[attributeName].set(value, dataVersion);

--- a/packages/protocol/src/cluster/client/ClusterClientTypes.ts
+++ b/packages/protocol/src/cluster/client/ClusterClientTypes.ts
@@ -102,10 +102,7 @@ type ClientAttributeGetters<A extends Attributes> = Omit<
 >;
 type ClientLocalAttributeGetters<A extends Attributes> = Omit<
     {
-        [P in keyof A as `get${Capitalize<string & P>}AttributeFromCache`]: (
-            requestFromRemote?: boolean,
-            isFabricFiltered?: boolean,
-        ) => Promise<GetterTypeFromSpec<A[P]>>;
+        [P in keyof A as `get${Capitalize<string & P>}AttributeFromCache`]: () => GetterTypeFromSpec<A[P]> | undefined;
     },
     keyof GlobalAttributes<any>
 >;

--- a/packages/protocol/src/cluster/client/ClusterClientTypes.ts
+++ b/packages/protocol/src/cluster/client/ClusterClientTypes.ts
@@ -100,6 +100,15 @@ type ClientAttributeGetters<A extends Attributes> = Omit<
     },
     keyof GlobalAttributes<any>
 >;
+type ClientLocalAttributeGetters<A extends Attributes> = Omit<
+    {
+        [P in keyof A as `get${Capitalize<string & P>}AttributeFromCache`]: (
+            requestFromRemote?: boolean,
+            isFabricFiltered?: boolean,
+        ) => Promise<GetterTypeFromSpec<A[P]>>;
+    },
+    keyof GlobalAttributes<any>
+>;
 type ClientGlobalAttributeGetters<F extends BitSchema> = {
     [P in GlobalAttributeNames<F> as `get${Capitalize<string & P>}Attribute`]: () => Promise<
         GetterTypeFromSpec<GlobalAttributes<F>[P]>
@@ -265,6 +274,7 @@ export type ClusterClientObj<T extends ClusterType = ClusterType> = BaseClusterC
     /** Returns if a given Command with provided name is present and supported at the connected cluster server. */
     isCommandSupportedByName: (commandName: string) => boolean;
 } & ClientAttributeGetters<T["attributes"]> &
+    ClientLocalAttributeGetters<T["attributes"]> &
     ClientGlobalAttributeGetters<T["features"]> &
     ClientAttributeSubscribers<T["attributes"]> &
     ClientAttributeListeners<T["attributes"]> &


### PR DESCRIPTION
... to expose the AttributeClient.getLocal() for legacy API. This is basically a miss as I added the getLocal() method on AttributeClient