### PR TITLE
Improve WebSocket testing

### DIFF
--- a/packages/node/src/behavior/system/remote/api/Api.ts
+++ b/packages/node/src/behavior/system/remote/api/Api.ts
@@ -71,7 +71,7 @@ export namespace Api {
     }
 
     export function logResponse(facility: string, response: RemoteResponse) {
-        const message = Array<unknown>("»", response.kind);
+        const message = Array<unknown>("»", RemoteResponse.describe(response));
         let level: "error" | "info";
         switch (response.kind) {
             case "error":

--- a/packages/node/src/behavior/system/remote/api/RemoteResponse.ts
+++ b/packages/node/src/behavior/system/remote/api/RemoteResponse.ts
@@ -67,4 +67,17 @@ export namespace RemoteResponse {
     }
 
     export type Change = Base & StateStream.WireChange;
+
+    export function describe(response: RemoteResponse) {
+        switch (response.kind) {
+            case "update":
+                return `update ${response.endpoint} ${response.behavior}`;
+
+            case "delete":
+                return `delete ${response.endpoint}`;
+
+            default:
+                return response.kind;
+        }
+    }
 }


### PR DESCRIPTION
* Abort rather than close the client WebSocket.  Otherwise it may hang waiting on message delivery/timeout when the test crashes

* Do not start the ServerNode; we don't need Matter networking; it makes the test much faster and removes networking except for the WebSockets themselves from the test

* Remove the longer timeouts that are no longer necessary

* Add endpoint and behavior to outbound message logging as applicable