### PR TITLE
Allow any aspectCache keys to be created

### DIFF
--- a/packages/model/src/aspects/Aspect.ts
+++ b/packages/model/src/aspects/Aspect.ts
@@ -11,12 +11,7 @@ const empty = new Map<new (definition?: any) => Aspect, Aspect>();
 
 // Aspects are immutable, there are not many permutations, and their definitions are largely normalized strings.  So we
 // cache them to keep the object count down
-const aspectCache: Record<string, Record<string, Aspect>> = {
-    Access: {},
-    Conformance: {},
-    Constraint: {},
-    Quality: {},
-};
+const aspectCache = new Map<new (definition?: any) => Aspect, Record<string, Aspect>>();
 
 /**
  * An "aspect" is metadata about a Matter element that affects implementation behavior.  Aspects are mostly "qualities"
@@ -83,7 +78,11 @@ export abstract class Aspect<D = any> {
         }
 
         if (typeof definition === "string") {
-            const slot = aspectCache[this.name];
+            let slot = aspectCache.get(this);
+            if (slot === undefined) {
+                slot = {};
+                aspectCache.set(this, slot);
+            }
 
             let some = slot[definition];
             if (some) {


### PR DESCRIPTION
Hello,

I working for a company that will be using matter in it's new products and I aim at using part of the Matter.js sdk in the browser.

However there is currently an error that is thrown when the SDK is bundled with frameworks like Angular and VueJS and I suspect the error would be found with other frameworks as well.

The error I get is the following : 
![image](https://github.com/user-attachments/assets/d6de9e58-49a0-4aab-8c61-918c68c7f266)

After some research I found out that the minification process from the bundlers, like esBuild is responsible of this error, which changes somehow some classes names that are used here in the Aspect cache

For example here the `this.name` would evaluate to `_Quality` instead of `Quality` which results in an error because the cache was initialized with the key `Quality`
![image](https://github.com/user-attachments/assets/b0b67d50-a91d-4898-83fd-23d8506f6c4f)

**So the goal of the PR is to always initialize the aspectCache with an empty object the first time it is accessed.**

I hope all of this makes sense to you, if you have any questions don't hesitate

I'm fairly new to the Pull Request game, I hope you will be indulgent 🙏