### PR TITLE
Correctly store and use FabricIndex in Resumption records

### DIFF
--- a/packages/protocol/src/session/SessionManager.ts
+++ b/packages/protocol/src/session/SessionManager.ts
@@ -615,7 +615,7 @@ export class SessionManager {
                 );
                 if (!fabric) {
                     logger.warn(
-                        `Ignoring resumption record for fabric 0x${toHex(fabricId)} and index ${fabricIndex} because we can not find a matching fabric`,
+                        `Ignoring resumption record for fabric 0x${toHex(fabricId)} and index ${fabricIndex} because we cannot find a matching fabric`,
                     );
                     return;
                 }


### PR DESCRIPTION
The absence of the fabricIndex lead to wrong mappings when nodeIds were colliding for a commissioned device. The new code is backward compatible and represent the former logic without fabricIndex, but work correctly with fabricIndex. Also logging is adjusted