### PR TITLE
Remote control servers for non-Matter protocols

### DIFF
--- a/packages/node/src/behavior/system/index.ts
+++ b/packages/node/src/behavior/system/index.ts
@@ -11,4 +11,5 @@ export * from "./index/index.js";
 export * from "./network/index.js";
 export * from "./parts/index.js";
 export * from "./product-description/index.js";
+export * from "./remote/index.js";
 export * from "./sessions/index.js";

--- a/packages/node/src/behavior/system/remote/RemoteInterface.ts
+++ b/packages/node/src/behavior/system/remote/RemoteInterface.ts
@@ -1,0 +1,123 @@
+/**
+ * @license
+ * Copyright 2022-2025 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { AppAddress, BasicMultiplex, ImplementationError, Logger, MaybePromise } from "#general";
+import type { ServerNode } from "#node/ServerNode.js";
+import { ApiPath } from "./api/ApiPath.js";
+
+const logger = Logger.get("RemoteAdapter");
+
+/**
+ * An implementation of a non-Matter network protocol for accessing a {@link ServerNode}.
+ */
+export abstract class RemoteInterface {
+    #node: ServerNode;
+    #address: AppAddress;
+    #abort = new AbortController();
+    #root: ApiPath;
+    #workers = new BasicMultiplex();
+
+    constructor(node: ServerNode, address: AppAddress) {
+        if (address.appProtocol !== (this.constructor as unknown as RemoteInterface.Type).protocol) {
+            throw new ImplementationError(
+                `API endpoint type ${this.constructor.name} does not support address ${address}`,
+            );
+        }
+        this.#node = node;
+        this.#address = address;
+        this.#root = new ApiPath(address);
+    }
+
+    get root() {
+        return this.#root;
+    }
+
+    get env() {
+        return this.#node.env;
+    }
+
+    get node() {
+        return this.#node;
+    }
+
+    get address() {
+        return this.#address;
+    }
+
+    get isAborted() {
+        return this.#abort.signal.aborted;
+    }
+
+    get abort() {
+        return this.#abort.signal;
+    }
+
+    static async create<This extends new (node: ServerNode, address: AppAddress) => RemoteInterface>(
+        this: This,
+        node: ServerNode,
+        address: AppAddress,
+    ) {
+        const instance = new this(node, address);
+        try {
+            await instance.start();
+        } catch (e) {
+            await instance.close();
+            throw e;
+        }
+        return instance;
+    }
+
+    async close(): Promise<void> {
+        if (this.isAborted) {
+            return;
+        }
+
+        this.#abort.abort();
+
+        try {
+            await this.stop();
+        } catch (e) {
+            logger.error(`Error terminating API endpoint ${this.address}`);
+        }
+    }
+
+    protected assertProtocol(appProtocol: string) {
+        if (this.address.appProtocol !== appProtocol) {
+            throw new ImplementationError(
+                `Invalid protocol ${this.address} for API endpoin type ${this.constructor.name}`,
+            );
+        }
+    }
+
+    protected addWorker(worker: Promise<void>, description: string) {
+        this.#workers.add(worker, description);
+    }
+
+    static protocol = "";
+
+    /**
+     * Initialize and begin handling requests to the interface.
+     */
+    protected abstract start(): Promise<void>;
+
+    /**
+     * Stop servicing requests.  Called on close.  The default implementation just waits for any workers to complete.
+     */
+    protected async stop(): Promise<void> {
+        await this.#workers.close();
+    }
+}
+
+export namespace RemoteInterface {
+    export interface Type {
+        protocol: string;
+        create(node: ServerNode, address: AppAddress): Promise<RemoteInterface>;
+    }
+
+    export interface Factory {
+        (node: ServerNode, address: AppAddress): MaybePromise<RemoteInterface | void>;
+    }
+}

--- a/packages/node/src/behavior/system/remote/RemoteInterfaceService.ts
+++ b/packages/node/src/behavior/system/remote/RemoteInterfaceService.ts
@@ -1,0 +1,68 @@
+/**
+ * @license
+ * Copyright 2022-2025 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+    AppAddress,
+    Diagnostic,
+    Environment,
+    Environmental,
+    ImplementationError,
+    Logger,
+    ServiceBundle,
+} from "#general";
+import type { ServerNode } from "#node/ServerNode.js";
+import type { RemoteInterface } from "./RemoteInterface.js";
+
+const logger = Logger.get("RemoteServer");
+
+/**
+ * Environmental registration for API adapters.
+ */
+export class RemoteInterfaceService {
+    #factories = new Set<RemoteInterface.Factory>();
+
+    add(factory: RemoteInterface.Factory) {
+        this.#factories.add(factory);
+    }
+
+    async create(node: ServerNode, address: AppAddress): Promise<RemoteInterface> {
+        for (const factory of this.#factories) {
+            let result = factory(node, address);
+
+            if (result) {
+                result = await result;
+            }
+
+            if (result === undefined) {
+                continue;
+            }
+
+            logger.info("Listening on", Diagnostic.strong(AppAddress.for(address)));
+
+            return result;
+        }
+        throw new ImplementationError(`No remote implementation available for address ${address}`);
+    }
+
+    static [Environmental.create](env: Environment) {
+        const instance = new RemoteInterfaceService();
+        env.set(RemoteInterfaceService, instance);
+        return instance;
+    }
+
+    /**
+     * Register an API adapter for use in any environment.
+     */
+    static register(type: RemoteInterface.Type) {
+        ServiceBundle.default.add(env => {
+            env.get(RemoteInterfaceService).add((node, address) => {
+                if (type.protocol === address.appProtocol) {
+                    return type.create(node, address);
+                }
+            });
+        });
+    }
+}

--- a/packages/node/src/behavior/system/remote/RemoteServer.ts
+++ b/packages/node/src/behavior/system/remote/RemoteServer.ts
@@ -1,0 +1,258 @@
+/**
+ * @license
+ * Copyright 2022-2025 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Behavior } from "#behavior/Behavior.js";
+import { AppAddress, MatterAggregateError } from "#general";
+import { DatatypeModel, FieldElement } from "#model";
+import type { ServerNode } from "#node/ServerNode.js";
+import { RemoteInterface } from "./RemoteInterface.js";
+import { RemoteInterfaceService } from "./RemoteInterfaceService.js";
+
+// Register built-in API interfaces
+import "./interfaces/index.js";
+
+/**
+ * Remote access server for a {@link ServerNode}.
+ *
+ *
+ * # Overview
+ *
+ * This behavior implements remote access to matter.js internals via non-Matter protocols.  Protocols included with
+ * matter.js include HTTP/REST, WebSockets and MQTT.
+ *
+ * Remote access supports various use cases:
+ *
+ *   - Local control of a node via UNIX socket
+ *
+ *   - Server-to-server communication such as synchronizing Matter state with another application
+ *
+ *   - Client-server communication between a node and mobile or web UI
+ *
+ *
+ * # Configuration
+ *
+ * You enable remote protocols in by specifying service addresses in {@link RemoteServer#state}.  A service address is a
+ * URL.  See {@link RemoteServer#State} for more details.
+ *
+ * The service URL protocol selects the type of API interface, which must have a corresponding {@link RemoteInterface}
+ * registered with {@link RemoteInterfaceService}.  If no appropriate API interface is present for a given protocol the
+ * server will log an error.
+ *
+ * API interfaces included with matter.js implement HTTP, WebSockets and MQTT if appropriate platform components are
+ * present.  Matter.js provides interfaces for common platforms with protocol support as follows.
+ *
+ * With an HTTP implementation such as that provided by @matter/nodejs:
+ *   - http
+ *   - https
+ *   - http+unix
+ *   - https+unix
+ *
+ * With a WebSocket implementation such as that provided by @matter/nodejs-ws:
+ *   - ws
+ *   - wss
+ *   - ws+unix
+ *   - wss+unix
+ *
+ * With an MQTT implementation such as that provided by @matter/mqtt:
+ *   - mqtt
+ *   - mqtts
+ *   - mqtt+ws
+ *   - mqtt+wss
+ *   - mqtt+unix
+ *   - mqtts+unix
+ *
+ * The "s" suffix indicates standard TLS support.
+ *
+ * The "+unix" suffix indicates that the hostname is a URL encoded path to a UNIX socket.  The socket path may be
+ * absolute or relative to the node's storage root.
+ *
+ *
+ * # Interface scope
+ *
+ * The path segment in the URL generally acts as additional scope dependent on the service type, as follows:
+ *
+ *   - For HTTP, this is the root path of matter.js APIs.  You may want to set this if you run multiple services on the
+ *     same HTTP server.
+ *
+ *   - For web sockets, this acts as an additional prefix on {@link RemoteRequest#target}.
+ *
+ *   - For MQTT, this adds an additional prefix to all matter.js topics.
+ *
+ * If you include the special token `{node}` in a service path, matter.js replaces it with {@link ServerNode#id}.
+ */
+export class RemoteServer extends Behavior {
+    static override readonly id = "remote";
+    static override readonly early = true;
+
+    declare internal: RemoteServer.Internal;
+    declare state: RemoteServer.State;
+
+    override async initialize() {
+        this.#configureProtocol("http", this.state.http ?? false, this.state.httpAddress);
+        this.#configureProtocol("ws", this.state.ws ?? false, this.state.httpAddress?.replace(/^http/, "ws"));
+        this.#configureProtocol("mqtt", this.state.mqtt ?? !!this.state.mqttAddress, this.state.mqttAddress);
+
+        this.reactTo((this.endpoint as ServerNode).lifecycle.online, this.#start);
+        this.reactTo((this.endpoint as ServerNode).lifecycle.offline, this.#onOffline);
+
+        // If configured to allow interfaces when offline, we must manually ensure we aren't active during node
+        // destruction
+        this.reactTo((this.endpoint as ServerNode).lifecycle.destroying, this.#stop);
+
+        if (this.state.allowOfflineUse) {
+            await this.#start();
+        }
+    }
+
+    override [Symbol.asyncDispose]() {
+        return this.#stop();
+    }
+
+    #configureProtocol(name: string, enabled: boolean, defaultAddress?: string) {
+        if (!enabled) {
+            this.state.services = this.state.services.filter(service => {
+                const address = new AppAddress(service);
+                return address.appProtocol !== name && address.appProtocol !== `${name}s`;
+            });
+            return;
+        }
+
+        if (defaultAddress === undefined) {
+            return;
+        }
+
+        if (this.state.services.some(service => service.toString() === defaultAddress)) {
+            return;
+        }
+
+        this.state.services.push(defaultAddress);
+    }
+
+    async #start() {
+        if (!this.state.enabled || this.internal.interfaces) {
+            return;
+        }
+
+        const interfaceService = this.env.get(RemoteInterfaceService);
+        const interfacePromises = this.state.services.map(address => {
+            const addr = AppAddress.for(address);
+            addr.pathname = addr.pathname.replace(/\{node\}|%7[bB]node%7[dD]/g, this.endpoint.id);
+            return interfaceService.create(this.endpoint as ServerNode, addr);
+        });
+
+        this.internal.interfaces = await MatterAggregateError.allSettled(interfacePromises);
+    }
+
+    async #stop() {
+        if (!this.internal.interfaces) {
+            return;
+        }
+
+        const { interfaces } = this.internal;
+
+        await MatterAggregateError.allSettled(interfaces.map(intf => intf.close()));
+    }
+
+    async #onOffline() {
+        if (!this.state.allowOfflineUse) {
+            await this.#stop();
+        }
+    }
+
+    static override readonly schema = new DatatypeModel(
+        {
+            name: "ApiState",
+            type: "struct",
+        },
+
+        FieldElement({ name: "httpAddress", type: "string" }),
+        FieldElement({ name: "http", type: "bool" }),
+        FieldElement({ name: "ws", type: "bool" }),
+        FieldElement({ name: "mqttAddress", type: "string" }),
+        FieldElement({ name: "mqtt", type: "bool" }),
+        FieldElement({ name: "services", type: "list" }, FieldElement({ name: "entry", type: "string" })),
+        FieldElement({ name: "enabled", type: "bool" }),
+        FieldElement({ name: "allowOfflineUse", type: "bool" }),
+    );
+}
+
+export namespace RemoteServer {
+    export class Internal {
+        interfaces?: Array<RemoteInterface>;
+    }
+
+    export class State {
+        #services?: string[];
+
+        /**
+         * The default address for HTTP and WebSocket endpoints.
+         */
+        httpAddress? = "http+unix://matter.sock";
+
+        /**
+         * Enable HTTP API.
+         *
+         * Adds an address to {@link services} if true.  Removes HTTP addresses from {@link services} if false.
+         *
+         * Defaults to false.  Ignored if {@link httpAddress} is undefined or there is no HTTP implementation installed.
+         */
+        http?: boolean;
+
+        /**
+         * Enable WebSocket API.
+         *
+         * Adds an address to {@link services} if true.  Removes WS addresses from {@link services} if false.
+         *
+         * Defaults to false.  Ignored if {@link httpAddress} is undefined or there is no WebSocket implementation
+         * installed.
+         */
+        ws?: boolean;
+
+        /**
+         * The default address for an MQTT broker.
+         */
+        mqttAddress?: string;
+
+        /**
+         * Enable MQTT API.
+         *
+         * Adds an address to {@link services} if true.  Removes WS addresses from {@link services} if false.
+         *
+         * Defaults to true if {@link mqttAddress} is defined.  Ignored if {@link mqttAddress} is undefined or there is
+         * no MQTT implementation installed.
+         */
+        mqtt?: boolean;
+
+        /**
+         * The API services to publish.
+         *
+         * Above shortcuts make configuration more straightforward, but you can also specify a list of services directly
+         * here.
+         */
+        get services(): string[] {
+            return this.#services ?? [];
+        }
+
+        set services(services: AppAddress.Definition[] | undefined) {
+            this.#services = services?.map(definition => new AppAddress(definition).toString()) ?? [];
+        }
+
+        /**
+         * Set to false to disable the server.
+         *
+         * This is useful to allow for runtime configuration of HTTP support.
+         */
+        enabled = true;
+
+        /**
+         * By default the HTTP endpoint is available as soon as the {@link Node} initializes.
+         *
+         * If you set this to false, the HTTP endpoint is only available when the {@link Node}'s Matter networking is
+         * also online.
+         */
+        allowOfflineUse = true;
+    }
+}

