### PR TITLE
Only use SO_REUSEADDR if we want to reuse address

### DIFF
--- a/packages/general/src/net/Network.ts
+++ b/packages/general/src/net/Network.ts
@@ -12,6 +12,10 @@ export class NetworkError extends MatterError {}
 
 export class NoAddressAvailableError extends NetworkError {}
 
+export class BindError extends NetworkError {}
+
+export class AddressInUseError extends BindError {}
+
 export const STANDARD_MATTER_PORT = 5540;
 
 /**

--- a/packages/general/src/net/udp/UdpChannel.ts
+++ b/packages/general/src/net/udp/UdpChannel.ts
@@ -11,13 +11,46 @@ import { ConnectionlessTransport } from "../ConnectionlessTransport.js";
 /** @see {@link MatterSpecification.v12.Core} § 4.4.4 */
 export const MAX_UDP_MESSAGE_SIZE = 1280 - 48; // 48 bytes IP and UDP header size for IPv6
 
-export type UdpSocketType = "udp4" | "udp6";
+/**
+ * UDP socket address type.
+ *
+ * "udp4" and "udp6" are IPv4 and IPv6 exclusively.  "udp" binds both IPv4 and IPv6 addresses.
+ */
+export type UdpSocketType = "udp" | "udp4" | "udp6";
 
 export interface UdpChannelOptions {
-    listeningPort?: number;
+    /**
+     * UDP channel type.  "udp4" and "udp6" mean IPv4 and IPv6 respectively.  "udp" is dual-mode IPv4/IPv6.
+     */
     type: UdpSocketType;
+
+    /**
+     * The port to listen on.  undefined or 0 directs the operating system to select an open port.
+     */
+    listeningPort?: number;
+
+    /**
+     * The address to listen on, either a hostname or IP address in correct format based on {@link type}.
+     *
+     * undefined directs the operating system to listen on all addresses on the port.  "0.0.0.0" is wildcard IPv4 and
+     * "::" is wildcard IPv6.
+     *
+     * "0.0.0.0" is not allowed if {@link type} is "udp".
+     */
     listeningAddress?: string;
+
+    /**
+     * Specifies a specific network interface.
+     *
+     * This is required for multicast sockets.
+     */
     netInterface?: string;
+
+    /**
+     * Address+port pairs are normally may normally only be opened by a single socket.  This allows shared access to a
+     * port.
+     */
+    reuseAddress?: boolean;
 }
 
 export interface UdpChannel {

--- a/packages/general/src/net/udp/UdpMulticastServer.ts
+++ b/packages/general/src/net/udp/UdpMulticastServer.ts
@@ -39,6 +39,7 @@ export class UdpMulticastServer {
                     type: "udp4",
                     netInterface,
                     listeningPort,
+                    reuseAddress: true,
                 });
                 await ipv4UdpChannel.addMembership(broadcastAddressIpv4);
             } catch (error) {
@@ -52,6 +53,7 @@ export class UdpMulticastServer {
                 type: "udp6",
                 netInterface,
                 listeningPort,
+                reuseAddress: true,
             });
             await ipv6UdpChannel.addMembership(broadcastAddressIpv6);
             return new UdpMulticastServer(
@@ -160,6 +162,7 @@ export class UdpMulticastServer {
             type: iPv4 ? "udp4" : "udp6",
             listeningPort: this.broadcastPort,
             netInterface,
+            reuseAddress: true,
         });
     }
 


### PR DESCRIPTION
* Do not apply SO_REUSEADDR by default.  This will cause a crash if two nodes are started accidentally.  Particularly important since we currently have no lockfile

* Add an option to enable SO_REUSEADDR to channel abstraction and enable it for multicast addresses, which covers MDNS

* Add "udp" socket type that allows for OS-controlled mixed IPv4/IPv6 binding.  Ported from old PR but not employed higher in the stack currently

* Map Node.js bind errors to MatterError