### PR TITLE
Pass fabric and ca from options to matter.js MatterController class

### DIFF
--- a/packages/matter.js/src/CommissioningController.ts
+++ b/packages/matter.js/src/CommissioningController.ts
@@ -241,6 +241,8 @@ export class CommissioningController {
             caseAuthenticatedTags,
             adminFabricLabel,
             rootNodeId,
+            rootCertificateAuthority,
+            rootFabric,
         } = this.#options;
 
         if (environment === undefined && storage === undefined) {
@@ -278,6 +280,8 @@ export class CommissioningController {
             caseAuthenticatedTags,
             adminFabricLabel,
             rootNodeId,
+            rootCertificateAuthority,
+            rootFabric,
         });
         if (this.#mdnsBroadcaster) {
             controller.addBroadcaster(this.#mdnsBroadcaster.createInstanceBroadcaster(port));


### PR DESCRIPTION
In the matter.js package the CommissioningControllerOptions interface defines two fields _rootFabric_ and _rootCertificateAuthority_ however the parameters are not passed into the MatterController instance created in **#initializeController** method.

This MR passes them from the CommissioningController class's _options_ property.