### PR TITLE
Fix for transactions with async post commit

### DIFF
--- a/packages/general/src/transaction/Tx.ts
+++ b/packages/general/src/transaction/Tx.ts
@@ -688,6 +688,7 @@ class Tx implements Transaction, Transaction.Finalization {
                     const promise = participant.postCommit?.();
 
                     if (MaybePromise.is(promise)) {
+                        i++;
                         return Promise.resolve(promise).then(executePostCommit, e => {
                             reportParticipantError(e);
                             executePostCommit();

--- a/packages/general/test/util/ObservableTest.ts
+++ b/packages/general/test/util/ObservableTest.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Observable, ObserverGroup } from "#util/Observable.js";
+import { AsyncObservable, Observable, ObserverGroup } from "#util/Observable.js";
 
 // Observable deserves proper unit tests but is tested heavily via other modules.  Currently this file just tests a
 // few spot cases
@@ -50,5 +50,41 @@ describe("ObservableGroup", () => {
         observers.close();
 
         expect(observable.isObserved).false;
+    });
+});
+
+describe("AsyncObservable", () => {
+    it("emits", async () => {
+        const observable = AsyncObservable<[foo: string]>();
+
+        let observedFoo;
+
+        observable.on(async foo => {
+            observedFoo = foo;
+        });
+
+        await observable.emit("what I expect");
+
+        expect(observedFoo).equals("what I expect");
+    });
+
+    it("emits with mix of observers", async () => {
+        const observable = AsyncObservable<[foo: string]>();
+
+        const observedFoos = Array<string>();
+
+        for (let i = 0; i < 3; i++) {
+            observable.on(async foo => {
+                observedFoos.push(foo);
+            });
+
+            observable.on(foo => {
+                observedFoos.push(foo);
+            });
+        }
+
+        await observable.emit("asdf");
+
+        expect(observedFoos).deep.equals(["asdf", "asdf", "asdf", "asdf", "asdf", "asdf"]);
     });
 });

--- a/packages/node/test/behaviors/on-off/OnOffServerTest.ts
+++ b/packages/node/test/behaviors/on-off/OnOffServerTest.ts
@@ -6,6 +6,7 @@
 
 import { OnOffServer } from "#behaviors/on-off";
 import { MaybePromise } from "#general";
+import { MockServerNode } from "../../node/mock-server-node.js";
 
 describe("OnOffServer", () => {
     it("accepts extensions of off-only commands", () => {
@@ -17,5 +18,29 @@ describe("OnOffServer", () => {
         const x = {} as MyOnOffServer;
 
         x satisfies { on(): MaybePromise };
+    });
+
+    it("properly supports async observers", async () => {
+        const server = await MockServerNode.createOnline();
+        const part = server.parts.get(1);
+
+        const observedValues = Array<boolean>();
+
+        part!.eventsOf(OnOffServer).onOff$Changed.on(async value => {
+            observedValues.push(value);
+        });
+
+        for (let i = 0; i < 2; i++) {
+            await part!.act(async agent => {
+                const onOff = agent.get(OnOffServer);
+                await onOff.toggle();
+            });
+        }
+
+        await server.close();
+
+        await MockTime.yield3();
+
+        expect(observedValues).deep.equals([true, false]);
     });
 });


### PR DESCRIPTION
Fixes bug reported on Discord whereby async "changed" observers cause an infinite loop when the transaction commits. Async reactors only install a synchronous observers so this is apparently not a common code path.

Also added tests on AsyncObservable (does not exhibit bug) and OnOffServer#events#onOff$Changed (does exhibit bug).