### PR TITLE
Fix DNS-SD encoding of special IPv6 addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Breaking: The `Network.get()` singleton is removed
     - Breaking: The Crypto interface has changed; `Crypto.get()` singleton is removed, the API is modernized, methods are renamed for clarity, and the ecdh* methods are replaced with generateDhSecret
     - Feature: Adds a crypto implementation that should function in any modern JS VM
-    - Fix: Fixes encoding of special IPv6 addresses in DNS-SS records
+    - Fix: Fixes encoding of special IPv6 addresses in DNS-SD records
 
 -   @matter/node
     - Enhancement: Finalizes behavior event `interactionBegin` to fire at the begin of an interaction as soon as the datasource is about to be changed on a behavior

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Breaking: The `Network.get()` singleton is removed
     - Breaking: The Crypto interface has changed; `Crypto.get()` singleton is removed, the API is modernized, methods are renamed for clarity, and the ecdh* methods are replaced with generateDhSecret
     - Feature: Adds a crypto implementation that should function in any modern JS VM
+    - Fix: Fixes encoding of special IPv6 addresses in DNS-SS records
 
 -   @matter/node
     - Enhancement: Finalizes behavior event `interactionBegin` to fire at the begin of an interaction as soon as the datasource is about to be changed on a behavior

--- a/packages/general/src/util/Ip.ts
+++ b/packages/general/src/util/Ip.ts
@@ -3,6 +3,7 @@
  * Copyright 2022-2025 Matter.js Authors
  * SPDX-License-Identifier: Apache-2.0
  */
+import { UnexpectedDataError } from "#MatterError.js";
 import { Bytes } from "./Bytes.js";
 
 export function isIPv4(ip: string) {
@@ -46,9 +47,16 @@ export function ipv6ToBytes(ip: string) {
     return Uint8Array.from(Array.from(ipv6ToArray(ip)).flatMap(value => [value >> 8, value & 0xff]));
 }
 
+export function ipv4BytesToString(bytes: Uint8Array): string {
+    if (bytes.length !== 4) {
+        throw new UnexpectedDataError("IPv4 address must be 4 bytes");
+    }
+    return bytes.join(".");
+}
+
 export function ipv6BytesToString(bytes: Uint8Array): string {
     if (bytes.length !== 16) {
-        throw new Error("IPv6 address must be 16 bytes");
+        throw new UnexpectedDataError("IPv6 address must be 16 bytes");
     }
 
     // Divide into 8 blocks of 2 bytes (16 bits) each

--- a/packages/general/test/codec/DnsCodecTest.ts
+++ b/packages/general/test/codec/DnsCodecTest.ts
@@ -278,4 +278,50 @@ describe("DnsCodec", () => {
             });
         }
     });
+
+    describe("encode and decode AAAA records", () => {
+        it("encodes and decodes AAAA fe80 record", () => {
+            const encoded = DnsCodec.encodeAaaaRecord("fe80::9580:b733:6f54:9f43");
+            expect(Bytes.toHex(encoded)).equal("fe800000000000009580b7336f549f43");
+            expect(encoded.length).equal(16);
+            const decoded = DnsCodec.decodeAaaaRecord(encoded);
+            expect(decoded).equal("fe80::9580:b733:6f54:9f43");
+            const reEncoded = DnsCodec.encodeAaaaRecord(decoded);
+            expect(Bytes.toHex(reEncoded)).equal("fe800000000000009580b7336f549f43");
+            expect(reEncoded.length).equal(16);
+        });
+
+        it("encodes and decodes AAAA record ::1", () => {
+            const encoded = DnsCodec.encodeAaaaRecord("::1");
+            expect(Bytes.toHex(encoded)).equal("00000000000000000000000000000001");
+            expect(encoded.length).equal(16);
+            const decoded = DnsCodec.decodeAaaaRecord(encoded);
+            expect(decoded).equal("::1");
+            const reEncoded = DnsCodec.encodeAaaaRecord(decoded);
+            expect(Bytes.toHex(reEncoded)).equal("00000000000000000000000000000001");
+            expect(reEncoded.length).equal(16);
+        });
+
+        it("encodes and decodes AAAA record ::", () => {
+            const encoded = DnsCodec.encodeAaaaRecord("::");
+            expect(Bytes.toHex(encoded)).equal("00000000000000000000000000000000");
+            expect(encoded.length).equal(16);
+            const decoded = DnsCodec.decodeAaaaRecord(encoded);
+            expect(decoded).equal("::");
+            const reEncoded = DnsCodec.encodeAaaaRecord(decoded);
+            expect(Bytes.toHex(reEncoded)).equal("00000000000000000000000000000000");
+            expect(reEncoded.length).equal(16);
+        });
+
+        it("encodes and decodes AAAA record with more cutted 0s", () => {
+            const encoded = DnsCodec.encodeAaaaRecord("fe80::1");
+            expect(Bytes.toHex(encoded)).equal("fe800000000000000000000000000001");
+            expect(encoded.length).equal(16);
+            const decoded = DnsCodec.decodeAaaaRecord(encoded);
+            expect(decoded).equal("fe80::1");
+            const reEncoded = DnsCodec.encodeAaaaRecord(decoded);
+            expect(Bytes.toHex(reEncoded)).equal("fe800000000000000000000000000001");
+            expect(reEncoded.length).equal(16);
+        });
+    });
 });


### PR DESCRIPTION
This fix removes some duplicate code and especially a buggy DNS-SD encoding of special IPv6 adresses like ::1 (this was encoded to >16 bytes)