--- a/packages/node/src/behavior/system/remote/api/Api.ts
+++ b/packages/node/src/behavior/system/remote/api/Api.ts
@@ -1,0 +1,171 @@
+/**
+ * @license
+ * Copyright 2022-2025 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Agent } from "#endpoint/Agent.js";
+import { Abort, asError, Diagnostic, InternalError, Logger } from "#general";
+import { Node } from "#node/Node.js";
+import { ServerNode } from "#node/ServerNode.js";
+import { StatusResponse, StatusResponseError } from "#types";
+import { ApiPath } from "./ApiPath.js";
+import { ApiResource } from "./ApiResource.js";
+import { LocalResponse } from "./LocalResponse.js";
+import { RemoteRequest } from "./RemoteRequest.js";
+import { RemoteResponse } from "./RemoteResponse.js";
+import { EndpointResource } from "./resources/EndpointResource.js";
+import { NodeResource } from "./resources/NodeResource.js";
+import { ServerNodeResource } from "./resources/ServerNodeResource.js";
+
+const loggers = new Map<string, Logger>();
+
+/**
+ * Common substrate for the network APIs.
+ *
+ * The logical API covers RPC and read/write semantics.  These involve a "/"-separated path and a logical operation
+ * (read, write, invoke, etc.)
+ *
+ * This namespace provides utilities for mapping paths to resources and taking action on the resource.
+ */
+export namespace Api {
+    /**
+     * Retrieve the {@link ApiResource} for a path.
+     */
+    export async function resourceFor(agent: Agent, path: ApiPath): Promise<ApiResource | void> {
+        let item;
+        if ("peers" in agent.endpoint) {
+            item = new ServerNodeResource(agent, undefined);
+        } else if (agent.endpoint instanceof Node) {
+            item = new NodeResource(agent, undefined);
+        } else {
+            item = new EndpointResource(agent, undefined);
+        }
+
+        const breadcrumb: ApiResource[] = [item];
+
+        for (const segment of path) {
+            const parent = breadcrumb[breadcrumb.length - 1];
+
+            const item = await parent.childFor(segment);
+            if (!item) {
+                return;
+            }
+
+            breadcrumb.push(item);
+        }
+
+        return breadcrumb[breadcrumb.length - 1];
+    }
+
+    export function log(level: "error" | "info", facility: string, id: string | undefined, ...message: unknown[]) {
+        let logger = loggers.get(facility);
+        if (!logger) {
+            loggers.set(facility, (logger = Logger.get(facility)));
+        }
+        logger[level](Diagnostic.via(id ?? "(anon)"), message);
+    }
+
+    export function logRequest(facility: string, id: string | undefined, method: string, target: string) {
+        log("info", facility, id, "«", Diagnostic.strong(method), target);
+    }
+
+    export function logResponse(facility: string, response: RemoteResponse) {
+        const message = Array<unknown>("»", response.kind);
+        let level: "error" | "info";
+        switch (response.kind) {
+            case "error":
+                message.push(Diagnostic.squash("[", Diagnostic.strong(response.code), "]"));
+                message.push(response.message);
+                level = "error";
+                break;
+
+            default:
+                level = "info";
+                break;
+        }
+        log(level, facility, response.id, message);
+    }
+
+    /**
+     * Execute a {@link RemoteRequest}.
+     */
+    export async function execute(
+        facility: string,
+        node: ServerNode,
+        request: RemoteRequest,
+        signal: Abort.Signal,
+    ): Promise<LocalResponse> {
+        const { target, method, id } = request;
+
+        logRequest(facility, id, method, target);
+
+        try {
+            const message = await node.act("remote", async (agent): Promise<LocalResponse> => {
+                const item = await resourceFor(agent, new ApiPath(target));
+                if (item === undefined) {
+                    throw new StatusResponse.NotFoundError(`Target "${target}" not found`);
+                }
+
+                switch (method) {
+                    case "read":
+                        const value = item.read();
+                        if (value === undefined) {
+                            throw new StatusResponse.UnsupportedReadError(`Target "${target}" is not readable`);
+                        }
+                        value.convertToJson();
+
+                        return {
+                            kind: "value",
+                            id,
+
+                            // TODO - consider handling serialization here (in agent context) so copy is unnecessary
+                            value,
+                        };
+
+                    case "write":
+                        item.write({ js: request.value });
+                        return { kind: "ok", id };
+
+                    case "add":
+                        item.add({ js: item.value });
+                        return { kind: "ok", id };
+
+                    case "delete":
+                        item.delete();
+                        return { kind: "ok", id };
+
+                    case "invoke": {
+                        const value = await item.invoke({ js: request.parameters });
+                        if (value?.js === undefined || value?.js === null) {
+                            return { kind: "ok", id };
+                        }
+                        value.convertToJson();
+                        return { id, kind: "value", value };
+                    }
+
+                    case "subscribe":
+                        const stream = item.subscribe(signal, { id, js: item });
+                        return { kind: "subscription", id, stream };
+                }
+            });
+
+            return message;
+        } catch (error) {
+            return errorResponseOf(facility, id, error);
+        }
+    }
+
+    export function errorResponseOf(facility: string, id: string | undefined, error: unknown): LocalResponse {
+        error = asError(error);
+
+        // User-facing message
+        if (error instanceof StatusResponseError) {
+            return { kind: "error", id, error };
+        }
+
+        // Internal error
+        log("error", facility, id, "Internal error:", error);
+        return { kind: "error", id, error: new InternalError() };
+    }
+}

