### PR TITLE
Introduce DCL types and basic fetch functions

### DIFF
--- a/packages/protocol/src/dcl/DclClient.ts
+++ b/packages/protocol/src/dcl/DclClient.ts
@@ -35,7 +35,7 @@ export class DclClient {
         this.#baseUrl = this.production ? DCL_PRODUCTION_URL : DCL_TEST_URL;
     }
 
-    async #fetchJson<T>(path: string): Promise<T> {
+    async #fetchJson<Response>(path: string): Promise<Response> {
         const url = new URL(path, this.#baseUrl);
         try {
             const response = await fetch(url.toString(), {

--- a/packages/protocol/src/dcl/DclClient.ts
+++ b/packages/protocol/src/dcl/DclClient.ts
@@ -1,0 +1,140 @@
+/**
+ * @license
+ * Copyright 2022-2025 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import {
+    DclApiErrorResponse,
+    DclModelModelsWithVidPidResponse,
+    DclModelVersionsWithVidPidResponse,
+    DclModelVersionWithVidPidSoftwareVersionResponse,
+    DclPkiCertificateResponse,
+    DclPkiRootCertificatesResponse,
+    DclPkiRootCertificateSubjectReference,
+} from "#dcl/DclRestApiTypes.js";
+import { MatterError } from "#general";
+
+const DCL_PRODUCTION_URL = "https://on.dcl.csa-iot.org";
+const DCL_TEST_URL = "https://on.test-net.dcl.csa-iot.org";
+
+/** Base class for all DCL-related errors */
+export class MatterDclError extends MatterError {}
+
+/** Error thrown when fetching data from DCL fails */
+export class MatterDclResponseError extends MatterDclError {
+    constructor(path: string, error: DclApiErrorResponse) {
+        super(`Error fetching ${path} from DCL: ${error.code} - ${error.message}`);
+    }
+}
+
+/** A client clas to use "fetch" to get REST DAta from DCL (Decentraland) */
+export class DclClient {
+    #baseUrl: string;
+
+    constructor(private readonly production: boolean = true) {
+        this.#baseUrl = this.production ? DCL_PRODUCTION_URL : DCL_TEST_URL;
+    }
+
+    async #fetchJson<T>(path: string): Promise<T> {
+        const url = new URL(path, this.#baseUrl);
+        try {
+            const response = await fetch(url.toString(), {
+                method: "GET",
+                headers: {
+                    "Content-Type": "application/json",
+                },
+                signal: AbortSignal.timeout(5_000), // 5 seconds timeout
+            });
+
+            if (!response.ok) {
+                throw new MatterDclResponseError(path, await response.json());
+            }
+
+            return await response.json();
+        } catch (error) {
+            if (error instanceof MatterDclResponseError) {
+                throw error; // Re-throw custom DCL error
+            }
+            throw new MatterDclResponseError(path, {
+                code: 500,
+                message: error instanceof Error ? error.message : "Unknown Error",
+                details: [],
+            });
+        }
+    }
+
+    async fetchRootCertificateList() {
+        const certList = await this.#fetchJson<DclPkiRootCertificatesResponse>("/certificates/approved");
+        if (certList?.approvedRootCertificates?.schemaVersion !== 0) {
+            throw new MatterDclError(
+                `Unsupported DCL Root Certificate schema version: ${certList.approvedRootCertificates.schemaVersion}`,
+            );
+        }
+        return certList.approvedRootCertificates.certs;
+    }
+
+    async fetchRootCertificateBySubject(subject: DclPkiRootCertificateSubjectReference) {
+        const path = `/certificates/${encodeURIComponent(subject.subject)}/${encodeURIComponent(subject.subjectKeyId)}`;
+        const response = await this.#fetchJson<DclPkiCertificateResponse>(path);
+        if (
+            !response ||
+            !response.approvedRootCertificates ||
+            response.approvedRootCertificates.subject !== subject.subject ||
+            response.approvedRootCertificates.subjectKeyId !== subject.subjectKeyId ||
+            response.approvedRootCertificates.schemaVersion !== 0
+        ) {
+            throw new MatterDclError(
+                `Root certificate not found for subject: ${subject.subject}, subjectKeyId: ${subject.subjectKeyId}`,
+            );
+        }
+        return response.approvedRootCertificates.certs;
+    }
+
+    async fetchModelByVidPid(vid: number, pid: number) {
+        const path = `/models/model/${encodeURIComponent(vid)}/${encodeURIComponent(pid)}`;
+        const response = await this.#fetchJson<DclModelModelsWithVidPidResponse>(path);
+        if (
+            !response ||
+            !response.model ||
+            response.model.vid !== vid ||
+            response.model.pid !== pid ||
+            response.model.schemaVersion !== 0
+        ) {
+            throw new MatterDclError(`Model not found for VID: ${vid}, PID: ${pid}`);
+        }
+        return response.model;
+    }
+
+    async fetchModelVersionsByVidPid(vid: number, pid: number) {
+        const path = `/models/versions/${encodeURIComponent(vid)}/${encodeURIComponent(pid)}`;
+        const response = await this.#fetchJson<DclModelVersionsWithVidPidResponse>(path);
+        if (
+            !response ||
+            !response.modelVersions ||
+            response.modelVersions.vid !== vid ||
+            response.modelVersions.pid !== pid ||
+            response.modelVersions.schemaVersion !== 0
+        ) {
+            throw new MatterDclError(`Model versions not found for VID: ${vid}, PID: ${pid}`);
+        }
+        return response.modelVersions.softwareVersions;
+    }
+
+    async fetchModelVersionByVidPidSoftwareVersion(vid: number, pid: number, softwareVersion: number) {
+        const path = `/models/versions/${encodeURIComponent(vid)}/${encodeURIComponent(pid)}/${encodeURIComponent(softwareVersion)}`;
+        const response = await this.#fetchJson<DclModelVersionWithVidPidSoftwareVersionResponse>(path);
+        if (
+            !response ||
+            !response.modelVersion ||
+            response.modelVersion.vid !== vid ||
+            response.modelVersion.pid !== pid ||
+            response.modelVersion.softwareVersion !== softwareVersion ||
+            response.modelVersion.schemaVersion !== 0
+        ) {
+            throw new MatterDclError(
+                `Model version not found for VID: ${vid}, PID: ${pid}, Software Version: ${softwareVersion}`,
+            );
+        }
+        return response.modelVersion;
+    }
+}

--- a/packages/protocol/src/dcl/DclClient.ts
+++ b/packages/protocol/src/dcl/DclClient.ts
@@ -35,7 +35,7 @@ export class DclClient {
         this.#baseUrl = this.production ? DCL_PRODUCTION_URL : DCL_TEST_URL;
     }
 
-    async #fetchJson<Response>(path: string): Promise<Response> {
+    async #fetchJson<ResponseT>(path: string): Promise<ResponseT> {
         const url = new URL(path, this.#baseUrl);
         try {
             const response = await fetch(url.toString(), {

--- a/packages/protocol/src/dcl/DclRestApiTypes.ts
+++ b/packages/protocol/src/dcl/DclRestApiTypes.ts
@@ -1,0 +1,55 @@
+/**
+ * @license
+ * Copyright 2022-2025 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { DeviceModelDclSchema, DeviceSoftwareVersionModelDclSchema, ProductAttestationDclSchema } from "@matter/types";
+
+export interface DclApiErrorResponse {
+    code: number;
+    message: string;
+    details: string[];
+}
+
+export interface DclPkiRootCertificateSubjectReference {
+    subject: string;
+    subjectKeyId: string;
+}
+
+/** Response for /dcl/pki/certificates/approved */
+export interface DclPkiRootCertificatesResponse {
+    approvedRootCertificates: {
+        certs: DclPkiRootCertificateSubjectReference[];
+        schemaVersion: number;
+    };
+}
+
+/** Response for /dcl/pki/certificates/{subject}/{subjectKeyId} */
+export interface DclPkiCertificateResponse {
+    approvedRootCertificates: {
+        subject: string;
+        subjectKeyId: string;
+        certs: ProductAttestationDclSchema[];
+        schemaVersion: number;
+    };
+}
+
+/** Response for /dcl/models/model/{vid}/{pid} */
+export interface DclModelModelsWithVidPidResponse {
+    model: DeviceModelDclSchema;
+}
+
+/** Response for /dcl/model/versions/{vid}/{pid} */
+export interface DclModelVersionsWithVidPidResponse {
+    modelVersions: {
+        vid: number;
+        pid: number;
+        softwareVersions: number[];
+        schemaVersion: number;
+    };
+}
+
+/** Response for /dcl/model/versions/{vid}/{pid}/{softwareVersion} */
+export interface DclModelVersionWithVidPidSoftwareVersionResponse {
+    modelVersion: DeviceSoftwareVersionModelDclSchema;
+}

--- a/packages/protocol/src/dcl/index.ts
+++ b/packages/protocol/src/dcl/index.ts
@@ -1,0 +1,7 @@
+/**
+ * @license
+ * Copyright 2022-2025 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export * from "./DclClient.js";

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -10,6 +10,7 @@ export * from "./certificate/index.js";
 export * from "./cluster/index.js";
 export * from "./codec/index.js";
 export * from "./common/index.js";
+export * from "./dcl/index.js";
 export * from "./events/index.js";
 export * from "./fabric/index.js";
 export * from "./groups/index.js";

--- a/packages/types/src/dcl/attestation-certificate.ts
+++ b/packages/types/src/dcl/attestation-certificate.ts
@@ -1,0 +1,114 @@
+/**
+ * @license
+ * Copyright 2022-2025 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { VendorId } from "../datatype/VendorId.js";
+
+export interface ApprovalOrRejectDetails {
+    address: string;
+    time: string; // but number content
+    info: string;
+    schemaVersion: number; // No info
+}
+
+/**
+ * Product Attestation Authority and Intermediate Certificate Schema
+ * @see {@link MatterSpecification.v141.Core} § 11.23.4.
+ * DCL Endpoints:
+ *   * /dcl/pki/certificates
+ *   * /dcl/pki/certificates/{subject}
+ *   * /dcl/pki/certificates/{subject}/{subjectKeyId}
+ */
+export interface ProductAttestationDclSchema {
+    /**
+     * This field uniquely identifies a certificate and SHALL contain the body of a certificate that has been
+     * added in the DCL. It SHALL be encoded in PEM format. The certificate SHALL respect the format
+     * constraints provided for that certificate type.
+     */
+    pemCert: string;
+
+    /**
+     * The field SHALL be used to identify the serial number field in the Matter certificate structure. A
+     * Matter certificate follows the same limitation on admissible serial numbers as in [RFC 5280], i.e.,
+     * that implementations SHALL admit serial numbers up to 20 octets in length, and certificate authorities
+     * SHALL NOT use serial numbers longer than 20 octets in length.
+     */
+    serialNumber: string;
+
+    /**
+     * The field SHALL be used to identify the Certificate Authority that issues the certificate. For a PAA
+     * Certificate, this field is OPTIONAL because Issuer and Subject are the same.
+     */
+    issuer?: string;
+
+    /**
+     * The authority key identifier extension provides a means of identifying the public key corresponding
+     * to the private key used to sign a Matter certificate. This is OPTIONAL for PAA Certificates.
+     */
+    authorityKeyID?: string;
+
+    /**
+     * This field SHALL contain the PAA certificate’s Subject field, as defined in PAA in PAA Certificate.
+     * This is OPTIONAL for PAA Certificates. This is encoded as defined in Section 6.1, “Certificate Common
+     * Conventions”.
+     */
+    rootSubject?: string;
+
+    /**
+     * This field SHALL uniquely identify the PAA certificate’s Subject Key Identifier mandatory extension.
+     * It is defined in PAA Certificate and Operational Root CA Certificates (RCAC). This is OPTIONAL
+     * for PAA Certificates. This is encoded as defined in Section 6.1, “Certificate Common Conventions”.
+     */
+    rootSubjectKeyID?: string;
+
+    /**
+     * This field SHALL signify whether the associated certificate is PAA Certificate.
+     */
+    isRoot: boolean;
+
+    /**
+     * This field uniquely identifies the DCL key that was used to register the certificate in DCL, pursuant
+     * to DCL policies.
+     */
+    owner: string;
+
+    /**
+     * This field SHALL contain the certificate’s Subject field. This is OPTIONAL for PAA Certificates. This
+     * is encoded as defined in Section 6.1, “Certificate Common Conventions”.
+     * Base64 encoded
+     * TODO Check optional or not??
+     */
+    subject?: string;
+
+    /**
+     * This field SHALL uniquely identify the PAA certificate’s Subject Key Identifier mandatory extension.
+     * This is encoded as defined in Section 6.1.2, “Key Identifier Extension Constraints”.
+     */
+    subjectKeyID: string;
+
+    /**
+     * This field SHALL contain list of DCL Keys that approved the PAA Certificate admission into DCL.
+     * This field SHALL be set only for a PAA Certificate.
+     */
+    approvals: ApprovalOrRejectDetails; // Spec: grantApprovals and other format
+
+    /**
+     * This field SHALL contain list of DCL Keys that rejected the PAA Certificate admission into DCL. This
+     * field SHALL be set only for a PAA Certificate
+     */
+    rejects: ApprovalOrRejectDetails; // Spec: grantRejects and other format
+
+    /**
+     * This field SHALL uniquely identify this Vendor Schema entry and it SHALL match the Vendor’s
+     * assigned Vendor ID.
+     */
+    vid: VendorId;
+
+    /**
+     * The SchemaVersion field value history for this schema is provided below:
+     * ???? TODO
+     */
+    schemaVersion: number;
+}

--- a/packages/types/src/dcl/device-attestation-revocation.ts
+++ b/packages/types/src/dcl/device-attestation-revocation.ts
@@ -1,0 +1,149 @@
+/**
+ * @license
+ * Copyright 2022-2025 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { VendorId } from "../datatype/VendorId.js";
+
+export enum RevocationTypeEnum {
+    /**
+     * RFC 5280 Certificate Revocation List (CRL)
+     */
+    Crl = 1,
+}
+
+/**
+ * Device Attestation PKI Revocation Distribution Points Schema
+ * @see {@link MatterSpecification.v141.Core} § 11.23.9.
+ * DCL endpoints:
+ *   * /dcl/pki/revocation-points
+ *   * /dcl/pki/revocation-points/{issuerSubjectKeyID}
+ *   * /dcl/pki/revocation-points/{issuerSubjectKeyID}/{vid}/{label}
+ */
+export interface DeviceAttestationPkiRevocationDclSchema {
+    /**
+     * This field SHALL indicate the VendorID associated with the PAA or PAI whose revocation information
+     * is provided. For a non-vendor-scoped PAA, this SHALL be the VendorID associated with the
+     * organization operating the PAA. For vendor-scoped PAA and for PAIs, this field SHALL contain the
+     * VendorID as found in the CRLSignerCertificate (see Section 6.2.2.2, “Encoding of Vendor ID and
+     * Product ID in subject and issuer fields” for encoding).
+     */
+    vid: VendorId; // Spec: vendorId
+
+    /**
+     * This field is only required when a PAI is making the distribution point available. This field SHALL
+     * only be provided if the IsPAA field is false and if the CRLSignerCertificate field has a ProductID in
+     * its subject (see Section 6.2.2.2, “Encoding of Vendor ID and Product ID in subject and issuer fields”
+     * for encoding).
+     */
+    pid?: number; // Spec: productId
+
+    /**
+     * This field SHALL be set to true if the revocation information distribution point relates to a PAA, otherwise
+     * it SHALL be set to false (i.e. it relates to a PAI, not a PAA)."
+     */
+    isPAA: boolean;
+
+    /**
+     * This field contains a label to disambiguate multiple revocation information partitions of a particular
+     * issuer. Uniqueness within the Device Attestation PKI Revocation Distribution Points schema
+     * SHALL be enforced against the tuple containing all of:
+     * • VendorID
+     * • Label
+     * • IssuerSubjectKeyID
+     * Therefore, there MAY be multiple entries for the same VendorID and IssuerSubjectKeyID in case
+     * partitioning is done, which are disambiguated by the Label.
+     * Enforcement of uniqueness constraints SHALL be done by the Distributed Compliance Ledger’s
+     * block transaction processing and SHALL also be done by clients making use of the information
+     * from this schema.
+     */
+    label: string;
+
+    /**
+     * This field SHALL be present and non-empty if all of the following are true:
+     * • Certificate in CRLSignerCertificate field is not self-signed.
+     * • IsPAA is false.
+     * • CRLSignerCertificate is not a PAI.
+     * When present, this field SHALL contain the issuer certificate which signed the CRLSignerCertificate,
+     * encoded in X.509v3 PEM format.
+     * Additional constraints related to the value of this field are specified in Section 11.23.9.6, “CRLSignerCertificate”.
+     */
+    crlSignerDelegator?: string;
+
+    /**
+     * This field SHALL contain the issuer certificate who signed the revocation information that is provided
+     * in the distribution point entry, encoded in X.509v3 PEM format.
+     * Additional constraints related to the value of this field are specified in
+     * @see {@link MatterSpecification.v141.Core} §11.23.9.6.
+     */
+    crlSignerCertificate: string;
+
+    /**
+     * This field SHALL uniquely identify the PAA or PAI for which this revocation distribution point is
+     * provided, via the certificate’s SubjectKeyIdentifier mandatory extension. This field is provided to
+     * assist queries without requiring additional certificate parsing. This field SHALL provide the subject
+     * key identifier as an even number of uppercase hexadecimal characters ([0-9A-F]), with no whitespace
+     * and no non-hexadecimal characters.
+     * For example, subject key ID A3:03:13:6D:54:A8:4B:E2:4C:48:87:B3:41:06:6D:C2:70:96:2F:99 (as it
+     * would appear in openssl x509 output, for human consumption) would be recorded as
+     * A303136D54A84BE24C4887B341066DC270962F99.
+     * When processing revocation information during the device Device Attestation Procedure, clients
+     * SHALL only use entries whose IssuerSubjectKeyID matches a candidate certificate’s Authority Key
+     * Identifier extension.
+     */
+    issuerSubjectKeyID: string;
+
+    /**
+     * This field SHALL indicate the URL where to obtain the information in the format indicated by the
+     * RevocationType field. The syntax of this field SHALL follow the syntax as specified in RFC 1738. The
+     * maximum length of this field is 256 ASCII characters. All URLs SHALL use either the http or https
+     * scheme.
+     * Additional details of the content by revocation type are specified in
+     * @see {@link MatterSpecification.v141.Core} §11.23.9.8
+     */
+    dataUrl: string;
+
+    /**
+     * This field, if present, SHALL indicate the total size in bytes of the file found at the DataUrl. This field
+     * SHALL be omitted if the RevocationType is 1, which refers to a type having built-in signatures.
+     */
+    dataFileSize?: number | bigint; // TODO
+
+    /**
+     * This field, if present, SHALL contain the digest of the entire contents of the associated file downloaded
+     * from the DataUrl field, encoded in base64 string representation. The digest SHALL have been
+     * computed using the algorithm specified in DataDigestType. This field SHALL be present if and only if
+     * the DataFileSize field is present.
+     */
+    dataDigest?: string;
+
+    /**
+     * This field, if present, SHALL indicate the type of digest used in the DataDigest field. This field SHALL
+     * be provided if and only if the DataDigest field is present.
+     * The value of this field SHALL be a supported numerical identifier value from the IANA Named
+     * Information Hash Algorithm Registry [https://www.iana.org/assignments/named-information/named-information.xhtml#hash-alg]
+     * established as part of RFC 6920. For example, a value of 1 would match the sha-
+     * 256 identifier, which maps to the SHA-256 digest algorithm per Section 6.2 of FIPS 180-4.
+     * The digest algorithm chosen SHALL have a minimum digest length of 256 bits, such as sha-256 (ID 1
+     * in the registry).
+     * To increase interoperability, DataDigestType, if present, SHALL be within the list of [1, 7, 8, 10, 11,
+     * 12].
+     */
+    dataDigestType?: number; // TODO: Define enum for digest types
+
+    /**
+     * This field SHALL indicate the type of revocation information provided in the DataUrl field. The
+     * following values are defined:
+     * • 0: CRL (Certificate Revocation List) in PEM format.
+     * • 1: Signed JSON object containing a list of revoked certificates.
+     * • 2: Signed JSON object containing a list of revoked certificates, with additional metadata.
+     */
+    revocationType: RevocationTypeEnum;
+
+    /**
+     * The SchemaVersion field value history for this schema is provided below:
+     * * 0: Initial Release
+     */
+    schemaVersion: number;
+}

--- a/packages/types/src/dcl/device-software-compliance.ts
+++ b/packages/types/src/dcl/device-software-compliance.ts
@@ -1,0 +1,108 @@
+/**
+ * @license
+ * Copyright 2022-2025 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { VendorId } from "../datatype/VendorId.js";
+
+export enum SoftwareVersionCertificationStatusEnum {
+    /**
+     * Used for development and test purposes
+     * (These will typically not be placed in DCL)
+     */
+    DevTest = 0,
+
+    /**
+     * Used for a SoftwareVersion when going into certification testing
+     * (These might or might not be placed in DCL, depending on CSA policy and procedures)
+     */
+    Provisional = 1,
+
+    /**
+     * Used for a SoftwareVersion which has been certified
+     */
+    Certified = 2,
+
+    /**
+     * Used for a SoftwareVersion which has been revoked
+     */
+    Revoked = 3,
+}
+
+/**
+ * DeviceSoftwareCompliance / Compliance test result Schema
+ * @see {@link MatterSpecification.v141.Core} § 11.23.8.
+ * DCL endpoint:
+ *   * /dcl/compliance/device-software-compliance
+ *   * /dcl/compliance/device-software-compliance/{cDCertificateId}
+ *
+ *   * /dcl/compliance/compliance-info
+ *   * /dcl/compliance/compliance-info/{vid}/{pid}/{softwareVersion}/{certificationType}
+ *   * /dcl/compliance/certified-models
+ *   * /dcl/compliance/certified-models/{vid}/{pid}/{softwareVersion}/{certificationType}
+ *
+ */
+export interface DeviceSoftwareComplianceDclSchema {
+    /**
+     * This field SHALL identify the vendor of the product by its Vendor ID and SHALL match the VendorID
+     * field in the Basic Information Cluster of a device running the software referenced by this
+     * DeviceModel/DeviceSoftwareVersionModel record.
+     */
+    vid: VendorId; // Spec: VendorId
+
+    /**
+     * This field SHALL identify the Product ID of the product instance to which a certification declaration,
+     * and thus a DCL entry, applies. This field SHALL match the ProductID field in the Basic Information
+     * Cluster of a device running the software referenced by this DeviceModel/DeviceSoftwareVersionModel
+     * record.
+     */
+    pid: number; // Spec: ProductId
+
+    /**
+     * SoftwareVersion SHALL identify the software version number for the device model consistent with
+     * the value found in Section 11.21.2.4.3, “SoftwareVersion field”. The SoftwareVersionNumber value
+     * SHOULD NOT be displayed to an end-user. SoftwareVersion is not editable, but it would be possible
+     * to create a new device model for the same VendorID/ProductID for different versions. Both SoftwareVersion
+     * and SoftwareVersionString SHALL be included. This field SHALL match the SoftwareVersion
+     * field in the Basic Information Cluster of a device running the software certified by this
+     * DeviceModel record.
+     */
+    softwareVersion: number;
+
+    /**
+     * This field SHALL match the Software Version String field in the Basic Information Cluster of a
+     * device running the software referenced by this DeviceModel record, including format constraints
+     * on that field.
+     */
+    softwareVersionString: string;
+
+    /**
+     * CDVersionNumber SHALL identify the CD Version Number of the Certification that applies to this
+     * Software Image. The CDVersionNumber maps to version_number defined in Certification Elements TLV
+     * structure.
+     */
+    cdVersionNumber: number;
+
+    /**
+     * The FirmwareInformation field, if present, SHALL match the firmware_information field in attestation-elements
+     * field included in the Device Attestation response when this Software Image boots on
+     * the device. It is an OPTIONAL field that MAY be present only for devices that meet the requirements
+     * listed in Section 6.3.2, “Firmware Information”.
+     */
+    softwareVersionCertificationStatus?: SoftwareVersionCertificationStatusEnum;
+
+    /**
+     * This field SHALL have the CSA certification’s certificate ID for the Certification that applies to this
+     * record. The value of this field is used in the Certification Declaration's certificate_id field (see Certification
+     * Elements TLV structure) for products using the VendorID, ProductID and SoftwareVersion
+     * in this schema entry.
+     */
+    cdCertificateId: string;
+
+    /**
+     * The SchemaVersion field value history for this schema is provided below:
+     * * 0: Initial Release
+     */
+    schemaVersion: number;
+}

--- a/packages/types/src/dcl/device-software-version.ts
+++ b/packages/types/src/dcl/device-software-version.ts
@@ -1,0 +1,143 @@
+/**
+ * @license
+ * Copyright 2022-2025 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { VendorId } from "../datatype/VendorId.js";
+
+/**
+ * DeviceSoftwareVersionModel Schema
+ * @see {@link MatterSpecification.v141.Core} § 11.23.7.
+ * DCL endpoints:
+ * * check with https://on.dcl.csa-iot.org/dcl/model/versions/{vid}/{pid} to get a list of software versions, check for newer ones
+ * * check with https://on.dcl.csa-iot.org/dcl/model/versions/{vid}/{pid}/{softwareVersion} for these details
+ * see also https://github.com/home-assistant-libs/python-matter-server/blob/main/matter_server/server/ota/dcl.py#L35
+ */
+export interface DeviceSoftwareVersionModelDclSchema {
+    /**
+     * This field SHALL identify the vendor of the product by its Vendor ID and SHALL match the VendorID
+     * field in the Basic Information Cluster of a device running the software referenced by this
+     * DeviceModel/DeviceSoftwareVersionModel record.
+     */
+    vid: VendorId; // Spec vendorId
+
+    /**
+     * This field SHALL identify the Product ID of the product instance to which a certification declaration,
+     * and thus a DCL entry, applies. This field SHALL match the ProductID field in the Basic Information
+     * Cluster of a device running the software referenced by this DeviceModel/DeviceSoftwareVersionModel
+     * record.
+     */
+    pid: number; // Spec productId
+
+    /**
+     * SoftwareVersion SHALL identify the software version number for the device model consistent with
+     * the value found in Section 11.21.2.4.3, “SoftwareVersion field”. The SoftwareVersionNumber value
+     * SHOULD NOT be displayed to an end-user. SoftwareVersion is not editable, but it would be possible
+     * to create a new device model for the same VendorID/ProductID for different versions. Both SoftwareVersion
+     * and SoftwareVersionString SHALL be included. This field SHALL match the SoftwareVersion
+     * field in the Basic Information Cluster of a device running the software certified by this
+     * DeviceModel record.
+     */
+    softwareVersion: number;
+
+    /**
+     * This field SHALL match the Software Version String field in the Basic Information Cluster of a
+     * device running the software referenced by this DeviceModel record, including format constraints
+     * on that field.
+     */
+    softwareVersionString: string;
+
+    /**
+     * CDVersionNumber SHALL identify the CD Version Number of the Certification that applies to this
+     * Software Image. The CDVersionNumber maps to version_number defined in Certification Elements TLV
+     * structure.
+     */
+    cdVersionNumber: number;
+
+    /**
+     * The FirmwareInformation field, if present, SHALL match the firmware_information field in attestation-elements
+     * field included in the Device Attestation response when this Software Image boots on
+     * the device. It is an OPTIONAL field that MAY be present only for devices that meet the requirements
+     * listed in Section 6.3.2, “Firmware Information”.
+     */
+    firmwareInformation?: string;
+
+    /**
+     * This field SHALL indicate whether this SoftwareVersion is valid. When creating an entry for a new
+     * SoftwareVersion, this typically is set to True. When the manufacturer later finds out there is some
+     * reason that this version should no longer be used (e.g. due to some bugs), the field SHALL be
+     * updated to False.
+     */
+    softwareVersionValid: boolean;
+
+    /**
+     * OtaUrl SHALL identify the URL where to obtain the OTA image. The OtaUrl field SHALL be populated
+     * unless the device manufacturer provides alternative means to update the product’s firmware.
+     * The specified URL SHOULD be available for the relevant lifetime of the corresponding software.
+     * The syntax of this field SHALL follow the syntax as specified in RFC 1738 and SHALL use the https
+     * scheme. The maximum length of this field is 256 ASCII characters.
+     */
+    otaUrl?: string;
+
+    /**
+     * OtaFileSize is the total size of the OTA software image in bytes. This field SHALL be provided if the
+     * OtaUrl field is populated.
+     */
+    otaFileSize?: number | bigint; // TODO
+
+    /**
+     * OtaChecksum SHALL contain the digest of the entire contents of the associated OTA Software
+     * Update Image under the OtaUrl field, encoded in base64 string representation. The digest SHALL
+     * have been computed using the algorithm specified in OtaChecksumType. This field SHALL be provided
+     * if the OtaUrl field is populated.
+     */
+    otaChecksum?: string;
+
+    /**
+     * OtaChecksumType SHALL identify the type of OtaChecksum. This field SHALL be provided if the
+     * OtaUrl field is populated.
+     * The value of this field SHALL be a supported numerical identifier value from the IANA Named
+     * Information Hash Algorithm Registry [https://www.iana.org/assignments/named-information/named-information.xhtml#hash-alg]
+     * established as part of RFC 6920. For example, a value of 1 would match the sha-
+     * 256 identifier, which maps to the SHA-256 digest algorithm per Section 6.2 of FIPS 180-4.
+     * The digest algorithm chosen SHALL have a minimum digest length of 256 bits, such as sha-256 (ID 1
+     * in the registry).
+     * To increase interoperability, OtaChecksumType SHALL be within the list of [1, 7, 8, 10, 11, 12].
+     */
+    otaChecksumType?: number; // TODO: Define enum for checksum types
+
+    /**
+     * MinApplicableSoftwareVersion SHALL be equal to the lowest SoftwareVersion for which this image
+     * can be applied. Also see Section 11.21.2.4.6, “MinApplicableSoftwareVersion field”.
+     */
+    minApplicableSoftwareVersion: number;
+
+    /**
+     * MaxApplicableSoftwareVersion SHALL be equal to the highest SoftwareVersion for which this
+     * image can be applied. Also see Section 11.21.2.4.7, “MaxApplicableSoftwareVersion field”.
+     */
+    maxApplicableSoftwareVersion: number;
+
+    /**
+     * ReleaseNotesUrl SHALL identify a product specific web page that contains release notes for the
+     * device model software. The specified URL SHOULD resolve to a maintained web page available for
+     * the lifetime of the corresponding software being relevant. The syntax of this field SHALL follow the
+     * syntax as specified in RFC 1738 and SHALL use the https scheme. The maximum length of this field
+     * is 256 ASCII characters.
+     */
+    releaseNotesUrl?: string;
+
+    /**
+     * SpecificationVersion SHALL identify the specification version applicable to the device model. This
+     * field SHALL match the SpecificationVersion field in the Basic Information Cluster of a device running
+     * the software certified by this DeviceModel record.
+     */
+    specificationVersion?: number;
+
+    /**
+     * The SchemaVersion field value history for this schema is provided below:
+     * * 0: Initial Release
+     */
+    schemaVersion: number;
+}

--- a/packages/types/src/dcl/device.ts
+++ b/packages/types/src/dcl/device.ts
@@ -1,0 +1,243 @@
+/**
+ * @license
+ * Copyright 2022-2025 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { DeviceTypeId } from "../datatype/DeviceTypeId.js";
+import { VendorId } from "../datatype/VendorId.js";
+
+/**
+ * DeviceModel Schema
+ * @see {@link MatterSpecification.v141.Core} § 11.23.6.
+ * DCL endpoint:
+ *   * /dcl/model/models
+ *   * /dcl/model/models/{vid}
+ *   * /dcl/model/models/{vid}/{pid}
+ */
+export interface DeviceModelDclSchema {
+    /**
+     * This field SHALL identify the vendor of the product by its Vendor ID and SHALL match the VendorID
+     * field in the Basic Information Cluster of a device running the software referenced by this
+     * DeviceModel/DeviceSoftwareVersionModel record.
+     */
+    vid: VendorId; // Spec: vendorId
+
+    /**
+     * This field SHALL identify the Product ID of the product instance to which a certification declaration,
+     * and thus a DCL entry, applies. This field SHALL match the ProductID field in the Basic Information
+     * Cluster of a device running the software referenced by this DeviceModel/DeviceSoftwareVersionModel
+     * record.
+     */
+    pid: number; // Spec: productId
+
+    /**
+     * DeviceTypeID is the Primary Device Type identifier for the device. For example, DeviceTypeID is 10
+     * (0x000A), which is the device type identifier for a Door Lock.
+     */
+    deviceTypeID: DeviceTypeId;
+
+    /**
+     * This field SHOULD match the ProductName field in the Basic Information Cluster of a device running
+     * the software referenced by this DeviceModel record.
+     */
+    productName: string;
+
+    /**
+     * This field SHOULD match the ProductLabel field in the Basic Information Cluster of a device running
+     * the software referenced by this DeviceModel record.
+     */
+    productLabel: string;
+
+    /**
+     * This field SHALL match the PartNumber field in the Basic Information Cluster of a device running the
+     * software referenced by this DeviceModel record.
+     * Multiple products (and hence PartNumbers) can share a ProductID. For instance, there may be different
+     * packaging (with different PartNumbers) for different regions; also different colors of a product
+     * might share the ProductID but may have a different PartNumber. In such cases, the choice of a
+     * single PartNumber out of the available set of PartNumbers using this ProductID SHALL be used to
+     * populate this field.
+     */
+    partNumber: string;
+
+    /**
+     * This field SHALL identify the device’s available technologies for device discovery which SHALL be
+     * encoded as defined in Table 40, “Discovery Capabilities Bitmask”. This field SHALL match the Table
+     * 40, “Discovery Capabilities Bitmask” provided in the Section 5.1.3, “QR Code” (if a QR-code is provided
+     * on or with the product). This field SHALL be populated if the CommissioningFallbackUrl is
+     * populated, and SHOULD be populated for all other products.
+     */
+    discoveryCapabilitiesBitmask: number; // TODO
+
+    /**
+     * This field SHALL identify the device’s commissioning flow with encoding as described in Custom
+     * Flow.
+     */
+    commissioningCustomFlow: number;
+
+    /**
+     * This field SHALL identify a vendor-specific commissioning URL for the device model when the
+     * CommissioningCustomFlow field is set to '2', and MAY be set for other values of CommissioningCustomFlow.
+     * See Custom Commissioning Flow section for how this URL is used. During the lifetime of
+     * the product, the specified URL SHOULD resolve to a maintained web page. The syntax of this field
+     * SHALL follow the syntax as specified in RFC 1738 and SHALL use the https scheme. The maximum
+     * length of this field is 256 ASCII characters.
+     */
+    commissioningCustomFlowUrl?: string;
+
+    /**
+     * This field SHALL identify a hint for the steps that MAY be used to put a device that has not yet been
+     * commissioned into commissioning mode. This field is a bitmap with values defined in the Pairing
+     * Hint Table. For example, a value of 1 (bit 0 is set) indicates that a device that has not yet been commissioned
+     * will enter Commissioning Mode upon a power cycle.
+     * Devices that implement Extended Discovery SHALL reflect this value in the Pairing Hint field of
+     * Commissionable Node Discovery when they have not yet been commissioned.
+     */
+    commissioningModeInitialStepsHint: number; // TODO
+
+    /**
+     * This field SHALL be populated with the appropriate Pairing Instruction for those values of
+     * CommissioningModeInitialStepsHint, for which the Pairing Hint Table indicates a Pairing Instruction (PI)
+     * dependency.
+     * Devices that implement Extended Discovery SHALL reflect this value in the Pairing Instruction field
+     * of Commissionable Node Discovery when they have not yet been commissioned.
+     */
+    commissioningModeInitialStepsInstruction?: string;
+
+    /**
+     * This field SHALL identify a hint for the steps that MAY be used to put a device that has already been
+     * commissioned into commissioning mode. This field is a bitmap with values defined in the Pairing
+     * Hint Table. At least bit 2 SHALL be set, to indicate that a current Administrator can be used to put a
+     * device that has already been commissioned into commissioning mode (see Section 5.6.3, “Enhanced
+     * Commissioning Method (ECM)”). Devices which implement additional mechanisms to put a device
+     * that has already been commissioned into commissioning mode SHALL reflect these mechanism by
+     * setting the corresponding bits in this field.
+     * Devices that implement Extended Discovery SHALL reflect this value in the Pairing Hint field of
+     * Commissionable Node Discovery when they have already been commissioned.
+     */
+    commissioningModeSecondaryStepsHint: number; // TODO
+
+    /**
+     * This field SHALL be populated with the appropriate Pairing Instruction for those values of
+     * CommissioningModeSecondaryStepsHint, for which the Pairing Hint Table indicates a Pairing Instruction
+     * (PI) dependency.
+     * Devices that implement Extended Discovery SHALL reflect this value in the Pairing Instruction field
+     * of Commissionable Node Discovery when they have already been commissioned.
+     */
+    commissioningModeSecondaryStepsInstruction?: string;
+
+    /**
+     * This field SHALL identify a vendor-specific commissioning-fallback URL for the device model,
+     * which can be used by a Commissioner in case commissioning fails to direct the user to a manufacturer-provided
+     * mechanism to provide resolution to commissioning issues. See Commissioning Fallback
+     * section for how this URL is used.
+     * During the lifetime of the product, the specified URL SHOULD resolve to a maintained web page.
+     * The syntax of this field SHALL follow the syntax as specified in RFC 1738 and SHALL use the https
+     * scheme. The maximum length of this field is 256 ASCII characters.
+     */
+    commissioningFallbackUrl?: string;
+
+    /**
+     * This field (when provided) SHALL identify a product-specific web page containing a user manual
+     * for the device model. During the lifetime of the product, the specified URL SHOULD resolve to a
+     * maintained web page. The syntax of this field SHALL follow the syntax as specified in RFC 1738 and
+     * SHALL use the https scheme. The maximum length of this field is 256 ASCII characters.
+     */
+    userManualUrl?: string;
+
+    /**
+     * This field (when provided) SHALL identify a product specific support web page. During the lifetime
+     * of the product, the specified URL SHOULD resolve to a maintained web page. The syntax of this
+     * field SHALL follow the syntax as specified in RFC 1738 and SHALL use the https scheme. The maximum
+     * length of this field is 256 ASCII characters.
+     */
+    supportUrl?: string;
+
+    /**
+     * This field (when provided) SHALL identify a link to a product specific web page. This field SHALL
+     * match the ProductURL field in the Basic Information Cluster of a device running the software referenced
+     * by this DeviceModel record. During the lifetime of the product, the specified URL SHOULD resolve to a
+     * maintained web page. The syntax of this field SHALL follow the syntax as specified in
+     * RFC 1738 and SHALL use the https scheme. The maximum length of this field is 256 ASCII characters.
+     */
+    productUrl?: string;
+
+    /**
+     * This field (when provided) SHALL identify a link to the Localized String File of this product. This
+     * field SHALL NOT have a localized string identifier. During the lifetime of the product, the specified
+     * URL SHOULD resolve to a maintained Localized String File. The syntax of this field SHALL follow
+     * the syntax as specified in RFC 1738 and SHALL use the https scheme. The maximum length of this
+     * field is 256 ASCII characters.
+     */
+    lsfUrl?: string;
+
+    /**
+     * LsfRevision is a monotonically increasing positive integer indicating the latest available version of
+     * Localized String File. Any client can use this field to check whether it has the latest version of the
+     * Localized String File cached. When the first version of the Localized String File is published, the
+     * value of this field SHOULD be 1. When a new revision of the Localized String File is published, this
+     * value SHALL monotonically increase by 1. When a client of this information finds this to be greater
+     * than its currently stored LSF revision number, it SHOULD download the latest version of the LSF
+     * from the LsfUrl, and update its local value of this field.
+     * This field SHALL be provided if and only if when LsfUrl is provided.
+     */
+    lsfRevision?: number;
+
+    /**
+     * This field SHALL identify the configuration options for the Enhanced Setup Flow. This field is a
+     * bitmap with values defined in Enhanced Setup Flow Options Table.
+     */
+    enhancedSetupFlowOptions?: number; // TODO
+
+    /**
+     * This field (when provided) SHALL identify a link to the Enhanced Setup Flow Terms and Condition
+     * File for this product. During the lifetime of the product, the specified URL SHOULD resolve to a
+     * maintained Terms and Conditions File. The syntax of this field SHALL follow the syntax as specified
+     * in RFC 1738. The maximum length of this field is 256 ASCII characters. All URLs SHALL use the
+     * https scheme. This field SHALL be present if and only if the EnhancedSetupFlowOptions field has
+     * bit 0 set.
+     */
+    enhancedSetupFlowTCUrl?: string;
+
+    /**
+     * This field (when provided) is an increasing positive integer indicating the latest available version of
+     * the Enhanced Setup Flow Terms and Conditions file. When a new revision of the File is published,
+     * this value SHALL increase (and SHOULD increase by 1). This field SHALL be present if and only if
+     * the EnhancedSetupFlowOptions field has bit 0 set.
+     */
+    enhancedSetupFlowTCRevision?: number;
+
+    /**
+     * This field (when provided) SHALL contain the digest of the entire contents of the associated file
+     * downloaded from the EnhancedSetupFlowTCUrl field, encoded in base64 string representation and
+     * SHALL be used to ensure the contents of the downloaded file are authentic. The digest SHALL have
+     * been computed using the SHA-256 digest algorithm. This field SHALL be present if and only if the
+     * EnhancedSetupFlowOptions field has bit 0 set.
+     */
+    enhancedSetupFlowTCDigest?: string;
+
+    /**
+     * This field (when provided) SHALL indicate the total size of the Enhanced Setup Flow Terms and
+     * Conditions file in bytes, and SHALL be used to ensure the downloaded file size is within the bounds
+     * of EnhancedSetupFlowTCFileSize. This field SHALL be provided if and only if the EnhancedSetupFlowTCUrl
+     * field is present.
+     */
+    enhancedSetupFlowTCFileSize?: number;
+
+    /**
+     * This field (when provided) SHALL identify a link to a vendor-specific URL which SHALL provide a
+     * manufacturer specific means to resolve any functionality limitations indicated by the
+     * TERMS_AND_CONDITIONS_CHANGED status code. This field SHALL be present if the EnhancedSetupFlowOptions
+     * field has bit 0 set. During the lifetime of the product, the specified URL SHOULD
+     * resolve to a maintained web page. The syntax of this field SHALL follow the syntax as specified in
+     * RFC 1738. The maximum length of this field is 256 ASCII characters. All URLs SHALL use the https
+     * scheme.
+     */
+    enhancedSetupFlowMaintenanceUrl?: string;
+
+    /**
+     * The SchemaVersion field value history for this schema is provided below:
+     * * 0: Initial Release
+     */
+    schemaVersion: number;
+}

--- a/packages/types/src/dcl/index.ts
+++ b/packages/types/src/dcl/index.ts
@@ -1,0 +1,13 @@
+/**
+ * @license
+ * Copyright 2022-2025 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export * from "./attestation-certificate.js";
+export * from "./device-attestation-revocation.js";
+export * from "./device-software-compliance.js";
+export * from "./device-software-version.js";
+export * from "./device.js";
+export * from "./operational-certificate.js";
+export * from "./vendor.js";

--- a/packages/types/src/dcl/operational-certificate.ts
+++ b/packages/types/src/dcl/operational-certificate.ts
@@ -1,0 +1,90 @@
+/**
+ * @license
+ * Copyright 2022-2025 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Operational Root and Intermediate Certificate Schema
+ * @see {@link MatterSpecification.v141.Core} § 11.23.5.
+ */
+export interface OperationalCertificateDclSchema {
+    /**
+     * This field uniquely identifies a certificate and SHALL contain the body of a certificate that has been
+     * added in the DCL. It SHALL be encoded in PEM format. The certificate SHALL respect the format
+     * constraints provided for that certificate type.
+     */
+    pemCert: string;
+
+    /**
+     * The field SHALL be used to identify the serial number field in the Matter certificate structure. A
+     * Matter certificate follows the same limitation on admissible serial numbers as in [RFC 5280], i.e.,
+     * that implementations SHALL admit serial numbers up to 20 octets in length, and certificate authorities
+     * SHALL NOT use serial numbers longer than 20 octets in length.
+     */
+    serialNumber: string;
+
+    /**
+     * The field SHALL be used to identify the Certificate Authority that issues the certificate. For a
+     * Operational Root CA Certificates (RCAC), this field is OPTIONAL because Issuer and
+     * Subject are the same.
+     */
+    issuer?: string;
+
+    /**
+     * The authority key identifier extension provides a means of identifying the public key corresponding
+     * to the private key used to sign a Matter certificate. This is OPTIONAL for Operational Root CA
+     * Certificates (RCAC).
+     */
+    authorityKeyID?: string;
+
+    /**
+     * This field SHALL contain the PAA certificate’s Subject field, as defined Operational Root CA Certificates
+     * (RCAC). This is OPTIONAL for Operational Root CA Certificates (RCAC). This is encoded as
+     * defined in Section 6.1, “Certificate Common Conventions”.
+     */
+    rootSubject?: string;
+
+    /**
+     * This field SHALL uniquely identify the PAA certificate’s Subject Key Identifier mandatory extension.
+     * It is defined in PAA Certificate and Operational Root CA Certificates (RCAC). This is OPTIONAL
+     * for Operational Root CA Certificates (RCAC). This is encoded as defined in Section 6.1, “Certificate
+     * Common Conventions”.
+     */
+    rootSubjectKeyID?: string;
+
+    /**
+     * This field SHALL signify whether the associated certificates is a Operational Root CA Certificate
+     * (RCAC).
+     */
+    isRoot: boolean;
+
+    /**
+     * This field uniquely identifies the DCL key that was used to register the certificate in DCL, pursuant
+     * to DCL policies.
+     */
+    owner: string;
+
+    /**
+     * This field SHALL contain the certificate’s Subject field. This is encoded as defined in Section 6.1,
+     * “Certificate Common Conventions”.
+     */
+    subject: string;
+
+    /**
+     * This field SHALL uniquely identify the PAA certificate’s Subject Key Identifier mandatory extension.
+     * This is encoded as defined in Section 6.1.2, “Key Identifier Extension Constraints”.
+     */
+    subjectKeyID: string;
+
+    /**
+     * This field SHALL contain the Vendor ID of the vendor that issued the certificate.
+     */
+    vid: number;
+
+    /**
+     * The SchemaVersion field value history for this schema is provided below:
+     * * ???
+     */
+    schemaVersion: number;
+}

--- a/packages/types/src/dcl/vendor.ts
+++ b/packages/types/src/dcl/vendor.ts
@@ -1,0 +1,53 @@
+/**
+ * @license
+ * Copyright 2022-2025 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { VendorId } from "../datatype/VendorId.js";
+
+/**
+ * Vendor Schema
+ * @see {@link MatterSpecification.v141.Core} § 11.23.3.
+ * DCL Endpoint: /dcl/vendorinfo/vendors or /dcl/vendorinfo/vendors/{vendorID}
+ */
+export interface VendorDclSchema {
+    /**
+     * This field SHALL uniquely identify this Vendor Schema entry and it SHALL match the Vendor’s
+     * assigned Vendor ID.
+     */
+    vendorID: VendorId;
+
+    /**
+     * This field SHALL provide a human readable (displayable) name for the product manufacturer associated
+     * with this record. Maximum length is 128 characters.
+     */
+    vendorName: string;
+
+    /**
+     * The CompanyLegalName field SHALL specify the legal name for the product manufacturer.
+     * Maximum length is 256 characters.
+     */
+    companyLegalName: string;
+
+    /**
+     * The CompanyPreferredName field, if provided, SHALL specify the Preferred Name that MAY be
+     * used for display purposes instead of the CompanyLegalName. Maximum length is 256 characters.
+     */
+    companyPreferredName?: string;
+
+    /**
+     * The VendorLandingPageUrl field (when provided) SHALL contain a link to a maintained web page
+     * containing more information about the device manufacturer, such as contact information, address,
+     * etc. During the lifetime of the products of this manufacturer, the specified URL SHOULD resolve to a
+     * maintained web page. The syntax of this field SHALL follow the syntax as specified in RFC 1738 and
+     * SHALL use the https scheme. The maximum length of this field is 256 ASCII characters.
+     */
+    vendorLandingPageUrl?: string;
+
+    /**
+     * The SchemaVersion field value history for this schema is provided below:
+     * * 0: Initial Release
+     */
+    schemaVersion: number;
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -10,6 +10,7 @@ export * from "./cluster/index.js";
 export * from "./commissioning/index.js";
 export * from "./common/index.js";
 export * from "./datatype/index.js";
+export * from "./dcl/index.js";
 export * from "./globals/index.js";
 export * from "./protocol/index.js";
 export * from "./schema/index.js";


### PR DESCRIPTION
This PR is preparing the ground for DCL usage, so it is not wired in. Types are taken from Spec but adjusted as it is in reality by the DCL servers, because some fields differ. A basic fetch client is also prepared to allow to read data from the DCL servers.

The real wiring-in comes later. Also some of the TODOS will then be clarified when we need/use the data