### PR TITLE
New "observable value" primitive

### DIFF
--- a/packages/general/src/util/Observable.ts
+++ b/packages/general/src/util/Observable.ts
@@ -106,6 +106,14 @@ export interface Observable<T extends any[] = any[], R = void> extends AsyncIter
     handlePromise: ObserverPromiseHandler | boolean;
 
     /**
+     * Creates a promise that resolves when next emitted.
+     */
+    then<TResult1 = T, TResult2 = never>(
+        onfulfilled?: ((value: T[0]) => TResult1 | PromiseLike<TResult1>) | null,
+        onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | null,
+    ): Promise<TResult1 | TResult2>;
+
+    /**
      * Observable supports standard "for await (const value of observable").
      *
      * Using an observer in this manner limits your listener to the first parameter normally emitted and your observer
@@ -117,6 +125,38 @@ export interface Observable<T extends any[] = any[], R = void> extends AsyncIter
      * Release resources associated with the observable.
      */
     [Symbol.dispose](): void;
+}
+
+/**
+ * An observable value.
+ *
+ * This is a stateful observable that remembers its last emitted value and maps to standard Promise semantics.
+ *
+ * Unlike a normal {@link Observable}, awaiting an {@link ObservableValue} will result in immediate resolution if the
+ * value is truthy, and immediately upon updating to a truthy value otherwise.
+ *
+ * Also unlike a normal {@link Observable}, an {@link ObservableValue} may be placed into an error state which will
+ * result in rejection if awaited.
+ */
+export interface ObservableValue<T extends [any, ...any[]] = [boolean]> extends Observable<T, void>, Promise<T[0]> {
+    value: T[0] | undefined;
+    error?: Error;
+
+    /**
+     * Place the observable into an error state.
+     *
+     * The error is cleared on next emit.
+     */
+    reject(cause: unknown): void;
+
+    then<TResult1 = T, TResult2 = never>(
+        onfulfilled?: ((value: T[0]) => TResult1 | PromiseLike<TResult1>) | null,
+        onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | null,
+    ): Promise<TResult1 | TResult2>;
+
+    catch<TResult = never>(
+        onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | null,
+    ): Promise<T[0] | TResult>;
 }
 
 /**
@@ -315,12 +355,12 @@ export class BasicObservable<T extends any[] = any[], R = void> implements Obser
     }
 
     then<TResult1 = T, TResult2 = never>(
-        onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | null,
+        onfulfilled?: ((value: T[0]) => TResult1 | PromiseLike<TResult1>) | null,
         onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | null,
-    ): PromiseLike<TResult1 | TResult2> {
+    ): Promise<TResult1 | TResult2> {
         return new Promise<T>(resolve => {
             this.once((...payload): undefined => {
-                resolve(payload);
+                resolve(payload[0]);
             });
         }).then(onfulfilled, onrejected);
     }
@@ -415,6 +455,115 @@ function event<E, N extends string>(emitter: E, name: N) {
         throw new ImplementationError(`Invalid event name ${name}`);
     }
     return observer as Observable;
+}
+
+/**
+ * A concrete {@link ObservableValue} implementation.
+ */
+export class BasicObservableValue<T extends [any, ...any[]] = [boolean]>
+    extends BasicObservable<T, void>
+    implements ObservableValue<T>
+{
+    #value: T | undefined;
+    #error?: Error;
+    #awaiters?: {
+        resolve?: ((value: T[0]) => void) | null;
+        reject?: ((reason: any) => void) | null;
+    }[];
+
+    constructor(value?: T, handleError?: ObserverErrorHandler, asyncConfig?: ObserverPromiseHandler | boolean) {
+        super(handleError, asyncConfig);
+        this.#value = value;
+        this.on(this.#maybeResolve.bind(this) as unknown as Observer<T, void>);
+    }
+
+    /**
+     * The current value.
+     *
+     * This will resolve the promise interface but you must use {@link emit} to also emit an event..
+     */
+    get value(): T[0] | undefined {
+        return this.#value;
+    }
+
+    set value(value: T[0] | undefined) {
+        this.#maybeResolve([value]);
+    }
+
+    get error() {
+        return this.#error;
+    }
+
+    reject(cause: unknown) {
+        cause = asError(cause);
+        this.#value = undefined;
+        this.#error = cause as Error;
+        const awaiters = this.#awaiters;
+        if (awaiters) {
+            this.#awaiters = undefined;
+            for (const awaiter of awaiters) {
+                awaiter.reject?.(cause as Error);
+            }
+        }
+    }
+
+    #maybeResolve(value: T[0] | undefined) {
+        this.#value = value;
+        if (!this.#value) {
+            return;
+        }
+
+        const awaiters = this.#awaiters;
+        if (awaiters) {
+            this.#awaiters = undefined;
+            for (const awaiter of awaiters) {
+                awaiter.resolve?.(this.#value);
+            }
+        }
+    }
+
+    override then<TResult1 = T, TResult2 = never>(
+        onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | null,
+        onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | null,
+    ): Promise<TResult1 | TResult2> {
+        if (this.#error) {
+            return Promise.reject(this.#error).then(onfulfilled, onrejected);
+        }
+        if (this.#value) {
+            return Promise.resolve(this.#value).then(onfulfilled, onrejected);
+        }
+
+        return new Promise<T>((resolve, reject) => {
+            if (!this.#awaiters) {
+                this.#awaiters = [];
+            }
+            this.#awaiters.push({ resolve, reject });
+        }).then(onfulfilled, onrejected);
+    }
+
+    catch<TResult = never>(
+        onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | null,
+    ): Promise<T | TResult> {
+        return this.then(undefined, onrejected);
+    }
+
+    finally(onfinally?: (() => void) | null): Promise<T> {
+        return Promise.resolve(this).finally(onfinally);
+    }
+
+    [Symbol.toStringTag] = "Promise";
+}
+
+/**
+ * Create an {@link ObservableValue}.
+ */
+export const ObservableValue = constructObservableValue as unknown as {
+    new <T extends [any, ...any[]]>(value?: T, errorHandler?: ObserverErrorHandler): ObservableValue<T>;
+    <T extends [any, ...any[]]>(value?: T, errorHandler?: ObserverErrorHandler): ObservableValue<T>;
+};
+
+function constructObservableValue(value?: [unknown, ...unknown[]], handleError?: ObserverErrorHandler) {
+    return new ObservableValue(value, handleError);
 }
 
 /**

--- a/packages/general/src/util/Set.ts
+++ b/packages/general/src/util/Set.ts
@@ -5,7 +5,7 @@
  */
 
 import { ImplementationError } from "#MatterError.js";
-import { Observable } from "./Observable.js";
+import { Observable, ObservableValue } from "./Observable.js";
 
 /**
  * A read-only set.
@@ -34,6 +34,7 @@ export interface MutableSet<T, AddT = T> {
 export interface ObservableSet<T> {
     get added(): Observable<[T]>;
     get deleted(): Observable<[T]>;
+    get empty(): ObservableValue;
 }
 
 /**
@@ -63,6 +64,7 @@ export class BasicSet<T, AddT = T> implements ImmutableSet<T>, MutableSet<T, Add
     #entries = new Set<T>();
     #added?: Observable<[T]>;
     #deleted?: Observable<[T]>;
+    #empty?: ObservableValue;
     #indices?: {
         [field in keyof T]?: Map<T[field], T>;
     };
@@ -211,6 +213,10 @@ export class BasicSet<T, AddT = T> implements ImmutableSet<T>, MutableSet<T, Add
 
         this.#deleted?.emit(item);
 
+        if (this.#empty && !this.size) {
+            this.#empty.emit(true);
+        }
+
         return true;
     }
 
@@ -232,6 +238,13 @@ export class BasicSet<T, AddT = T> implements ImmutableSet<T>, MutableSet<T, Add
             this.#deleted = Observable();
         }
         return this.#deleted;
+    }
+
+    get empty() {
+        if (this.#empty === undefined) {
+            this.#empty = ObservableValue();
+        }
+        return this.#empty;
     }
 
     protected create(definition: AddT) {

--- a/packages/node/src/endpoint/properties/EndpointContainer.ts
+++ b/packages/node/src/endpoint/properties/EndpointContainer.ts
@@ -72,6 +72,10 @@ export class EndpointContainer<T extends Endpoint = Endpoint>
         return this.#children.deleted;
     }
 
+    get empty() {
+        return this.#children.empty;
+    }
+
     get size() {
         return this.#children.size;
     }

--- a/packages/node/test/node/mock-site.ts
+++ b/packages/node/test/node/mock-site.ts
@@ -82,7 +82,9 @@ export class MockSite {
 
         await node.start();
 
-        node.lifecycle.destroyed.then(() => this.#nodes.delete(node));
+        node.lifecycle.destroyed.once(() => {
+            this.#nodes.delete(node);
+        });
 
         return node;
     }

--- a/packages/protocol/src/peer/PeerSet.ts
+++ b/packages/protocol/src/peer/PeerSet.ts
@@ -197,6 +197,10 @@ export class PeerSet implements ImmutableSet<OperationalPeer>, ObservableSet<Ope
         return this.#peers.deleted;
     }
 
+    get empty() {
+        return this.#peers.empty;
+    }
+
     get disconnected() {
         return this.#disconnected;
     }


### PR DESCRIPTION
This is a new class that does a better job of marrying `Observable` and `Promise` semantics.  It is similar to gate but with the `Observable` interface so you can listen for an event repeatedly.  This would theoretically make a good replacement for events like `NodeLifecycle#online` so you can await them without checking e.g. `NodeLifecycle.#isOnline` but not making that move for now.  I did use it to implement new `ObservableSet#empty` event.