### PR TITLE
Move more logic from ClusterType to ClusterModel

### DIFF
--- a/packages/model/src/logic/ClusterModifier.ts
+++ b/packages/model/src/logic/ClusterModifier.ts
@@ -1,0 +1,171 @@
+/**
+ * @license
+ * Copyright 2022-2025 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Constraint } from "#aspects/Constraint.js";
+import type { ElementTag } from "#common/ElementTag.js";
+import type { FieldValue } from "#common/FieldValue.js";
+import { isDeepEqual } from "#general";
+import type { ClusterModel } from "#models/ClusterModel.js";
+import { Model as Schema, StructuralModelError } from "#models/Model.js";
+import { ValueModel } from "#models/ValueModel.js";
+import { Scope } from "./Scope.js";
+
+/**
+ * Apply a declarative set of modifications to a {@link ClusterModel}.
+ *
+ * We use this to apply a limited set of modifications such as those expressed by device type requirements.  We track
+ * these modifications with individual fields because we use them to modify types in addition to the underlying model.
+ */
+export namespace ClusterModifier {
+    /**
+     * Apply the modifications defined by a device type.
+     */
+    export function applyRequirements(target: ClusterModel, modifications: ClusterModifier.RequirementModifications) {
+        return apply(target, modifications, (element, patch) => {
+            if (patch.optional !== undefined) {
+                const desiredConformance = patch.optional ? "O" : "M";
+                if (element.conformance.toString() !== desiredConformance) {
+                    if (element.isFinal) {
+                        element = element.clone();
+                    }
+                    element.conformance = desiredConformance;
+                }
+            }
+
+            if (patch.default !== undefined) {
+                if (!isDeepEqual(element.default, patch.default)) {
+                    if (element.isFinal) {
+                        element = element.clone();
+                    }
+                    element.default = patch.default;
+                }
+            }
+
+            if (patch.min !== undefined) {
+                const constraint = element.constraint;
+                if (constraint.min !== patch.min) {
+                    if (element.isFinal) {
+                        element = element.clone();
+                    }
+                    element.constraint = new Constraint({ ...element.constraint, min: patch.min });
+                }
+            }
+
+            if (patch.max !== undefined) {
+                const constraint = element.constraint;
+                if (constraint.max !== patch.max) {
+                    if (element.isFinal) {
+                        element = element.clone();
+                    }
+                    element.constraint = new Constraint({ ...element.constraint, max: patch.max });
+                }
+            }
+
+            return element;
+        });
+    }
+
+    /**
+     * Set {@link Model#isPresent} for the specified elements.
+     */
+    export function applyPresence(target: ClusterModel, modifications: ClusterModifier.PresenceModifications) {
+        return apply(target, modifications, (element, isSupported) => {
+            if (element.isSupported === isSupported) {
+                return;
+            }
+
+            if (element.isFinal) {
+                element = element.clone();
+            }
+            element.isSupported = isSupported;
+
+            return element;
+        });
+    }
+
+    export function apply<T>(
+        target: ClusterModel,
+        modifications: ClusterModifier.ModificationSet<T>,
+        apply: (model: ClusterModel.Child, modification: T) => ClusterModel.Child | undefined,
+    ) {
+        const scope = Scope(target);
+        let model: ClusterModel | undefined;
+
+        for (const [pluralTag, mods] of Object.entries(modifications)) {
+            const tag = (
+                pluralTag.endsWith("s") ? pluralTag.substring(0, pluralTag.length - 1) : pluralTag
+            ) as ElementTag;
+            if (Schema.types[tag] === undefined) {
+                throw new StructuralModelError(`Unknown modifier set key ${pluralTag}`);
+            }
+
+            const members = scope.membersOf(target, { conformance: Scope.ConformantConformance, tags: [tag] });
+
+            for (const [name, mod] of Object.entries(mods)) {
+                const member = members.for(name);
+                if (member === undefined) {
+                    throw new StructuralModelError(`${member} has no ${tag} "${name}"`);
+                }
+
+                if (!(member instanceof ValueModel)) {
+                    throw new StructuralModelError(`Tag ${tag} cannot be modified because it is not a value element`);
+                }
+
+                const replacement = apply(member, mod as T);
+                if (replacement === member || replacement === undefined) {
+                    return;
+                }
+
+                if (model === undefined) {
+                    model = target.extend();
+                }
+
+                model.children.push(replacement);
+            }
+        }
+
+        return model ?? target;
+    }
+}
+
+export namespace ClusterModifier {
+    /**
+     * Apply modifications as defined by device type requirements.
+     */
+    export interface RequirementModifications extends ModificationSet<RequirementModification> {}
+
+    /**
+     * Mark elements as active or inactive by default (if allowed by conformance).
+     */
+    export interface PresenceModifications extends ModificationSet<boolean> {}
+
+    export interface RequirementModification {
+        /**
+         * If present, forces conformance to O or M.
+         */
+        optional?: boolean;
+
+        /**
+         * Replaces the default for the element.
+         */
+        default?: FieldValue;
+
+        /**
+         * Modifies the lower bound of the element's constraint.
+         */
+        min?: FieldValue;
+
+        /**
+         * Modifies the upper bound of the element's constraint.
+         */
+        max?: FieldValue;
+    }
+
+    /**
+     * A set of element modifications keyed by tag and name
+     */
+    export interface ModificationSet<T> extends Partial<Record<`${ElementTag}s`, Record<string, T | undefined>>> {}
+}

