### PR TITLE
Fix cyclic import that broke DiagnosticSource

### DIFF
--- a/packages/general/src/environment/Environmental.ts
+++ b/packages/general/src/environment/Environmental.ts
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Diagnostic } from "../log/Diagnostic.js";
 import { Observable } from "../util/Observable.js";
 import type { Environment } from "./Environment.js";
 
@@ -21,16 +20,6 @@ export namespace Environmental {
          * Asynchronous construction, respected by {@link Environment.load}.
          */
         construction?: Promise<any>;
-
-        /**
-         * Standard diagnostic presentation.
-         */
-        [Diagnostic.presentation]?: Diagnostic.Presentation;
-
-        /**
-         * Standard diagnostic value.
-         */
-        [Diagnostic.value]?: unknown;
     }
 
     /**
@@ -38,7 +27,7 @@ export namespace Environmental {
      *
      * A "factory" is just a class with a static {@link create} method that performs instantiation.
      */
-    export interface Factory<T extends Service = Service> {
+    export interface Factory<T extends object> {
         new (...args: any[]): T;
 
         /**

--- a/packages/general/src/environment/RuntimeService.ts
+++ b/packages/general/src/environment/RuntimeService.ts
@@ -203,7 +203,7 @@ export class RuntimeService implements Multiplex {
                 let diagnostic: unknown = worker[RuntimeService.label];
 
                 if (diagnostic === undefined) {
-                    diagnostic = worker[Diagnostic.value];
+                    diagnostic = Diagnostic.valueOf(worker);
 
                     if (diagnostic === undefined) {
                         diagnostic = worker.toString();
@@ -302,10 +302,5 @@ export namespace RuntimeService {
          * If label is present, it will be presented in diagnostics.  This takes precedence over [Diagnostic.value].
          */
         [label]?: unknown;
-
-        /**
-         * In diagnostics workers render using toString() unless they provide explicit diagnostics.
-         */
-        [Diagnostic.value]?: unknown;
     }
 }

--- a/packages/general/src/log/DiagnosticPresentation.ts
+++ b/packages/general/src/log/DiagnosticPresentation.ts
@@ -1,0 +1,77 @@
+/**
+ * @license
+ * Copyright 2022-2025 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export enum DiagnosticPresentation {
+    /**
+     * Render an object as a log message.
+     */
+    Message = "message",
+
+    /**
+     * By default iterables render as a single line with spaces separating.  The "list" presentation treats elements
+     * instead as separate entities which typically means presentation on different lines.
+     *
+     * Within an iterable, a list also serves to present contained items as subordinate to the previous item.
+     */
+    List = "list",
+
+    /**
+     * Render iterables without intervening spaces.
+     */
+    Squash = "squash",
+
+    /**
+     * An emphasized diagnostic.  Rendered to draw attention.
+     */
+    Strong = "strong",
+
+    /**
+     * A deemphasized diagnostic.  Rendered to draw less attention than default rendering.
+     */
+    Weak = "weak",
+
+    /**
+     * A keylike diagnostic to list flags.  The key gets suppressed and the value is rendered as a key.
+     */
+    Flag = "flag",
+
+    /**
+     * An error message diagnostic.
+     */
+    Error = "error",
+
+    /**
+     * A key/value diagnostic.  Rendered as a group of key/value pairs.
+     */
+    Dictionary = "dictionary",
+
+    /**
+     * Path, resource or session identifier.
+     */
+    Via = "via",
+
+    /**
+     * Resource that was added.
+     */
+    Added = "added",
+
+    /**
+     * Resource that was removed.
+     */
+    Deleted = "deleted",
+}
+
+export namespace DiagnosticPresentation {
+    /**
+     * Property name allowing objects to indicate their preferred presentation.
+     */
+    export const presentation: unique symbol = Symbol("presentation");
+
+    /**
+     * Property name that redirects diagnostic presentation.
+     */
+    export const value: unique symbol = Symbol.for("value");
+}

--- a/packages/general/src/log/DiagnosticSource.ts
+++ b/packages/general/src/log/DiagnosticSource.ts
@@ -4,7 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Diagnostic } from "./Diagnostic.js";
+// Note we cannot import diagnostic directly as it causes circular reference
+import type { Diagnostic } from "./Diagnostic.js";
+import { DiagnosticPresentation } from "./DiagnosticPresentation.js";
 
 const sources = new Set<Diagnostic>();
 