--- a/packages/node/src/behavior/system/remote/api/ApiPath.ts
+++ b/packages/node/src/behavior/system/remote/api/ApiPath.ts
@@ -1,0 +1,101 @@
+/**
+ * @license
+ * Copyright 2022-2025 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { AppAddress, isDeepEqual } from "#general";
+
+/**
+ * A logical path in the API.
+ */
+export class ApiPath {
+    #segments = Array<string>();
+
+    /**
+     * Create a new path from:
+     *
+     * * An {@link AppAddress#pathname}
+     * * A text path, delimited with "/" with URL encoded segments
+     * * An array of decoded segments
+     *
+     * Ignores path segments that are empty or ".".  ".." resolves up one level.
+     *
+     * So generally normal UNIX/URL semantics.
+     */
+    constructor(path: AppAddress | string | string[]) {
+        if (path instanceof URL) {
+            path = path.pathname;
+        }
+
+        if (!Array.isArray(path)) {
+            path = path.split("/").map(decodeURIComponent);
+        }
+
+        for (const segment of path) {
+            if (segment === "" || segment === ".") {
+                continue;
+            }
+
+            if (segment === "..") {
+                this.#segments.pop();
+                continue;
+            }
+
+            this.#segments.push(segment);
+        }
+    }
+
+    get isEmpty() {
+        return !this.#segments.length;
+    }
+
+    [Symbol.iterator]() {
+        return this.#segments[Symbol.iterator]();
+    }
+
+    slice(start?: number, end?: number) {
+        return new ApiPath(this.#segments.slice(start, end));
+    }
+
+    at(path: AppAddress | string | string[]) {
+        if (this.isEmpty) {
+            return new ApiPath(path);
+        }
+
+        if (path instanceof URL) {
+            path = path.pathname;
+        }
+
+        if (Array.isArray(path)) {
+            path = path.map(encodeURIComponent).join("/");
+        }
+
+        if (path.startsWith("/")) {
+            return new ApiPath(path);
+        }
+
+        // Note - parse combined path as a string so that ".." resolves relative to myself if necessary
+        return new ApiPath(`${this.toString()}/${path}`);
+    }
+
+    toString() {
+        return `${this.#segments.map(encodeURIComponent).join("/")}`;
+    }
+
+    includes(other: ApiPath) {
+        return isDeepEqual(this.#segments, other.slice(0, this.#segments.length).#segments);
+    }
+
+    subpathFor(other: ApiPath) {
+        if (!this.#segments.length) {
+            return other;
+        }
+
+        if (!this.includes(other)) {
+            return undefined;
+        }
+
+        return other.slice(this.#segments.length);
+    }
+}

--- a/packages/node/src/behavior/system/remote/api/ApiResource.ts
+++ b/packages/node/src/behavior/system/remote/api/ApiResource.ts
@@ -1,0 +1,146 @@
+/**
+ * @license
+ * Copyright 2022-2025 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Abort, MaybePromise, NotImplementedError } from "#general";
+import { any, DataModelPath, Schema } from "#model";
+import { Envelope } from "./Envelope.js";
+import { LocalResponse } from "./LocalResponse.js";
+
+/**
+ * A node in the logical API tree structure.
+ *
+ * {@link ApiResource}s are ephemeral objects created on-demand as the server navigates paths.
+ */
+export abstract class ApiResource {
+    /**
+     * The item's identifier in the logical model path.
+     */
+    abstract readonly id: string;
+
+    /**
+     * The item's owner, if any.
+     */
+    readonly parent?: ApiResource;
+
+    /**
+     * Data model path used for diagnostics.
+     */
+    abstract readonly dataModelPath: DataModelPath;
+
+    /**
+     * Data schema, if any.
+     */
+    abstract readonly schema?: Schema;
+
+    /**
+     * Data value.
+     */
+    abstract readonly value: unknown;
+
+    /**
+     * Indicates whether this is an RPC endpoint.
+     */
+    readonly isInvocable: boolean = false;
+
+    /**
+     * Indicates whether this is an event endpoint.
+     */
+    readonly isSubscribable: boolean = false;
+
+    /**
+     * The {@link ApiResource.Kind} for {@link value}.
+     */
+    abstract readonly valueKind: ApiResource.Kind;
+
+    constructor(parent: undefined | ApiResource) {
+        this.parent = parent;
+    }
+
+    /**
+     * Retrieve the body of the item.
+     */
+    read() {
+        if (this.value === undefined) {
+            return;
+        }
+
+        return new Envelope({
+            schema: this.schema ?? any,
+            js: this.value,
+        });
+    }
+
+    /**
+     * Create or replace item.
+     */
+    write(_request: Envelope.Data): void {
+        throw new NotImplementedError();
+    }
+
+    /**
+     * Update item using matter.js patch semantics.
+     */
+    patch(_request: Envelope.Data): MaybePromise<void> {
+        throw new NotImplementedError();
+    }
+
+    /**
+     * Add a child item of this item.
+     */
+    add(_request: Envelope.Data): MaybePromise<void> {
+        throw new NotImplementedError();
+    }
+
+    /**
+     * Remove this item.
+     */
+    delete(): MaybePromise<void> {
+        throw new NotImplementedError();
+    }
+
+    /**
+     * Execute a procedure.
+     */
+    async invoke(_request?: Envelope.Data): Promise<undefined | Envelope> {
+        throw new NotImplementedError();
+    }
+
+    /**
+     * Subscribe to events.
+     */
+    // eslint-disable-next-line require-yield
+    async *subscribe(
+        _abort: Abort.Signal,
+        _request?: Envelope.Data,
+    ): AsyncGenerator<Envelope<LocalResponse>, void, void> {
+        throw new NotImplementedError();
+    }
+
+    /**
+     * Retrieve a child with the specified ID.
+     */
+    async childFor(_id: string): Promise<ApiResource | void> {
+        return undefined;
+    }
+}
+
+export namespace ApiResource {
+    /**
+     * "Kind" values provided in response JSON payloads.
+     */
+    export type Kind =
+        | "ok"
+        | "node"
+        | "endpoint"
+        | "index"
+        | "cluster"
+        | "attribute"
+        | "field"
+        | "error"
+        | "command"
+        | "response"
+        | "changes";
+}

--- a/packages/node/src/behavior/system/remote/api/Envelope.ts
+++ b/packages/node/src/behavior/system/remote/api/Envelope.ts
@@ -1,0 +1,110 @@
+/**
+ * @license
+ * Copyright 2022-2025 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { LocalActorContext } from "#behavior/context/index.js";
+import { RootSupervisor } from "#behavior/supervision/RootSupervisor.js";
+import { Bytes } from "#general";
+import { DataModelPath, Schema } from "#model";
+import { StatusResponse, TlvOfModel } from "#types";
+
+/**
+ * Api data envelope packages used for request and response.
+ *
+ * This allows for transparent conversion between our three "native" formats -- JS values, serialized JSON and
+ * serialized TLV.
+ */
+export class Envelope<T = unknown> {
+    #schema: Schema;
+    #js?: T;
+    #json?: string;
+    #tlv?: Bytes;
+
+    constructor({ schema, js, json, tlv }: Envelope.Definition<T>) {
+        this.#schema = schema;
+        this.#js = js;
+        this.#json = json;
+        this.#tlv = tlv;
+    }
+
+    /**
+     * Validate against the schema.
+     */
+    validate(path?: DataModelPath) {
+        if (!path) {
+            path = DataModelPath(this.#schema.path);
+        }
+        RootSupervisor.for(this.#schema).validate?.(this.js, LocalActorContext.ReadOnly, { path });
+    }
+
+    /**
+     * Convert a {@link js} value to {@link JSON}.
+     *
+     * This acts as a deep copy and optimizes JSON access.  If TLV becomes a priority then we can make this conversion
+     * configurable.
+     */
+    convertToJson() {
+        if (this.#js !== undefined) {
+            void this.json;
+        }
+        this.#js = undefined;
+    }
+
+    /**
+     * Native JS format.
+     */
+    get js() {
+        if (this.#js === undefined) {
+            if (this.#json) {
+                try {
+                    this.#js = JSON.parse(this.#json) as T;
+                } catch (e) {
+                    if (e instanceof SyntaxError) {
+                        throw new StatusResponse.FailureError(`Unparseable JSON: ${e.message}`);
+                    }
+                    throw e;
+                }
+            } else if (this.#tlv) {
+                this.#js = TlvOfModel(this.#schema).decode(this.#tlv) as T;
+            } else {
+                this.#js = null as T;
+            }
+        }
+        return this.#js;
+    }
+
+    /**
+     * JSON format.
+     */
+    get json() {
+        if (this.#json === undefined) {
+            this.#json = JSON.stringify(this.js);
+        }
+        return this.#json;
+    }
+
+    /**
+     * Serialized TLV format.
+     */
+    get tlv() {
+        if (this.#tlv === undefined) {
+            this.#tlv = TlvOfModel(this.#schema).encode(this.#js);
+        }
+        return this.#tlv;
+    }
+}
+
+export namespace Envelope {
+    export interface Data<T = unknown> {
+        id?: string;
+        js?: T;
+        json?: string;
+        tlv?: Bytes;
+    }
+
+    export interface Definition<T = unknown> extends Data<T> {
+        schema: Schema;
+    }
+}

--- a/packages/node/src/behavior/system/remote/api/LocalResponse.ts
+++ b/packages/node/src/behavior/system/remote/api/LocalResponse.ts
@@ -1,0 +1,37 @@
+/**
+ * @license
+ * Copyright 2022-2025 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Envelope } from "./Envelope.js";
+import { RemoteResponse } from "./RemoteResponse.js";
+
+/**
+ * The intermediate version of a {@link RemoteResponse}, transformed before transmission.
+ */
+export type LocalResponse =
+    | RemoteResponse.OK
+    | RemoteResponse.Change
+    | LocalResponse.Value
+    | LocalResponse.Subscription
+    | LocalResponse.Error;
+
+export namespace LocalResponse {
+    export interface Value extends RemoteResponse.Base {
+        kind: "value";
+        value: Envelope;
+    }
+
+    export interface Subscription extends RemoteResponse.Base {
+        kind: "subscription";
+        stream: Stream;
+    }
+
+    export interface Error extends RemoteResponse.Base {
+        kind: "error";
+        error: globalThis.Error;
+    }
+
+    export interface Stream extends AsyncIterableIterator<Envelope<LocalResponse>, void, void> {}
+}

--- a/packages/node/src/behavior/system/remote/api/RemoteRequest.ts
+++ b/packages/node/src/behavior/system/remote/api/RemoteRequest.ts
@@ -1,0 +1,88 @@
+/**
+ * @license
+ * Copyright 2022-2025 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { isObject } from "#general";
+import { StateStream } from "#node/index.js";
+import { StatusResponse } from "#types";
+
+/**
+ * An RPC request.
+ */
+export type RemoteRequest =
+    | RemoteRequest.Read
+    | RemoteRequest.Write
+    | RemoteRequest.Add
+    | RemoteRequest.Delete
+    | RemoteRequest.Invoke
+    | RemoteRequest.Subscribe;
+
+/**
+ * Validate and return request object.
+ */
+export function RemoteRequest(request: unknown) {
+    if (!isObject(request)) {
+        throw new StatusResponse.InvalidActionError("Request is not an object");
+    }
+
+    const { target, method } = request;
+    if (typeof method !== "string") {
+        throw new StatusResponse.InvalidActionError('Request does not specify opcode in "method" property');
+    }
+
+    switch (method) {
+        case "read":
+        case "write":
+        case "add":
+        case "delete":
+        case "invoke":
+        case "subscribe":
+            break;
+
+        default:
+            throw new StatusResponse.InvalidActionError(`Unsupported request method "${method}"`);
+    }
+
+    if (typeof target !== "string") {
+        throw new StatusResponse.InvalidActionError('Request does not specify resource in "target" property');
+    }
+
+    return request as unknown as RemoteRequest;
+}
+
+export namespace RemoteRequest {
+    export interface Base {
+        target: string;
+        id?: string;
+    }
+
+    export interface Read extends Base {
+        method: "read";
+    }
+
+    export interface Write extends Base {
+        method: "write";
+        value: unknown;
+    }
+
+    export interface Add extends Base {
+        method: "add";
+        value: unknown;
+    }
+
+    export interface Delete extends Base {
+        method: "delete";
+    }
+
+    export interface Invoke extends Base {
+        method: "invoke";
+        target: string;
+        parameters?: unknown;
+    }
+
+    export interface Subscribe extends Base, StateStream.Options {
+        method: "subscribe";
+    }
+}

--- a/packages/node/src/behavior/system/remote/api/RemoteResponse.ts
+++ b/packages/node/src/behavior/system/remote/api/RemoteResponse.ts
@@ -1,0 +1,70 @@
+/**
+ * @license
+ * Copyright 2022-2025 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { InternalError, MatterError } from "#general";
+import type { StateStream } from "#node/integration/StateStream.js";
+import { StatusResponseError } from "#types";
+import type { LocalResponse } from "./LocalResponse.js";
+
+/**
+ * An RPC response.
+ *
+ * This is the serializable object delivered over the wire.
+ */
+export type RemoteResponse = RemoteResponse.OK | RemoteResponse.Value | RemoteResponse.Error | RemoteResponse.Change;
+
+/**
+ * Create a {@link RemoteResponse} from a {@link LocalResponse}.
+ */
+export function RemoteResponse(local: LocalResponse): RemoteResponse {
+    switch (local.kind) {
+        case "ok":
+        case "update":
+        case "delete":
+            return local;
+
+        case "value":
+            return {
+                ...local,
+                value: local.value.js,
+            };
+
+        case "error":
+            return {
+                kind: "error",
+                id: local.id,
+                code: MatterError.idFor(local.error.constructor),
+                message: (local.error as StatusResponseError).bareMessage ?? local.error.message,
+            };
+
+        default:
+            throw new InternalError(`Cannot convert local response kind "${local.kind}" to remote response`);
+    }
+}
+
+export namespace RemoteResponse {
+    export interface Base {
+        id?: string;
+    }
+
+    export interface OK extends Base {
+        kind: "ok";
+        requestId?: string;
+    }
+
+    export interface Value extends Base {
+        kind: "value";
+        value: unknown;
+    }
+
+    export interface Error extends Base {
+        kind: "error";
+        message: string;
+        code: string;
+    }
+
+    export type Change = Base & StateStream.WireChange;
+}

--- a/packages/node/src/behavior/system/remote/api/index.ts
+++ b/packages/node/src/behavior/system/remote/api/index.ts
@@ -1,0 +1,13 @@
+/**
+ * @license
+ * Copyright 2022-2025 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export * from "./Api.js";
+export * from "./ApiResource.js";
+export * from "./Envelope.js";
+export * from "./LocalResponse.js";
+export * from "./RemoteRequest.js";
+export * from "./RemoteResponse.js";
+export * from "./resources/index.js";

--- a/packages/node/src/behavior/system/remote/api/resources/BehaviorResource.ts
+++ b/packages/node/src/behavior/system/remote/api/resources/BehaviorResource.ts
@@ -1,0 +1,61 @@
+/**
+ * @license
+ * Copyright 2022-2025 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Behavior } from "#behavior/Behavior.js";
+import { InternalError } from "#general";
+import { ClusterModel, CommandModel } from "#model";
+import { StatusResponse } from "#types";
+import { ApiResource } from "../ApiResource.js";
+import { CommandResource } from "./CommandResource.js";
+import { PropertyResource } from "./PropertyResource.js";
+
+/**
+ * API item for behaviors.
+ */
+export class BehaviorResource extends PropertyResource {
+    #behavior: Behavior;
+
+    override get valueKind(): ApiResource.Kind {
+        return "cluster";
+    }
+
+    constructor(behavior: Behavior, parent: ApiResource) {
+        const { id, schema } = behavior.type;
+        if (schema === undefined) {
+            throw new InternalError(`API behavior reference has no schema`);
+        }
+
+        super(parent, id, schema, behavior.endpoint.path.at(id));
+        this.#behavior = behavior;
+    }
+
+    override get value() {
+        return this.#behavior.state;
+    }
+
+    override write() {
+        throw new StatusResponse.UnsupportedWriteError(`Only patch supported for this path`);
+    }
+
+    override async childFor(id: string) {
+        // "state" is a view of the cluster without commands; adds consistency w/ JS API and useful for handling name
+        // collision
+        if (id === "state") {
+            return new PropertyResource(this, "state", this.schema, this.dataModelPath.at("state"));
+        }
+
+        // For direct children, commands take precedence should there be a name collision
+        if (this.schema instanceof ClusterModel) {
+            const command = this.schema.conformant.commands.for(id, CommandModel);
+            if (command) {
+                return new CommandResource(this, this.#behavior, command);
+            }
+        }
+
+        // Now attributes (or fields in case of non-Matter properties)
+        return super.childFor(id);
+    }
+}

--- a/packages/node/src/behavior/system/remote/api/resources/ChangesResource.ts
+++ b/packages/node/src/behavior/system/remote/api/resources/ChangesResource.ts
@@ -1,0 +1,68 @@
+/**
+ * @license
+ * Copyright 2022-2025 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Abort, InternalError } from "#general";
+import { StateStream } from "#node/integration/StateStream.js";
+import { ServerNode } from "#node/ServerNode.js";
+import { ApiResource } from "../ApiResource.js";
+import { Envelope } from "../Envelope.js";
+import { LocalResponse } from "../LocalResponse.js";
+import { NodeResource as ServerNodeItem } from "./NodeResource.js";
+
+/**
+ * An item that delivers state changes via subscription.
+ */
+export class ChangesResource extends ApiResource {
+    readonly id = "changes";
+    readonly valueKind = "changes";
+    readonly schema = undefined;
+    readonly value = undefined;
+    override readonly isSubscribable = true;
+
+    declare readonly parent: ServerNodeItem;
+
+    constructor(parent: ServerNodeItem) {
+        super(parent);
+    }
+
+    get dataModelPath() {
+        return this.parent.dataModelPath.at("changes");
+    }
+
+    override async *subscribe(
+        abort: Abort.Signal,
+        request: Envelope.Data,
+    ): AsyncGenerator<Envelope<LocalResponse>, void, void> {
+        const requestEnv = new Envelope({ schema: StateStream.OptionsSchema, ...request });
+
+        let options: undefined | StateStream.Options;
+        if (requestEnv.js) {
+            requestEnv.validate();
+            options = requestEnv.js as StateStream.Options;
+        }
+
+        const stream = StateStream(this.parent.node as ServerNode, { ...options, abort });
+
+        const { id } = request;
+
+        for await (const change of stream) {
+            const wire = StateStream.WireChange(change);
+
+            switch (change.kind) {
+                case "update":
+                    yield new Envelope({ schema: StateStream.WireUpdateSchema, js: { id, ...wire } });
+                    break;
+
+                case "delete":
+                    yield new Envelope({ schema: StateStream.WireDeleteSchema, js: { id, ...wire } });
+                    break;
+
+                default:
+                    throw new InternalError(`Unsupported change kind ${(change as StateStream.Change).kind}`);
+            }
+        }
+    }
+}

--- a/packages/node/src/behavior/system/remote/api/resources/CommandResource.ts
+++ b/packages/node/src/behavior/system/remote/api/resources/CommandResource.ts
@@ -1,0 +1,87 @@
+/**
+ * @license
+ * Copyright 2022-2025 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Behavior } from "#behavior/Behavior.js";
+import { RootSupervisor } from "#behavior/supervision/RootSupervisor.js";
+import { camelize, decamelize, ImplementationError, NotImplementedError } from "#general";
+import { CommandModel } from "#model";
+import { ApiResource } from "../ApiResource.js";
+import { Envelope } from "../Envelope.js";
+
+/**
+ * API item for commands.
+ */
+export class CommandResource extends ApiResource {
+    #behavior: Behavior;
+    schema: CommandModel;
+
+    override readonly isInvocable = true;
+
+    constructor(parent: ApiResource, behavior: Behavior, schema: CommandModel) {
+        super(parent);
+        this.#behavior = behavior;
+        this.schema = schema;
+    }
+
+    get id() {
+        return decamelize(this.schema.name);
+    }
+
+    get dataModelPath() {
+        return this.parent!.dataModelPath.at(this.id);
+    }
+
+    override get valueKind(): ApiResource.Kind {
+        return "command";
+    }
+
+    get value() {
+        return undefined;
+    }
+
+    override async invoke(request?: Envelope.Data) {
+        let payload = new Envelope({ schema: this.schema, ...request }).js;
+        if (payload === undefined || payload === null) {
+            // The command validator always expects an object even if empty
+            payload = {};
+        }
+
+        // Method must exist on behavior or we cannot invoke
+        const name = camelize(this.id);
+        const method = (this.#behavior as unknown as Record<string, undefined | ((...args: unknown[]) => unknown)>)[
+            name
+        ];
+        if (typeof method !== "function") {
+            throw new NotImplementedError();
+        }
+
+        // Validate input
+        const inputSupervisor = RootSupervisor.for(this.schema);
+        inputSupervisor.validate?.(payload, this.#behavior.agent.context, { path: this.dataModelPath });
+
+        // Invoke
+        const result = await method.call(this.#behavior, payload);
+
+        // Validate output
+        const responseSchema = this.schema.responseModel;
+        if (responseSchema) {
+            const outputSupervisor = RootSupervisor.for(responseSchema);
+            try {
+                outputSupervisor.validate?.(payload, this.#behavior.agent.context, { path: this.dataModelPath });
+            } catch (e) {
+                const error = new ImplementationError("Command output validation failed");
+                error.cause = e;
+                throw error;
+            }
+        }
+
+        // Done
+        if (result === undefined) {
+            return;
+        }
+        return new Envelope({ schema: this.schema, js: result });
+    }
+}

--- a/packages/node/src/behavior/system/remote/api/resources/EndpointContainerResource.ts
+++ b/packages/node/src/behavior/system/remote/api/resources/EndpointContainerResource.ts
@@ -1,0 +1,45 @@
+/**
+ * @license
+ * Copyright 2022-2025 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ApiResource } from "../ApiResource.js";
+import type { EndpointResource } from "./EndpointResource.js";
+
+/**
+ * API item for collections of endpoints.
+ */
+export class EndpointContainerResource extends ApiResource {
+    readonly id: string;
+    readonly #list: () => string[];
+    readonly #find: (path: string) => ApiResource | undefined;
+    declare readonly parent: EndpointResource;
+    schema: undefined;
+    readonly valueKind: ApiResource.Kind = "index";
+
+    constructor(
+        parent: EndpointResource,
+        id: string,
+        list: () => string[],
+        find: (path: string) => ApiResource | undefined,
+    ) {
+        super(parent);
+
+        this.id = id;
+        this.#list = list;
+        this.#find = find;
+    }
+
+    get dataModelPath() {
+        return this.parent.dataModelPath.at(this.id);
+    }
+
+    get value() {
+        return this.#list();
+    }
+
+    override async childFor(id: string) {
+        return this.#find(id);
+    }
+}

--- a/packages/node/src/behavior/system/remote/api/resources/EndpointResource.ts
+++ b/packages/node/src/behavior/system/remote/api/resources/EndpointResource.ts
@@ -1,0 +1,78 @@
+/**
+ * @license
+ * Copyright 2022-2025 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Agent } from "#endpoint/Agent.js";
+import { camelize } from "#general";
+import { ApiResource } from "../ApiResource.js";
+import { BehaviorResource } from "./BehaviorResource.js";
+import { EndpointContainerResource } from "./EndpointContainerResource.js";
+
+/**
+ * API item for endpoints.
+ *
+ * Direct descendents are either behaviors or collections, represented by {@link BehaviorResource} and
+ * {@link EndpointContainerResource} respectively.
+ */
+export class EndpointResource extends ApiResource {
+    readonly agent: Agent;
+
+    constructor(agent: Agent, parent: undefined | ApiResource) {
+        super(parent);
+        this.agent = agent;
+    }
+
+    get valueKind(): ApiResource.Kind {
+        return "endpoint";
+    }
+
+    get id() {
+        return this.agent.endpoint.id;
+    }
+
+    get schema() {
+        return undefined;
+    }
+
+    get dataModelPath() {
+        return this.agent.endpoint.path;
+    }
+
+    override get value() {
+        return this.agent.endpoint.state;
+    }
+
+    override async childFor(name: string): Promise<ApiResource | void> {
+        if (name === "parts") {
+            return new EndpointContainerResource(
+                this,
+                "parts",
+                () => this.agent.endpoint.parts.map(part => part.id),
+                name => {
+                    const part = this.agent.endpoint.parts.get(name);
+                    if (part) {
+                        return new EndpointResource(part.agentFor(this.agent.context), this);
+                    }
+                },
+            );
+        }
+
+        name = camelize(name);
+
+        const { supported } = this.agent.endpoint.behaviors;
+        if (name in supported) {
+            const type = supported[name];
+
+            const behavior = this.agent.get(type);
+
+            // A behavior must have schema to be publicly accessible
+            if (behavior.type.schema === undefined) {
+                return;
+            }
+
+            return new BehaviorResource(behavior, this);
+        }
+    }
+}

--- a/packages/node/src/behavior/system/remote/api/resources/NodeResource.ts
+++ b/packages/node/src/behavior/system/remote/api/resources/NodeResource.ts
@@ -1,0 +1,71 @@
+/**
+ * @license
+ * Copyright 2022-2025 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Agent } from "#endpoint/Agent.js";
+import { Node } from "#node/Node.js";
+import { ApiResource } from "../ApiResource.js";
+import { EndpointContainerResource } from "./EndpointContainerResource.js";
+import { EndpointResource } from "./EndpointResource.js";
+
+/**
+ * Specialization for {@link EndpointResource} that adds "endpoints" collection.
+ */
+export class NodeResource extends EndpointResource {
+    constructor(agent: Agent, parent: undefined | ApiResource) {
+        super(agent, parent);
+    }
+
+    override get valueKind(): ApiResource.Kind {
+        return "node";
+    }
+
+    override async childFor(name: string): Promise<ApiResource | void> {
+        const {
+            node: { endpoints },
+        } = this;
+
+        // The "flat" endpoint IDs only apply at the top-level of an endpoint; otherwise they map to cluster IDs.  That
+        // should be fine because clusters will usually be referenced by name
+        if (!this.isSelfReferential) {
+            // Numeric indices on nodes map to endpoints
+            if (name.match(/^\d+$/)) {
+                return (await this.childFor("endpoints"))?.childFor(name);
+            }
+        }
+
+        // Endpoint collection
+        if (name === "endpoints") {
+            return new EndpointContainerResource(
+                this,
+                "endpoints",
+                () => endpoints.map(endpoint => endpoint.number.toString()),
+                name => {
+                    if (!name.match(/^\d+$/)) {
+                        return;
+                    }
+                    const number = Number.parseInt(name);
+                    if (Number.isNaN(number) || !endpoints.has(number)) {
+                        return;
+                    }
+
+                    const endpoint = endpoints.for(number);
+                    return new EndpointResource(endpoint.agentFor(this.agent.context), this);
+                },
+            );
+        }
+
+        // Pass to endpoint resolver
+        return super.childFor(name);
+    }
+
+    get node() {
+        return this.agent.endpoint as Node;
+    }
+
+    get isSelfReferential() {
+        return this.parent instanceof NodeResource && this.parent.node === this.node;
+    }
+}

--- a/packages/node/src/behavior/system/remote/api/resources/PropertyResource.ts
+++ b/packages/node/src/behavior/system/remote/api/resources/PropertyResource.ts
@@ -1,0 +1,117 @@
+/**
+ * @license
+ * Copyright 2022-2025 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { RootSupervisor } from "#behavior/supervision/RootSupervisor.js";
+import { InternalError, NotImplementedError } from "#general";
+import { DataModelPath, Metatype, Schema } from "#model";
+import { Val } from "@matter/protocol";
+import { StatusResponse } from "@matter/types";
+import { ApiResource } from "../ApiResource.js";
+import { Envelope } from "../Envelope.js";
+
+/**
+ * API item for sub-properties of collections (clusters, structs and lists in the Matter data model).
+ */
+export class PropertyResource extends ApiResource {
+    id: string;
+    schema: Schema;
+    dataModelPath: DataModelPath;
+
+    get valueKind(): ApiResource.Kind {
+        if (this.schema.tag === "attribute") {
+            return "attribute";
+        }
+        return "field";
+    }
+
+    constructor(parent: ApiResource, id: string, schema: Schema, path: DataModelPath) {
+        super(parent);
+
+        this.id = id;
+        this.schema = schema;
+        this.dataModelPath = path;
+    }
+
+    get value() {
+        return (this.parent?.value as Val.Struct | undefined)?.[this.id];
+    }
+
+    override write(request: Envelope.Data) {
+        request = new Envelope({ schema: this.schema, ...request });
+        this.#target[this.id] = request.js;
+    }
+
+    override patch(request: Envelope) {
+        request = new Envelope({ schema: this.schema, ...request });
+        this.#targetSupervisor.patch({ [this.id]: request.js }, this.#target, this.dataModelPath);
+    }
+
+    override add(request: Envelope) {
+        const struct = this.#target;
+        if (!Array.isArray(struct)) {
+            throw new NotImplementedError();
+        }
+
+        request = new Envelope({ schema: this.schema, ...request });
+        struct.push(request.js);
+    }
+
+    override delete() {
+        const struct = this.#target;
+        if (Array.isArray(struct)) {
+            struct.splice(this.id as unknown as number, 1);
+        } else {
+            this.#target[this.id] = undefined;
+        }
+    }
+
+    override async childFor(id: string): Promise<ApiResource | void> {
+        let mySchema: Schema | undefined;
+        switch (this.schema.effectiveMetatype) {
+            case Metatype.object:
+                mySchema = this.schema.conformant.properties.for(id);
+                break;
+
+            case Metatype.array:
+                if (!id.match(/^\d+$/)) {
+                    mySchema = undefined;
+                } else {
+                    mySchema = this.schema.conformant.properties.for("entry");
+                }
+                break;
+
+            default:
+                throw new NotImplementedError();
+        }
+
+        if (!mySchema) {
+            throw new StatusResponse.NotFoundError();
+        }
+
+        const myCollection = this.#target[this.id];
+        if (!myCollection) {
+            return;
+        }
+
+        return new PropertyResource(this, id, mySchema, this.dataModelPath.at(id));
+    }
+
+    get #target() {
+        const collection = this.parent?.value as Val.Struct;
+        if (!collection || typeof collection !== "object") {
+            throw new InternalError("Value of property item has no collection");
+        }
+        return collection;
+    }
+
+    get #targetSupervisor() {
+        const supervisor = RootSupervisor.for(this.parent?.schema);
+        if (!supervisor) {
+            throw new InternalError("No supervisor for parent collection");
+        }
+        return supervisor;
+    }
+}

--- a/packages/node/src/behavior/system/remote/api/resources/ServerNodeResource.ts
+++ b/packages/node/src/behavior/system/remote/api/resources/ServerNodeResource.ts
@@ -1,0 +1,63 @@
+/**
+ * @license
+ * Copyright 2022-2025 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { ServerNode } from "#node/ServerNode.js";
+import { ChangesResource } from "./ChangesResource.js";
+import { EndpointContainerResource } from "./EndpointContainerResource.js";
+import { NodeResource } from "./NodeResource.js";
+
+/**
+ * Specialization of {@link NodeResource} that adds "peers" collection and "changes" subscription item.
+ */
+export class ServerNodeResource extends NodeResource {
+    /**
+     * For the root node, we provide a "flat" namespace that is rooted at Node IDs, in addition to the normal
+     * endpoint namespace.  This could conceivably lead to conflict but we also provide typed subcollections that
+     * cannot have conflicts.
+     *
+     * We disable the flat namespace if the node is referenced as a child of itself so conflicts cannot occur.
+     */
+    override async childFor(name: string) {
+        if (!this.isSelfReferential) {
+            // Dedicated name "host" and my node ID always map back to myself
+            if (name === this.id || name === "host") {
+                return this;
+            }
+
+            // If the name is a peer, map to that
+            const peer = this.node.peers.get(name);
+            if (peer) {
+                return new NodeResource(peer.agentFor(this.agent.context), this);
+            }
+        }
+
+        switch (name) {
+            // Explicit collection of peers
+            case "peers":
+                return new EndpointContainerResource(
+                    this,
+                    "peers",
+                    () => this.node.peers.map(peer => peer.id),
+                    id => {
+                        const peer = this.node.peers.get(id);
+                        if (peer) {
+                            return new NodeResource(peer.agentFor(this.agent.context), this);
+                        }
+                    },
+                );
+
+            // Subscription target
+            case "changes":
+                return new ChangesResource(this);
+        }
+
+        return super.childFor(name);
+    }
+
+    override get node() {
+        return this.agent.endpoint as ServerNode;
+    }
+}

--- a/packages/node/src/behavior/system/remote/api/resources/index.ts
+++ b/packages/node/src/behavior/system/remote/api/resources/index.ts
@@ -1,0 +1,13 @@
+/**
+ * @license
+ * Copyright 2022-2025 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export * from "./BehaviorResource.js";
+export * from "./CommandResource.js";
+export * from "./EndpointContainerResource.js";
+export * from "./EndpointResource.js";
+export * from "./NodeResource.js";
+export * from "./PropertyResource.js";
+export * from "./ServerNodeResource.js";

--- a/packages/node/src/behavior/system/remote/index.ts
+++ b/packages/node/src/behavior/system/remote/index.ts
@@ -1,0 +1,10 @@
+/**
+ * @license
+ * Copyright 2022-2025 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export * from "./api/index.js";
+export * from "./interfaces/index.js";
+export * from "./RemoteInterface.js";
+export * from "./RemoteServer.js";

--- a/packages/node/src/behavior/system/remote/interfaces/HttpInterface.ts
+++ b/packages/node/src/behavior/system/remote/interfaces/HttpInterface.ts
@@ -1,0 +1,329 @@
+/**
+ * @license
+ * Copyright 2022-2025 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+    AppAddress,
+    asError,
+    Bytes,
+    Diagnostic,
+    HttpEndpoint,
+    HttpService,
+    InternalError,
+    Logger,
+    MatterError,
+    NotImplementedError,
+    Stream,
+} from "#general";
+import { StatusResponse, StatusResponseError } from "#types";
+import { Api } from "../api/Api.js";
+import { ApiPath } from "../api/ApiPath.js";
+import { ApiResource } from "../api/ApiResource.js";
+import { Envelope } from "../api/Envelope.js";
+import { LocalResponse } from "../api/LocalResponse.js";
+import { RemoteInterface } from "../RemoteInterface.js";
+import { RemoteInterfaceService } from "../RemoteInterfaceService.js";
+
+const logger = Logger.get("HttpInterface");
+
+/**
+ * HTTP remote interface.
+ */
+export class HttpInterface extends RemoteInterface {
+    static override protocol = "http";
+    #http?: HttpEndpoint;
+
+    protected override async start() {
+        this.#http = await this.env.get(HttpService).create(this.address);
+        this.#http.http = this.#handleRequest.bind(this);
+    }
+
+    protected override async stop() {
+        await this.#http?.close();
+    }
+
+    async #handleRequest(request: Request) {
+        let response: Response;
+
+        try {
+            const address = new AppAddress(request.url);
+            const path = this.root.subpathFor(new ApiPath(address));
+            if (!path) {
+                return;
+            }
+
+            response = await this.node.act("http", async agent => {
+                const resource = await Api.resourceFor(agent, path);
+                if (resource === undefined) {
+                    throw new StatusResponse.NotFoundError(`Path "${address.pathname}" not found`);
+                }
+
+                return this.#applyRequestToItem(request, resource);
+            });
+
+            logSuccess(request, response);
+
+            return response;
+        } catch (e) {
+            const response = adaptError(e);
+
+            logError(request, response, e);
+
+            return response;
+        }
+    }
+
+    async #applyRequestToItem(request: Request, item: ApiResource) {
+        switch (request.method) {
+            case "GET": {
+                const responseEnv = item.read();
+                if (responseEnv === undefined) {
+                    throw new NotImplementedError();
+                }
+                return adaptResponse(request, responseEnv);
+            }
+
+            case "POST": {
+                const requestEnv = await adaptRequest(request);
+
+                if (item.isInvocable) {
+                    const responseEnv = await item.invoke(requestEnv);
+                    if (responseEnv === undefined) {
+                        return ok();
+                    }
+                    return adaptResponse(request, responseEnv);
+                }
+
+                if (item.isSubscribable) {
+                    return adaptResponse(request, item.subscribe(this.abort, requestEnv));
+                }
+
+                await item.add(requestEnv);
+                return ok();
+            }
+
+            case "PUT": {
+                const requestPayload = await adaptRequest(request);
+                item.write(requestPayload);
+                return ok();
+            }
+
+            case "PATCH": {
+                const requestPayload = await adaptRequest(request);
+                item.write(requestPayload);
+                return ok();
+            }
+
+            case "DELETE":
+                await item.delete();
+                break;
+        }
+
+        throw new NotImplementedError();
+    }
+}
+
+export class UnnacceptableError extends MatterError {}
+export class UnsupportedRequestContentTypeError extends MatterError {}
+
+// A bit half-assed but 4xx vs 5xx is the important thing; put in more effort if necessary
+const ErrorMappings: [new (...args: any[]) => Error, HttpStatusCode][] = [
+    [StatusResponse.UnsupportedAccessError, 401],
+    [StatusResponse.NotFoundError, 404],
+    [NotImplementedError, 405],
+    [UnnacceptableError, 406],
+    [UnsupportedRequestContentTypeError, 415],
+];
+
+const StatusCode = {
+    200: "OK",
+    400: "Bad Request",
+    401: "Unauthorized",
+    404: "Not Found",
+    405: "Method Not Allowed",
+    406: "Unnacceptable",
+    415: "Unsupported Media Type",
+    500: "Internal Server Error",
+};
+
+export type HttpStatusCode = keyof typeof StatusCode;
+
+export const JSON_CONTENT_TYPE = "application/json";
+export const JSONL_CONTENT_TYPE = "application/jsonl";
+export const TLV_CONTENT_TYPE = "application/matter-tlv";
+
+async function adaptRequest(request: Request): Promise<Envelope.Data> {
+    let contentType = request.headers.get("Content-Type");
+    if (contentType) {
+        contentType = contentType.split(";")[0].trim();
+    } else {
+        contentType = "application/json";
+    }
+
+    switch (contentType) {
+        case JSON_CONTENT_TYPE:
+            return { json: await request.text() };
+
+        case TLV_CONTENT_TYPE:
+            return { tlv: await request.bytes() };
+
+        default:
+            throw new UnsupportedRequestContentTypeError();
+    }
+}
+
+function ok() {
+    return new Response(null, {
+        status: 200,
+        statusText: StatusCode[200],
+    });
+}
+
+function adaptResponse(request: Request, response: Envelope | LocalResponse.Stream) {
+    const streamingResponse = Symbol.asyncIterator in response;
+
+    const accept = request.headers.get("Accept-Encoding");
+
+    const encodings = accept?.split(",").map(encoding => encoding.split(";")[0].trim());
+
+    let contentType;
+    if (encodings) {
+        for (const encoding of encodings) {
+            if (encoding === JSONL_CONTENT_TYPE) {
+                if (streamingResponse) {
+                    contentType = encoding;
+                } else {
+                    contentType = JSON_CONTENT_TYPE;
+                }
+                break;
+            }
+
+            if ((!streamingResponse && encoding === JSON_CONTENT_TYPE) || encoding === TLV_CONTENT_TYPE) {
+                contentType = encoding;
+                break;
+            }
+        }
+
+        if (contentType === undefined) {
+            throw new UnnacceptableError(`Cannot produce requested MIME type "${accept}"`);
+        }
+    } else if (streamingResponse) {
+        contentType = JSONL_CONTENT_TYPE;
+    } else {
+        contentType = JSON_CONTENT_TYPE;
+    }
+
+    let body: BodyInit;
+    if (streamingResponse) {
+        // Streaming body
+        body = Stream.from(EnvelopeStreamIterator(contentType, response));
+    } else if (contentType === TLV_CONTENT_TYPE) {
+        // Body encoded as TLV
+        body = Bytes.exclusive(response.tlv);
+    } else {
+        // Body encoded as JSON
+        body = response.json;
+    }
+
+    return new Response(
+        body,
+
+        {
+            status: 200,
+            statusText: StatusCode[200],
+            headers: {
+                "Content-Type": contentType,
+            },
+        },
+    );
+}
+
+function adaptError(e: unknown) {
+    const error = asError(e);
+
+    let status: number | undefined;
+    for (const [type, typeStatus] of ErrorMappings) {
+        if (error instanceof type) {
+            status = typeStatus;
+        }
+    }
+
+    if (status === undefined) {
+        if (e instanceof StatusResponseError) {
+            status = 400;
+        } else {
+            status = 500;
+        }
+    }
+
+    let code, message;
+    if (status >= 400 && status < 500) {
+        code = (error as MatterError).id ?? "unknown";
+        message = (error as StatusResponseError).bareMessage ?? error.message;
+    } else {
+        code = "internal";
+        message = "Internal error";
+    }
+
+    return new Response(
+        JSON.stringify({
+            kind: "error",
+            code,
+            message,
+        }),
+
+        {
+            status: status,
+            statusText: (StatusCode as Record<number, string>)[status] ?? "Error",
+            headers: {
+                "Content-Type": JSON_CONTENT_TYPE,
+                "Error-Code": code,
+            },
+        },
+    );
+}
+
+function logSuccess(request: Request, response: Response) {
+    logger.notice(diagnosticHeaderFor(request, response));
+}
+
+function logError(request: Request, response: Response, error: unknown) {
+    if (response.status >= 500 && response.status < 600) {
+        logger.error(diagnosticHeaderFor(request, response), error);
+    } else if (error instanceof MatterError) {
+        logger.error(
+            diagnosticHeaderFor(request, response),
+            Diagnostic.squash("[", Diagnostic.strong(error.id), "]"),
+            error.message,
+        );
+    } else {
+        logger.warn(diagnosticHeaderFor(request, response), asError(error).message);
+    }
+}
+
+function diagnosticHeaderFor(request: Request, response: Response) {
+    return Diagnostic.squash("[", Diagnostic.strong(request.url), " ", request.method, " ", response.status, "]");
+}
+
+async function* EnvelopeStreamIterator(contentType: string, iterator: AsyncIterable<Envelope, void, void>) {
+    switch (contentType) {
+        case TLV_CONTENT_TYPE:
+            for await (const envelope of iterator) {
+                yield envelope.tlv;
+            }
+            break;
+
+        case JSONL_CONTENT_TYPE:
+            for await (const envelope of iterator) {
+                yield `${envelope.json}\n`;
+            }
+            break;
+
+        default:
+            throw new InternalError(`Unsupported streaming content type ${contentType}`);
+    }
+}
+
+RemoteInterfaceService.register(HttpInterface);

--- a/packages/node/src/behavior/system/remote/interfaces/MqttInterface.ts
+++ b/packages/node/src/behavior/system/remote/interfaces/MqttInterface.ts
@@ -1,0 +1,413 @@
+/**
+ * @license
+ * Copyright 2022-2025 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { RootSupervisor } from "#behavior/supervision/RootSupervisor.js";
+import {
+    Abort,
+    Base64,
+    Bytes,
+    decamelize,
+    InternalError,
+    MqttEndpoint,
+    MqttService,
+    Mutex,
+    NotImplementedError,
+} from "#general";
+import { any, CommandModel, Metatype, Schema } from "#model";
+import { StateStream } from "#node/integration/StateStream.js";
+import { StatusResponse } from "#types";
+import { Api } from "../api/Api.js";
+import { ApiPath } from "../api/ApiPath.js";
+import { Envelope } from "../api/Envelope.js";
+import { LocalResponse } from "../api/LocalResponse.js";
+import { RemoteRequest } from "../api/RemoteRequest.js";
+import { RemoteResponse } from "../api/RemoteResponse.js";
+import { RemoteInterface } from "../RemoteInterface.js";
+import { RemoteInterfaceService } from "../RemoteInterfaceService.js";
+
+const LOG_FACILITY = "MQTT";
+
+/**
+ * MQTT remote interface.
+ *
+ * Currently publishes a read-only feed.  Will address TODOs if there is real-world use.
+ *
+ * TODO - events
+ * TODO - clean out topics from previous runs that are no longer relevant, e.g. deleted endpoint, removed attrs, etc.
+ * TODO - TLV serialiation/deserialization
+ */
+export class MqttInterface extends RemoteInterface {
+    static override protocol = "mqtt";
+
+    #endpoint?: MqttEndpoint;
+    #mutex = new Mutex(this);
+    #retainedTopics = new Map<string, Map<number, Set<string>>>();
+
+    protected override async start() {
+        this.#endpoint = await this.env.get(MqttService).connect({
+            address: this.address,
+            environment: this.node.env,
+
+            will: {
+                topic: this.root.at("status").toString(),
+                payload: "offline",
+            },
+
+            onUp: endpoint => {
+                if (!this.#endpoint) {
+                    this.#endpoint = endpoint;
+                }
+
+                return this.#publish({
+                    topic: this.root.at("status").toString(),
+                    payload: "online",
+                });
+            },
+        });
+
+        this.addWorker(this.#listen(), "mqtt listener");
+        this.addWorker(this.#feed(), "mqtt feeder");
+    }
+
+    protected override async stop() {
+        await this.#mutex.then();
+        await this.#mqtt?.close();
+    }
+
+    /**
+     * A background process that handles incoming MQTT messages.
+     */
+    async #listen() {
+        await Abort.race(this.abort, this.node.construction);
+        if (Abort.is(this.abort)) {
+            return;
+        }
+
+        let topic = this.root.toString();
+        if (topic !== "") {
+            topic += "/#";
+        } else {
+            topic = "#";
+        }
+
+        for await (const message of this.#mqtt.subscribe(`${topic}`, { noLocal: true, abort: this.abort })) {
+            // We publish retained messages so ignore these; if not retained it's a write or invoke
+            if (message.retain) {
+                continue;
+            }
+
+            // This should always be true but make sure
+            const relativeTopic = this.root.subpathFor(new ApiPath(message.topic));
+            if (!relativeTopic) {
+                continue;
+            }
+
+            await this.#respond(relativeTopic, message);
+        }
+    }
+
+    async #respond(topic: ApiPath, message: MqttEndpoint.Message) {
+        let response: LocalResponse | undefined;
+
+        const via = message.correlationData ? Bytes.toHex(message.correlationData) : message.responseTopic;
+
+        try {
+            await this.node.act("MQTT listener", async agent => {
+                // Specialized topic "call" is for RPC messaging using RemoteRequest/RemoteResponse
+                if (topic.toString() === "call") {
+                    response = await this.#call(message);
+                    return;
+                }
+
+                const item = await Api.resourceFor(agent, topic);
+                if (item === undefined) {
+                    throw new StatusResponse.NotFoundError(`No resource at subtopic ${topic}`);
+                }
+
+                const schema = item.schema;
+                if (!schema) {
+                    throw new NotImplementedError();
+                }
+                const input = payloadToJs(schema, message.payload);
+
+                if (item.isInvocable) {
+                    Api.logRequest(LOG_FACILITY, via, "invoke", topic.toString());
+
+                    let value = await item.invoke({ js: input });
+
+                    const responseSchema = (schema as CommandModel).responseModel;
+                    if (responseSchema) {
+                        value ??= new Envelope({ schema: responseSchema, js: null });
+                        response = { kind: "value", value };
+                    }
+                } else {
+                    Api.logRequest(LOG_FACILITY, via, "update", topic.toString());
+
+                    await item.patch(input ?? { js: null });
+                }
+            });
+        } catch (e) {
+            response = Api.errorResponseOf(LOG_FACILITY, via, e);
+        }
+
+        if (!response) {
+            response = { kind: "ok" };
+        }
+
+        response.id = via;
+        Api.logResponse(LOG_FACILITY, RemoteResponse(response));
+
+        if (message.responseTopic) {
+            await this.#publish({
+                topic: message.responseTopic,
+                correlationData: message.correlationData,
+                payload: JSON.stringify(response),
+            });
+        }
+    }
+
+    /**
+     * Specialized handling for "call" topic to support full {@link RemoteRequest}/{@link RemoteResponse} interaction.
+     */
+    async #call(message: MqttEndpoint.Message) {
+        const request = parseJsonPayload(message.payload);
+        const response = await Api.execute(LOG_FACILITY, this.node, request, this.abort);
+
+        // I don't think there's any point in supporting subscriptions when MQTT offers a superior mechanism, so for now
+        // just throw if this is attempted
+        if (response.kind === "subscription") {
+            await response.stream.return?.();
+            throw new StatusResponse.InvalidSubscriptionError(
+                "Subscription via RPC is not supported, use MQTT instead",
+            );
+        }
+
+        return response;
+    }
+
+    /**
+     * A background process that continuously updates MQTT topics.
+     */
+    async #feed() {
+        const stream = StateStream(this.node, { abort: this.abort });
+
+        for await (const change of stream) {
+            await this.#mutex.produce(async () => {
+                switch (change.kind) {
+                    case "update":
+                        await this.#publishUpdate(change);
+                        break;
+
+                    case "delete":
+                        await this.#publishDelete(change);
+                }
+            });
+        }
+    }
+
+    /**
+     * Publish attribute values for state changes.
+     */
+    async #publishUpdate({ node, endpoint, behavior, changes }: StateStream.Update) {
+        let nodeTopics = this.#retainedTopics.get(node.id);
+        if (nodeTopics === undefined) {
+            this.#retainedTopics.set(node.id, (nodeTopics = new Map()));
+        }
+        let endpointTopics = nodeTopics.get(endpoint.number);
+        if (endpointTopics === undefined) {
+            nodeTopics.set(endpoint.number, (endpointTopics = new Set()));
+        }
+
+        const behaviorRoot = this.#nodeRoot(node.id).at([endpoint.number.toString(), decamelize(behavior.id)]);
+        for (const name in changes) {
+            const value = changes[name];
+            const schema = behavior.schema?.conformant.properties.for(name);
+            const payload = jsToPayload(schema ?? any, value);
+
+            const topic = behaviorRoot.at([name]).toString();
+            endpointTopics.add(topic);
+
+            await this.#publish({
+                topic,
+                payload,
+                retain: true,
+            });
+        }
+    }
+
+    /**
+     * Delete all published topics for an endpoint or node that has disappeared.
+     */
+    async #publishDelete(change: StateStream.Delete) {
+        const nodeTopics = this.#retainedTopics.get(change.node.id);
+        if (!nodeTopics) {
+            return;
+        }
+
+        const deleteEndpoint = async (endpoint: number) => {
+            const topics = nodeTopics.get(endpoint);
+            if (!topics) {
+                return;
+            }
+
+            for (const topic of topics) {
+                await this.#publish({
+                    topic,
+                    payload: null,
+                    retain: true,
+                });
+            }
+
+            nodeTopics.delete(endpoint);
+        };
+
+        if (change.endpoint === change.node) {
+            for (const number of nodeTopics.keys()) {
+                await deleteEndpoint(number);
+            }
+            this.#retainedTopics.delete(change.node.id);
+        } else {
+            await deleteEndpoint(change.endpoint.number);
+        }
+    }
+
+    /**
+     * Obtain the root path for a node.
+     *
+     * This will either be the root path for the server or a subpath for peers.
+     */
+    #nodeRoot(id: string) {
+        if (id === this.node.id) {
+            return this.root;
+        }
+
+        return this.root.at(["peers", id]);
+    }
+
+    /**
+     * Safe access to the MQTT endpoint.
+     */
+    get #mqtt() {
+        if (this.#endpoint === undefined) {
+            throw new InternalError("MQTT endpoint missing");
+        }
+        return this.#endpoint;
+    }
+
+    /**
+     * Publish a message.
+     *
+     * Default QOS is 2.
+     */
+    #publish(message: MqttEndpoint.Message) {
+        if (this.abort.aborted) {
+            throw new InternalError("MQTT publish after abort");
+        }
+        if (message.qos === undefined) {
+            message.qos = 2;
+        }
+        return this.#mqtt.publish(message);
+    }
+}
+
+function payloadToJs(schema: Schema, payload: Bytes | string | null): unknown {
+    if (payload === null) {
+        return null;
+    }
+
+    const length = typeof payload === "string" ? payload.length : payload.byteLength;
+    if (!length) {
+        return null;
+    }
+
+    let js;
+    switch (schema.effectiveMetatype) {
+        case Metatype.object:
+        case Metatype.array:
+        case Metatype.bitmap:
+            js = parseJsonPayload(payload);
+            break;
+
+        case Metatype.bytes:
+            if (typeof payload === "string") {
+                try {
+                    js = Base64.decode(payload);
+                } catch (e) {
+                    if (e instanceof SyntaxError) {
+                        throw new StatusResponse.InvalidDataTypeError(
+                            `Value is not binary or a base64 string: ${e.message}`,
+                        );
+                    }
+                }
+                break;
+            }
+
+            js = payload;
+            break;
+
+        default:
+            if (Bytes.isBytes(payload)) {
+                try {
+                    payload = Bytes.toString(payload);
+                } catch (e) {
+                    if (e instanceof TypeError) {
+                        throw new StatusResponse.InvalidDataTypeError(
+                            `Value is not a valid UTF-8 string: ${e.message}`,
+                        );
+                    }
+                }
+            }
+            break;
+    }
+
+    const supervisor = RootSupervisor.for(schema);
+    return supervisor.cast(js);
+}
+
+function jsToPayload(schema: Schema, js: unknown): Bytes | string {
+    if (js === undefined || js === null || js === "") {
+        return Bytes.empty;
+    }
+
+    switch (schema.effectiveMetatype) {
+        case Metatype.object:
+        case Metatype.array:
+        case Metatype.bitmap:
+            // TODO - serialize bitmap as number?
+            return JSON.stringify(js);
+
+        case Metatype.bytes:
+            if (Bytes.isBytes(js)) {
+                return js;
+            }
+            return Bytes.fromString(js.toString());
+
+        default:
+            if (Bytes.isBytes(js)) {
+                return js;
+            }
+            return js.toString();
+    }
+}
+
+function parseJsonPayload(payload: MqttEndpoint.Message["payload"]) {
+    if (payload === null) {
+        throw new StatusResponse.InvalidDataTypeError("Empty payload where JSON expected");
+    }
+    if (Bytes.isBytes(payload)) {
+        payload = Bytes.toString(payload);
+    }
+    try {
+        return JSON.parse(payload);
+    } catch (e) {
+        if (e instanceof SyntaxError) {
+            throw new StatusResponse.InvalidDataTypeError(`Payload is not valid JSON: ${e.message}`);
+        }
+        throw e;
+    }
+}
+
+RemoteInterfaceService.register(MqttInterface);