--- a/packages/model/src/logic/Scope.ts
+++ b/packages/model/src/logic/Scope.ts
@@ -218,8 +218,8 @@ export namespace Scope {
     export const IgnoreConformance = "ignore";
 
     /**
-     * Use conformance to resolve conflicts but otherwise return all members.  Useful to detect errors in input
-     * that may contain non-conformant values.
+     * Use conformance to resolve conflicts but otherwise return all members.  Useful to detect errors in input that may
+     * contain non-conformant values.
      */
     export const DeconflictedConformance = "deconflicted";
 

--- a/packages/model/src/logic/cluster-variance/IllegalFeatureCombinations.ts
+++ b/packages/model/src/logic/cluster-variance/IllegalFeatureCombinations.ts
@@ -89,7 +89,7 @@ function addFeatureNode(
             add({ [feature.name]: true });
             break;
 
-        case Conformance.Special.Group:
+        case Conformance.Special.Otherwise:
             const rules = node.param;
 
             // Temporary storage for exclusions used in algorithm below

--- a/packages/model/src/logic/definition-validation/ValueValidator.ts
+++ b/packages/model/src/logic/definition-validation/ValueValidator.ts
@@ -43,6 +43,7 @@ export class ValueValidator<T extends ValueModel> extends ModelValidator<T> {
                 }
             }
         });
+        this.model.conformance.validateComputation(this, this.model.owner(ClusterModel)?.featureNames);
 
         this.#validateAspect("constraint");
         this.#validateAspect("access");

--- a/packages/model/src/logic/index.ts
+++ b/packages/model/src/logic/index.ts
@@ -9,6 +9,7 @@ export * from "./cluster-variance/IllegalFeatureCombinations.js";
 export * from "./cluster-variance/InferredComponents.js";
 export * from "./cluster-variance/NamedComponents.js";
 export * from "./cluster-variance/VarianceCondition.js";
+export * from "./ClusterModifier.js";
 export * from "./ClusterVariance.js";
 export * from "./DefaultValue.js";
 export * from "./MergedModel.js";

--- a/packages/model/src/models/Model.ts
+++ b/packages/model/src/models/Model.ts
@@ -29,11 +29,6 @@ export abstract class Model<E extends BaseElement = BaseElement, C extends Model
     type?: string;
     isSeed?: boolean;
 
-    #id: E["id"];
-    #name: string;
-    #isFinal?: boolean;
-    #resource?: Resource;
-
     /**
      * Indicates that an element defines a datatype.
      */
@@ -54,6 +49,17 @@ export abstract class Model<E extends BaseElement = BaseElement, C extends Model
      */
     operationalShadow?: Model | null;
 
+    /**
+     * Indicates whether the corresponding element is supported by an implementation.
+     *
+     * This is an operational implementation hint and does not override conformance.
+     */
+    isSupported?: boolean;
+
+    #id: E["id"];
+    #name: string;
+    #isFinal?: boolean;
+    #resource?: Resource;
     #children?: InternalChildren<C>;
     #parent?: Model;
     #root?: MatterModel;
