### PR TITLE
Fix fabric scoped event read without payload

### DIFF
--- a/packages/protocol/src/action/server/EventReadResponse.ts
+++ b/packages/protocol/src/action/server/EventReadResponse.ts
@@ -336,15 +336,14 @@ export class EventReadResponse<
                 // This event is not in the allowed list, so skip it
                 continue;
             }
-            // Filter out if we need to do fabric filtering and  the event is not for the current fabric
+            // Filter out if we need to do fabric filtering and the event is not for the current fabric
             if (this.#filteredForFabricIndex !== undefined) {
                 const { payload } = event;
-                if (!isObject(payload)) {
-                    continue;
-                }
-                const { fabricIndex } = payload;
-                if (fabricIndex !== undefined && fabricIndex !== this.#filteredForFabricIndex) {
-                    continue;
+                if (payload !== undefined && isObject(payload)) {
+                    const { fabricIndex } = payload;
+                    if (fabricIndex !== undefined && fabricIndex !== this.#filteredForFabricIndex) {
+                        continue;
+                    }
                 }
             }
             yield this.#asValue(event, tlv);


### PR DESCRIPTION
When the Read was fabric scoped and the event had no payload (which e.g. happens on the shutDown event) then the event was skipped. Fix for Backporting