--- a/packages/node/src/behavior/system/remote/interfaces/WsInterface.ts
+++ b/packages/node/src/behavior/system/remote/interfaces/WsInterface.ts
@@ -1,0 +1,130 @@
+/**
+ * @license
+ * Copyright 2022-2025 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Abort, AppAddress, Bytes, HttpEndpoint, HttpService, Mutex, Stream } from "#general";
+import { StatusResponse, StatusResponseError } from "#types";
+import { Api } from "../api/Api.js";
+import { ApiPath } from "../api/ApiPath.js";
+import { LocalResponse } from "../api/LocalResponse.js";
+import { RemoteRequest } from "../api/RemoteRequest.js";
+import { RemoteResponse } from "../api/RemoteResponse.js";
+import { RemoteInterface } from "../RemoteInterface.js";
+import { RemoteInterfaceService } from "../RemoteInterfaceService.js";
+
+const LOG_FACILITY = "WebSocket";
+
+/**
+ * WebSocket remote interface.
+ */
+export class WsInterface extends RemoteInterface {
+    static override protocol = "ws";
+
+    #http?: HttpEndpoint;
+    #mutex = new Mutex(this);
+
+    protected override async start() {
+        this.#http = await this.env.get(HttpService).create(this.address);
+        this.#http.ws = this.#handleConnection.bind(this);
+    }
+
+    protected override async stop() {
+        await super.stop();
+        await this.#http?.close();
+    }
+
+    /**
+     * Handle HTTP connections.
+     *
+     * Checks path, upgrades to a WebSocket if the path applies, then processes input messages
+     */
+    async #handleConnection(request: Request, upgrade: () => Promise<HttpEndpoint.WsConnection>) {
+        // Normalize path and compare to root
+        const address = new AppAddress(request.url);
+        const path = new ApiPath(address).toString();
+        if (path !== this.root.toString()) {
+            return;
+        }
+
+        // Upgrade to WebSocket
+        const ws = await Abort.race(this.abort, await upgrade());
+        if (!ws) {
+            return;
+        }
+
+        using subtask = Abort.subtask(this.abort);
+
+        const send = async (local: LocalResponse) => {
+            await this.#mutex.produce(async () => {
+                const message = RemoteResponse(local);
+                Api.logResponse(LOG_FACILITY, message);
+                const writer = ws.writable.getWriter();
+                try {
+                    await writer.write(JSON.stringify(message));
+                } finally {
+                    writer.releaseLock();
+                }
+            });
+        };
+
+        for await (let message of Stream.iterable(ws.readable)) {
+            let requestId: string | undefined;
+            try {
+                message = Bytes.toString(message);
+
+                let parsed;
+                try {
+                    parsed = JSON.parse(message);
+                } catch (e) {
+                    if (e instanceof SyntaxError) {
+                        throw new StatusResponse.InvalidCommandError(`Request parse error: ${e.message}`);
+                    }
+                    throw e;
+                }
+                requestId = (parsed as RemoteRequest)?.id;
+
+                const request = RemoteRequest(parsed);
+
+                await this.#handleRequest(request, subtask, send);
+            } catch (error) {
+                StatusResponseError.accept(error);
+
+                await send({
+                    kind: "error",
+                    id: requestId,
+                    error,
+                });
+            }
+        }
+
+        // Abort any ongoing subscriptions associated with the connection
+        subtask.abort();
+    }
+
+    async #handleRequest(
+        request: RemoteRequest,
+        abort: AbortController,
+        send: (message: LocalResponse) => Promise<void>,
+    ) {
+        const response = await this.#mutex.produce(() => Api.execute(LOG_FACILITY, this.node, request, abort));
+
+        if (response.kind !== "subscription") {
+            await send(response);
+            return;
+        }
+
+        await send({ id: request.id, kind: "ok" });
+
+        this.addWorker(this.#handleSubscription(response.stream, send), "ws subscription handler");
+    }
+
+    async #handleSubscription(stream: LocalResponse.Stream, send: (message: LocalResponse) => Promise<void>) {
+        for await (const update of stream) {
+            await send(update.js);
+        }
+    }
+}
+
+RemoteInterfaceService.register(WsInterface);