@@ -567,6 +573,7 @@ export abstract class Model<E extends BaseElement = BaseElement, C extends Model
         this.isSeed = definition.isSeed;
         this.operationalBase = definition.operationalBase;
         this.operationalShadow = definition.operationalShadow;
+        this.isSupported = definition.isSupported;
 
         if (isClone) {
             if (definition.hasLocalResource) {
@@ -755,6 +762,7 @@ export namespace Model {
               parent?: Model;
               operationalBase?: Model;
               operationalShadow?: Model;
+              isSupported?: boolean;
           })
         | T;
 

--- a/packages/node/src/behavior/state/validation/conformance-compiler.ts
+++ b/packages/node/src/behavior/state/validation/conformance-compiler.ts
@@ -187,7 +187,7 @@ export function astToFunction(schema: ValueModel, supervisor: RootSupervisor): V
             case Conformance.Special.Choice:
                 return createChoice(ast.param);
 
-            case Conformance.Special.Group:
+            case Conformance.Special.Otherwise:
                 return createGroup(ast.param);
 
             case Conformance.Special.Name:
@@ -281,7 +281,7 @@ export function astToFunction(schema: ValueModel, supervisor: RootSupervisor): V
      * A "group" node is a list or the entries in an optional ([ ... ]) clause. The resulting node is the value of the
      * first list member that does not report as Code.Nonconformant.
      */
-    function createGroup(param: Conformance.Ast.Group): DynamicNode {
+    function createGroup(param: Conformance.Ast.Otherwise): DynamicNode {
         if (!Array.isArray(param)) {
             throw new SchemaImplementationError(
                 DataModelPath(schema.path),

--- a/packages/node/test/behavior/cluster/ClusterBehaviorTest.ts
+++ b/packages/node/test/behavior/cluster/ClusterBehaviorTest.ts
@@ -25,7 +25,7 @@ import {
     Attribute,
     ClusterId,
     ClusterType,
-    ElementModifier,
+    ClusterTypeModifier,
     TlvBoolean,
     TlvInt32,
     TlvNullable,
@@ -214,10 +214,10 @@ describe("ClusterBehavior", () => {
                     name: "MyCluster",
                     id: 1,
                     children: [
-                        AttributeElement({ id: 1, name: "Attr1", type: "int32", quality: "X" }),
-                        AttributeElement({ id: 2, name: "Attr2", type: "int32", default: 123 }),
-                        AttributeElement({ id: 3, name: "Attr3", type: "string", default: "abc" }),
-                        AttributeElement({ id: 4, name: "Attr4", type: "bool" }),
+                        AttributeElement({ id: 1, name: "Attr1", type: "int32", quality: "X", conformance: "M" }),
+                        AttributeElement({ id: 2, name: "Attr2", type: "int32", default: 123, conformance: "M" }),
+                        AttributeElement({ id: 3, name: "Attr3", type: "string", default: "abc", conformance: "M" }),
+                        AttributeElement({ id: 4, name: "Attr4", type: "bool", conformance: "M" }),
                     ],
                 }),
             );
@@ -265,7 +265,7 @@ describe("ClusterBehavior", () => {
             // Test constituent parts
             MyCluster.name satisfies "MyCluster";
 
-            const AlteredCluster = new ElementModifier(MyCluster).alter({});
+            const AlteredCluster = new ClusterTypeModifier(MyCluster).alter({});
             AlteredCluster.name satisfies "MyCluster";
 
             const BehaviorForAlteredCluster = MyBehavior.for(AlteredCluster);

--- a/packages/node/test/behavior/cluster/cluster-behavior-test-util.ts
+++ b/packages/node/test/behavior/cluster/cluster-behavior-test-util.ts
@@ -101,14 +101,14 @@ export const MySchema = new ClusterModel({
     name: "MyCluster",
 
     children: [
-        AttributeElement({ id: 1, name: "ReqAttr", type: "string", conformance: "M" }),
-        AttributeElement({ id: 2, name: "OptAttr", type: "bool", conformance: "O" }),
+        AttributeElement({ id: 1, name: "ReqAttr", type: "string", conformance: "M", default: "hello" }),
+        AttributeElement({ id: 2, name: "OptAttr", type: "bool", conformance: "O", default: true }),
         CommandElement({ id: 5, name: "ReqCmd", response: "ReqResponse", type: "string", conformance: "M" }),
         CommandElement({ id: 5, name: "ReqResponse", direction: "response", type: "string", conformance: "M" }),
         CommandElement({ id: 6, name: "OptCmd", response: "ReqResponse", type: "string", conformance: "O" }),
         CommandElement({ id: 6, name: "OptResponse", direction: "response", type: "string", conformance: "O" }),
-        EventElement({ id: 7, name: "ReqEv", priority: "critical", type: "string" }),
-        EventElement({ id: 8, name: "OptEv", priority: "debug", type: "string" }),
+        EventElement({ id: 7, name: "ReqEv", priority: "critical", type: "string", conformance: "M" }),
+        EventElement({ id: 8, name: "OptEv", priority: "debug", type: "string", conformance: "O" }),
 
         AttributeElement(
             {

--- a/packages/types/src/cluster/mutation/ClusterTypeModifier.ts
+++ b/packages/types/src/cluster/mutation/ClusterTypeModifier.ts
@@ -7,21 +7,21 @@
 import { ClusterType } from "../ClusterType.js";
 
 /**
- * An "element modifier" mutates cluster elements based on a predefined set of
- * alterations described in the Matter device library.
+ * An "cluster type modifier" mutates {@link ClusterType} elements based on a predefined set of alterations described in
+ * the Matter device library.
  */
-export class ElementModifier<const T extends ClusterType> {
+export class ClusterTypeModifier<const T extends ClusterType> {
     constructor(public cluster: T) {}
 
     /**
      * Create a new cluster with modified elements.
      */
-    alter<const AlterationsT extends ElementModifier.Alterations<T>>(alterations: AlterationsT) {
+    alter<const AlterationsT extends ClusterTypeModifier.Alterations<T>>(alterations: AlterationsT) {
         return modifyElements(this.cluster, alterations, (element, alteration: any) => {
             for (const property in alteration) {
                 element[property] = alteration[property];
             }
-        }) as ElementModifier.WithAlterations<T, AlterationsT>;
+        }) as ClusterTypeModifier.WithAlterations<T, AlterationsT>;
     }
 
     /**
@@ -33,7 +33,7 @@ export class ElementModifier<const T extends ClusterType> {
     set<const ValuesT extends Partial<ClusterType.AttributeValues<T>>>(values: ValuesT) {
         return modifyElements(this.cluster, { attributes: values }, (element, defaultValue) => {
             element.default = defaultValue;
-        }) as ElementModifier.WithValues<T, ValuesT>;
+        }) as ClusterTypeModifier.WithValues<T, ValuesT>;
     }
 
     /**
@@ -41,18 +41,18 @@ export class ElementModifier<const T extends ClusterType> {
      *
      * This informs matter.js that an application supports these elements.
      */
-    enable<const FlagsT extends ElementModifier.ElementFlags<T>>(flags: FlagsT) {
+    enable<const FlagsT extends ClusterTypeModifier.ElementFlags<T>>(flags: FlagsT) {
         return modifyElements(this.cluster, flags, (element, flag) => {
             if (flag === true) {
                 element.optional = false;
             } else if (flag === false) {
                 element.optional = true;
             }
-        }) as ElementModifier.WithAlterations<T, ElementModifier.ElementFlagAlterations<FlagsT>>;
+        }) as ClusterTypeModifier.WithAlterations<T, ClusterTypeModifier.ElementFlagAlterations<FlagsT>>;
     }
 }
 
-export namespace ElementModifier {
+export namespace ClusterTypeModifier {
     /**
      * A set of modifications to cluster elements of a specific type.
      */

--- a/packages/types/src/cluster/mutation/MutableCluster.ts
+++ b/packages/types/src/cluster/mutation/MutableCluster.ts
@@ -8,7 +8,7 @@ import { ClusterId } from "../../datatype/ClusterId.js";
 import { ConditionalFeatureList } from "../Cluster.js";
 import { ClusterType } from "../ClusterType.js";
 import { ClusterComposer } from "./ClusterComposer.js";
-import { ElementModifier } from "./ElementModifier.js";
+import { ClusterTypeModifier } from "./ClusterTypeModifier.js";
 
 /**
  * A "mutable cluster" is a {@link ClusterType} with builder methods that support a limited number of modifications as
@@ -37,16 +37,16 @@ export function MutableCluster<const T extends ClusterType.Options, const C exte
             return new ClusterComposer(cluster).compose(features);
         },
 
-        alter(alterations: ElementModifier.Alterations<typeof cluster>) {
-            return new ElementModifier(cluster).alter(alterations);
+        alter(alterations: ClusterTypeModifier.Alterations<typeof cluster>) {
+            return new ClusterTypeModifier(cluster).alter(alterations);
         },
 
         set(values: Partial<ClusterType.AttributeValues<typeof cluster>>) {
-            return new ElementModifier(cluster).set(values);
+            return new ClusterTypeModifier(cluster).set(values);
         },
 
-        enable(flags: ElementModifier.ElementFlags<typeof cluster>) {
-            return new ElementModifier(cluster).enable(flags);
+        enable(flags: ClusterTypeModifier.ElementFlags<typeof cluster>) {
+            return new ClusterTypeModifier(cluster).enable(flags);
         },
     });
 
@@ -77,25 +77,25 @@ export namespace MutableCluster {
         ): ClusterComposer.Of<T, SelectionT>;
 
         /**
-         * Modify elements using {@link ElementModifier.alter}.
+         * Modify elements using {@link ClusterTypeModifier.alter}.
          */
-        alter<const AlterationsT extends ElementModifier.Alterations<T>>(
+        alter<const AlterationsT extends ClusterTypeModifier.Alterations<T>>(
             alterations: AlterationsT,
-        ): ElementModifier.WithAlterations<T, AlterationsT>;
+        ): ClusterTypeModifier.WithAlterations<T, AlterationsT>;
 
         /**
-         * Modify elements using {@link ElementModifier.set}.
+         * Modify elements using {@link ClusterTypeModifier.set}.
          */
         set<const ValuesT extends Partial<ClusterType.AttributeValues<T>>>(
             values: ValuesT,
-        ): ElementModifier.WithValues<T, ValuesT>;
+        ): ClusterTypeModifier.WithValues<T, ValuesT>;
 
         /**
-         * Modify elements using {@link ElementModifier.enable}.
+         * Modify elements using {@link ClusterTypeModifier.enable}.
          */
-        enable<const FlagsT extends ElementModifier.ElementFlags<T>>(
+        enable<const FlagsT extends ClusterTypeModifier.ElementFlags<T>>(
             flags: FlagsT,
-        ): ElementModifier.WithFlags<T, FlagsT>;
+        ): ClusterTypeModifier.WithFlags<T, FlagsT>;
     }
 
     /**

--- a/packages/types/src/cluster/mutation/index.ts
+++ b/packages/types/src/cluster/mutation/index.ts
@@ -5,5 +5,5 @@
  */
 
 export * from "./ClusterComposer.js";
-export * from "./ElementModifier.js";
+export * from "./ClusterTypeModifier.js";
 export * from "./MutableCluster.js";

--- a/packages/types/test/cluster/mutation/ClusterTypeModifierTest.ts
+++ b/packages/types/test/cluster/mutation/ClusterTypeModifierTest.ts
@@ -14,7 +14,7 @@ import {
     OptionalEvent,
 } from "#cluster/Cluster.js";
 import { ClusterType } from "#cluster/ClusterType.js";
-import { ElementModifier } from "#cluster/mutation/ElementModifier.js";
+import { ClusterTypeModifier } from "#cluster/mutation/ClusterTypeModifier.js";
 import { Priority } from "#globals/Priority.js";
 import { TlvBoolean } from "#tlv/TlvBoolean.js";
 import { TlvUInt8 } from "#tlv/TlvNumber.js";
@@ -46,21 +46,24 @@ describe("ElementModifier", () => {
             } as const;
 
             // Type: Alteration without optional flag
-            type AlteredWithoutOptionalT = ElementModifier.WithAlterations<typeof cluster, { attributes: { foo: {} } }>;
+            type AlteredWithoutOptionalT = ClusterTypeModifier.WithAlterations<
+                typeof cluster,
+                { attributes: { foo: {} } }
+            >;
             const alteredWithoutOptional = {} as AlteredWithoutOptionalT;
             alteredWithoutOptional satisfies typeof cluster;
             const awoFooOptional = {} as AlteredWithoutOptionalT["attributes"]["foo"]["optional"];
             awoFooOptional satisfies true;
 
             // Type: Entire alteration
-            type AlteredT = ElementModifier.WithAlterations<typeof cluster, typeof alterations>;
+            type AlteredT = ClusterTypeModifier.WithAlterations<typeof cluster, typeof alterations>;
             const altered = { attributes: {} } as AlteredT;
             altered.attributes satisfies {};
             altered.attributes.foo satisfies { optional: false };
             altered.attributes.bar satisfies { optional: true };
 
             // Functional
-            const cluster2 = new ElementModifier(cluster).alter(alterations);
+            const cluster2 = new ClusterTypeModifier(cluster).alter(alterations);
             expect(cluster.attributes.foo.optional).equal(true);
             cluster2.attributes.foo satisfies { optional: false };
             cluster2.attributes.bar satisfies { optional: true };
@@ -69,15 +72,15 @@ describe("ElementModifier", () => {
 
         it("handles empty element set alteration", () => {
             // Type: Altered with empty attribute modifications
-            const emptyAttrs = {} as ElementModifier.WithAlterations<ClusterType, { attributes: {} }>;
+            const emptyAttrs = {} as ClusterTypeModifier.WithAlterations<ClusterType, { attributes: {} }>;
             emptyAttrs satisfies ClusterType;
 
             // Type: Altered with empty command modifications
-            const emptyCommands = {} as ElementModifier.WithAlterations<ClusterType, { commands: {} }>;
+            const emptyCommands = {} as ClusterTypeModifier.WithAlterations<ClusterType, { commands: {} }>;
             emptyCommands satisfies ClusterType;
 
             // Type: Altered with empty command modifications
-            const emptyEvents = {} as ElementModifier.WithAlterations<ClusterType, { commands: {} }>;
+            const emptyEvents = {} as ClusterTypeModifier.WithAlterations<ClusterType, { commands: {} }>;
             emptyEvents satisfies ClusterType;
         });
     });
@@ -86,8 +89,7 @@ describe("ElementModifier", () => {
         it("has correct input values", () => {
             type IsNever<T> = [T] extends [never] ? true : false;
 
-            // Test InputAttributeValues and constituents first as they are
-            // the key to set
+            // Test InputAttributeValues and constituents first as they are the key to set
 
             // Type: Test AttributesOf
             type Attrs = ClusterType.AttributesOf<ClusterType>;
@@ -102,17 +104,17 @@ describe("ElementModifier", () => {
 
         it("sets default value", () => {
             // Type: Value alterations
-            type Alterations = ElementModifier.AttributeValueAlterations<{}>;
+            type Alterations = ClusterTypeModifier.AttributeValueAlterations<{}>;
             const alterations = {} as Alterations;
             alterations satisfies { attributes: {} };
 
             // Type: Untyped cluster & empty values
-            type UntypedEmpty = ElementModifier.WithValues<ClusterType, {}>;
+            type UntypedEmpty = ClusterTypeModifier.WithValues<ClusterType, {}>;
             const untypedEmpty = {} as UntypedEmpty;
             untypedEmpty satisfies ClusterType;
 
             // Type: Untyped cluster
-            type UntypedCluster = ElementModifier.WithValues<
+            type UntypedCluster = ClusterTypeModifier.WithValues<
                 ClusterType,
                 Partial<ClusterType.AttributeValues<ClusterType>>
             >;
@@ -120,7 +122,7 @@ describe("ElementModifier", () => {
             untypedCluster satisfies ClusterType;
 
             // Type: Untyped values
-            type UntypedValues = ElementModifier.WithValues<
+            type UntypedValues = ClusterTypeModifier.WithValues<
                 typeof TestBase,
                 Partial<ClusterType.AttributeValues<typeof TestBase>>
             >;
@@ -128,27 +130,27 @@ describe("ElementModifier", () => {
             untypedValues satisfies Elements1ish;
 
             // Type: Empty values
-            type EmptyValues = ElementModifier.WithValues<typeof TestBase, {}>;
+            type EmptyValues = ClusterTypeModifier.WithValues<typeof TestBase, {}>;
             const emptyValues = {} as EmptyValues;
             emptyValues satisfies Elements1ish;
 
             // Type: Fully specified
-            type Set = ElementModifier.WithValues<typeof TestBase, { attr1: 4 }>;
+            type Set = ClusterTypeModifier.WithValues<typeof TestBase, { attr1: 4 }>;
             const set = {} as Set;
             set satisfies Elements1ish;
 
             // Functional: Generic cluster
-            const generic = new ElementModifier({ attributes: {} } as ClusterType).set({});
+            const generic = new ClusterTypeModifier({ attributes: {} } as ClusterType).set({});
             generic satisfies ClusterType;
             expect(generic.attributes).deep.equal({});
 
             // Functional: Empty attributes
-            const empty = new ElementModifier(ClusterType({ id: 1, revision: 1, name: "One" })).set({});
+            const empty = new ClusterTypeModifier(ClusterType({ id: 1, revision: 1, name: "One" })).set({});
             empty satisfies ClusterType;
             expect(stripFunctions(empty.attributes)).deep.equal(stripFunctions(GlobalAttributes({})));
 
             // Functional: With attribute
-            const withAttr = new ElementModifier(TestBase).set({ attr1: 4 });
+            const withAttr = new ClusterTypeModifier(TestBase).set({ attr1: 4 });
             expect(withAttr.attributes.attr1.default).equal(4);
         });
     });
@@ -177,7 +179,7 @@ describe("ElementModifier", () => {
             };
 
             // Type: Flags to alterations
-            type Alterations = ElementModifier.ElementFlagAlterations<typeof flags>;
+            type Alterations = ClusterTypeModifier.ElementFlagAlterations<typeof flags>;
             ({}) as Alterations satisfies {
                 attributes: { attr: { optional: true } };
                 commands: { cmd: { optional: true } };
@@ -185,11 +187,11 @@ describe("ElementModifier", () => {
             };
 
             // Type: Fully specified
-            type Enabled = ElementModifier.WithFlags<typeof cluster, typeof flags>;
+            type Enabled = ClusterTypeModifier.WithFlags<typeof cluster, typeof flags>;
             ({}) as Enabled satisfies Altered;
 
             // Functional
-            const enabled = new ElementModifier(cluster).enable(flags);
+            const enabled = new ClusterTypeModifier(cluster).enable(flags);
             enabled satisfies Altered;
             expect(enabled.attributes.attr.optional).equal(true);
             expect(enabled.commands.cmd.optional).equal(true);
@@ -219,7 +221,7 @@ describe("ElementModifier", () => {
             };
 
             // Type: Flags to alterations
-            type Alterations = ElementModifier.ElementFlagAlterations<typeof flags>;
+            type Alterations = ClusterTypeModifier.ElementFlagAlterations<typeof flags>;
             ({}) as Alterations satisfies {
                 attributes: { attr: { optional: false } };
                 commands: { cmd: { optional: false } };
@@ -227,11 +229,11 @@ describe("ElementModifier", () => {
             };
 
             // Type: Fully specified
-            type Enabled = ElementModifier.WithFlags<typeof cluster, typeof flags>;
+            type Enabled = ClusterTypeModifier.WithFlags<typeof cluster, typeof flags>;
             ({}) as Enabled satisfies Altered;
 
             // Functional
-            const disabled = new ElementModifier(cluster).enable(flags);
+            const disabled = new ClusterTypeModifier(cluster).enable(flags);
             disabled satisfies Altered;
             expect(disabled.attributes.attr.optional).equal(false);
             expect(disabled.commands.cmd.optional).equal(false);


### PR DESCRIPTION
This supports the 1.4.2 effort as well as migration to runtime generation of ClusterType.

* Add "ClusterModifier" that modifies ClusterModel in the same way as we modify ClusterType

* Use previous in `for` and `enable` methods of Behavior.Type so that `schema` remains fully synced

* Update `Conformance.applicabilityOf` to improve accuracy and distinguish between "optional" and "conditional" applicability

* Modify `ClusterBehaviorUtil` to drive all configuration off of `schema` rather than `cluster`