### PR TITLE
Move agentFor from ActionContext to Endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ The main work (all changes without a GitHub username in brackets in the below li
 -   @matter/node
     - Breaking: `Endpoint` and `Node` initialization values now require the correct type for some time values and IDs.  So for example, `VendorId(1234)` instead of just `1234`
     - Breaking: `SubscriptionBehavior` is renamed to `SubscriptionsServer` with corresponding ID change to "subscriptions".  This means in part that matter.js will ignore saved subscriptions but devices will recreate them automatically
+    - Breaking: The `agentFor` method of `ActionContext` has moved to `Endpoint`.  You likely do not use this directly but if you do you must change `context.agentFor(endpoint)` to `endpoint.agentFor(context)`
     - Fix: (rsulzenbacher) Adjusted OnOffServer default implementation for offWaitTime to be fully compliant to 1.4.1 spec
 
 -   @matter/nodejs

--- a/packages/node/src/behavior/context/ActionContext.ts
+++ b/packages/node/src/behavior/context/ActionContext.ts
@@ -6,7 +6,6 @@
 
 import type { Agent } from "#endpoint/Agent.js";
 import type { Endpoint } from "#endpoint/Endpoint.js";
-import type { EndpointType } from "#endpoint/type/EndpointType.js";
 import type { AccessLevel } from "#model";
 import type { Message, SecureSession } from "#protocol";
 import { MessageExchange } from "#protocol";
@@ -62,9 +61,4 @@ export interface ActionContext extends ValueSupervisor.Session {
      * The priority of actions in this context.
      */
     priority?: Priority;
-
-    /**
-     * Obtain an agent for interacting with an endpoint in this context.
-     */
-    agentFor<const T extends EndpointType>(endpoint: Endpoint<T>): Agent.Instance<T>;
 }

--- a/packages/node/src/behavior/context/server/ContextAgents.ts
+++ b/packages/node/src/behavior/context/server/ContextAgents.ts
@@ -12,9 +12,25 @@ import type { ActionContext } from "../ActionContext.js";
 /**
  * Internal helper for managing agents associated with a session.
  */
-export interface ContextAgents extends ReturnType<typeof ContextAgents> {}
+export interface ContextAgents {
+    [Symbol.toStringTag]: "ContextAgents";
+    agentFor<const T extends EndpointType>(endpoint: Endpoint<T>): Agent.Instance<T>;
+}
+
+const contextAgents = new WeakMap<ActionContext, ContextAgents>();
 
 export function ContextAgents(context: ActionContext) {
+    let instance = contextAgents.get(context);
+
+    if (instance === undefined) {
+        instance = create(context);
+        contextAgents.set(context, instance);
+    }
+
+    return instance;
+}
+
+function create(context: ActionContext): ContextAgents {
     const agents = new Map<Endpoint, Agent>();
 
     return {

--- a/packages/node/src/behavior/context/server/OfflineContext.ts
+++ b/packages/node/src/behavior/context/server/OfflineContext.ts
@@ -5,15 +5,12 @@
  */
 
 import type { Agent } from "#endpoint/Agent.js";
-import type { Endpoint } from "#endpoint/Endpoint.js";
-import type { EndpointType } from "#endpoint/type/EndpointType.js";
 import { Diagnostic, InternalError, MaybePromise, Transaction } from "#general";
 import { AccessLevel } from "#model";
 import { AccessControl } from "#protocol";
 import type { ActionContext } from "../ActionContext.js";
 import { Contextual } from "../Contextual.js";
 import type { NodeActivity } from "../NodeActivity.js";
-import { ContextAgents } from "./ContextAgents.js";
 
 export let nextInternalId = 1;
 
@@ -70,7 +67,6 @@ export const OfflineContext = {
 
         try {
             frame = options?.activity?.begin(via);
-            let agents: undefined | ContextAgents;
 
             transaction = Transaction.open(via, options?.isolation);
 
@@ -92,13 +88,6 @@ export const OfflineContext = {
                     return desiredAccessLevel === AccessLevel.View
                         ? AccessControl.Authority.Granted
                         : AccessControl.Authority.Unauthorized;
-                },
-
-                agentFor<const T extends EndpointType>(endpoint: Endpoint<T>): Agent.Instance<T> {
-                    if (!agents) {
-                        agents = ContextAgents(context);
-                    }
-                    return agents?.agentFor(endpoint);
                 },
 
                 get [Contextual.context]() {

--- a/packages/node/src/behavior/context/server/OnlineContext.ts
+++ b/packages/node/src/behavior/context/server/OnlineContext.ts
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Agent } from "#endpoint/Agent.js";
-import { Endpoint } from "#endpoint/Endpoint.js";
-import { EndpointType } from "#endpoint/type/EndpointType.js";
 import { AsyncObservable, Diagnostic, ImplementationError, InternalError, MaybePromise, Transaction } from "#general";
 import { AccessLevel } from "#model";
 import type { Node } from "#node/Node.js";
@@ -23,7 +20,6 @@ import { FabricIndex, NodeId } from "#types";
 import { ActionContext } from "../ActionContext.js";
 import { Contextual } from "../Contextual.js";
 import { NodeActivity } from "../NodeActivity.js";
-import { ContextAgents } from "./ContextAgents.js";
 
 /**
  * Caches completion events per exchange. Uses if multiple OnlineContext instances are created for an exchange.
@@ -150,7 +146,6 @@ export function OnlineContext(options: OnlineContext.Options) {
         if (session) {
             SecureSession.assert(session);
         }
-        let agents: undefined | ContextAgents;
         let interactionComplete: AsyncObservable<[session?: ActionContext | undefined]> | undefined;
         if (exchange !== undefined) {
             interactionComplete = exchangeCompleteEvents.get(exchange);
@@ -209,13 +204,6 @@ export function OnlineContext(options: OnlineContext.Options) {
                 return accessLevels.includes(desiredAccessLevel)
                     ? AccessControl.Authority.Granted
                     : AccessControl.Authority.Unauthorized;
-            },
-
-            agentFor<T extends EndpointType>(endpoint: Endpoint<T>): Agent.Instance<T> {
-                if (!agents) {
-                    agents = ContextAgents(context);
-                }
-                return agents.agentFor(endpoint);
             },
 
             get [Contextual.context](): ActionContext {

--- a/packages/node/src/behavior/internal/Reactors.ts
+++ b/packages/node/src/behavior/internal/Reactors.ts
@@ -411,7 +411,7 @@ class ReactorBacking<T extends any[], R> {
      * Bind the reactor to a behavior instance once locks are held.
      */
     #bindReactor(context: ActionContext, backing: BehaviorBacking): Reactor<T, Awaited<R>> {
-        const agent = context.agentFor(this.#endpoint);
+        const agent = this.#endpoint.agentFor(context);
 
         // Do not use Agent.get because it will throw during initialization
         const behavior = backing.createBehavior(agent, backing.type);

--- a/packages/node/src/behavior/system/parts/PartsBehavior.ts
+++ b/packages/node/src/behavior/system/parts/PartsBehavior.ts
@@ -37,7 +37,7 @@ export class PartsBehavior extends Behavior implements MutableSet<Endpoint, Endp
 
     *[Symbol.iterator]() {
         for (const part of this.endpoint.parts) {
-            yield this.context.agentFor(part);
+            yield part.agentFor(this.context);
         }
     }
 }

--- a/packages/node/src/behavior/system/product-description/ProductDescriptionServer.ts
+++ b/packages/node/src/behavior/system/product-description/ProductDescriptionServer.ts
@@ -116,7 +116,7 @@ function inferDeviceType(agent: Agent): DeviceTypeId | undefined {
     }
 
     for (const child of agent.endpoint.parts) {
-        const deviceType = inferDeviceType(agent.context.agentFor(child));
+        const deviceType = inferDeviceType(child.agentFor(agent.context));
         if (deviceType !== undefined) {
             return deviceType;
         }

--- a/packages/node/src/behaviors/general-commissioning/ServerNodeFailsafeContext.ts
+++ b/packages/node/src/behaviors/general-commissioning/ServerNodeFailsafeContext.ts
@@ -81,7 +81,7 @@ export class ServerNodeFailsafeContext extends FailsafeContext {
             await this.#node.visit(async endpoint => {
                 const networks = this.#storedState?.networks.get(endpoint);
                 if (networks) {
-                    context.agentFor(endpoint).get(NetworkCommissioningBehavior).state.networks = [...networks];
+                    endpoint.agentFor(context).get(NetworkCommissioningBehavior).state.networks = [...networks];
                 }
             });
         });

--- a/packages/node/src/behaviors/groups/GroupsServer.ts
+++ b/packages/node/src/behaviors/groups/GroupsServer.ts
@@ -67,7 +67,7 @@ export class GroupsServer extends GroupsBase {
 
     // We need to search the root here ourselves because we cannot include ServerNode because else we generate a
     // circular dependency
-    #rootEndpoint(): Endpoint<RootEndpoint> {
+    get #rootEndpoint(): Endpoint<RootEndpoint> {
         const rootEndpoint = this.endpoint.ownerOfType(RootEndpoint);
         if (rootEndpoint === undefined) {
             throw new InternalError("RootEndpoint not found");
@@ -76,7 +76,7 @@ export class GroupsServer extends GroupsBase {
     }
 
     async #actOnGroupKeyManagement<T>(act: (groupKeyManagement: GroupKeyManagementServer) => T): Promise<T> {
-        const agent = this.context.agentFor(this.#rootEndpoint());
+        const agent = this.#rootEndpoint.agentFor(this.context);
         const gkm = agent.get(GroupKeyManagementServer);
         await agent.context.transaction.addResources(gkm);
         await agent.context.transaction.begin();
@@ -122,7 +122,7 @@ export class GroupsServer extends GroupsBase {
         const fabricIndex = fabric.fabricIndex;
         const endpointNumber = this.endpoint.number;
 
-        const { groupTable } = this.#rootEndpoint().stateOf(GroupKeyManagementServer);
+        const { groupTable } = this.#rootEndpoint.stateOf(GroupKeyManagementServer);
         const groupEntry = groupTable.find(entry => entry.groupId === groupId && entry.fabricIndex === fabricIndex);
         if (groupEntry === undefined || !groupEntry.endpoints.includes(endpointNumber)) {
             return { status: StatusCode.NotFound, groupId, groupName: "" };
@@ -137,7 +137,7 @@ export class GroupsServer extends GroupsBase {
         const fabricIndex = fabric.fabricIndex;
         const endpointNumber = this.endpoint.number;
 
-        const { groupTable } = this.#rootEndpoint().stateOf(GroupKeyManagementServer);
+        const { groupTable } = this.#rootEndpoint.stateOf(GroupKeyManagementServer);
         const endpointGroups = groupTable.filter(
             entry => entry.endpoints.includes(endpointNumber) && entry.fabricIndex === fabricIndex,
         );

--- a/packages/node/src/endpoint/Agent.ts
+++ b/packages/node/src/endpoint/Agent.ts
@@ -51,7 +51,7 @@ export class Agent {
         if (this.#endpoint.owner === undefined) {
             return undefined;
         }
-        return this.context.agentFor(this.#endpoint.owner);
+        return this.#endpoint.owner.agentFor(this.context);
     }
 
     /**

--- a/packages/node/src/endpoint/Endpoint.ts
+++ b/packages/node/src/endpoint/Endpoint.ts
@@ -5,7 +5,9 @@
  */
 
 import { Behavior } from "#behavior/Behavior.js";
+import { ActionContext } from "#behavior/context/ActionContext.js";
 import { NodeActivity } from "#behavior/context/NodeActivity.js";
+import { ContextAgents } from "#behavior/context/server/ContextAgents.js";
 import { OfflineContext } from "#behavior/context/server/OfflineContext.js";
 import {
     Construction,
@@ -110,6 +112,17 @@ export class Endpoint<T extends EndpointType = EndpointType.Empty> {
      */
     get owner(): Endpoint | undefined {
         return this.#owner;
+    }
+
+    /**
+     * Access an {@link Agent} for this endpoint.
+     *
+     * An {@link Agent} allows you to interact directly with the behaviors supported by the endpoint.  Normally you
+     * would use {@link act} to obtain an agent but {@link agentFor} is useful if you need to interact with multiple
+     * endpoints in the same context.
+     */
+    agentFor<T extends EndpointType>(this: Endpoint<T>, context: ActionContext) {
+        return ContextAgents(context).agentFor(this);
     }
 
     get endpointProtocol() {
@@ -599,7 +612,7 @@ export class Endpoint<T extends EndpointType = EndpointType.Empty> {
         return OfflineContext.act(
             purpose,
             context => {
-                return actor(context.agentFor(this));
+                return actor(this.agentFor(context));
             },
             { activity: this.#activity },
         );

--- a/packages/node/src/endpoint/properties/Behaviors.ts
+++ b/packages/node/src/endpoint/properties/Behaviors.ts
@@ -186,7 +186,7 @@ export class Behaviors {
 
         // Initialization action.  We initialize all behaviors in the same transaction
         const initializeBehaviors = (context: ActionContext): MaybePromise => {
-            const agent = context.agentFor(this.#endpoint);
+            const agent = this.#endpoint.agentFor(context);
 
             // Activate behaviors
             //
@@ -377,7 +377,7 @@ export class Behaviors {
      */
     async close() {
         const dispose = async (context: ActionContext) => {
-            const agent = context.agentFor(this.#endpoint);
+            const agent = this.#endpoint.agentFor(context);
 
             let destroyNow = new Set(Object.keys(this.#backings));
             while (destroyNow.size) {
@@ -565,7 +565,7 @@ export class Behaviors {
         const result = OfflineContext.act(
             "behavior-late-activation",
             context => {
-                this.activate(type, context.agentFor(this.#endpoint));
+                this.activate(type, this.#endpoint.agentFor(context));
 
                 // Agent must remain active until backing is initialized
                 const backing = this.#backingFor(type);

--- a/packages/node/src/endpoint/properties/Commands.ts
+++ b/packages/node/src/endpoint/properties/Commands.ts
@@ -67,7 +67,7 @@ function Implementation(endpoint: Endpoint, type: Behavior.Type, name: string): 
 
             // Create function to perform invocation
             function invokerFor(context: ActionContext) {
-                const agent = context.agentFor(endpoint);
+                const agent = endpoint.agentFor(context);
                 const behavior = agent.get(type);
                 const method = (behavior as unknown as Record<string, Commands.Command>)[name];
                 if (typeof method !== "function") {

--- a/packages/node/src/node/server/IdentityService.ts
+++ b/packages/node/src/node/server/IdentityService.ts
@@ -44,7 +44,7 @@ export class IdentityService {
             other = this.#node;
         } else {
             if (this.#partsById === undefined) {
-                this.#partsById = OfflineContext.ReadOnly.agentFor(this.#node).get(IndexBehavior).partsById;
+                this.#partsById = this.#node.agentFor(OfflineContext.ReadOnly).get(IndexBehavior).partsById;
             }
             other = this.#partsById?.[number];
         }

--- a/packages/node/src/node/server/ProtocolService.ts
+++ b/packages/node/src/node/server/ProtocolService.ts
@@ -602,7 +602,7 @@ function invokeCommand(
         requestDiagnostic,
     );
 
-    const agent = context.agentFor(endpoint);
+    const agent = endpoint.agentFor(context);
     const behavior = agent.get(backing.type);
 
     let isAsync = false;

--- a/packages/node/test/behavior/internal/ReactorsTest.ts
+++ b/packages/node/test/behavior/internal/ReactorsTest.ts
@@ -26,17 +26,8 @@ class MockAgent {
 }
 
 function MockContext(offline = true) {
-    let agent: MockAgent | undefined;
-
     const context = {
         offline,
-
-        agentFor() {
-            if (agent === undefined) {
-                agent = new MockAgent(undefined, this as ActionContext);
-            }
-            return agent;
-        },
 
         get [Contextual.context]() {
             return this;
@@ -51,6 +42,7 @@ function MockContext(offline = true) {
 }
 
 class MockEndpoint {
+    agent: MockAgent | undefined;
     event = Observable<[value: string, context?: ActionContext], MaybePromise<string>>();
     env = new Environment("reactor-test");
     activity = new NodeActivity();
@@ -68,6 +60,13 @@ class MockEndpoint {
 
     get agentType() {
         return MockAgent;
+    }
+
+    agentFor(context: ActionContext) {
+        if (this.agent === undefined) {
+            this.agent = new MockAgent(undefined, context);
+        }
+        return this.agent;
     }
 
     constructor(isAsync = false) {
@@ -267,7 +266,7 @@ describe("Reactors", () => {
         expect(reactionText).equals("foo");
         expect(offline).false;
         expect(reactionContext).equals(context);
-        expect(reactionThis).equals(context.agentFor({} as any).get({} as Behavior.Type));
+        expect(reactionThis).equals(endpoint.agentFor(context).get());
 
         expect(reacted).equals(1);
     });

--- a/packages/node/test/behaviors/color-control/ColorControlServerTest.ts
+++ b/packages/node/test/behaviors/color-control/ColorControlServerTest.ts
@@ -21,7 +21,7 @@ describe("ColorControlServer", () => {
         });
 
         await node.online({ command: true }, async agent => {
-            const endpointAgent = agent.context.agentFor(endpoint);
+            const endpointAgent = endpoint.agentFor(agent.context);
 
             await agent.context.transaction.addResources(endpointAgent.colorControl);
 

--- a/packages/node/test/behaviors/level-control/LevelControlServerTest.ts
+++ b/packages/node/test/behaviors/level-control/LevelControlServerTest.ts
@@ -66,7 +66,7 @@ describe("LevelControlServer", () => {
         });
 
         await node.online({ command: true }, async agent => {
-            const endpointAgent = agent.context.agentFor(endpoint);
+            const endpointAgent = endpoint.agentFor(agent.context);
 
             await agent.context.transaction.addResources(endpointAgent.levelControl);
 
@@ -237,7 +237,7 @@ async function initializeDimmableLight() {
 async function changeLevel(endpoint: Endpoint<DimmableLightDevice>, steps = 200) {
     const node = endpoint.owner as MockServerNode;
     await node.online({ command: true }, async agent => {
-        const endpointAgent = agent.context.agentFor(endpoint);
+        const endpointAgent = endpoint.agentFor(agent.context);
 
         await agent.context.transaction.addResources(endpointAgent.levelControl);
 

--- a/packages/node/test/node/mock-server-node.ts
+++ b/packages/node/test/node/mock-server-node.ts
@@ -93,7 +93,7 @@ export class MockServerNode<T extends ServerNode.RootEndpoint = ServerNode.RootE
         if (!options.node) {
             options.node = this;
         }
-        return OnlineContext(options as OnlineContext.Options).act(context => actor(context.agentFor(this)));
+        return OnlineContext(options as OnlineContext.Options).act(context => actor(this.agentFor(context)));
     }
 
     static async createOnline<T extends ServerNode.RootEndpoint = ServerNode.RootEndpoint>(


### PR DESCRIPTION
This moves ActionContext more toward a dumb object which is a precursor step to future cleanup.

I like how `endpoint.agentFor(context)` reads better than `context.agentFor(endpoint)` regardless.