### PR TITLE
Fix ModeSelect.StandardNamespace

### DIFF
--- a/packages/model/src/models/SemanticNamespaceModel.ts
+++ b/packages/model/src/models/SemanticNamespaceModel.ts
@@ -15,7 +15,7 @@ export class SemanticNamespaceModel
     override tag: SemanticNamespaceElement.Tag = SemanticNamespaceElement.Tag;
     mfgCode?: number;
 
-    get endpoints() {
+    get tags() {
         return this.children;
     }
 

--- a/packages/model/src/standard/elements/mode-select-cluster.element.ts
+++ b/packages/model/src/standard/elements/mode-select-cluster.element.ts
@@ -27,7 +27,7 @@ export const ModeSelect = Cluster(
         quality: "F"
     }),
     Attribute({
-        name: "StandardNamespace", id: 0x1, type: "enum16", access: "R V", conformance: "M",
+        name: "StandardNamespace", id: 0x1, type: "uint16", access: "R V", conformance: "M",
         constraint: "desc", default: null, quality: "X F"
     }),
 

--- a/support/models/src/local/ModeSelectOverrides.ts
+++ b/support/models/src/local/ModeSelectOverrides.ts
@@ -20,5 +20,14 @@ LocalMatter.children.push({
                 { tag: "field", name: "Value", id: 0x1, type: "uint16" },
             ],
         },
+
+        // Spec defines as an enum but does not define values.  We could special case to generate an enum from the
+        // standard namespaces but for now we just set as an integer
+        {
+            tag: "attribute",
+            name: "StandardNamespace",
+            id: 0x1,
+            type: "uint16",
+        },
     ],
 });


### PR DESCRIPTION
Spec specifies as an enum16 without values.  Treat as uint16 instead.

Also "tags" property of SemanticNamespaceModel that was incorrectly named "endpoints" due to code copy.

Fixes #2240