### PR TITLE
Improve convenience of abort code patterns

### DIFF
--- a/packages/general/src/MatterError.ts
+++ b/packages/general/src/MatterError.ts
@@ -318,3 +318,33 @@ export class TimeoutError extends MatterError {
         super(message, options);
     }
 }
+
+/**
+ * Thrown on abort when there is not an underlying error.
+ */
+export class AbortedError extends CanceledError {
+    constructor(message = "This operation was aborted", options?: ErrorOptions) {
+        super(message, options);
+    }
+
+    /**
+     * Determine whether a cause signifies abort.
+     *
+     * We include {@link DOMException} with name "AbortError" which is the standard error thrown if you invoke
+     * {@link AbortController#abort} without a cause.
+     */
+    static is(cause: unknown) {
+        return cause instanceof AbortedError || (cause instanceof DOMException && cause.name === "AbortError");
+    }
+
+    /**
+     * Accept both {@link AbortedError} and {@link DOMException} with name "AbortError".
+     */
+    static override accept(cause: unknown) {
+        if (AbortedError.is(cause)) {
+            return;
+        }
+
+        return super.accept(cause);
+    }
+}

--- a/packages/general/src/util/Abort.ts
+++ b/packages/general/src/util/Abort.ts
@@ -4,26 +4,216 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { TimeoutError } from "#MatterError.js";
+import { AbortedError, TimeoutError } from "#MatterError.js";
 import { Duration } from "#time/Duration.js";
 import { Time, Timer } from "#time/Time.js";
+import { asError } from "./Error.js";
+import { Callable } from "./Function.js";
 import { SafePromise } from "./Promises.js";
