### PR TITLE
Split entropy from crypto

### DIFF
--- a/packages/general/src/crypto/StandardCrypto.ts
+++ b/packages/general/src/crypto/StandardCrypto.ts
@@ -9,6 +9,7 @@ import { DerBigUint, DerCodec, DerError } from "#codec/DerCodec.js";
 import { Environment } from "#environment/Environment.js";
 import { ImplementationError, NotImplementedError } from "#MatterError.js";
 import { Bytes } from "#util/Bytes.js";
+import { Entropy } from "#util/Entropy.js";
 import { MaybePromise } from "#util/Promises.js";
 import { describeList } from "#util/String.js";
 import { Ccm } from "./aes/Ccm.js";
@@ -305,5 +306,7 @@ function assertInterface<T extends {}>(name: string, object: T, requiredMethods:
 // If available, unconditionally add to Environment as it has not been exported yet so there can be no other
 // implementation present
 if ("crypto" in globalThis && globalThis.crypto?.subtle) {
-    Environment.default.set(Crypto, new StandardCrypto());
+    const crypto = new StandardCrypto();
+    Environment.default.set(Entropy, crypto);
+    Environment.default.set(Crypto, crypto);
 }

--- a/packages/general/src/net/RetrySchedule.ts
+++ b/packages/general/src/net/RetrySchedule.ts
@@ -4,19 +4,19 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Crypto } from "#crypto/Crypto.js";
 import { Duration } from "#time/Duration.js";
 import { Instant, Millis, Seconds } from "#time/TimeUnit.js";
