### PR TITLE
Improved model access patterns

### DIFF
--- a/packages/model/src/elements/DatatypeElement.ts
+++ b/packages/model/src/elements/DatatypeElement.ts
@@ -43,9 +43,8 @@ export namespace DatatypeElement {
     /**
      * Convert a TypeScript enum to Matter enum values.
      *
-     * Matter enums include conformance and other metadata.  They may also have
-     * multiple definitions of the same value selectable by conformance.  So
-     * we can't use a TypeScript enum directly.
+     * Matter enums include conformance and other metadata.  They may also have multiple definitions of the same value
+     * selectable by conformance.  So we can't use a TypeScript enum directly.
      */
     export function ListValues(values: ValueMap): ListValues {
         const result = Array<FieldElement>();
@@ -67,16 +66,14 @@ export namespace DatatypeElement {
     }
 
     /**
-     * We express enum values as IntElements as this gives us conformance
-     * and other metadata.
+     * We express enum values as IntElements as this gives us conformance and other metadata.
      */
     export type ListValues = FieldElement[];
 
     /**
-     * Per the Matter specification, enums are named integers.  The following
-     * allows TypeScript enums to be supplied for translation into Matter
-     * enums.  To do so, we must accept both numeric and string values.  For
-     * generating the Matter enum we ignore the string keys.
+     * Per the Matter specification, enums are named integers.  The following allows TypeScript enums to be supplied for
+     * translation into Matter enums.  To do so, we must accept both numeric and string values.  For generating the
+     * Matter enum we ignore the string keys.
      */
     export type ValueMap = { [name: string]: number | string };
 }

--- a/packages/model/src/logic/ModelIndex.ts
+++ b/packages/model/src/logic/ModelIndex.ts
@@ -1,0 +1,125 @@
+/**
+ * @license
+ * Copyright 2022-2025 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { camelize } from "#general";
+import { Model } from "../models/Model.js";
+
+/**
+ * An read-only array of models with support for efficient lookup by name and ID.
+ *
+ * Name search uses canonical camel case, so "FooBar", "fooBar" and "foo-bar" are considered equivalent.
+ */
+export interface ModelIndex<T extends Model = Model> extends ReadonlyArray<T> {
+    /**
+     * Retrieve a model for the given ID or name.
+     *
+     * Use the two-parameter version for indices that contain multiple model types.
+     */
+    for(key: number | string): T | undefined;
+
+    /**
+     * Retrieve a model of the specific type for the given ID or name.
+     *
+     * Name search uses canonical camel case.
+     */
+    for<M extends T>(key: number | string, type: Model.Type<M>): M | undefined;
+
+    /**
+     * Filter to a specific model subtype.
+     */
+    ofType<M extends T>(type: Model.Type<M>): M[];
+}
+
+/**
+ * Implementation of {@link ModelIndex} used for initial creation.
+ */
+export class MutableModelIndex<T extends Model = Model> extends Array<T> implements ModelIndex {
+    #nameIndex?: Map<string, T | T[]>;
+    #idIndex?: Map<number, T | T[]>;
+
+    for(key: number | string): T;
+    for<M extends T>(key: number | string, type: Model.Type<M>): M;
+
+    for(key: number | string, type?: Model.Type): Model | undefined {
+        let untyped: undefined | Model | Model[];
+
+        if (typeof key === "number") {
+            untyped = this.#ids.get(key);
+        } else {
+            untyped = this.#names.get(camelize(key));
+        }
+
+        if (untyped === undefined) {
+            return undefined;
+        }
+
+        if (Array.isArray(untyped)) {
+            if (type) {
+                return untyped.find(m => m instanceof type);
+            }
+            return untyped[0];
+        }
+
+        if (type && !(untyped instanceof type)) {
+            return undefined;
+        }
+
+        return untyped;
+    }
+
+    ofType<T extends Model.Type>(type: T): InstanceType<T>[] {
+        return this.filter(m => m instanceof type) as InstanceType<T>[];
+    }
+
+    get #ids() {
+        if (this.#idIndex) {
+            return this.#idIndex;
+        }
+
+        const index = (this.#idIndex = new Map<number, T | T[]>());
+        for (const model of this) {
+            if (model.id === undefined) {
+                continue;
+            }
+
+            const already = index.get(model.id);
+            if (already) {
+                if (Array.isArray(already)) {
+                    already.push(model);
+                } else {
+                    index.set(model.id, [already, model]);
+                }
+            } else {
+                index.set(model.id, model);
+            }
+        }
+
+        return this.#idIndex;
+    }
+
+    get #names() {
+        if (this.#nameIndex) {
+            return this.#nameIndex;
+        }
+
+        const index = (this.#nameIndex = new Map<string, T | T[]>());
+        for (const model of this) {
+            const name = camelize(model.name);
+            const already = index.get(name);
+            if (already) {
+                if (Array.isArray(already)) {
+                    already.push(model);
+                } else {
+                    index.set(name, [already, model]);
+                }
+            } else {
+                index.set(name, model);
+            }
+        }
+
+        return this.#nameIndex;
+    }
+}

--- a/packages/model/src/logic/index.ts
+++ b/packages/model/src/logic/index.ts
@@ -13,6 +13,7 @@ export * from "./ClusterVariance.js";
 export * from "./DefaultValue.js";
 export * from "./MergedModel.js";
 export * from "./ModelDiff.js";
+export * from "./ModelIndex.js";
 export * from "./ModelVariantTraversal.js";
 export * from "./Scope.js";
 export * from "./ValidateModel.js";

--- a/packages/node/src/behavior/supervision/ValueSupervisor.ts
+++ b/packages/node/src/behavior/supervision/ValueSupervisor.ts
@@ -54,7 +54,7 @@ export interface ValueSupervisor {
     readonly manage: ValueSupervisor.Manage;
 
     /**
-     * Apply changes.  Does not validate perform validation.
+     * Apply changes.  Does not perform validation.
      */
     readonly patch: ValueSupervisor.Patch;
 

--- a/packages/node/src/node/server/ProtocolService.ts
+++ b/packages/node/src/node/server/ProtocolService.ts
@@ -303,7 +303,7 @@ class ClusterState implements DisposableClusterProtocol {
         this.#datasource = backing.datasource;
         this.#endpointId = backing.endpoint.number;
 
-        const attributeNameToIdMap = backing.type.supervisor.attributeNamesToIds;
+        const attributeNameToIdMap = backing.type.supervisor.propertyNamesAndIds;
         // For quieter attributes, we need to use the online events to get real state changes
         for (const attr of type.attributes) {
             attributeNameToIdMap.set(attr.name, attr.id);


### PR DESCRIPTION
* Change accessors for specific model subtypes from a plain array to a dedicated "ModelIndex" type.  This adds `for` and `ofType` for performing lookup filtering by type, respectively.

* Add `conformant` property to ClusterModel and ValueModel.  These contain subtype properties like the parent object but return conformant members from `Scope`.