--- a/packages/node/src/behavior/system/remote/interfaces/index.ts
+++ b/packages/node/src/behavior/system/remote/interfaces/index.ts
@@ -1,0 +1,9 @@
+/**
+ * @license
+ * Copyright 2022-2025 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export * from "./HttpInterface.js";
+export * from "./MqttInterface.js";
+export * from "./WsInterface.js";

--- a/packages/node/src/node/ServerNode.ts
+++ b/packages/node/src/node/ServerNode.ts
@@ -11,6 +11,7 @@ import { EventsBehavior } from "#behavior/system/events/EventsBehavior.js";
 import { NetworkServer } from "#behavior/system/network/NetworkServer.js";
 import { ServerNetworkRuntime } from "#behavior/system/network/ServerNetworkRuntime.js";
 import { ProductDescriptionServer } from "#behavior/system/product-description/ProductDescriptionServer.js";
+import { RemoteServer } from "#behavior/system/remote/RemoteServer.js";
 import { SessionsBehavior } from "#behavior/system/sessions/SessionsBehavior.js";
 import { SubscriptionsBehavior } from "#behavior/system/subscriptions/SubscriptionsServer.js";
 import { Endpoint } from "#endpoint/Endpoint.js";
@@ -211,6 +212,7 @@ export namespace ServerNode {
         SessionsBehavior,
         EventsBehavior,
         ControllerBehavior,
+        RemoteServer,
     );
 
     export interface RootEndpoint extends Identity<typeof RootEndpoint> {}


### PR DESCRIPTION
* The goal here is to support a variety of use cases:

    - Standard control channel via TCP or UNIX sockets to control devices and controllers from the local system

    - Offer a variety of higher-level interfaces for integration with 3rd party environments

    - Offer a standard channel for direct communication with mobile and web apps

    - High-level protocol appropriate for backchannel communication with test suites

* Adds a generic `ApiResource` object model that maps a generic API built on method + resource path command abstraction

* Implements a new `RemoteServer` behavior for managing pluggable protocols implementing a `RemoteInterface` protocol

* Adds three remote interfaces, HTTP (REST + RPC over HTTP), WebSockets and MQTT

* Goal of each API is to expose full Matter semantics while making APIs appear "native" to the external protocol

* A secondary goal is to align API semantics across disparate protocols and with matter.js API to:

    - Reduce the number of API "shapes" we need to document and devs need to learn

    - Reduce maintenance burden via shared implementation

* These are tested to varying degrees, current automated tests are only for WebSockets