+import { Entropy } from "#util/Entropy.js";
 
 /**
  * An iterable of retry values based on a scheduling configuration.
  */
 export class RetrySchedule {
-    #crypto: Crypto;
+    #entropy: Entropy;
     readonly config: RetrySchedule.Configuration;
 
-    constructor(crypto: Crypto, config: RetrySchedule.Configuration) {
-        this.#crypto = crypto;
+    constructor(entropy: Entropy, config: RetrySchedule.Configuration) {
+        this.#entropy = entropy;
         this.config = config;
     }
 
@@ -42,7 +42,7 @@ export class RetrySchedule {
         while ((timeout === undefined || timeSoFar < timeout) && (maximumCount === undefined || maximumCount > count)) {
             count++;
             const maxJitter = jitterFactor * baseInterval;
-            const jitter = Millis.floor(Millis((maxJitter * this.#crypto.randomUint32) / Math.pow(2, 32)));
+            const jitter = Millis.floor(Millis((maxJitter * this.#entropy.randomUint32) / Math.pow(2, 32)));
             let interval = Millis(baseInterval + jitter);
 
             if (timeout !== undefined && timeSoFar + interval > timeout) {

--- a/packages/general/src/util/Entropy.ts
+++ b/packages/general/src/util/Entropy.ts
@@ -1,0 +1,44 @@
+/**
+ * @license
+ * Copyright 2022-2025 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Bytes } from "#util/Bytes.js";
+
+/**
+ * A source of entropy.
+ */
+export abstract class Entropy {
+    /**
+     * Create a random buffer from the most cryptographically-appropriate source available.
+     */
+    abstract randomBytes(length: number): Bytes;
+
+    get randomUint8() {
+        return Bytes.of(this.randomBytes(1))[0];
+    }
+
+    get randomUint16() {
+        return Bytes.dataViewOf(this.randomBytes(2)).getUint16(0);
+    }
+
+    get randomUint32() {
+        return Bytes.dataViewOf(this.randomBytes(4)).getUint32(0);
+    }
+
+    get randomBigUint64() {
+        return Bytes.dataViewOf(this.randomBytes(8)).getBigUint64(0);
+    }
+
+    randomBigInt(size: number, maxValue?: bigint) {
+        if (maxValue === undefined) {
+            return Bytes.asBigInt(this.randomBytes(size));
+        }
+
+        while (true) {
+            const random = Bytes.asBigInt(this.randomBytes(size));
+            if (random < maxValue) return random;
+        }
+    }
+}

--- a/packages/general/src/util/index.ts
+++ b/packages/general/src/util/index.ts
@@ -17,6 +17,7 @@ export * from "./DataWriter.js";
 export * from "./Decorator.js";
 export * from "./DeepCopy.js";
 export * from "./DeepEqual.js";
+export * from "./Entropy.js";
 export * from "./Error.js";
 export * from "./FormattedText.js";
 export * from "./GeneratedClass.js";

--- a/packages/node/src/behavior/internal/BehaviorBacking.ts
+++ b/packages/node/src/behavior/internal/BehaviorBacking.ts
@@ -13,7 +13,7 @@ import type { SupportedElements } from "#endpoint/properties/Behaviors.js";
 import {
     camelize,
     Construction,
-    Crypto,
+    Entropy,
     EventEmitter,
     ImplementationError,
     InternalError,
@@ -212,7 +212,7 @@ export abstract class BehaviorBacking {
 
     protected get datasourceOptions(): Datasource.Options {
         return {
-            crypto: this.#endpoint.env.get(Crypto),
+            entropy: this.#endpoint.env.get(Entropy),
             location: {
                 path: this.#endpoint.path.at(this.#type.id).at("state"),
                 endpoint: this.#endpoint.number,

--- a/packages/node/src/behavior/state/managed/Datasource.ts
+++ b/packages/node/src/behavior/state/managed/Datasource.ts
@@ -6,8 +6,8 @@
 
 import {
     camelize,
-    Crypto,
     deepCopy,
+    Entropy,
     ImplementationError,
     InternalError,
     isDeepEqual,
@@ -153,9 +153,9 @@ export namespace Datasource {
         location: AccessControl.Location;
 
         /**
-         * Used for random data.
+         * Used to generate initial version numbers.
          */
-        crypto: Crypto;
+        entropy: Entropy;
 
         /**
          * Events triggered automatically.
@@ -327,7 +327,7 @@ function configure(options: Datasource.Options): Internals {
         ...options,
         primaryKey: options.primaryKey === "id" ? "id" : "name",
         events,
-        version: options.crypto.randomUint32,
+        version: options.entropy.randomUint32,
         values,
         featuresKey,
         manageVersion: true,

--- a/packages/node/test/behavior/state/managed/DatasourceTest.ts
+++ b/packages/node/test/behavior/state/managed/DatasourceTest.ts
@@ -51,7 +51,7 @@ function createDatasource<const T extends StateType = typeof MyState>(
     options: Partial<Datasource.Options<T>> = {},
 ): Datasource<T> {
     return Datasource({
-        crypto: MockCrypto(),
+        entropy: MockCrypto(),
         location: {
             endpoint: EndpointNumber(1),
             path: DataModelPath("TestDatasource"),

--- a/packages/node/test/behavior/state/managed/values/StructManagerTest.ts
+++ b/packages/node/test/behavior/state/managed/values/StructManagerTest.ts
@@ -79,7 +79,7 @@ async function testDuality(life: boolean, actor: (struct: { alive?: boolean }) =
     const supervisor = RootSupervisor.for(schema);
 
     const datasource = Datasource({
-        crypto: MockCrypto(),
+        entropy: MockCrypto(),
         type: SchrödingersCatsState,
         supervisor,
         location: { endpoint: EndpointNumber(1), path: DataModelPath(0) },

--- a/packages/node/test/behavior/state/managed/values/value-utils.ts
+++ b/packages/node/test/behavior/state/managed/values/value-utils.ts
@@ -83,7 +83,7 @@ export function TestStruct(fields: Record<string, string | Partial<FieldElement>
     }
 
     const datasource = Datasource({
-        crypto: MockCrypto(),
+        entropy: MockCrypto(),
         location: {
             endpoint: EndpointNumber(1),
             cluster: ClusterId(1),

--- a/packages/node/test/node/mock-server-node.ts
+++ b/packages/node/test/node/mock-server-node.ts
@@ -12,6 +12,7 @@ import {
     AsyncObservable,
     Crypto,
     DataReadQueue,
+    Entropy,
     Environment,
     MaybePromise,
     MockCrypto,
@@ -51,7 +52,9 @@ export class MockServerNode<T extends ServerNode.RootEndpoint = ServerNode.RootE
         }
 
         // Stabilize random numbers
-        environment.set(Crypto, MockCrypto(options?.index));
+        const crypto = MockCrypto(options?.index);
+        environment.set(Entropy, crypto);
+        environment.set(Crypto, crypto);
 
         const storage = environment.get(StorageService);
         if (storage.location !== "(memory-for-test)") {

--- a/packages/node/test/node/mock-site.ts
+++ b/packages/node/test/node/mock-site.ts
@@ -7,6 +7,7 @@
 import { OnOffLightDevice } from "#devices/on-off-light";
 import {
     Crypto,
+    Entropy,
     Environment,
     Logger,
     MatterAggregateError,
@@ -56,7 +57,9 @@ export class MockSite {
         const id = (config.id ??= `node${index.toString(16).padStart(2, "0")}`);
         const env = (config.environment ??= new Environment(id));
         if (!env.has(Crypto)) {
-            env.set(Crypto, MockCrypto(index));
+            const crypto = MockCrypto(index);
+            env.set(Entropy, crypto);
+            env.set(Crypto, crypto);
         }
         if (!env.has(Network)) {
             env.set(Network, (config.simulator ?? this.#simulator).addHost(index));

--- a/packages/nodejs/src/environment/NodeJsEnvironment.ts
+++ b/packages/nodejs/src/environment/NodeJsEnvironment.ts
@@ -10,6 +10,7 @@ import {
     asError,
     Boot,
     Crypto,
+    Entropy,
     Environment,
     HttpEndpointFactory,
     ImplementationError,
@@ -139,9 +140,16 @@ function rootDirOf(env: Environment) {
 function configureCrypto(env: Environment) {
     Boot.init(() => {
         if (config.installCrypto || (env.vars.boolean("nodejs.crypto") ?? true)) {
-            env.set(Crypto, new NodeJsCrypto());
-        } else if (Environment.default.has(Crypto)) {
-            env.set(Crypto, Environment.default.get(Crypto));
+            const crypto = new NodeJsCrypto();
+            env.set(Entropy, crypto);
+            env.set(Crypto, crypto);
+        } else {
+            if (Environment.default.has(Entropy)) {
+                env.set(Entropy, Environment.default.get(Entropy));
+            }
+            if (Environment.default.has(Crypto)) {
+                env.set(Crypto, Environment.default.get(Crypto));
+            }
         }
     });
 }

--- a/packages/protocol/src/protocol/ExchangeManager.ts
+++ b/packages/protocol/src/protocol/ExchangeManager.ts
@@ -10,8 +10,8 @@ import {
     Channel,
     ConnectionlessTransport,
     ConnectionlessTransportSet,
-    Crypto,
     Diagnostic,
+    Entropy,
     Environment,
     Environmental,
     ImplementationError,
@@ -48,7 +48,7 @@ const MAXIMUM_CONCURRENT_EXCHANGES_PER_SESSION = 5;
  * Interfaces {@link ExchangeManager} with other components.
  */
 export interface ExchangeManagerContext {
-    crypto: Crypto;
+    entropy: Entropy;
     netInterface: ConnectionlessTransportSet;
     sessionManager: SessionManager;
     channelManager: ChannelManager;
@@ -70,7 +70,7 @@ export class ExchangeManager {
         this.#transports = context.netInterface;
         this.#sessionManager = context.sessionManager;
         this.#channelManager = context.channelManager;
-        this.#exchangeCounter = new ExchangeCounter(context.crypto);
+        this.#exchangeCounter = new ExchangeCounter(context.entropy);
 
         for (const netInterface of this.#transports) {
             this.#addListener(netInterface);
@@ -89,7 +89,7 @@ export class ExchangeManager {
 
     static [Environmental.create](env: Environment) {
         const instance = new ExchangeManager({
-            crypto: env.get(Crypto),
+            entropy: env.get(Entropy),
             netInterface: env.get(ConnectionlessTransportSet),
             sessionManager: env.get(SessionManager),
             channelManager: env.get(ChannelManager),
@@ -480,8 +480,8 @@ export class ExchangeManager {
 export class ExchangeCounter {
     #exchangeCounter: number;
 
-    constructor(crypto: Crypto) {
-        this.#exchangeCounter = crypto.randomUint16;
+    constructor(entropy: Entropy) {
+        this.#exchangeCounter = entropy.randomUint16;
     }
 
     getIncrementedCounter() {

--- a/packages/react-native/src/crypto/ReactNativeCrypto.ts
+++ b/packages/react-native/src/crypto/ReactNativeCrypto.ts
@@ -9,6 +9,7 @@ import {
     Crypto,
     CRYPTO_HASH_LEN_BYTES,
     CRYPTO_SYMMETRIC_KEY_LENGTH,
+    Entropy,
     Environment,
     Key,
     NodeJsCryptoApiLike,
@@ -122,4 +123,8 @@ export class ReactNativeCrypto extends StandardCrypto {
     override signHmac = nodeJsCrypto.signHmac.bind(nodeJsCrypto);
 }
 
-Environment.default.set(Crypto, new ReactNativeCrypto(crypto as unknown as WebCrypto));
+{
+    const rnCrypto = new ReactNativeCrypto(crypto as unknown as WebCrypto);
+    Environment.default.set(Entropy, rnCrypto);
+    Environment.default.set(Crypto, rnCrypto);
+}


### PR DESCRIPTION
Requiring something called "crypto" just to get random numbers seemed a little awkward, so this splits out an "Entropy" abstraction from the Crypto abstraction.  Crypto extends Entropy for implementation convenience.