### PR TITLE
Allow BLE Scanner to be cancelable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ The main work (all changes without a GitHub username in brackets in the below li
 -   @matter/nodejs
     - Enhancement: New variables `nodejs.crypto`, `nodejs.network` and `nodejs.storage` allow users to enable/disable the implementation of these features that use Node.js APIs
 
+-   @matter/nodejs-ble
+    - Fix: Removes Windows-specific workaround needed in older versions of Noble
+    - Fix: Adjusts BLEScanner to also be cancelable to allow cancellation of discovery processes
+
 ## 0.14.0 (2025-06-04)
 
 - NOTE: This version is compatible with Node.js 20.x, 22.x and 24.x. Node.js 18.x is also supported with the following exceptions:

--- a/packages/nodejs-ble/src/NobleBleClient.ts
+++ b/packages/nodejs-ble/src/NobleBleClient.ts
@@ -90,9 +90,7 @@ export class NobleBleClient {
         this.shouldScan = true;
         if (this.nobleState === "poweredOn") {
             logger.debug("Start BLE scanning for Matter Services ...");
-            // TODO Remove this Windows hack once Noble Windows issue is fixed
-            //  see https://github.com/stoprocent/noble/issues/20
-            await noble.startScanningAsync(process.platform !== "win32" ? [BLE_MATTER_SERVICE_UUID] : undefined, true);
+            await noble.startScanningAsync([BLE_MATTER_SERVICE_UUID], true);
         } else {
             logger.debug("noble state is not poweredOn ... delay scanning till poweredOn");
         }

--- a/packages/protocol/src/mdns/MdnsScanner.ts
+++ b/packages/protocol/src/mdns/MdnsScanner.ts
@@ -120,9 +120,7 @@ export interface MdnsScannerTargetCriteria {
  * queries to discover various types of Matter device types and listens for announcements.
  */
 export class MdnsScanner implements Scanner {
-    get type() {
-        return ChannelType.UDP;
-    }
+    readonly type = ChannelType.UDP;
 
     static async create(network: Network, options?: { enableIpv4?: boolean; netInterface?: string }) {
         const { enableIpv4, netInterface } = options ?? {};
@@ -502,9 +500,7 @@ export class MdnsScanner implements Scanner {
         const { timer, resolver, resolveOnUpdatedRecords, commissionable } = waiter;
         if (isUpdatedRecord && !resolveOnUpdatedRecords) return;
         logger.debug(`Finishing waiter for query ${queryId}, resolving: ${resolvePromise}`);
-        if (timer !== undefined) {
-            timer.stop();
-        }
+        timer?.stop();
         if (resolvePromise) {
             resolver();
         }


### PR DESCRIPTION
Some changes introduced to MDNS Scanner som time ago - mainly allowing outside cancelation were not included on BLEScanner. This PR brings this back into sync

fixes #2131