### PR TITLE
Fixes the lower bound for unsigned ints

### DIFF
--- a/packages/node/src/behavior/state/validation/assertions.ts
+++ b/packages/node/src/behavior/state/validation/assertions.ts
@@ -87,8 +87,9 @@ for (let i = 1n; i < 9n; i++) {
     assertInt.notNullable[uintName] = createIntAssertion(uintName, 0n, unsignedMax);
     assertInt.nullable[uintName] = createIntAssertion(`nullable ${uintName}`, 0n, unsignedMax - 1n);
 
-    const signedMax = numValues / 2n - 1n;
-    const signedMin = -signedMax;
+    const halfNumValues = numValues / 2n;
+    const signedMax = halfNumValues - 1n;
+    const signedMin = -halfNumValues;
     assertInt.notNullable[intName] = createIntAssertion(intName, signedMin, signedMax);
     assertInt.nullable[intName] = createIntAssertion(`nullable ${intName}`, signedMin + 1n, signedMax);
 }

--- a/packages/node/test/behavior/state/validation/ValueValidatorTest.ts
+++ b/packages/node/test/behavior/state/validation/ValueValidatorTest.ts
@@ -13,9 +13,9 @@ describe("ValueValidator", () => {
     implementInt("uint8", 0, 0xff);
     implementInt("uint32", 0, 0xffffffff);
     implementInt("uint64", 0, 0xffffffffffffffffn);
-    implementInt("int8", -127, 127);
-    implementInt("int32", -2147483647, 2147483647);
-    implementInt("int64", -9223372036854775807n, 9223372036854775807n);
+    implementInt("int8", -128, 127);
+    implementInt("int32", -2147483648, 2147483647);
+    implementInt("int64", -9223372036854775808n, 9223372036854775807n);
 });
 
 function implementInt(type: string, min: number | bigint, max: number | bigint) {


### PR DESCRIPTION
Tests were using the nullable lower bound but should have been the not-nullable version