### PR TITLE
Fix attribute generation for [Field] conformance

### DIFF
--- a/packages/model/src/logic/cluster-variance/InferredComponents.ts
+++ b/packages/model/src/logic/cluster-variance/InferredComponents.ts
@@ -109,7 +109,7 @@ const VarianceMatchers: VarianceMatcher[] = [
     {
         pattern: pattern("[", FIELD, "]"),
         processor(add) {
-            add(false);
+            add(true);
         },
     },
 

--- a/packages/node/test/behavior/state/validation/conformanceTest.ts
+++ b/packages/node/test/behavior/state/validation/conformanceTest.ts
@@ -542,6 +542,66 @@ const AllTests = Tests({
             },
         ),
 
+        "optional field dependency": Tests(
+            Fields(
+                {
+                    name: "CurrentArea",
+                    type: "uint32",
+                    quality: "X",
+                    conformance: "desc",
+                },
+                {
+                    name: "EstimatedEndTime",
+                    type: "epoch-s",
+                    quality: "X",
+                    conformance: "[CurrentArea]",
+                },
+            ),
+            {
+                "accepts neither": {
+                    record: {},
+                },
+
+                "accepts CurrentArea without EstimatedEndTime": {
+                    record: {
+                        currentArea: 4,
+                    },
+                },
+
+                "accepts CurrentArea as null without EstimatedEndTime": {
+                    record: {
+                        currentArea: null,
+                    },
+                },
+
+                "rejects EstimatedEndTime without CurrentArea": {
+                    record: {
+                        estimatedEndTime: 4,
+                    },
+
+                    error: {
+                        type: ConformanceError,
+                        message:
+                            'Validating Test.estimatedEndTime: Conformance "[CurrentArea]": Matter does not allow you to set this attribute',
+                    },
+                },
+
+                "accepts EstimatedEndTime with CurrentArea": {
+                    record: {
+                        currentArea: 1,
+                        estimatedEndTime: 4,
+                    },
+                },
+
+                "accepts EstimatedEndTime with null CurrentArea": {
+                    record: {
+                        currentArea: null,
+                        estimatedEndTime: 4,
+                    },
+                },
+            },
+        ),
+
         "hairy real-world": Tests(
             Features({
                 PIR: "PIR",

--- a/packages/node/test/behaviors/service-area/ServiceAreaServerTest.ts
+++ b/packages/node/test/behaviors/service-area/ServiceAreaServerTest.ts
@@ -1,0 +1,64 @@
+/**
+ * @license
+ * Copyright 2022-2025 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ServiceAreaServer } from "#behaviors/service-area";
+import { RvcOperationalState } from "#clusters/rvc-operational-state";
+import { RvcRunMode } from "#clusters/rvc-run-mode";
+import { RoboticVacuumCleanerDevice } from "#devices/robotic-vacuum-cleaner";
+import { Endpoint } from "#endpoint/Endpoint.js";
+import { MockServerNode } from "../../node/mock-server-node.js";
+
+const DeviceType = RoboticVacuumCleanerDevice.with(ServiceAreaServer.with("Maps", "SelectWhileRunning"));
+
+async function createNode(options?: Endpoint.Options<typeof DeviceType>) {
+    const node = await MockServerNode.create();
+    if (!options) {
+        options = {};
+    }
+
+    const rvcRunMode = options.rvcRunMode ?? {};
+    options.rvcRunMode = {
+        supportedModes: [
+            {
+                label: "Idle",
+                mode: 0,
+                modeTags: [{ value: RvcRunMode.ModeTag.Idle }],
+            },
+            {
+                label: "Cleaning",
+                mode: 1,
+                modeTags: [{ value: RvcRunMode.ModeTag.Cleaning }],
+            },
+        ],
+        currentMode: 0,
+        ...rvcRunMode,
+    };
+
+    const rvcOperationalState = options.rvcOperationalState ?? {};
+    options.rvcOperationalState = {
+        operationalStateList: [{ operationalStateId: RvcOperationalState.OperationalState.Error }],
+        operationalState: RvcOperationalState.OperationalState.Error,
+        ...rvcOperationalState,
+    };
+
+    const endpoint = await node.add(DeviceType, options);
+
+    return { node, endpoint };
+}
+
+describe("ServiceAreaServer", () => {
+    it("allows undefined estimatedEndTime", async () => {
+        await createNode({
+            serviceArea: {
+                estimatedEndTime: undefined,
+            },
+        });
+    });
+
+    it("allows empty estimatedEndTime", async () => {
+        await createNode();
+    });
+});

--- a/packages/types/src/clusters/service-area.ts
+++ b/packages/types/src/clusters/service-area.ts
@@ -786,7 +786,7 @@ export namespace ServiceArea {
              *
              * @see {@link MatterSpecification.v141.Cluster} § 1.17.6.5
              */
-            estimatedEndTime: Attribute(0x4, TlvNullable(TlvEpochS), { default: null })
+            estimatedEndTime: OptionalAttribute(0x4, TlvNullable(TlvEpochS), { default: null })
         },
 
         commands: {

--- a/support/chip-testing/src/RvcTestInstance.ts
+++ b/support/chip-testing/src/RvcTestInstance.ts
@@ -42,7 +42,7 @@ const TestRvcDevice = RoboticVacuumCleanerDevice.with(
     TestRvcOperationalStateServer,
     TestRvcRunModeServer,
     TestRvcCleanModeServer,
-    TestServiceAreaServer,
+    TestServiceAreaServer.enable({ attributes: { estimatedEndTime: true } }),
 );
 
 export class RvcTestInstance extends NodeTestInstance {

--- a/support/chip-testing/test/.gitignore
+++ b/support/chip-testing/test/.gitignore
@@ -1,0 +1,1 @@
+DEV.test.ts


### PR DESCRIPTION
Was treating as mandatory when should have been optional.  Includes new test coverage.

Fixes #2224