### PR TITLE
Flesh out write logic for ClientNode

### DIFF
--- a/packages/general/src/MatterError.ts
+++ b/packages/general/src/MatterError.ts
@@ -210,6 +210,17 @@ export class MatterAggregateError extends AggregateError {
         return MatterError.idFor(this);
     }
 
+    /**
+     * Add causes without stack traces.
+     *
+     * This is useful to create a compact representation if all child errors originate externally or from the same
+     * logical location as the parent error.
+     */
+    addStackless(error: Error) {
+        error.stack = undefined;
+        this.errors.push(error);
+    }
+
     // TODO - see comment on MatterError.  If that one is correct this is incorrect
     static override [Symbol.hasInstance](instance: unknown) {
         if (instance instanceof MatterError) {

--- a/packages/general/src/transaction/index.ts
+++ b/packages/general/src/transaction/index.ts
@@ -5,4 +5,5 @@
  */
 
 export * from "./errors.js";
+export * from "./Participant.js";
 export * from "./Transaction.js";

--- a/packages/matter.js/src/device/CachedClientNodeStore.ts
+++ b/packages/matter.js/src/device/CachedClientNodeStore.ts
@@ -84,7 +84,7 @@ export class CachedClientNodeStore extends PeerDataStore {
         attributeId: AttributeId,
     ): DecodedAttributeReportValue<any> | undefined {
         const store = this.#storeForEndpoint(endpointId);
-        const clusterValues = store.get[clusterId];
+        const clusterValues = store.get.get(clusterId.toString());
         if (clusterValues === undefined) {
             return undefined;
         }
@@ -112,7 +112,7 @@ export class CachedClientNodeStore extends PeerDataStore {
 
     retrieveAttributes(endpointId: EndpointNumber, clusterId: ClusterId): DecodedAttributeReportValue<any>[] {
         const store = this.#storeForEndpoint(endpointId);
-        const clusterValues = store.get[clusterId];
+        const clusterValues = store.get.get(clusterId.toString());
         if (clusterValues === undefined) {
             return [];
         }
@@ -166,7 +166,7 @@ export class CachedClientNodeStore extends PeerDataStore {
 
     getClusterDataVersion(endpointId: EndpointNumber, clusterId: ClusterId): number | undefined {
         const store = this.#storeForEndpoint(endpointId);
-        const clusterValues = store.get[clusterId];
+        const clusterValues = store.get.get(clusterId.toString());
         return clusterValues?.[VERSION_KEY] as number | undefined;
     }
 
@@ -185,7 +185,7 @@ export class CachedClientNodeStore extends PeerDataStore {
                 if (filterClusterIdStr !== undefined && clusterId !== filterClusterIdStr) {
                     continue;
                 }
-                const version = endpointData[clusterId][VERSION_KEY];
+                const version = endpointData.get(clusterId.toString())![VERSION_KEY];
                 if (typeof version === "number") {
                     versions.push({ endpointId, clusterId: ClusterId(parseInt(clusterId)), dataVersion: version });
                 }

--- a/packages/matter.js/src/device/ClientEndpointStore.ts
+++ b/packages/matter.js/src/device/ClientEndpointStore.ts
@@ -15,7 +15,7 @@ import { Val } from "@matter/protocol";
  */
 export class ClientEndpointStore extends ServerEndpointStore {
     readonly #construction: Construction<ServerEndpointStore>;
-    #values: Record<string, Val.Struct> = {};
+    #values = new Map<string, Val.Struct>();
 
     constructor(storage: StorageContext, load = true) {
         super(storage);
@@ -26,7 +26,7 @@ export class ClientEndpointStore extends ServerEndpointStore {
 
                 // Copy over initial values from the superclass
                 this.#values = this.initialValues;
-                this.initialValues = {};
+                this.initialValues = new Map();
             }
         });
     }
@@ -46,19 +46,20 @@ export class ClientEndpointStore extends ServerEndpointStore {
         for (const behaviorId in values) {
             const behaviorValues = values[behaviorId];
             if (behaviorValues === undefined) {
-                delete this.#values[behaviorId];
+                this.#values.delete(behaviorId);
             } else {
                 for (const key in behaviorValues) {
                     const value = behaviorValues[key];
                     if (value === undefined) {
-                        delete this.#values[behaviorId][key];
+                        delete this.#values.get(behaviorId)?.[key];
                     } else {
-                        if (!this.#values[behaviorId]) {
-                            this.#values[behaviorId] = {};
-                        } else if (isDeepEqual(this.#values[behaviorId][key], value)) {
+                        let vals = this.#values.get(behaviorId);
+                        if (!vals) {
+                            this.#values.set(behaviorId, (vals = {}));
+                        } else if (isDeepEqual(vals[key], value)) {
                             delete behaviorValues[key];
                         }
-                        this.#values[behaviorId][key] = value;
+                        vals[key] = value;
                     }
                 }
             }

--- a/packages/model/src/common/DataModelPath.ts
+++ b/packages/model/src/common/DataModelPath.ts
@@ -4,12 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { Diagnostic } from "#general";
+
 /**
  * Utility for tracking location in the Matter data model.  This location is used for diagnostics.
  *
  * The path consists of a sequence of IDs, optionally with type information.
  */
-export interface DataModelPath {
+export interface DataModelPath extends Diagnostic {
     parent?: DataModelPath;
 
     id: string | number;
@@ -21,6 +23,8 @@ export interface DataModelPath {
     toString(includeType?: boolean): string;
 
     toArray(): (string | number)[];
+
+    [Diagnostic.value]: Diagnostic;
 }
 
 /**
@@ -48,6 +52,17 @@ export function DataModelPath(id: string | number, type?: string): DataModelPath
         return [this.id];
     }
 
+    function asDiagnostic(this: DataModelPath) {
+        const result = Array<unknown>();
+        for (const segment of this.toArray()) {
+            if (result.length) {
+                result.push(".");
+            }
+            result.push(Diagnostic.strong(segment));
+        }
+        return Diagnostic.squash(result);
+    }
+
     function at(this: DataModelPath, id: string | number, type?: string): DataModelPath {
         return {
             parent: this,
@@ -56,6 +71,9 @@ export function DataModelPath(id: string | number, type?: string): DataModelPath
             at,
             toString,
             toArray,
+            get [Diagnostic.value]() {
+                return asDiagnostic.apply(this);
+            },
         };
     }
 
@@ -65,6 +83,9 @@ export function DataModelPath(id: string | number, type?: string): DataModelPath
         at,
         toString,
         toArray,
+        get [Diagnostic.value]() {
+            return asDiagnostic.apply(this);
+        },
     };
 }
 

--- a/packages/node/src/behavior/internal/BehaviorBacking.ts
+++ b/packages/node/src/behavior/internal/BehaviorBacking.ts
@@ -46,9 +46,10 @@ export abstract class BehaviorBacking {
         return this.#construction;
     }
 
-    constructor(endpoint: Endpoint, type: Behavior.Type, options?: Behavior.Options) {
+    constructor(endpoint: Endpoint, type: Behavior.Type, store: Datasource.Store, options?: Behavior.Options) {
         this.#endpoint = endpoint;
         this.#type = type;
+        this.store = store;
         this.#options = options;
 
         this.#construction = Construction(this);
@@ -201,7 +202,7 @@ export abstract class BehaviorBacking {
     /**
      * The data provider for {@link datasource}.
      */
-    protected abstract readonly store?: Datasource.Store;
+    protected readonly store: Datasource.Store;
 
     /**
      * Obtain internal state for a behavior instance.

--- a/packages/node/src/behavior/internal/ClientBehaviorBacking.ts
+++ b/packages/node/src/behavior/internal/ClientBehaviorBacking.ts
@@ -4,10 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Behavior } from "#behavior/Behavior.js";
 import { GlobalAttributeState } from "#behavior/cluster/ClusterState.js";
-import { Datasource } from "#behavior/state/managed/Datasource.js";
-import { Endpoint } from "#endpoint/Endpoint.js";
 import { SupportedElements } from "#endpoint/properties/Behaviors.js";
 import { camelize } from "#general";
 import { ClusterModel } from "#model";
@@ -18,19 +15,7 @@ import { BehaviorBacking } from "./BehaviorBacking.js";
  * This class backs the client implementation of a behavior.
  */
 export class ClientBehaviorBacking extends BehaviorBacking {
-    protected override store: Datasource.ExternallyMutableStore;
     #elements?: SupportedElements;
-
-    constructor(
-        endpoint: Endpoint,
-        behavior: Behavior.Type,
-        store: Datasource.ExternallyMutableStore,
-        options?: Behavior.Options,
-    ) {
-        super(endpoint, behavior, options);
-
-        this.store = store;
-    }
 
     get elements(): SupportedElements | undefined {
         if (this.#elements) {

--- a/packages/node/src/behavior/internal/ServerBehaviorBacking.ts
+++ b/packages/node/src/behavior/internal/ServerBehaviorBacking.ts
@@ -11,11 +11,8 @@ import type { SupportedElements } from "#endpoint/properties/Behaviors.js";
 import { camelize } from "#general";
 import { FieldValue } from "#model";
 import { Val } from "#protocol";
-import { NodeStore } from "#storage/NodeStore.js";
-import { DatasourceStore } from "#storage/server/DatasourceStore.js";
 import { ClusterType, TlvNoResponse } from "#types";
 import { Behavior } from "../Behavior.js";
-import { Datasource } from "../state/managed/Datasource.js";
 import { BehaviorBacking } from "./BehaviorBacking.js";
 
 const NoElements = new Set<string>();
@@ -24,19 +21,7 @@ const NoElements = new Set<string>();
  * This class backs the server implementation of a behavior.
  */
 export class ServerBehaviorBacking extends BehaviorBacking {
-    #store?: Datasource.Store;
     #elements?: SupportedElements;
-
-    override get store() {
-        if (!this.#store) {
-            this.#store = this.createStore();
-        }
-        return this.#store;
-    }
-
-    protected createStore() {
-        return this.#nodeStore.storeForEndpoint(this.endpoint).createStoreForBehavior(this.type.id, DatasourceStore);
-    }
 
     get elements() {
         return this.#elements;
@@ -68,10 +53,6 @@ export class ServerBehaviorBacking extends BehaviorBacking {
         }
 
         finalizeState();
-    }
-
-    get #nodeStore() {
-        return this.endpoint.env.get(NodeStore);
     }
 
     /**

--- a/packages/node/src/node/ClientNode.ts
+++ b/packages/node/src/node/ClientNode.ts
@@ -14,7 +14,7 @@ import { EndpointInitializer } from "#endpoint/properties/EndpointInitializer.js
 import { Identity, Lifecycle, MaybePromise } from "#general";
 import { Interactable } from "#protocol";
 import { ClientNodeStore } from "#storage/client/ClientNodeStore.js";
-import { NodeStore } from "#storage/NodeStore.js";
+import { RemoteWriter } from "#storage/client/RemoteWriter.js";
 import { ServerNodeStore } from "#storage/server/ServerNodeStore.js";
 import { Matter, MatterModel } from "@matter/model";
 import { ClientEndpointInitializer } from "./client/ClientEndpointInitializer.js";
@@ -58,11 +58,13 @@ export class ClientNode extends Node<ClientNode.RootEndpoint> {
 
     override initialize() {
         const store = this.env.get(ServerNodeStore).clientStores.storeForNode(this);
-        this.env.set(NodeStore, store);
+
         this.env.set(ClientNodeStore, store);
 
         const initializer = new ClientEndpointInitializer(this);
         this.env.set(EndpointInitializer, initializer);
+
+        store.write = RemoteWriter(this, initializer.structure);
 
         initializer.structure.loadCache();
 

--- a/packages/node/src/node/ServerNode.ts
+++ b/packages/node/src/node/ServerNode.ts
@@ -17,7 +17,7 @@ import { Endpoint } from "#endpoint/Endpoint.js";
 import type { Environment } from "#general";
 import { asyncNew, Construction, DiagnosticSource, errorOf, Identity, MatterError } from "#general";
 import { FabricManager, Interactable, OccurrenceManager, ServerInteraction, SessionManager } from "#protocol";
-import { NodeStore } from "#storage/NodeStore.js";
+import { ServerNodeStore } from "#storage/server/ServerNodeStore.js";
 import { RootEndpoint as BaseRootEndpoint } from "../endpoints/root.js";
 import { Node } from "./Node.js";
 import { ClientNodes } from "./client/ClientNodes.js";
@@ -192,7 +192,7 @@ export class ServerNode<T extends ServerNode.RootEndpoint = ServerNode.RootEndpo
         await this.env.get(SessionManager).clear();
         await this.env.get(FabricManager).clear();
         await this.env.get(OccurrenceManager).clear();
-        await this.env.get(NodeStore).erase();
+        await this.env.get(ServerNodeStore).erase();
     }
 
     /**

--- a/packages/node/src/node/server/ServerEndpointInitializer.ts
+++ b/packages/node/src/node/server/ServerEndpointInitializer.ts
@@ -59,7 +59,9 @@ export class ServerEndpointInitializer extends EndpointInitializer {
      * initializes.
      */
     createBacking(endpoint: Endpoint, type: Behavior.Type): BehaviorBacking {
-        return new ServerBehaviorBacking(endpoint, type, endpoint.behaviors.optionsFor(type));
+        const store = this.#store.storeForEndpoint(endpoint).createStoreForBehavior(type.id);
+
+        return new ServerBehaviorBacking(endpoint, type, store, endpoint.behaviors.optionsFor(type));
     }
 
     /**

--- a/packages/node/src/node/server/ServerEnvironment.ts
+++ b/packages/node/src/node/server/ServerEnvironment.ts
@@ -10,7 +10,6 @@ import { Crypto, Observable } from "#general";
 import { ServerEndpointInitializer } from "#node/server/ServerEndpointInitializer.js";
 import type { ServerNode } from "#node/ServerNode.js";
 import { FabricManager, SessionManager } from "#protocol";
-import { NodeStore } from "#storage/NodeStore.js";
 import { ServerNodeStore } from "#storage/server/ServerNodeStore.js";
 import { IdentityService } from "./IdentityService.js";
 
@@ -26,7 +25,6 @@ export namespace ServerEnvironment {
 
         // Install support services
         const store = await ServerNodeStore.create(env, node.id);
-        env.set(NodeStore, store);
         env.set(ServerNodeStore, store);
         env.set(EndpointInitializer, new ServerEndpointInitializer(env));
         env.set(IdentityService, new IdentityService(node));

--- a/packages/node/src/storage/client/ClientEndpointStore.ts
+++ b/packages/node/src/storage/client/ClientEndpointStore.ts
@@ -1,0 +1,53 @@
+/**
+ * @license
+ * Copyright 2022-2025 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { StorageContext, Transaction } from "#general";
+import { EndpointStore } from "#storage/EndpointStore.js";
+import { DatasourceStore } from "#storage/server/DatasourceStore.js";
+import type { EndpointNumber } from "#types";
+import type { ClientNodeStore } from "./ClientNodeStore.js";
+import { DatasourceCache } from "./DatasourceCache.js";
+import { RemoteWriteParticipant } from "./RemoteWriteParticipant.js";
+
+export class ClientEndpointStore extends EndpointStore {
+    #owner: ClientNodeStore;
+    #number: EndpointNumber;
+
+    constructor(owner: ClientNodeStore, number: EndpointNumber, storage: StorageContext) {
+        super(storage);
+        this.#owner = owner;
+        this.#number = number;
+    }
+
+    get number() {
+        return this.#number;
+    }
+
+    participantFor(transaction: Transaction) {
+        let participant = transaction.getParticipant(this.#owner);
+        if (participant === undefined) {
+            participant = new RemoteWriteParticipant(this.#owner);
+            transaction.addParticipants(participant);
+        }
+        return participant;
+    }
+
+    /**
+     * Create a {@link Datasource.ExternallyMutableStore} for a behavior.
+     */
+    createStoreForBehavior(behaviorId: string) {
+        const initialValues = this.consumeInitialValues(behaviorId);
+        return DatasourceCache(this, behaviorId, initialValues);
+    }
+
+    /**
+     * Create a {@link Datasource.Store} for a behavior that does not track a remote cluster.
+     */
+    createStoreForLocalBehavior(behaviorId: string) {
+        const initialValues = this.consumeInitialValues(behaviorId);
+        return DatasourceStore(this, behaviorId, initialValues);
+    }
+}

--- a/packages/node/src/storage/client/ClientNodeStores.ts
+++ b/packages/node/src/storage/client/ClientNodeStores.ts
@@ -7,7 +7,6 @@
 import { Construction, MatterAggregateError, StorageContext } from "#general";
 import type { ClientNode } from "#node/ClientNode.js";
 import type { Node } from "#node/Node.js";
-import { NodeStore } from "../NodeStore.js";
 import { ClientNodeStore } from "./ClientNodeStore.js";
 
 const CLIENT_ID_PREFIX = "peer";
@@ -17,7 +16,7 @@ const CLIENT_ID_PREFIX = "peer";
  */
 export class ClientNodeStores {
     #storage: StorageContext;
-    #stores = {} as Record<string, NodeStore>;
+    #stores = {} as Record<string, ClientNodeStore>;
     #construction: Construction<ClientNodeStores>;
     #nextAutomaticId = 1;
 
@@ -72,7 +71,7 @@ export class ClientNodeStores {
      *
      * These stores are cached internally by ID.
      */
-    storeForNode(node: ClientNode): NodeStore {
+    storeForNode(node: ClientNode): ClientNodeStore {
         this.#construction.assert();
 
         const store = this.#stores[node.id];
@@ -97,7 +96,7 @@ export class ClientNodeStores {
     }
 
     #createNodeStore(id: string) {
-        const store = new ClientNodeStore(this.#storage.createContext(id));
+        const store = new ClientNodeStore(id, this.#storage.createContext(id));
         store.construction.start();
         this.#stores[id] = store;
         return store;

--- a/packages/node/src/storage/client/RemoteWriteParticipant.ts
+++ b/packages/node/src/storage/client/RemoteWriteParticipant.ts
@@ -1,0 +1,62 @@
+/**
+ * @license
+ * Copyright 2022-2025 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Transaction } from "#general";
+import { Val } from "#protocol";
+import { EndpointNumber } from "#types";
+import type { ClientNodeStore } from "./ClientNodeStore.js";
+import type { RemoteWriter } from "./RemoteWriter.js";
+
+/**
+ * A transaction participant that persists changes to a remote node.
+ *
+ * There is one of these for node/transaction pair.  All attributes in a transaction commit with a single interaction.
+ */
+export class RemoteWriteParticipant implements Transaction.Participant {
+    #request: RemoteWriter.Request = [];
+    #store: ClientNodeStore;
+
+    /**
+     * There is one participant for each transaction/client node pair.  We therefore use the store as the role.
+     */
+    get role() {
+        return this.#store;
+    }
+
+    /**
+     * Add an attribute update to the write request.
+     */
+    set(endpointNumber: EndpointNumber, behaviorId: string, values: Val.Struct) {
+        this.#request.push({
+            number: endpointNumber,
+            behaviorId: behaviorId,
+            values,
+        });
+    }
+
+    async commit2() {
+        if (!this.#request.length) {
+            return;
+        }
+
+        const request = this.#request;
+        this.#request = [];
+
+        await this.#store.write(request);
+    }
+
+    rollback() {
+        this.#request = [];
+    }
+
+    toString() {
+        return `writer#${this.#store.id}`;
+    }
+
+    constructor(store: ClientNodeStore) {
+        this.#store = store;
+    }
+}

--- a/packages/node/src/storage/client/RemoteWriter.ts
+++ b/packages/node/src/storage/client/RemoteWriter.ts
@@ -1,0 +1,81 @@
+/**
+ * @license
+ * Copyright 2022-2025 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { InternalError } from "#general";
+import { ClientStructure } from "#node/client/ClientStructure.js";
+import type { ClientNode } from "#node/ClientNode.js";
+import { Write, WriteResult, type Val } from "#protocol";
+import type { ClusterId, ClusterType, EndpointNumber } from "#types";
+import type { ClientNodeStore } from "./ClientNodeStore.js";
+
+/**
+ * Persistence handler for {@link ClientNodeStore}.
+ *
+ * A remote writer conveys updates to the remote node.  This performs actual persistence for client nodes where the
+ * local store is just a cache and the source of truth is on the remote device.
+ */
+export interface RemoteWriter {
+    (request: RemoteWriter.Request): Promise<void>;
+}
+
+const attrCache = new WeakMap<ClusterType, Record<string, ClusterType.Attribute>>();
+
+export function RemoteWriter(node: ClientNode, structure: ClientStructure): RemoteWriter {
+    return async function writeRemote(request: RemoteWriter.Request) {
+        const attrWrites = Array<Write.Attribute>();
+        for (const { number, behaviorId, values } of request) {
+            const cluster = structure.clusterFor(number, Number.parseInt(behaviorId) as ClusterId);
+            if (cluster === undefined) {
+                throw new InternalError(`Cannot remote write to non-cluster behavior ${behaviorId}`);
+            }
+            const attrs = attrsFor(cluster);
+
+            for (const id in values) {
+                const attr = attrs[id];
+                if (attr === undefined) {
+                    if (id.startsWith("__")) {
+                        continue;
+                    }
+
+                    throw new InternalError(`Cannot write unknown attribute ${id} for ${behaviorId}`);
+                }
+
+                attrWrites.push(
+                    Write.Attribute({
+                        endpoint: number,
+                        cluster,
+                        attributes: [attrs[id]],
+                        value: values[id],
+                    }),
+                );
+            }
+        }
+
+        const write = Write(...attrWrites);
+        const response = await node.interaction.write(write);
+        WriteResult.assertSuccess(response);
+    };
+}
+
+export namespace RemoteWriter {
+    export interface EndpointUpdateRequest {
+        number: EndpointNumber;
+        behaviorId: string;
+        values: Val.Struct;
+    }
+
+    export interface Request extends Array<EndpointUpdateRequest> {}
+}
+
+function attrsFor(cluster: ClusterType) {
+    let attrs = attrCache.get(cluster);
+    if (attrs) {
+        return attrs;
+    }
+    attrs = Object.fromEntries(Object.values(cluster.attributes).map(attr => [attr.id, attr]));
+    attrCache.set(cluster, attrs);
+    return attrs;
+}

--- a/packages/node/src/storage/server/DatasourceStore.ts
+++ b/packages/node/src/storage/server/DatasourceStore.ts
@@ -67,8 +67,7 @@ function participantFor(transaction: Transaction, endpointStore: EndpointStore) 
         },
 
         commit1(): MaybePromise {
-            // Persistence serves phase one commit; values are added directly to
-            // the journal so nothing necessary here
+            // Persistence serves phase one commit; values are added directly to the journal so nothing necessary here
         },
 
         async commit2() {
@@ -85,8 +84,4 @@ function participantFor(transaction: Transaction, endpointStore: EndpointStore) 
     transaction.addParticipants(participant);
 
     return participant;
-}
-
-export namespace DatasourceStore {
-    export type Type = typeof DatasourceStore;
 }

--- a/packages/node/src/storage/server/ServerEndpointStore.ts
+++ b/packages/node/src/storage/server/ServerEndpointStore.ts
@@ -7,6 +7,7 @@
 import { Endpoint } from "#endpoint/Endpoint.js";
 import { ImplementationError, StorageContext } from "#general";
 import { EndpointStore } from "#storage/EndpointStore.js";
+import { DatasourceStore } from "./DatasourceStore.js";
 
 const NUMBER_KEY = "__number__";
 
@@ -35,6 +36,14 @@ export class ServerEndpointStore extends EndpointStore {
         super(storage);
 
         this.#childStorage = storage.createContext("parts");
+    }
+
+    /**
+     * Create a {@link Datasource.Store} for a behavior.
+     */
+    createStoreForBehavior(behaviorId: string) {
+        const initialValues = this.consumeInitialValues(behaviorId);
+        return DatasourceStore(this, behaviorId, initialValues);
     }
 
     /**

--- a/packages/node/src/storage/server/ServerNodeStore.ts
+++ b/packages/node/src/storage/server/ServerNodeStore.ts
@@ -15,6 +15,7 @@ import {
     StorageManager,
     StorageService,
 } from "#general";
+import type { ServerNode } from "#node/ServerNode.js";
 import { NodeStore } from "../NodeStore.js";
 import { ClientNodeStores } from "../client/ClientNodeStores.js";
 import { ServerEndpointStores } from "./ServerEndpointStores.js";
@@ -22,8 +23,9 @@ import { ServerEndpointStores } from "./ServerEndpointStores.js";
 const logger = Logger.get("ServerNodeStore");
 
 /**
- * The "server" node store is a {@link NodeStore} with storage for components shared by the server node and client
- * nodes.
+ * {@link ServerNode} persistence.
+ *
+ * Each {@link ServerNode} has an instance of this store.
  */
 export class ServerNodeStore extends NodeStore implements Destructable {
     #env: Environment;

--- a/packages/node/test/node/mock-site.ts
+++ b/packages/node/test/node/mock-site.ts
@@ -82,20 +82,24 @@ export class MockSite {
         return node;
     }
 
-    async addUncommissionedPair() {
+    async addUncommissionedPair(options?: MockSite.PairOptions) {
+        options ??= {};
+
         const controller = await this.addNode(undefined, {
             online: false,
-            commissioning: { enabled: false },
+            ...options.controller,
+            commissioning: { enabled: false, ...options.controller?.commissioning },
         });
         const device = await this.addNode(undefined, {
+            ...options.device,
             device: OnOffLightDevice,
         });
 
         return { controller, device };
     }
 
-    async addCommissionedPair() {
-        const { controller, device } = await this.addUncommissionedPair();
+    async addCommissionedPair(options?: MockSite.PairOptions) {
+        const { controller, device } = await this.addUncommissionedPair(options);
 
         const controllerCrypto = controller.env.get(Crypto) as MockCrypto;
         const deviceCrypto = device.env.get(Crypto) as MockCrypto;
@@ -142,5 +146,12 @@ export class MockSite {
 
     async [Symbol.asyncDispose]() {
         await this.close();
+    }
+}
+
+export namespace MockSite {
+    export interface PairOptions {
+        controller?: MockServerNode.Configuration<any>;
+        device?: MockServerNode.Configuration<any>;
     }
 }

--- a/packages/protocol/src/action/errors.ts
+++ b/packages/protocol/src/action/errors.ts
@@ -5,7 +5,7 @@
  */
 
 import { Schema, SchemaErrorPath, ValueModel } from "#model";
-import { StatusCode, StatusResponseError } from "#types";
+import { Status, StatusResponseError } from "#types";
 
 export { SchemaImplementationError } from "#model";
 
@@ -13,7 +13,7 @@ export { SchemaImplementationError } from "#model";
  * Thrown due operational schema violations.
  */
 export class SchemaViolationError extends StatusResponseError {
-    constructor(prefix: string, path: SchemaErrorPath, message: string, code: StatusCode) {
+    constructor(prefix: string, path: SchemaErrorPath, message: string, code: Status) {
         const text = `${prefix} ${path.path ?? path}: ${message} (${code})`;
         super(text, code);
 
@@ -26,8 +26,8 @@ export class SchemaViolationError extends StatusResponseError {
  * Thrown for invalid reads.
  */
 export class ReadError extends SchemaViolationError {
-    constructor(path: SchemaErrorPath, message: string, code?: StatusCode) {
-        super("Reading", path, message, code ?? StatusCode.UnsupportedRead);
+    constructor(path: SchemaErrorPath, message: string, code?: Status) {
+        super("Reading", path, message, code ?? Status.UnsupportedRead);
     }
 }
 
@@ -35,8 +35,8 @@ export class ReadError extends SchemaViolationError {
  * Thrown for invalid writes.
  */
 export class WriteError extends SchemaViolationError {
-    constructor(path: SchemaErrorPath, message: string, code?: StatusCode) {
-        super("Writing", path, message, code ?? StatusCode.UnsupportedWrite);
+    constructor(path: SchemaErrorPath, message: string, code?: Status) {
+        super("Writing", path, message, code ?? Status.UnsupportedWrite);
     }
 }
 
@@ -44,8 +44,8 @@ export class WriteError extends SchemaViolationError {
  * Thrown for invalid invokes.
  */
 export class InvokeError extends SchemaViolationError {
-    constructor(path: SchemaErrorPath, message: string, code?: StatusCode) {
-        super("Invoking", path, message, code ?? StatusCode.UnsupportedAccess);
+    constructor(path: SchemaErrorPath, message: string, code?: Status) {
+        super("Invoking", path, message, code ?? Status.UnsupportedAccess);
     }
 }
 
@@ -53,8 +53,8 @@ export class InvokeError extends SchemaViolationError {
  * Thrown when validation fails.
  */
 export class ValidateError extends SchemaViolationError {
-    constructor(path: SchemaErrorPath, message: string, code?: StatusCode) {
-        super("Validating", path, message, code ?? StatusCode.InvalidDataType);
+    constructor(path: SchemaErrorPath, message: string, code?: Status) {
+        super("Validating", path, message, code ?? Status.InvalidDataType);
     }
 }
 
@@ -62,7 +62,7 @@ export class ValidateError extends SchemaViolationError {
  * Thrown when a value is of the wrong datatype.
  */
 export class DatatypeError extends ValidateError {
-    constructor(path: SchemaErrorPath, type: string, value: unknown, code?: StatusCode) {
+    constructor(path: SchemaErrorPath, type: string, value: unknown, code?: Status) {
         let str = `${value}`;
         if (str.length > 60) {
             str = `${str.substring(60)}…`;
@@ -76,7 +76,7 @@ export class DatatypeError extends ValidateError {
  */
 export class ConstraintError extends ValidateError {
     constructor(schema: Schema, path: SchemaErrorPath, message: string) {
-        super(path, `Constraint "${(schema as ValueModel).constraint}": ${message}`, StatusCode.ConstraintError);
+        super(path, `Constraint "${(schema as ValueModel).constraint}": ${message}`, Status.ConstraintError);
     }
 }
 
@@ -85,7 +85,7 @@ export class ConstraintError extends ValidateError {
  */
 export class UnknownEnumValueError extends ValidateError {
     constructor(path: SchemaErrorPath, message: string) {
-        super(path, message, StatusCode.ConstraintError);
+        super(path, message, Status.ConstraintError);
     }
 }
 
@@ -100,7 +100,7 @@ export class ConformanceError extends ValidateError {
         } else {
             prefix = `Conformance "${(schema as ValueModel).conformance}"`;
         }
-        super(path, `${prefix}: ${message}`, StatusCode.ConstraintError);
+        super(path, `${prefix}: ${message}`, Status.ConstraintError);
     }
 }
 
@@ -118,12 +118,7 @@ export class EnumValueConformanceError extends ConformanceError {
  */
 export class ExpiredReferenceError extends SchemaViolationError {
     constructor(path: SchemaErrorPath) {
-        super(
-            "Referencing",
-            path,
-            "This value is no longer available because its context has exited",
-            StatusCode.Failure,
-        );
+        super("Referencing", path, "This value is no longer available because its context has exited", Status.Failure);
     }
 }
 
@@ -132,6 +127,6 @@ export class ExpiredReferenceError extends SchemaViolationError {
  */
 export class PhantomReferenceError extends SchemaViolationError {
     constructor(path: SchemaErrorPath) {
-        super("Referencing", path, "Container was removed", StatusCode.Failure);
+        super("Referencing", path, "Container was removed", Status.Failure);
     }
 }

--- a/packages/protocol/src/action/response/WriteResult.ts
+++ b/packages/protocol/src/action/response/WriteResult.ts
@@ -5,9 +5,13 @@
  */
 
 import { Write } from "#action/request/Write.js";
-import type { AttributeId, AttributePath, ClusterId, EndpointNumber, NodeId, StatusCode } from "#types";
+import { ExpandedPath } from "#common/ExpandedPath.js";
+import { ExpandedStatus } from "#common/ExpandedStatus.js";
+import { PathError } from "#common/PathError.js";
+import { MatterAggregateError } from "#general";
+import { Status, type AttributeId, type AttributePath, type ClusterId, type EndpointNumber, type NodeId } from "#types";
 
-export type WriteResult<T extends Write> = Promise<
+export type WriteResult<T extends Write = Write> = Promise<
     T extends { suppressResponse: true } ? void : WriteResult.AttributeStatus[]
 >;
 
@@ -23,7 +27,27 @@ export namespace WriteResult {
     export interface AttributeStatus {
         kind: "attr-status";
         path: ConcreteAttributePath;
-        status: StatusCode;
+        status: Status;
         clusterStatus?: number;
+    }
+
+    export function assertSuccess(result: AttributeStatus[]) {
+        const errors = result
+            .filter(attr => attr.status !== Status.Success)
+            .map(attr => {
+                const path = ExpandedPath({ ...attr, kind: "attribute" });
+                const status = new ExpandedStatus(attr);
+                return new PathError({ path, status });
+            });
+
+        if (!errors.length) {
+            return;
+        }
+
+        if (errors.length === 1) {
+            throw errors[0];
+        }
+
+        throw new MatterAggregateError(errors, "Multiple writes failed");
     }
 }

--- a/packages/protocol/src/common/ExpandedPath.ts
+++ b/packages/protocol/src/common/ExpandedPath.ts
@@ -1,0 +1,87 @@
+/**
+ * @license
+ * Copyright 2022-2025 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { camelize } from "#general";
+import {
+    AttributeModel,
+    ClusterModel,
+    CommandModel,
+    DataModelPath,
+    EventModel,
+    Matter,
+    MatterModel,
+    Model,
+} from "#model";
+import { AttributePath, CommandPath, EventPath } from "#types";
+
+/**
+ * Creates a {@link DataModelPath} from a Matter wire-format {@link AttributePath}, {@link EventPath}, or
+ * {@link CommandPath}.
+ *
+ * This is useful for creating human-readable diagnostics.
+ */
+export function ExpandedPath({ path, matter, base, kind }: ExpandedPath.Definition): DataModelPath {
+    if (matter === undefined) {
+        matter = Matter;
+    }
+
+    if (base && "path" in base) {
+        base = base.path;
+    }
+
+    const endpointIdent = path.endpointId ?? "*";
+    base = base ? base.at(endpointIdent, "endpoint") : DataModelPath(endpointIdent, "endpoint");
+
+    let cluster: ClusterModel | undefined;
+    base = base.at(identityOf(matter, ClusterModel, path.clusterId), "cluster");
+
+    if ("attributeId" in path) {
+        base = base.at("state").at(identityOf(cluster, AttributeModel, path.attributeId));
+        if (path.listIndex) {
+            return base.at(path.listIndex, "entry");
+        }
+        return base;
+    }
+
+    if ("commandId" in path) {
+        return base.at(identityOf(cluster, CommandModel, path.commandId));
+    }
+
+    if ("eventId" in path) {
+        return base.at("events").at(identityOf(cluster, EventModel, path.eventId));
+    }
+
+    return base.at("*", kind ?? "element");
+
+    function identityOf(parent: undefined | Model, type: Model.Type, id: undefined | number | string) {
+        if (id === undefined) {
+            return "*";
+        }
+
+        const instance = parent?.get(type, id);
+        if (instance === undefined) {
+            if (typeof id === "string") {
+                return camelize(id);
+            }
+            return id;
+        }
+
+        if (type === ClusterModel) {
+            cluster = instance as ClusterModel;
+        }
+
+        return camelize(instance.name);
+    }
+}
+
+export namespace ExpandedPath {
+    export interface Definition {
+        path: AttributePath | EventPath | CommandPath;
+        matter?: MatterModel;
+        base?: DataModelPath | { path: DataModelPath };
+        kind?: "attribute" | "command" | "event" | "entry";
+    }
+}

--- a/packages/protocol/src/common/ExpandedStatus.ts
+++ b/packages/protocol/src/common/ExpandedStatus.ts
@@ -1,0 +1,71 @@
+/**
+ * @license
+ * Copyright 2022-2025 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { decamelize } from "#general";
+import { ClusterModel, Matter, MatterModel } from "#model";
+import { ClusterId, Status } from "#types";
+
+/**
+ * Detailed status information expanded from status codes.
+ *
+ * TODO - maybe update codegen to include description in operational models so we can use as detailed error message
+ */
+export class ExpandedStatus {
+    id: string;
+    status: Status;
+    clusterStatus?: number;
+
+    constructor({ matter, status, cluster, clusterStatus }: ExpandedStatus.Definition) {
+        this.status = status ?? Status.Failure;
+        this.clusterStatus = clusterStatus;
+
+        let statusStr: undefined | string;
+        if (status !== Status.Failure) {
+            const name = Status[this.status];
+            if (name === undefined) {
+                statusStr = `unknown-${this.status}`;
+            } else {
+                statusStr = decamelize(name);
+            }
+        }
+
+        if (clusterStatus === undefined) {
+            this.id = statusStr ?? "failure";
+            return;
+        }
+
+        let clusterStr;
+        if (typeof cluster === "number") {
+            matter ??= Matter;
+            const model = matter.get(ClusterModel, cluster);
+            if (model === undefined) {
+                clusterStr = `cluster-${cluster}`;
+            } else {
+                clusterStr = decamelize(model.name);
+            }
+        } else if (cluster) {
+            clusterStr = decamelize(cluster.name);
+        } else {
+            clusterStr = "unknown-cluster";
+        }
+
+        if (statusStr === undefined) {
+            this.id = clusterStr;
+            return;
+        }
+
+        this.id = `${statusStr}+${clusterStr}`;
+    }
+}
+
+export namespace ExpandedStatus {
+    export interface Definition {
+        matter?: MatterModel;
+        status?: Status;
+        cluster?: ClusterModel | ClusterId;
+        clusterStatus?: number;
+    }
+}

--- a/packages/protocol/src/common/PathError.ts
+++ b/packages/protocol/src/common/PathError.ts
@@ -1,0 +1,46 @@
+/**
+ * @license
+ * Copyright 2022-2025 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ExpandedStatus } from "#common/ExpandedStatus.js";
+import { camelize, capitalize, decamelize, MatterAggregateError } from "#general";
+import { DataModelPath } from "#model";
+import { StatusResponseError } from "#types";
+
+/**
+ * A protocol error associated with a specific data model path.
+ */
+export class PathError extends StatusResponseError {
+    #id: string;
+    #path: DataModelPath;
+
+    constructor({ path, status: { id, status, clusterStatus }, message }: PathError.Definition) {
+        if (message === undefined) {
+            message = capitalize(decamelize(camelize(id), " "));
+        }
+
+        super(message, status, clusterStatus);
+        this.#id = id;
+        this.#path = path;
+    }
+
+    override get id() {
+        return this.#id;
+    }
+
+    get path() {
+        return this.#path;
+    }
+}
+
+export namespace PathError {
+    export interface Definition {
+        path: DataModelPath;
+        status: ExpandedStatus;
+        message?: string;
+    }
+}
+
+export class AggregatePathError extends MatterAggregateError {}

--- a/packages/protocol/src/common/index.ts
+++ b/packages/protocol/src/common/index.ts
@@ -5,6 +5,7 @@
  */
 
 export * from "../peer/PeerAddress.js";
+export * from "./ExpandedPath.js";
 export * from "./FailsafeContext.js";
 export * from "./FailsafeTimer.js";
 export * from "./InstanceBroadcaster.js";


### PR DESCRIPTION
Implemented state writes for the clusters on ClientNode:

  * Implemented ClientEndpointStore with specialization specific to ClientNodes

  * Added RemoteWriteParticipant.  This transaction participant roles up all mutations to endpoints associated with a specific node into a single Matter interaction

  * Added RemoteWriter utility class that performs actual persistence.  This acts as a bridge between RemoteWriteParticipant and Interactable

  * Implemented test for new logic

  * Added `WriteResult.assertSuccess` utility function that throws a (possibly aggregate) error if any writes fail (see supporting updates below)

Improved behavior infrastructure:

  * Create backing stores when creating the backing and various other tweaks that make initialization easier to follow

  * Add tracking of persistent fields by ID or name

  * Fixed persistence of "server" behaviors on client nodes (those that aren't ClusterBehaviors)

Includes various related error handling/diagnostic updates (fixes #2044):

  * MatterAggregateError can now have "stackless" children where differences from the parent stack are irrelevant (such as for compound errors in a Matter response)

  * Error formatting is enhanced to support a "path" property.  This is included in output on the message line

  * Added new PathError base class that is an error with an associated DataModelPath in the "path" property

  * Created ExpandedStatus utility function that converts a wire-format matter status response into a user-presentable object.  This maps status and/or cluster status to string identifiers, if possible

  * Created ExpandedPath utility function that converts from a wire-format matter path into a user-presentable DataModelPath.  This encapsulates logic related to resolving IDs into names

  * DataModelPath now formats itself as a diagnostic with names bolded