+
+/**
+ * Convenience abort implementation.
+ *
+ * Acts as both an {@link AbortController} and {@link AbortSignal}.
+ *
+ * May be awaited like a promise, although it returns the {@link reason} rather than throwing.
+ *
+ * May be invoked as a function to perform abort.
+ *
+ * Optionally will register for abort with an outer {@link AbortController} and/or add a timeout.  You must abort or
+ * invoke {@link close} if you use either of these options.
+ */
+export class Abort extends Callable<[reason?: Error]> implements AbortController, AbortSignal, PromiseLike<Error> {
+    // The native controller implementation
+    #controller: AbortController;
+
+    // Optional abort chaining
+    #dependents?: AbortSignal[];
+    #listener?: (reason: any) => void;
+
+    // Optional PromiseLike behavior
+    #aborted?: Promise<Error>;
+    #resolve?: (reason: Error) => void;
+
+    // Optional timeout
+    #timeout?: Timer;
+
+    constructor({ abort, timeout, handler }: Abort.Options = {}) {
+        super(() => this.abort());
+
+        this.#controller = new AbortController();
+
+        const self = (reason?: any) => {
+            this.abort(reason);
+        };
+        Object.setPrototypeOf(self, Object.getPrototypeOf(this));
+
+        if (abort && !Array.isArray(abort)) {
+            abort = [abort];
+        }
+
+        if (abort?.length) {
+            const dependents = abort.map(abort => ("signal" in abort ? abort.signal : abort));
+            this.#dependents = dependents;
+
+            this.#listener = (reason: any) => this.abort(reason);
+            for (const dependent of dependents) {
+                dependent.addEventListener("abort", this.#listener);
+            }
+        }
+
+        if (timeout) {
+            this.#timeout = Time.getPeriodicTimer("subtask timeout", timeout, () => {
+                if (this.aborted) {
+                    return;
+                }
+
+                this.abort(new TimeoutError());
+            });
+
+            this.#timeout.start();
+        }
+
+        if (handler) {
+            this.addEventListener("abort", () => handler(this.reason));
+        }
+    }
+
+    abort(reason?: any) {
+        this.#controller.abort(reason ?? new AbortedError());
+    }
+
+    get signal() {
+        return this.#controller.signal;
+    }
+
+    /**
+     * Race one or more promises with my abort signal.
+     *
+     * If aborted returns undefined.
+     */
+    async race<T>(...promises: Array<T | PromiseLike<T>>): Promise<Awaited<T> | void> {
+        return Abort.race(this, ...promises);
+    }
+
+    /**
+     * Free resources.
+     *
+     * You must abort or invoke {@link close} when finished if you construct with {@link Abort.Options#abort} or
+     * {@link Abort.Options#timeout}.
+     */
+    close() {
+        this.#timeout?.stop();
+        if (this.#listener && this.#dependents) {
+            for (const dependent of this.#dependents) {
+                dependent.removeEventListener("abort", this.#listener);
+            }
+        }
+    }
+
+    [Symbol.dispose]() {
+        this.close();
+    }
+
+    get aborted() {
+        return this.signal.aborted;
+    }
+
+    set onabort(onabort: ((this: AbortSignal, ev: Event) => any) | null) {
+        this.signal.onabort = onabort;
+    }
+
+    get onabort() {
+        return this.signal.onabort;
+    }
+
+    get reason() {
+        return asError(this.signal.reason);
+    }
+
+    throwIfAborted() {
+        this.signal.throwIfAborted();
+    }
+
+    then<TResult1 = void, TResult2 = never>(
+        onfulfilled?: ((value: Error) => TResult1 | PromiseLike<TResult1>) | null,
+        onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | null,
+    ): PromiseLike<TResult1 | TResult2> {
+        if (!this.#aborted) {
+            this.#aborted = new Promise(resolve => (this.#resolve = resolve));
+            this.addEventListener("abort", () => this.#resolve!(asError(this.reason)));
+        }
+        return this.#aborted.then(onfulfilled, onrejected);
+    }
+
+    addEventListener<K extends keyof AbortSignalEventMap>(
+        type: K,
+        listener: (this: AbortSignal, ev: AbortSignalEventMap[K]) => any,
+        options?: boolean | AddEventListenerOptions,
+    ): void;
+    addEventListener(
+        type: string,
+        listener: EventListenerOrEventListenerObject,
+        options?: boolean | AddEventListenerOptions,
+    ): void;
+    addEventListener(type: any, listener: any, options?: any) {
+        this.signal.addEventListener(type, listener, options);
+    }
+
+    removeEventListener<K extends keyof AbortSignalEventMap>(
+        type: K,
+        listener: (this: AbortSignal, ev: AbortSignalEventMap[K]) => any,
+        options?: boolean | EventListenerOptions,
+    ): void;
+    removeEventListener(
+        type: string,
+        listener: EventListenerOrEventListenerObject,
+        options?: boolean | EventListenerOptions,
+    ): void;
+    removeEventListener(type: any, listener: any, options?: any) {
+        this.signal.addEventListener(type, listener, options);
+    }
+
+    dispatchEvent(event: Event) {
+        return this.signal.dispatchEvent(event);
+    }
+}
 
 /**
  * Utilities for implementing abort logic.
  */
 export namespace Abort {
     /**
+     * Optional configuration for {@link Abort}.
+     */
+    export interface Options {
+        /**
+         * One or more parent abort signals.
+         *
+         * If a parent aborts, this {@link Abort} will abort as well.  However the inverse is not true, so this task is
+         * independently abortable.
+         *
+         * This functions similarly to {@link AbortSignal.any} but has additional protection against memory leaks.
+         */
+        abort?: Signal | Signal[];
+
+        /**
+         * An abort timeout.
+         *
+         * If you specify a timeout, you must either abort or close the {@link Abort}.
+         */
+        timeout?: Duration;
+
+        /**
+         * Adds a default abort handler.
+         */
+        handler?: (reason?: Error) => void;
+    }
+
+    /**
      * An entity that may be used to signal abort of an operation.
      */
     export type Signal = AbortController | AbortSignal;
-
-    /**
-     * An abort controller that can be closed.
-     */
-    export interface DisposableController extends AbortController {
-        [Symbol.dispose](): void;
-    }
 
     /**
      * Determine whether a {@link Signal} is aborted.
@@ -73,6 +263,17 @@ export namespace Abort {
     }
 
     /**
+     * Perform abortable sleep.
+     */
+    export function sleep(description: string, abort: Signal | undefined, duration: Duration) {
+        let timer!: Timer;
+        const rested = new Promise<void>(resolve => {
+            timer = Time.getTimer(description, duration, resolve);
+        });
+        return race(abort, rested).finally(timer.stop.bind(timer));
+    }
+
+    /**
      * Create independently abortable subtask with a new {@link AbortController} that is aborted if another controller
      * aborts.
      *
@@ -80,39 +281,39 @@ export namespace Abort {
      *
      * {@link timeout} is a convenience for adding a timeout.
      */
-    export function subtask(signal: Signal | undefined, timeout?: Duration): DisposableController {
-        let timer: Timer | undefined;
+    export function subtask(signal: Signal | undefined, timeout?: Duration): Abort {
+        return new Abort({ abort: signal, timeout });
+    }
 
-        if (signal && "signal" in signal) {
+    /**
+     * Like {@link AbortSignal.any} but does not leak memory so long as the returned {@link Abort} is aborted or closed.
+     */
+    export function any(...signals: (Signal | undefined)[]) {
+        return new Abort({ abort: [...(signals.filter(signal => signal) as Signal[])] });
+    }
+
+    /**
+     * Generate a function that will throw if aborted.
+     */
+    export function checkerFor(signal?: Signal | { abort?: Signal }) {
+        if (!signal) {
+            return () => {};
+        }
+
+        if ("abort" in signal && typeof signal.abort === "object") {
+            signal = signal.abort;
+        }
+        if (!signal) {
+            return () => {};
+        }
+
+        if ("signal" in signal) {
             signal = signal.signal;
         }
-
-        const controller = new AbortController() as DisposableController;
-
-        if (timeout) {
-            timer = Time.getPeriodicTimer("subtask timeout", timeout, () => {
-                if (controller.signal.aborted) {
-                    return;
-                }
-
-                controller.abort(new TimeoutError());
-            });
-            timer.start();
+        if (!signal) {
+            return () => {};
         }
 
-        if (signal) {
-            const outerHandler = () => controller.abort(signal.reason);
-            signal.addEventListener("abort", outerHandler);
-            controller[Symbol.dispose] = () => {
-                signal.removeEventListener("abort", outerHandler);
-                timer?.stop();
-            };
-        } else {
-            controller[Symbol.dispose] = () => {
-                timer?.stop();
-            };
-        }
-
-        return controller;
+        return (signal as AbortSignal).throwIfAborted.bind(signal);
     }
 }

--- a/packages/general/src/util/Error.ts
+++ b/packages/general/src/util/Error.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { AbortedError } from "#MatterError.js";
 import type { Constructable } from "./Construction.js";
 import { ClassExtends } from "./Type.js";
 
@@ -14,6 +15,14 @@ function considerAsError(error: unknown): error is Error {
 
 export function asError(e: any): Error {
     if (considerAsError(e)) {
+        // AbortController defaults to a DOMException which isn't ideal; translate here
+        if (e instanceof DOMException && e.name === "AbortError") {
+            const aborted = new AbortedError(e.message);
+            aborted.stack = e.stack;
+            aborted.cause = e.cause;
+            return aborted;
+        }
+
         return e;
     }
     return new Error(e?.toString() ?? "Unknown error");

--- a/packages/general/src/util/Function.ts
+++ b/packages/general/src/util/Function.ts
@@ -1,0 +1,23 @@
+/**
+ * @license
+ * Copyright 2022-2025 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * A base for classes that are also functions.
+ */
+export interface Callable<A extends unknown[], R = void> {
+    (...args: A): R;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export class Callable<A extends unknown[], R> {
+    /**
+     * Create a new invocable
+     */
+    constructor(invoke: Callable<A, R>) {
+        Object.setPrototypeOf(invoke, new.target.prototype);
+        return invoke;
+    }
+}

--- a/packages/general/src/util/Set.ts
+++ b/packages/general/src/util/Set.ts
@@ -138,6 +138,10 @@ export class BasicSet<T, AddT = T> implements ImmutableSet<T>, MutableSet<T, Add
         }
 
         this.#added?.emit(created);
+
+        if (this.#empty && this.#empty.value) {
+            this.#empty.emit(false);
+        }
     }
 
     get<F extends keyof T>(field: F, value: T[F]) {
@@ -242,7 +246,7 @@ export class BasicSet<T, AddT = T> implements ImmutableSet<T>, MutableSet<T, Add
 
     get empty() {
         if (this.#empty === undefined) {
-            this.#empty = ObservableValue();
+            this.#empty = ObservableValue(!this.#entries.size);
         }
         return this.#empty;
     }

--- a/packages/general/src/util/index.ts
+++ b/packages/general/src/util/index.ts
@@ -20,6 +20,7 @@ export * from "./DeepEqual.js";
 export * from "./Entropy.js";
 export * from "./Error.js";
 export * from "./FormattedText.js";
+export * from "./Function.js";
 export * from "./GeneratedClass.js";
 export * from "./Ip.js";
 export * from "./Lifecycle.js";


### PR DESCRIPTION
Abort related updates:

* Adds an `AbortedError` to indicate "aborted without prejudice"

* Maps the standard AbortController DOMException to AbortError and generally treats interchangeably

* Adds an `Abort` class that extends standard `AbortController` with a number of convenience functions

* Adds an abortable equivalent of `Time.sleep`

Includes a handful of other updates:

* Add `Callable` base class for classes that produce instances you can use as a function

* Add `AsyncObservableValue` factory method

* Fixes to `BasicSet#empty` and `ObservableValue`