@@ -20,11 +22,11 @@ export const DiagnosticSource = {
         sources.delete(source);
     },
 
-    get [Diagnostic.presentation]() {
-        return Diagnostic.Presentation.List;
+    get [DiagnosticPresentation.presentation]() {
+        return DiagnosticPresentation.List;
     },
 
-    get [Diagnostic.value]() {
+    get [DiagnosticPresentation.value]() {
         return sources;
     },
 };

--- a/packages/general/src/log/index.ts
+++ b/packages/general/src/log/index.ts
@@ -5,6 +5,7 @@
  */
 
 export * from "./Diagnostic.js";
+export * from "./DiagnosticPresentation.js";
 export * from "./DiagnosticSource.js";
 export * from "./LogDestination.js";
 export * from "./LogFormat.js";

--- a/packages/node/src/endpoint/Endpoint.ts
+++ b/packages/node/src/endpoint/Endpoint.ts
@@ -536,7 +536,14 @@ export class Endpoint<T extends EndpointType = EndpointType.Empty> {
      * Is this a parent Endpoint?
      */
     get hasParts() {
-        return !!this.#parts?.size;
+        // This doesn't work, apparent TS bug
+        //return !!this.#parts?.size;
+
+        if (this.#parts?.size) {
+            return true;
+        }
+
+        return false;
     }
 
     /**

--- a/packages/node/src/node/Node.ts
+++ b/packages/node/src/node/Node.ts
@@ -199,7 +199,7 @@ export abstract class Node<T extends Node.CommonRootEndpoint = Node.CommonRootEn
         return ["Runtime for", Diagnostic.strong(this.toString())];
     }
 
-    override get [Diagnostic.value](): unknown {
+    get [Diagnostic.value](): unknown {
         const nodeActivity = this.#environment.get(NodeActivity);
         using _activity = nodeActivity.begin("diagnostics");
         return Diagnostic.node("🧩", this.id, {

--- a/packages/protocol/src/bdx/BdxMessenger.ts
+++ b/packages/protocol/src/bdx/BdxMessenger.ts
@@ -92,7 +92,7 @@ export class BdxMessenger {
 
         logger.debug(
             `Received Bdx ${BdxMessageType[messageType]}${message.payload.byteLength > 0 ? ` with ${message.payload.byteLength}bytes` : ""}`,
-            message,
+            Diagnostic.dict(message),
         );
         return BdxMessage.decode(messageType, message.payload);
     }

--- a/packages/protocol/test/bdx/BdxTest.ts
+++ b/packages/protocol/test/bdx/BdxTest.ts
@@ -1375,7 +1375,6 @@ describe("BdxTest", () => {
                     serverStorage,
                     { clientExchangeData, serverExchangeData, clientError },
                 ) => {
-                    console.log(clientError);
                     expect(clientError instanceof BdxError).equals(true);
                     expect(clientError.code).equals(BdxStatusCode.LengthTooShort);
 

--- a/packages/react-native/src/crypto/ReactNativeCrypto.ts
+++ b/packages/react-native/src/crypto/ReactNativeCrypto.ts
@@ -11,6 +11,7 @@ import {
     CRYPTO_SYMMETRIC_KEY_LENGTH,
     Environment,
     Key,
+    NodeJsCryptoApiLike,
     NodeJsStyleCrypto,
     PrivateKey,
     PublicKey,
@@ -22,7 +23,7 @@ import QuickCrypto from "react-native-quick-crypto";
 
 // This is probably the crypto implementation we should be building on because Quick Crypto's node.js emulation is more
 // mature than their web crypto support.  However, for now we just use for API portions where web crypto does not work
-const nodeJsCrypto = new NodeJsStyleCrypto(QuickCrypto);
+const nodeJsCrypto = new NodeJsStyleCrypto(QuickCrypto as unknown as NodeJsCryptoApiLike);
 
 // The default export from QuickCrypto should be compatible with the standard `crypto` object but the type system
 // seems confused by CJS exports.  Use a forced cast to correct types.


### PR DESCRIPTION
Also tweaks how we handle diagnostic presentations to make slightly more logical and fix raft of type errors inflicted by TS confusion resulting from above.