### PR TITLE
Promise.race without memory leaks

### DIFF
--- a/packages/cli-tool/src/domain.ts
+++ b/packages/cli-tool/src/domain.ts
@@ -13,6 +13,7 @@ import {
     LogFormat,
     MaybePromise,
     Observable,
+    SafePromise,
 } from "#general";
 import { bin, globals as defaultGlobals } from "#globals.js";
 import { Location, undefinedValue } from "#location.js";
@@ -423,7 +424,7 @@ export async function Domain(context: DomainContext): Promise<Domain> {
                     };
                 });
 
-                const returnValue = await Promise.race([discarded, result]);
+                const returnValue = await SafePromise.race([discarded, result]);
 
                 if (isDiscarded) {
                     result.then(

--- a/packages/general/src/util/Abort.ts
+++ b/packages/general/src/util/Abort.ts
@@ -7,6 +7,7 @@
 import { TimeoutError } from "#MatterError.js";
 import { Duration } from "#time/Duration.js";
 import { Time, Timer } from "#time/Time.js";
+import { SafePromise } from "./Promises.js";
 
 /**
  * Utilities for implementing abort logic.
@@ -61,14 +62,14 @@ export namespace Abort {
                 off = () => (signal as AbortSignal).removeEventListener("abort", onabort);
             });
 
-            return Promise.race([aborted, ...promises]).finally(off!);
+            return SafePromise.race([aborted, ...promises]).finally(off!);
         }
 
         if (promises.length === 1) {
             return Promise.resolve(promises[0]);
         }
 
-        return Promise.race(promises);
+        return SafePromise.race(promises);
     }
 
     /**

--- a/packages/general/test/util/PromisesTest.ts
+++ b/packages/general/test/util/PromisesTest.ts
@@ -1,0 +1,72 @@
+/**
+ * @license
+ * Copyright 2022-2025 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { SafePromise } from "#util/Promises.js";
+
+describe("Promises", () => {
+    describe("SafePromise.race", () => {
+        it("works with two resolutions", async () => {
+            const promise1 = Promise.resolve("foo");
+            const promise2 = Promise.resolve("bar");
+
+            expect(await SafePromise.race([promise1, promise2])).equals("foo");
+        });
+
+        it("works with partial resolution", async () => {
+            const promise1 = new Promise(() => {});
+            const promise2 = Promise.resolve("bar");
+
+            expect(await SafePromise.race([promise1, promise2])).equals("bar");
+        });
+
+        it("works with eventual partial resolution", async () => {
+            const promise1 = new Promise(() => {});
+
+            let resolve!: (str: string) => void;
+            const promise2 = new Promise<string>(r => (resolve = r));
+
+            const race = SafePromise.race([promise1, promise2]);
+
+            resolve("foo");
+
+            expect(await race).equals("foo");
+        });
+
+        it("works with errors", async () => {
+            const promise1 = new Promise(() => {});
+            const promise2 = Promise.reject(new Error("oops"));
+
+            expect(SafePromise.race([promise1, promise2])).rejectedWith(Error, "oops");
+        });
+
+        it("doesn't register more than one listener", async () => {
+            let thens = 0;
+
+            let promise!: PromiseLike<void>;
+            let resolve!: () => void;
+            const realPromise = new Promise<void>(r => {
+                resolve = r;
+                promise = {
+                    then(resolve, reject) {
+                        thens++;
+                        return realPromise.then(resolve, reject);
+                    },
+                };
+            });
+
+            // Change this to "Promise.race" and the test will fail due to leak
+            const promise1 = SafePromise.race([promise]);
+            const promise2 = SafePromise.race([promise, promise]);
+
+            resolve();
+
+            await promise1;
+            await promise2;
+
+            expect(thens).equals(1);
+        });
+    });
+});

--- a/support/tests/src/common/process-parent.ts
+++ b/support/tests/src/common/process-parent.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { InternalError, Logger } from "@matter/main";
+import { InternalError, Logger, SafePromise } from "@matter/main";
 import { afterRun } from "@matter/testing";
 import { ChildProcess, fork } from "node:child_process";
 import { join } from "node:path";
@@ -55,7 +55,7 @@ export class ParentProcess {
     protected send<T extends Message.Acknowledged>(message: Omit<T, "exchangeNo">) {
         const exchangeNo = ++this.#nextExchangeNo;
 
-        return Promise.race([
+        return SafePromise.race([
             new Promise<void>((resolve, reject) => {
                 this.#child.process.send({ ...message, exchangeNo }, error => {
                     if (error) {


### PR DESCRIPTION
Promise.race will leak memory with long-lived promises.  This implements a "safe" version that will not leak.

I'm not sure this would've caused us many issues yet because we don't use Promise.race much but that's partially because I suspected it would leak.  Plan to race more going forward.