### PR TITLE
Move time for chip image job a bit

### DIFF
--- a/.github/workflows/build-test.chip.yml
+++ b/.github/workflows/build-test.chip.yml
@@ -26,7 +26,7 @@ name: CHIP Image - Build and Test
 
 on:
   schedule:
-    - cron: 0 0 * * * # Every day at 01:00
+    - cron: 0 0 * * * # Every day at 00:00 (midnight)
   workflow_dispatch: # Manually on demand
     inputs:
       updateChipSha:


### PR DESCRIPTION
... seems we have an overlap between the jobs because of runtimes