### PR TITLE
Adjust ClientNode endpoint type handling

### DIFF
--- a/packages/matter.js/src/device/DeviceTypes.ts
+++ b/packages/matter.js/src/device/DeviceTypes.ts
@@ -997,7 +997,7 @@ export function getDeviceTypeDefinitionFromModelByCode(code: number): DeviceType
         name: `MA-${device.name.toLowerCase()}`,
         revision: 0,
         code: device.id,
-        deviceClass: capitalize(device.classification) as DeviceClasses,
+        deviceClass: capitalize(device.classification as string) as DeviceClasses,
         superSet: device.type
             ?.replace(/([A-Z])/g, "_$1")
             .substring(1)

--- a/packages/model/src/common/DeviceClassification.ts
+++ b/packages/model/src/common/DeviceClassification.ts
@@ -47,3 +47,20 @@ export enum DeviceClassification {
      */
     Node = "node",
 }
+
+export namespace DeviceClassification {
+    export function isUtility(classification: DeviceClassification | undefined) {
+        switch (classification) {
+            case DeviceClassification.Node:
+            case DeviceClassification.Utility:
+                return true;
+
+            default:
+                return false;
+        }
+    }
+
+    export function isApplication(classification: DeviceClassification | undefined) {
+        return !isUtility(classification);
+    }
+}

--- a/packages/model/src/models/ClusterModel.ts
+++ b/packages/model/src/models/ClusterModel.ts
@@ -27,6 +27,7 @@ export class ClusterModel
     implements ClusterElement, Conformance.FeatureContext
 {
     override tag: ClusterElement.Tag = ClusterElement.Tag;
+    classification?: ClusterElement.Classification;
 
     #quality: Quality;
 
@@ -62,16 +63,6 @@ export class ClusterModel
 
     get conformant() {
         return new ClusterModel.Conformant(this);
-    }
-
-    get classification(): ClusterElement.Classification | undefined {
-        return this.resource?.classification as ClusterElement.Classification | undefined;
-    }
-
-    set classification(classification: `${ClusterElement.Classification}` | undefined) {
-        if (classification || this.hasLocalResource) {
-            this.localResource.classification = classification;
-        }
     }
 
     get pics() {
@@ -171,15 +162,16 @@ export class ClusterModel
         super(definition, ...children);
 
         this.#quality = Quality.create(definition.quality);
+        this.classification = definition.classification as ClusterElement.Classification;
         if (!(definition instanceof Model)) {
             this.pics = definition.pics;
-            this.classification = definition.classification as ClusterElement.Classification;
         }
     }
 
     override toElement(omitResources = false, extra?: Record<string, unknown>) {
         return super.toElement(omitResources, {
             quality: this.quality.valueOf(),
+            classification: this.classification,
             ...extra,
         });
     }

--- a/packages/model/src/models/DeviceTypeModel.ts
+++ b/packages/model/src/models/DeviceTypeModel.ts
@@ -12,6 +12,7 @@ import { RequirementModel } from "./RequirementModel.js";
 
 export class DeviceTypeModel extends Model<DeviceTypeElement, DeviceTypeModel.Child> implements DeviceTypeElement {
     override tag: DeviceTypeElement.Tag = DeviceTypeElement.Tag;
+    classification?: DeviceClassification;
 
     get requirements() {
         return this.all(RequirementModel);
@@ -23,31 +24,13 @@ export class DeviceTypeModel extends Model<DeviceTypeElement, DeviceTypeModel.Ch
         );
     }
 
-    get classification() {
-        return this.hasLocalResource
-            ? (this.localResource.classification as DeviceClassification)
-            : DeviceClassification.Simple;
-    }
-
-    set classification(classification: DeviceClassification) {
-        if (classification || this.hasLocalResource) {
-            this.localResource.classification = classification;
-        }
-    }
-
     constructor(definition: Model.Definition<DeviceTypeModel>, ...children: Model.ChildDefinition<DeviceTypeModel>[]) {
         super(definition, ...children);
 
-        if (!(definition instanceof Model)) {
-            this.classification = definition.classification as DeviceClassification;
-        }
+        this.classification = definition.classification as DeviceClassification;
     }
 
     override toElement(omitResources = false, extra?: Record<string, unknown>) {
-        if (omitResources) {
-            return super.toElement(omitResources, extra);
-        }
-
         return super.toElement(omitResources, {
             classification: this.classification,
             ...extra,

--- a/packages/model/src/models/Resource.ts
+++ b/packages/model/src/models/Resource.ts
@@ -28,7 +28,6 @@ export class Resource {
         id?: string | number;
         name?: string;
     };
-    classification?: string;
     pics?: string;
     description?: string;
     xref?: Specification.CrossReference;
@@ -46,7 +45,6 @@ export class Resource {
         this.asOf = resources.asOf;
         this.until = resources.until;
         this.matchTo = resources.matchTo;
-        this.classification = resources.classification;
         this.pics = resources.pics;
     }
 }

--- a/packages/model/src/standard/elements/access-control.element.ts
+++ b/packages/model/src/standard/elements/access-control.element.ts
@@ -17,7 +17,7 @@ import {
 } from "../../elements/index.js";
 
 export const AccessControl = Cluster(
-    { name: "AccessControl", id: 0x1f },
+    { name: "AccessControl", id: 0x1f, classification: "node" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 2 }),
     Attribute(
         { name: "FeatureMap", id: 0xfffc, type: "FeatureMap" },

--- a/packages/model/src/standard/elements/account-login.element.ts
+++ b/packages/model/src/standard/elements/account-login.element.ts
@@ -16,7 +16,7 @@ import {
 } from "../../elements/index.js";
 
 export const AccountLogin = Cluster(
-    { name: "AccountLogin", id: 0x50e },
+    { name: "AccountLogin", id: 0x50e, classification: "application" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 2 }),
     Event(
         { name: "LoggedOut", id: 0x0, access: "S A", conformance: "O", priority: "critical" },

--- a/packages/model/src/standard/elements/actions.element.ts
+++ b/packages/model/src/standard/elements/actions.element.ts
@@ -17,7 +17,7 @@ import {
 } from "../../elements/index.js";
 
 export const Actions = Cluster(
-    { name: "Actions", id: 0x25 },
+    { name: "Actions", id: 0x25, classification: "application" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 1 }),
 
     Attribute(

--- a/packages/model/src/standard/elements/administrator-commissioning.element.ts
+++ b/packages/model/src/standard/elements/administrator-commissioning.element.ts
@@ -16,7 +16,7 @@ import {
 } from "../../elements/index.js";
 
 export const AdministratorCommissioning = Cluster(
-    { name: "AdministratorCommissioning", id: 0x3c },
+    { name: "AdministratorCommissioning", id: 0x3c, classification: "node" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 1 }),
     Attribute(
         { name: "FeatureMap", id: 0xfffc, type: "FeatureMap" },

--- a/packages/model/src/standard/elements/aggregator.element.ts
+++ b/packages/model/src/standard/elements/aggregator.element.ts
@@ -14,7 +14,7 @@ import {
 } from "../../elements/index.js";
 
 export const AggregatorDt = DeviceType(
-    { name: "Aggregator", id: 0xe },
+    { name: "Aggregator", id: 0xe, classification: "simple" },
     Requirement(
         { name: "Descriptor", id: 0x1d, element: "serverCluster" },
         Requirement({ name: "DeviceTypeList", default: [ { deviceType: 14, revision: 2 } ], element: "attribute" })

--- a/packages/model/src/standard/elements/air-purifier.element.ts
+++ b/packages/model/src/standard/elements/air-purifier.element.ts
@@ -10,7 +10,7 @@ import { MatterDefinition } from "../MatterDefinition.js";
 import { DeviceTypeElement as DeviceType, RequirementElement as Requirement } from "../../elements/index.js";
 
 export const AirPurifierDt = DeviceType(
-    { name: "AirPurifier", id: 0x2d },
+    { name: "AirPurifier", id: 0x2d, classification: "simple" },
     Requirement(
         { name: "Descriptor", id: 0x1d, element: "serverCluster" },
         Requirement({ name: "DeviceTypeList", default: [ { deviceType: 45, revision: 2 } ], element: "attribute" })

--- a/packages/model/src/standard/elements/air-quality-sensor.element.ts
+++ b/packages/model/src/standard/elements/air-quality-sensor.element.ts
@@ -10,7 +10,7 @@ import { MatterDefinition } from "../MatterDefinition.js";
 import { DeviceTypeElement as DeviceType, RequirementElement as Requirement } from "../../elements/index.js";
 
 export const AirQualitySensorDt = DeviceType(
-    { name: "AirQualitySensor", id: 0x2c },
+    { name: "AirQualitySensor", id: 0x2c, classification: "simple" },
     Requirement(
         { name: "Descriptor", id: 0x1d, element: "serverCluster" },
         Requirement({ name: "DeviceTypeList", default: [ { deviceType: 44, revision: 1 } ], element: "attribute" })

--- a/packages/model/src/standard/elements/air-quality.element.ts
+++ b/packages/model/src/standard/elements/air-quality.element.ts
@@ -15,7 +15,7 @@ import {
 } from "../../elements/index.js";
 
 export const AirQuality = Cluster(
-    { name: "AirQuality", id: 0x5b },
+    { name: "AirQuality", id: 0x5b, classification: "application" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 1 }),
 
     Attribute(

--- a/packages/model/src/standard/elements/alarm-base.element.ts
+++ b/packages/model/src/standard/elements/alarm-base.element.ts
@@ -17,7 +17,7 @@ import {
 } from "../../elements/index.js";
 
 export const AlarmBase = Cluster(
-    { name: "AlarmBase" },
+    { name: "AlarmBase", classification: "application" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 2 }),
     Attribute(
         { name: "FeatureMap", id: 0xfffc, type: "FeatureMap" },

--- a/packages/model/src/standard/elements/application-basic.element.ts
+++ b/packages/model/src/standard/elements/application-basic.element.ts
@@ -15,7 +15,7 @@ import {
 } from "../../elements/index.js";
 
 export const ApplicationBasic = Cluster(
-    { name: "ApplicationBasic", id: 0x50d },
+    { name: "ApplicationBasic", id: 0x50d, classification: "application" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 1 }),
     Attribute({
         name: "VendorName", id: 0x0, type: "string", access: "R V", conformance: "O", constraint: "max 32",

--- a/packages/model/src/standard/elements/application-launcher.element.ts
+++ b/packages/model/src/standard/elements/application-launcher.element.ts
@@ -16,7 +16,7 @@ import {
 } from "../../elements/index.js";
 
 export const ApplicationLauncher = Cluster(
-    { name: "ApplicationLauncher", id: 0x50c },
+    { name: "ApplicationLauncher", id: 0x50c, classification: "application" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 2 }),
     Attribute(
         { name: "FeatureMap", id: 0xfffc, type: "FeatureMap" },

--- a/packages/model/src/standard/elements/audio-output.element.ts
+++ b/packages/model/src/standard/elements/audio-output.element.ts
@@ -16,7 +16,7 @@ import {
 } from "../../elements/index.js";
 
 export const AudioOutput = Cluster(
-    { name: "AudioOutput", id: 0x50b },
+    { name: "AudioOutput", id: 0x50b, classification: "application" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 1 }),
     Attribute(
         { name: "FeatureMap", id: 0xfffc, type: "FeatureMap" },

--- a/packages/model/src/standard/elements/base.element.ts
+++ b/packages/model/src/standard/elements/base.element.ts
@@ -14,7 +14,7 @@ import {
 } from "../../elements/index.js";
 
 export const BaseDt = DeviceType(
-    { name: "Base" },
+    { name: "Base", classification: "base" },
 
     Field(
         { name: "conditions", type: "enum8" },

--- a/packages/model/src/standard/elements/basic-information.element.ts
+++ b/packages/model/src/standard/elements/basic-information.element.ts
@@ -16,7 +16,7 @@ import {
 } from "../../elements/index.js";
 
 export const BasicInformation = Cluster(
-    { name: "BasicInformation", id: 0x28 },
+    { name: "BasicInformation", id: 0x28, classification: "node" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 5 }),
     Attribute({
         name: "DataModelRevision", id: 0x0, type: "uint16", access: "R V", conformance: "M",

--- a/packages/model/src/standard/elements/basic-video-player.element.ts
+++ b/packages/model/src/standard/elements/basic-video-player.element.ts
@@ -14,7 +14,7 @@ import {
 } from "../../elements/index.js";
 
 export const BasicVideoPlayerDt = DeviceType(
-    { name: "BasicVideoPlayer", id: 0x28 },
+    { name: "BasicVideoPlayer", id: 0x28, classification: "simple" },
     Requirement(
         { name: "Descriptor", id: 0x1d, element: "serverCluster" },
         Requirement({ name: "DeviceTypeList", default: [ { deviceType: 40, revision: 2 } ], element: "attribute" })

--- a/packages/model/src/standard/elements/battery-storage.element.ts
+++ b/packages/model/src/standard/elements/battery-storage.element.ts
@@ -10,7 +10,7 @@ import { MatterDefinition } from "../MatterDefinition.js";
 import { DeviceTypeElement as DeviceType, RequirementElement as Requirement } from "../../elements/index.js";
 
 export const BatteryStorageDt = DeviceType(
-    { name: "BatteryStorage", id: 0x18 },
+    { name: "BatteryStorage", id: 0x18, classification: "simple" },
     Requirement(
         { name: "Descriptor", id: 0x1d, element: "serverCluster" },
         Requirement({ name: "DeviceTypeList", default: [ { deviceType: 24, revision: 1 } ], element: "attribute" })

--- a/packages/model/src/standard/elements/binding.element.ts
+++ b/packages/model/src/standard/elements/binding.element.ts
@@ -15,7 +15,7 @@ import {
 } from "../../elements/index.js";
 
 export const Binding = Cluster(
-    { name: "Binding", id: 0x1e },
+    { name: "Binding", id: 0x1e, classification: "endpoint" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 1 }),
 
     Attribute(

--- a/packages/model/src/standard/elements/boolean-state-configuration.element.ts
+++ b/packages/model/src/standard/elements/boolean-state-configuration.element.ts
@@ -17,7 +17,7 @@ import {
 } from "../../elements/index.js";
 
 export const BooleanStateConfiguration = Cluster(
-    { name: "BooleanStateConfiguration", id: 0x80 },
+    { name: "BooleanStateConfiguration", id: 0x80, classification: "application" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 1 }),
 
     Attribute(

--- a/packages/model/src/standard/elements/boolean-state.element.ts
+++ b/packages/model/src/standard/elements/boolean-state.element.ts
@@ -15,7 +15,7 @@ import {
 } from "../../elements/index.js";
 
 export const BooleanState = Cluster(
-    { name: "BooleanState", id: 0x45 },
+    { name: "BooleanState", id: 0x45, classification: "application" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 1 }),
     Attribute({ name: "StateValue", id: 0x0, type: "bool", access: "R V", conformance: "M", quality: "P" }),
     Event(

--- a/packages/model/src/standard/elements/bridged-device-basic-information.element.ts
+++ b/packages/model/src/standard/elements/bridged-device-basic-information.element.ts
@@ -16,7 +16,7 @@ import {
 } from "../../elements/index.js";
 
 export const BridgedDeviceBasicInformation = Cluster(
-    { name: "BridgedDeviceBasicInformation", id: 0x39, type: "BasicInformation" },
+    { name: "BridgedDeviceBasicInformation", id: 0x39, type: "BasicInformation", classification: "endpoint" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 5 }),
     Attribute(
         { name: "FeatureMap", id: 0xfffc, type: "FeatureMap" },

--- a/packages/model/src/standard/elements/bridged-node.element.ts
+++ b/packages/model/src/standard/elements/bridged-node.element.ts
@@ -14,7 +14,7 @@ import {
 } from "../../elements/index.js";
 
 export const BridgedNodeDt = DeviceType(
-    { name: "BridgedNode", id: 0x13 },
+    { name: "BridgedNode", id: 0x13, classification: "utility" },
     Requirement(
         { name: "Descriptor", id: 0x1d, element: "serverCluster" },
         Requirement({ name: "DeviceTypeList", default: [ { deviceType: 19, revision: 3 } ], element: "attribute" })

--- a/packages/model/src/standard/elements/casting-video-client.element.ts
+++ b/packages/model/src/standard/elements/casting-video-client.element.ts
@@ -10,7 +10,7 @@ import { MatterDefinition } from "../MatterDefinition.js";
 import { DeviceTypeElement as DeviceType, RequirementElement as Requirement } from "../../elements/index.js";
 
 export const CastingVideoClientDt = DeviceType(
-    { name: "CastingVideoClient", id: 0x29 },
+    { name: "CastingVideoClient", id: 0x29, classification: "simple" },
     Requirement(
         { name: "Descriptor", id: 0x1d, element: "serverCluster" },
         Requirement({ name: "DeviceTypeList", default: [ { deviceType: 41, revision: 2 } ], element: "attribute" })

--- a/packages/model/src/standard/elements/casting-video-player.element.ts
+++ b/packages/model/src/standard/elements/casting-video-player.element.ts
@@ -14,7 +14,7 @@ import {
 } from "../../elements/index.js";
 
 export const CastingVideoPlayerDt = DeviceType(
-    { name: "CastingVideoPlayer", id: 0x23 },
+    { name: "CastingVideoPlayer", id: 0x23, classification: "simple" },
     Requirement(
         { name: "Descriptor", id: 0x1d, element: "serverCluster" },
         Requirement({ name: "DeviceTypeList", default: [ { deviceType: 35, revision: 2 } ], element: "attribute" })

--- a/packages/model/src/standard/elements/channel.element.ts
+++ b/packages/model/src/standard/elements/channel.element.ts
@@ -16,7 +16,7 @@ import {
 } from "../../elements/index.js";
 
 export const Channel = Cluster(
-    { name: "Channel", id: 0x504 },
+    { name: "Channel", id: 0x504, classification: "application" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 2 }),
 
     Attribute(

--- a/packages/model/src/standard/elements/color-control.element.ts
+++ b/packages/model/src/standard/elements/color-control.element.ts
@@ -16,7 +16,7 @@ import {
 } from "../../elements/index.js";
 
 export const ColorControl = Cluster(
-    { name: "ColorControl", id: 0x300 },
+    { name: "ColorControl", id: 0x300, classification: "application" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 7 }),
 
     Attribute(

--- a/packages/model/src/standard/elements/color-dimmer-switch.element.ts
+++ b/packages/model/src/standard/elements/color-dimmer-switch.element.ts
@@ -10,7 +10,7 @@ import { MatterDefinition } from "../MatterDefinition.js";
 import { DeviceTypeElement as DeviceType, RequirementElement as Requirement } from "../../elements/index.js";
 
 export const ColorDimmerSwitchDt = DeviceType(
-    { name: "ColorDimmerSwitch", id: 0x105 },
+    { name: "ColorDimmerSwitch", id: 0x105, classification: "simple" },
     Requirement(
         { name: "Descriptor", id: 0x1d, element: "serverCluster" },
         Requirement({ name: "DeviceTypeList", default: [ { deviceType: 261, revision: 3 } ], element: "attribute" })

--- a/packages/model/src/standard/elements/color-temperature-light.element.ts
+++ b/packages/model/src/standard/elements/color-temperature-light.element.ts
@@ -10,7 +10,7 @@ import { MatterDefinition } from "../MatterDefinition.js";
 import { DeviceTypeElement as DeviceType, RequirementElement as Requirement } from "../../elements/index.js";
 
 export const ColorTemperatureLightDt = DeviceType(
-    { name: "ColorTemperatureLight", id: 0x10c },
+    { name: "ColorTemperatureLight", id: 0x10c, classification: "simple" },
     Requirement(
         { name: "Descriptor", id: 0x1d, element: "serverCluster" },
         Requirement({ name: "DeviceTypeList", default: [ { deviceType: 268, revision: 4 } ], element: "attribute" })

--- a/packages/model/src/standard/elements/commissioner-control.element.ts
+++ b/packages/model/src/standard/elements/commissioner-control.element.ts
@@ -17,7 +17,7 @@ import {
 } from "../../elements/index.js";
 
 export const CommissionerControl = Cluster(
-    { name: "CommissionerControl", id: 0x751 },
+    { name: "CommissionerControl", id: 0x751, classification: "node" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 1 }),
     Attribute({
         name: "SupportedDeviceCategories", id: 0x0, type: "SupportedDeviceCategoryBitmap", access: "R M",

--- a/packages/model/src/standard/elements/concentration-measurement.element.ts
+++ b/packages/model/src/standard/elements/concentration-measurement.element.ts
@@ -15,7 +15,7 @@ import {
 } from "../../elements/index.js";
 
 export const ConcentrationMeasurement = Cluster(
-    { name: "ConcentrationMeasurement" },
+    { name: "ConcentrationMeasurement", classification: "application" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 3 }),
 
     Attribute(

--- a/packages/model/src/standard/elements/contact-sensor.element.ts
+++ b/packages/model/src/standard/elements/contact-sensor.element.ts
@@ -10,7 +10,7 @@ import { MatterDefinition } from "../MatterDefinition.js";
 import { DeviceTypeElement as DeviceType, RequirementElement as Requirement } from "../../elements/index.js";
 
 export const ContactSensorDt = DeviceType(
-    { name: "ContactSensor", id: 0x15 },
+    { name: "ContactSensor", id: 0x15, classification: "simple" },
     Requirement(
         { name: "Descriptor", id: 0x1d, element: "serverCluster" },
         Requirement({ name: "DeviceTypeList", default: [ { deviceType: 21, revision: 2 } ], element: "attribute" })

--- a/packages/model/src/standard/elements/content-app-observer.element.ts
+++ b/packages/model/src/standard/elements/content-app-observer.element.ts
@@ -16,7 +16,7 @@ import {
 } from "../../elements/index.js";
 
 export const ContentAppObserver = Cluster(
-    { name: "ContentAppObserver", id: 0x510 },
+    { name: "ContentAppObserver", id: 0x510, classification: "application" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 1 }),
 
     Command(

--- a/packages/model/src/standard/elements/content-app.element.ts
+++ b/packages/model/src/standard/elements/content-app.element.ts
@@ -14,7 +14,7 @@ import {
 } from "../../elements/index.js";
 
 export const ContentAppDt = DeviceType(
-    { name: "ContentApp", id: 0x24 },
+    { name: "ContentApp", id: 0x24, classification: "simple" },
     Requirement(
         { name: "Descriptor", id: 0x1d, element: "serverCluster" },
         Requirement({ name: "DeviceTypeList", default: [ { deviceType: 36, revision: 2 } ], element: "attribute" })

--- a/packages/model/src/standard/elements/content-control.element.ts
+++ b/packages/model/src/standard/elements/content-control.element.ts
@@ -17,7 +17,7 @@ import {
 } from "../../elements/index.js";
 
 export const ContentControl = Cluster(
-    { name: "ContentControl", id: 0x50f },
+    { name: "ContentControl", id: 0x50f, classification: "application" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 1 }),
 
     Attribute(

--- a/packages/model/src/standard/elements/content-launcher.element.ts
+++ b/packages/model/src/standard/elements/content-launcher.element.ts
@@ -16,7 +16,7 @@ import {
 } from "../../elements/index.js";
 
 export const ContentLauncher = Cluster(
-    { name: "ContentLauncher", id: 0x50a },
+    { name: "ContentLauncher", id: 0x50a, classification: "application" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 2 }),
 
     Attribute(

--- a/packages/model/src/standard/elements/control-bridge.element.ts
+++ b/packages/model/src/standard/elements/control-bridge.element.ts
@@ -10,7 +10,7 @@ import { MatterDefinition } from "../MatterDefinition.js";
 import { DeviceTypeElement as DeviceType, RequirementElement as Requirement } from "../../elements/index.js";
 
 export const ControlBridgeDt = DeviceType(
-    { name: "ControlBridge", id: 0x840 },
+    { name: "ControlBridge", id: 0x840, classification: "simple" },
     Requirement(
         { name: "Descriptor", id: 0x1d, element: "serverCluster" },
         Requirement({ name: "DeviceTypeList", default: [ { deviceType: 2112, revision: 3 } ], element: "attribute" })

--- a/packages/model/src/standard/elements/cook-surface.element.ts
+++ b/packages/model/src/standard/elements/cook-surface.element.ts
@@ -10,7 +10,7 @@ import { MatterDefinition } from "../MatterDefinition.js";
 import { DeviceTypeElement as DeviceType, RequirementElement as Requirement } from "../../elements/index.js";
 
 export const CookSurfaceDt = DeviceType(
-    { name: "CookSurface", id: 0x77 },
+    { name: "CookSurface", id: 0x77, classification: "simple" },
     Requirement(
         { name: "Descriptor", id: 0x1d, element: "serverCluster" },
         Requirement({ name: "DeviceTypeList", default: [ { deviceType: 119, revision: 2 } ], element: "attribute" })

--- a/packages/model/src/standard/elements/cooktop.element.ts
+++ b/packages/model/src/standard/elements/cooktop.element.ts
@@ -10,7 +10,7 @@ import { MatterDefinition } from "../MatterDefinition.js";
 import { DeviceTypeElement as DeviceType, RequirementElement as Requirement } from "../../elements/index.js";
 
 export const CooktopDt = DeviceType(
-    { name: "Cooktop", id: 0x78 },
+    { name: "Cooktop", id: 0x78, classification: "simple" },
     Requirement(
         { name: "Descriptor", id: 0x1d, element: "serverCluster" },
         Requirement({ name: "DeviceTypeList", default: [ { deviceType: 120, revision: 1 } ], element: "attribute" })

--- a/packages/model/src/standard/elements/descriptor.element.ts
+++ b/packages/model/src/standard/elements/descriptor.element.ts
@@ -15,7 +15,7 @@ import {
 } from "../../elements/index.js";
 
 export const Descriptor = Cluster(
-    { name: "Descriptor", id: 0x1d },
+    { name: "Descriptor", id: 0x1d, classification: "endpoint" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 3 }),
     Attribute(
         { name: "FeatureMap", id: 0xfffc, type: "FeatureMap" },

--- a/packages/model/src/standard/elements/device-energy-management-cluster.element.ts
+++ b/packages/model/src/standard/elements/device-energy-management-cluster.element.ts
@@ -17,7 +17,7 @@ import {
 } from "../../elements/index.js";
 
 export const DeviceEnergyManagement = Cluster(
-    { name: "DeviceEnergyManagement", id: 0x98 },
+    { name: "DeviceEnergyManagement", id: 0x98, classification: "application" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 4 }),
 
     Attribute(

--- a/packages/model/src/standard/elements/device-energy-management-device.element.ts
+++ b/packages/model/src/standard/elements/device-energy-management-device.element.ts
@@ -14,7 +14,7 @@ import {
 } from "../../elements/index.js";
 
 export const DeviceEnergyManagementDt = DeviceType(
-    { name: "DeviceEnergyManagement", id: 0x50d },
+    { name: "DeviceEnergyManagement", id: 0x50d, classification: "utility" },
     Requirement(
         { name: "Descriptor", id: 0x1d, element: "serverCluster" },
         Requirement({ name: "DeviceTypeList", default: [ { deviceType: 1293, revision: 2 } ], element: "attribute" })

--- a/packages/model/src/standard/elements/device-energy-management-mode.element.ts
+++ b/packages/model/src/standard/elements/device-energy-management-mode.element.ts
@@ -15,7 +15,7 @@ import {
 } from "../../elements/index.js";
 
 export const DeviceEnergyManagementMode = Cluster(
-    { name: "DeviceEnergyManagementMode", id: 0x9f, type: "ModeBase" },
+    { name: "DeviceEnergyManagementMode", id: 0x9f, type: "ModeBase", classification: "application" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 2 }),
     Attribute(
         { name: "FeatureMap", id: 0xfffc, type: "FeatureMap" },

--- a/packages/model/src/standard/elements/diagnostic-logs.element.ts
+++ b/packages/model/src/standard/elements/diagnostic-logs.element.ts
@@ -16,7 +16,7 @@ import {
 } from "../../elements/index.js";
 
 export const DiagnosticLogs = Cluster(
-    { name: "DiagnosticLogs", id: 0x32, quality: "K" },
+    { name: "DiagnosticLogs", id: 0x32, classification: "node", quality: "K" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 1 }),
 
     Command(

--- a/packages/model/src/standard/elements/dimmable-light.element.ts
+++ b/packages/model/src/standard/elements/dimmable-light.element.ts
@@ -10,7 +10,7 @@ import { MatterDefinition } from "../MatterDefinition.js";
 import { DeviceTypeElement as DeviceType, RequirementElement as Requirement } from "../../elements/index.js";
 
 export const DimmableLightDt = DeviceType(
-    { name: "DimmableLight", id: 0x101 },
+    { name: "DimmableLight", id: 0x101, classification: "simple" },
     Requirement(
         { name: "Descriptor", id: 0x1d, element: "serverCluster" },
         Requirement({ name: "DeviceTypeList", default: [ { deviceType: 257, revision: 3 } ], element: "attribute" })

--- a/packages/model/src/standard/elements/dimmable-plug-in-unit.element.ts
+++ b/packages/model/src/standard/elements/dimmable-plug-in-unit.element.ts
@@ -10,7 +10,7 @@ import { MatterDefinition } from "../MatterDefinition.js";
 import { DeviceTypeElement as DeviceType, RequirementElement as Requirement } from "../../elements/index.js";
 
 export const DimmablePlugInUnitDt = DeviceType(
-    { name: "DimmablePlugInUnit", id: 0x10b },
+    { name: "DimmablePlugInUnit", id: 0x10b, classification: "simple" },
     Requirement(
         { name: "Descriptor", id: 0x1d, element: "serverCluster" },
         Requirement({ name: "DeviceTypeList", default: [ { deviceType: 267, revision: 5 } ], element: "attribute" })

--- a/packages/model/src/standard/elements/dimmer-switch.element.ts
+++ b/packages/model/src/standard/elements/dimmer-switch.element.ts
@@ -10,7 +10,7 @@ import { MatterDefinition } from "../MatterDefinition.js";
 import { DeviceTypeElement as DeviceType, RequirementElement as Requirement } from "../../elements/index.js";
 
 export const DimmerSwitchDt = DeviceType(
-    { name: "DimmerSwitch", id: 0x104 },
+    { name: "DimmerSwitch", id: 0x104, classification: "simple" },
     Requirement(
         { name: "Descriptor", id: 0x1d, element: "serverCluster" },
         Requirement({ name: "DeviceTypeList", default: [ { deviceType: 260, revision: 3 } ], element: "attribute" })

--- a/packages/model/src/standard/elements/dishwasher-alarm.element.ts
+++ b/packages/model/src/standard/elements/dishwasher-alarm.element.ts
@@ -15,7 +15,7 @@ import {
 } from "../../elements/index.js";
 
 export const DishwasherAlarm = Cluster(
-    { name: "DishwasherAlarm", id: 0x5d, type: "AlarmBase" },
+    { name: "DishwasherAlarm", id: 0x5d, type: "AlarmBase", classification: "application" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 1 }),
 
     Datatype(

--- a/packages/model/src/standard/elements/dishwasher-mode.element.ts
+++ b/packages/model/src/standard/elements/dishwasher-mode.element.ts
@@ -15,7 +15,7 @@ import {
 } from "../../elements/index.js";
 
 export const DishwasherMode = Cluster(
-    { name: "DishwasherMode", id: 0x59, type: "ModeBase" },
+    { name: "DishwasherMode", id: 0x59, type: "ModeBase", classification: "application" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 3 }),
     Attribute(
         { name: "FeatureMap", id: 0xfffc, type: "FeatureMap" },

--- a/packages/model/src/standard/elements/dishwasher.element.ts
+++ b/packages/model/src/standard/elements/dishwasher.element.ts
@@ -10,7 +10,7 @@ import { MatterDefinition } from "../MatterDefinition.js";
 import { DeviceTypeElement as DeviceType, RequirementElement as Requirement } from "../../elements/index.js";
 
 export const DishwasherDt = DeviceType(
-    { name: "Dishwasher", id: 0x75 },
+    { name: "Dishwasher", id: 0x75, classification: "simple" },
     Requirement(
         { name: "Descriptor", id: 0x1d, element: "serverCluster" },
         Requirement({ name: "DeviceTypeList", default: [ { deviceType: 117, revision: 2 } ], element: "attribute" })

--- a/packages/model/src/standard/elements/door-lock-cluster.element.ts
+++ b/packages/model/src/standard/elements/door-lock-cluster.element.ts
@@ -17,7 +17,7 @@ import {
 } from "../../elements/index.js";
 
 export const DoorLock = Cluster(
-    { name: "DoorLock", id: 0x101 },
+    { name: "DoorLock", id: 0x101, classification: "application" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 9 }),
 
     Attribute(

--- a/packages/model/src/standard/elements/door-lock-controller.element.ts
+++ b/packages/model/src/standard/elements/door-lock-controller.element.ts
@@ -10,7 +10,7 @@ import { MatterDefinition } from "../MatterDefinition.js";
 import { DeviceTypeElement as DeviceType, RequirementElement as Requirement } from "../../elements/index.js";
 
 export const DoorLockControllerDt = DeviceType(
-    { name: "DoorLockController", id: 0xb },
+    { name: "DoorLockController", id: 0xb, classification: "simple" },
     Requirement(
         { name: "Descriptor", id: 0x1d, element: "serverCluster" },
         Requirement({ name: "DeviceTypeList", default: [ { deviceType: 11, revision: 3 } ], element: "attribute" })

--- a/packages/model/src/standard/elements/door-lock-device.element.ts
+++ b/packages/model/src/standard/elements/door-lock-device.element.ts
@@ -10,7 +10,7 @@ import { MatterDefinition } from "../MatterDefinition.js";
 import { DeviceTypeElement as DeviceType, RequirementElement as Requirement } from "../../elements/index.js";
 
 export const DoorLockDt = DeviceType(
-    { name: "DoorLock", id: 0xa },
+    { name: "DoorLock", id: 0xa, classification: "simple" },
     Requirement(
         { name: "Descriptor", id: 0x1d, element: "serverCluster" },
         Requirement({ name: "DeviceTypeList", default: [ { deviceType: 10, revision: 3 } ], element: "attribute" })

--- a/packages/model/src/standard/elements/ecosystem-information.element.ts
+++ b/packages/model/src/standard/elements/ecosystem-information.element.ts
@@ -15,7 +15,7 @@ import {
 } from "../../elements/index.js";
 
 export const EcosystemInformation = Cluster(
-    { name: "EcosystemInformation", id: 0x750 },
+    { name: "EcosystemInformation", id: 0x750, classification: "endpoint" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 1 }),
     Attribute(
         { name: "DeviceDirectory", id: 0x0, type: "list", access: "R F M", conformance: "M", quality: "N" },

--- a/packages/model/src/standard/elements/electrical-energy-measurement.element.ts
+++ b/packages/model/src/standard/elements/electrical-energy-measurement.element.ts
@@ -16,7 +16,7 @@ import {
 } from "../../elements/index.js";
 
 export const ElectricalEnergyMeasurement = Cluster(
-    { name: "ElectricalEnergyMeasurement", id: 0x91 },
+    { name: "ElectricalEnergyMeasurement", id: 0x91, classification: "application" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 1 }),
 
     Attribute(

--- a/packages/model/src/standard/elements/electrical-power-measurement.element.ts
+++ b/packages/model/src/standard/elements/electrical-power-measurement.element.ts
@@ -16,7 +16,7 @@ import {
 } from "../../elements/index.js";
 
 export const ElectricalPowerMeasurement = Cluster(
-    { name: "ElectricalPowerMeasurement", id: 0x90 },
+    { name: "ElectricalPowerMeasurement", id: 0x90, classification: "application" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 3 }),
 
     Attribute(

--- a/packages/model/src/standard/elements/electrical-sensor.element.ts
+++ b/packages/model/src/standard/elements/electrical-sensor.element.ts
@@ -10,7 +10,7 @@ import { MatterDefinition } from "../MatterDefinition.js";
 import { DeviceTypeElement as DeviceType, RequirementElement as Requirement } from "../../elements/index.js";
 
 export const ElectricalSensorDt = DeviceType(
-    { name: "ElectricalSensor", id: 0x510 },
+    { name: "ElectricalSensor", id: 0x510, classification: "utility" },
     Requirement(
         { name: "Descriptor", id: 0x1d, element: "serverCluster" },
         Requirement({ name: "DeviceTypeList", default: [ { deviceType: 1296, revision: 1 } ], element: "attribute" })

--- a/packages/model/src/standard/elements/energy-evse-cluster.element.ts
+++ b/packages/model/src/standard/elements/energy-evse-cluster.element.ts
@@ -17,7 +17,7 @@ import {
 } from "../../elements/index.js";
 
 export const EnergyEvse = Cluster(
-    { name: "EnergyEvse", id: 0x99 },
+    { name: "EnergyEvse", id: 0x99, classification: "application" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 3 }),
 
     Attribute(

--- a/packages/model/src/standard/elements/energy-evse-device.element.ts
+++ b/packages/model/src/standard/elements/energy-evse-device.element.ts
@@ -10,7 +10,7 @@ import { MatterDefinition } from "../MatterDefinition.js";
 import { DeviceTypeElement as DeviceType, RequirementElement as Requirement } from "../../elements/index.js";
 
 export const EnergyEvseDt = DeviceType(
-    { name: "EnergyEvse", id: 0x50c },
+    { name: "EnergyEvse", id: 0x50c, classification: "simple" },
     Requirement(
         { name: "Descriptor", id: 0x1d, element: "serverCluster" },
         Requirement({ name: "DeviceTypeList", default: [ { deviceType: 1292, revision: 2 } ], element: "attribute" })

--- a/packages/model/src/standard/elements/energy-evse-mode.element.ts
+++ b/packages/model/src/standard/elements/energy-evse-mode.element.ts
@@ -15,7 +15,7 @@ import {
 } from "../../elements/index.js";
 
 export const EnergyEvseMode = Cluster(
-    { name: "EnergyEvseMode", id: 0x9d, type: "ModeBase" },
+    { name: "EnergyEvseMode", id: 0x9d, type: "ModeBase", classification: "application" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 2 }),
     Attribute(
         { name: "FeatureMap", id: 0xfffc, type: "FeatureMap" },

--- a/packages/model/src/standard/elements/energy-preference.element.ts
+++ b/packages/model/src/standard/elements/energy-preference.element.ts
@@ -15,7 +15,7 @@ import {
 } from "../../elements/index.js";
 
 export const EnergyPreference = Cluster(
-    { name: "EnergyPreference", id: 0x9b },
+    { name: "EnergyPreference", id: 0x9b, classification: "application" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 1 }),
     Attribute(
         { name: "FeatureMap", id: 0xfffc, type: "FeatureMap" },

--- a/packages/model/src/standard/elements/ethernet-network-diagnostics.element.ts
+++ b/packages/model/src/standard/elements/ethernet-network-diagnostics.element.ts
@@ -16,7 +16,7 @@ import {
 } from "../../elements/index.js";
 
 export const EthernetNetworkDiagnostics = Cluster(
-    { name: "EthernetNetworkDiagnostics", id: 0x37, quality: "K" },
+    { name: "EthernetNetworkDiagnostics", id: 0x37, classification: "node", quality: "K" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 1 }),
     Attribute(
         { name: "FeatureMap", id: 0xfffc, type: "FeatureMap" },

--- a/packages/model/src/standard/elements/extended-color-light.element.ts
+++ b/packages/model/src/standard/elements/extended-color-light.element.ts
@@ -10,7 +10,7 @@ import { MatterDefinition } from "../MatterDefinition.js";
 import { DeviceTypeElement as DeviceType, RequirementElement as Requirement } from "../../elements/index.js";
 
 export const ExtendedColorLightDt = DeviceType(
-    { name: "ExtendedColorLight", id: 0x10d },
+    { name: "ExtendedColorLight", id: 0x10d, classification: "simple" },
     Requirement(
         { name: "Descriptor", id: 0x1d, element: "serverCluster" },
         Requirement({ name: "DeviceTypeList", default: [ { deviceType: 269, revision: 4 } ], element: "attribute" })

--- a/packages/model/src/standard/elements/extractor-hood.element.ts
+++ b/packages/model/src/standard/elements/extractor-hood.element.ts
@@ -10,7 +10,7 @@ import { MatterDefinition } from "../MatterDefinition.js";
 import { DeviceTypeElement as DeviceType, RequirementElement as Requirement } from "../../elements/index.js";
 
 export const ExtractorHoodDt = DeviceType(
-    { name: "ExtractorHood", id: 0x7a },
+    { name: "ExtractorHood", id: 0x7a, classification: "simple" },
     Requirement(
         { name: "Descriptor", id: 0x1d, element: "serverCluster" },
         Requirement({ name: "DeviceTypeList", default: [ { deviceType: 122, revision: 1 } ], element: "attribute" })

--- a/packages/model/src/standard/elements/fan-control.element.ts
+++ b/packages/model/src/standard/elements/fan-control.element.ts
@@ -16,7 +16,7 @@ import {
 } from "../../elements/index.js";
 
 export const FanControl = Cluster(
-    { name: "FanControl", id: 0x202 },
+    { name: "FanControl", id: 0x202, classification: "application" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 5 }),
 
     Attribute(

--- a/packages/model/src/standard/elements/fan.element.ts
+++ b/packages/model/src/standard/elements/fan.element.ts
@@ -10,7 +10,7 @@ import { MatterDefinition } from "../MatterDefinition.js";
 import { DeviceTypeElement as DeviceType, RequirementElement as Requirement } from "../../elements/index.js";
 
 export const FanDt = DeviceType(
-    { name: "Fan", id: 0x2b },
+    { name: "Fan", id: 0x2b, classification: "simple" },
     Requirement(
         { name: "Descriptor", id: 0x1d, element: "serverCluster" },
         Requirement({ name: "DeviceTypeList", default: [ { deviceType: 43, revision: 3 } ], element: "attribute" })

--- a/packages/model/src/standard/elements/fixed-label.element.ts
+++ b/packages/model/src/standard/elements/fixed-label.element.ts
@@ -14,7 +14,7 @@ import {
 } from "../../elements/index.js";
 
 export const FixedLabel = Cluster(
-    { name: "FixedLabel", id: 0x40, type: "Label" },
+    { name: "FixedLabel", id: 0x40, type: "Label", classification: "endpoint" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 1 }),
     Attribute(
         { name: "LabelList", id: 0x0, type: "list", access: "R V", conformance: "M", default: [], quality: "N" },

--- a/packages/model/src/standard/elements/flow-measurement.element.ts
+++ b/packages/model/src/standard/elements/flow-measurement.element.ts
@@ -10,7 +10,7 @@ import { MatterDefinition } from "../MatterDefinition.js";
 import { ClusterElement as Cluster, AttributeElement as Attribute } from "../../elements/index.js";
 
 export const FlowMeasurement = Cluster(
-    { name: "FlowMeasurement", id: 0x404 },
+    { name: "FlowMeasurement", id: 0x404, classification: "application" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 3 }),
     Attribute({
         name: "MeasuredValue", id: 0x0, type: "uint16", access: "R V", conformance: "M",

--- a/packages/model/src/standard/elements/flow-sensor.element.ts
+++ b/packages/model/src/standard/elements/flow-sensor.element.ts
@@ -10,7 +10,7 @@ import { MatterDefinition } from "../MatterDefinition.js";
 import { DeviceTypeElement as DeviceType, RequirementElement as Requirement } from "../../elements/index.js";
 
 export const FlowSensorDt = DeviceType(
-    { name: "FlowSensor", id: 0x306 },
+    { name: "FlowSensor", id: 0x306, classification: "simple" },
     Requirement(
         { name: "Descriptor", id: 0x1d, element: "serverCluster" },
         Requirement({ name: "DeviceTypeList", default: [ { deviceType: 774, revision: 2 } ], element: "attribute" })

--- a/packages/model/src/standard/elements/general-commissioning.element.ts
+++ b/packages/model/src/standard/elements/general-commissioning.element.ts
@@ -16,7 +16,7 @@ import {
 } from "../../elements/index.js";
 
 export const GeneralCommissioning = Cluster(
-    { name: "GeneralCommissioning", id: 0x30 },
+    { name: "GeneralCommissioning", id: 0x30, classification: "node" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 2 }),
     Attribute(
         { name: "FeatureMap", id: 0xfffc, type: "FeatureMap" },

--- a/packages/model/src/standard/elements/general-diagnostics.element.ts
+++ b/packages/model/src/standard/elements/general-diagnostics.element.ts
@@ -17,7 +17,7 @@ import {
 } from "../../elements/index.js";
 
 export const GeneralDiagnostics = Cluster(
-    { name: "GeneralDiagnostics", id: 0x33, quality: "K" },
+    { name: "GeneralDiagnostics", id: 0x33, classification: "node", quality: "K" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 2 }),
     Attribute(
         { name: "FeatureMap", id: 0xfffc, type: "FeatureMap" },

--- a/packages/model/src/standard/elements/generic-switch.element.ts
+++ b/packages/model/src/standard/elements/generic-switch.element.ts
@@ -10,7 +10,7 @@ import { MatterDefinition } from "../MatterDefinition.js";
 import { DeviceTypeElement as DeviceType, RequirementElement as Requirement } from "../../elements/index.js";
 
 export const GenericSwitchDt = DeviceType(
-    { name: "GenericSwitch", id: 0xf },
+    { name: "GenericSwitch", id: 0xf, classification: "simple" },
     Requirement(
         { name: "Descriptor", id: 0x1d, element: "serverCluster" },
         Requirement({ name: "DeviceTypeList", default: [ { deviceType: 15, revision: 3 } ], element: "attribute" })

--- a/packages/model/src/standard/elements/group-key-management.element.ts
+++ b/packages/model/src/standard/elements/group-key-management.element.ts
@@ -16,7 +16,7 @@ import {
 } from "../../elements/index.js";
 
 export const GroupKeyManagement = Cluster(
-    { name: "GroupKeyManagement", id: 0x3f },
+    { name: "GroupKeyManagement", id: 0x3f, classification: "node" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 2 }),
     Attribute(
         { name: "FeatureMap", id: 0xfffc, type: "FeatureMap" },

--- a/packages/model/src/standard/elements/groups.element.ts
+++ b/packages/model/src/standard/elements/groups.element.ts
@@ -16,7 +16,7 @@ import {
 } from "../../elements/index.js";
 
 export const Groups = Cluster(
-    { name: "Groups", id: 0x4 },
+    { name: "Groups", id: 0x4, classification: "endpoint" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 4 }),
     Attribute(
         { name: "FeatureMap", id: 0xfffc, type: "FeatureMap" },

--- a/packages/model/src/standard/elements/heat-pump.element.ts
+++ b/packages/model/src/standard/elements/heat-pump.element.ts
@@ -10,7 +10,7 @@ import { MatterDefinition } from "../MatterDefinition.js";
 import { DeviceTypeElement as DeviceType, RequirementElement as Requirement } from "../../elements/index.js";
 
 export const HeatPumpDt = DeviceType(
-    { name: "HeatPump", id: 0x309 },
+    { name: "HeatPump", id: 0x309, classification: "simple" },
     Requirement(
         { name: "Descriptor", id: 0x1d, element: "serverCluster" },
         Requirement({ name: "DeviceTypeList", default: [ { deviceType: 777, revision: 1 } ], element: "attribute" })

--- a/packages/model/src/standard/elements/humidity-sensor.element.ts
+++ b/packages/model/src/standard/elements/humidity-sensor.element.ts
@@ -10,7 +10,7 @@ import { MatterDefinition } from "../MatterDefinition.js";
 import { DeviceTypeElement as DeviceType, RequirementElement as Requirement } from "../../elements/index.js";
 
 export const HumiditySensorDt = DeviceType(
-    { name: "HumiditySensor", id: 0x307 },
+    { name: "HumiditySensor", id: 0x307, classification: "simple" },
     Requirement(
         { name: "Descriptor", id: 0x1d, element: "serverCluster" },
         Requirement({ name: "DeviceTypeList", default: [ { deviceType: 775, revision: 2 } ], element: "attribute" })

--- a/packages/model/src/standard/elements/icd-management.element.ts
+++ b/packages/model/src/standard/elements/icd-management.element.ts
@@ -16,7 +16,7 @@ import {
 } from "../../elements/index.js";
 
 export const IcdManagement = Cluster(
-    { name: "IcdManagement", id: 0x46 },
+    { name: "IcdManagement", id: 0x46, classification: "node" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 3 }),
 
     Attribute(

--- a/packages/model/src/standard/elements/identify.element.ts
+++ b/packages/model/src/standard/elements/identify.element.ts
@@ -16,7 +16,7 @@ import {
 } from "../../elements/index.js";
 
 export const Identify = Cluster(
-    { name: "Identify", id: 0x3 },
+    { name: "Identify", id: 0x3, classification: "endpoint" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 6 }),
     Attribute({ name: "IdentifyTime", id: 0x0, type: "uint16", access: "RW VO", conformance: "M", quality: "Q" }),
     Attribute({ name: "IdentifyType", id: 0x1, type: "IdentifyTypeEnum", access: "R V", conformance: "M", constraint: "desc" }),

--- a/packages/model/src/standard/elements/illuminance-measurement.element.ts
+++ b/packages/model/src/standard/elements/illuminance-measurement.element.ts
@@ -15,7 +15,7 @@ import {
 } from "../../elements/index.js";
 
 export const IlluminanceMeasurement = Cluster(
-    { name: "IlluminanceMeasurement", id: 0x400 },
+    { name: "IlluminanceMeasurement", id: 0x400, classification: "application" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 3 }),
     Attribute({
         name: "MeasuredValue", id: 0x0, type: "uint16", access: "R V", conformance: "M",

--- a/packages/model/src/standard/elements/joint-fabric-administrator-cluster.element.ts
+++ b/packages/model/src/standard/elements/joint-fabric-administrator-cluster.element.ts
@@ -16,7 +16,7 @@ import {
 } from "../../elements/index.js";
 
 export const JointFabricAdministrator = Cluster(
-    { name: "JointFabricAdministrator", id: 0x753 },
+    { name: "JointFabricAdministrator", id: 0x753, classification: "node" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 1 }),
     Attribute({
         name: "AdministratorFabricIndex", id: 0x0, type: "fabric-idx", access: "A", conformance: "P, M",

--- a/packages/model/src/standard/elements/joint-fabric-administrator-device.element.ts
+++ b/packages/model/src/standard/elements/joint-fabric-administrator-device.element.ts
@@ -10,7 +10,7 @@ import { MatterDefinition } from "../MatterDefinition.js";
 import { DeviceTypeElement as DeviceType, RequirementElement as Requirement } from "../../elements/index.js";
 
 export const JointFabricAdministratorDt = DeviceType(
-    { name: "JointFabricAdministrator", id: 0x130 },
+    { name: "JointFabricAdministrator", id: 0x130, classification: "utility" },
     Requirement(
         { name: "Descriptor", id: 0x1d, element: "serverCluster" },
         Requirement({ name: "DeviceTypeList", default: [ { deviceType: 304, revision: 1 } ], element: "attribute" })

--- a/packages/model/src/standard/elements/joint-fabric-datastore.element.ts
+++ b/packages/model/src/standard/elements/joint-fabric-datastore.element.ts
@@ -16,7 +16,7 @@ import {
 } from "../../elements/index.js";
 
 export const JointFabricDatastore = Cluster(
-    { name: "JointFabricDatastore", id: 0x752 },
+    { name: "JointFabricDatastore", id: 0x752, classification: "node" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 1 }),
     Attribute({ name: "AnchorRootCa", id: 0x0, type: "octstr", access: "R A", conformance: "P, M" }),
     Attribute({ name: "AnchorNodeId", id: 0x1, type: "node-id", access: "R A", conformance: "P, M" }),

--- a/packages/model/src/standard/elements/keypad-input.element.ts
+++ b/packages/model/src/standard/elements/keypad-input.element.ts
@@ -16,7 +16,7 @@ import {
 } from "../../elements/index.js";
 
 export const KeypadInput = Cluster(
-    { name: "KeypadInput", id: 0x509 },
+    { name: "KeypadInput", id: 0x509, classification: "application" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 1 }),
 
     Attribute(

--- a/packages/model/src/standard/elements/label.element.ts
+++ b/packages/model/src/standard/elements/label.element.ts
@@ -15,7 +15,7 @@ import {
 } from "../../elements/index.js";
 
 export const Label = Cluster(
-    { name: "Label" },
+    { name: "Label", classification: "endpoint" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 1 }),
     Attribute(
         { name: "LabelList", id: 0x0, type: "list", conformance: "M", constraint: "derived", default: [] },

--- a/packages/model/src/standard/elements/laundry-dryer-controls.element.ts
+++ b/packages/model/src/standard/elements/laundry-dryer-controls.element.ts
@@ -15,7 +15,7 @@ import {
 } from "../../elements/index.js";
 
 export const LaundryDryerControls = Cluster(
-    { name: "LaundryDryerControls", id: 0x4a },
+    { name: "LaundryDryerControls", id: 0x4a, classification: "application" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 1 }),
 
     Attribute(

--- a/packages/model/src/standard/elements/laundry-dryer.element.ts
+++ b/packages/model/src/standard/elements/laundry-dryer.element.ts
@@ -10,7 +10,7 @@ import { MatterDefinition } from "../MatterDefinition.js";
 import { DeviceTypeElement as DeviceType, RequirementElement as Requirement } from "../../elements/index.js";
 
 export const LaundryDryerDt = DeviceType(
-    { name: "LaundryDryer", id: 0x7c },
+    { name: "LaundryDryer", id: 0x7c, classification: "simple" },
     Requirement(
         { name: "Descriptor", id: 0x1d, element: "serverCluster" },
         Requirement({ name: "DeviceTypeList", default: [ { deviceType: 124, revision: 2 } ], element: "attribute" })

--- a/packages/model/src/standard/elements/laundry-washer-controls.element.ts
+++ b/packages/model/src/standard/elements/laundry-washer-controls.element.ts
@@ -15,7 +15,7 @@ import {
 } from "../../elements/index.js";
 
 export const LaundryWasherControls = Cluster(
-    { name: "LaundryWasherControls", id: 0x53 },
+    { name: "LaundryWasherControls", id: 0x53, classification: "application" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 2 }),
     Attribute(
         { name: "FeatureMap", id: 0xfffc, type: "FeatureMap" },

--- a/packages/model/src/standard/elements/laundry-washer-mode.element.ts
+++ b/packages/model/src/standard/elements/laundry-washer-mode.element.ts
@@ -15,7 +15,7 @@ import {
 } from "../../elements/index.js";
 
 export const LaundryWasherMode = Cluster(
-    { name: "LaundryWasherMode", id: 0x51, type: "ModeBase" },
+    { name: "LaundryWasherMode", id: 0x51, type: "ModeBase", classification: "application" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 3 }),
     Attribute(
         { name: "FeatureMap", id: 0xfffc, type: "FeatureMap" },

--- a/packages/model/src/standard/elements/laundry-washer.element.ts
+++ b/packages/model/src/standard/elements/laundry-washer.element.ts
@@ -10,7 +10,7 @@ import { MatterDefinition } from "../MatterDefinition.js";
 import { DeviceTypeElement as DeviceType, RequirementElement as Requirement } from "../../elements/index.js";
 
 export const LaundryWasherDt = DeviceType(
-    { name: "LaundryWasher", id: 0x73 },
+    { name: "LaundryWasher", id: 0x73, classification: "simple" },
     Requirement(
         { name: "Descriptor", id: 0x1d, element: "serverCluster" },
         Requirement({ name: "DeviceTypeList", default: [ { deviceType: 115, revision: 2 } ], element: "attribute" })

--- a/packages/model/src/standard/elements/level-control.element.ts
+++ b/packages/model/src/standard/elements/level-control.element.ts
@@ -16,7 +16,7 @@ import {
 } from "../../elements/index.js";
 
 export const LevelControl = Cluster(
-    { name: "LevelControl", id: 0x8 },
+    { name: "LevelControl", id: 0x8, classification: "application" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 6 }),
 
     Attribute(

--- a/packages/model/src/standard/elements/light-sensor.element.ts
+++ b/packages/model/src/standard/elements/light-sensor.element.ts
@@ -10,7 +10,7 @@ import { MatterDefinition } from "../MatterDefinition.js";
 import { DeviceTypeElement as DeviceType, RequirementElement as Requirement } from "../../elements/index.js";
 
 export const LightSensorDt = DeviceType(
-    { name: "LightSensor", id: 0x106 },
+    { name: "LightSensor", id: 0x106, classification: "simple" },
     Requirement(
         { name: "Descriptor", id: 0x1d, element: "serverCluster" },
         Requirement({ name: "DeviceTypeList", default: [ { deviceType: 262, revision: 3 } ], element: "attribute" })

--- a/packages/model/src/standard/elements/localization-configuration.element.ts
+++ b/packages/model/src/standard/elements/localization-configuration.element.ts
@@ -14,7 +14,7 @@ import {
 } from "../../elements/index.js";
 
 export const LocalizationConfiguration = Cluster(
-    { name: "LocalizationConfiguration", id: 0x2b },
+    { name: "LocalizationConfiguration", id: 0x2b, classification: "node" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 1 }),
     Attribute({
         name: "ActiveLocale", id: 0x0, type: "string", access: "RW VM", conformance: "M",

--- a/packages/model/src/standard/elements/low-power.element.ts
+++ b/packages/model/src/standard/elements/low-power.element.ts
@@ -14,7 +14,7 @@ import {
 } from "../../elements/index.js";
 
 export const LowPower = Cluster(
-    { name: "LowPower", id: 0x508 },
+    { name: "LowPower", id: 0x508, classification: "application" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 1 }),
     Command({ name: "Sleep", id: 0x0, access: "O", conformance: "M", direction: "request", response: "status" })
 );

--- a/packages/model/src/standard/elements/media-input.element.ts
+++ b/packages/model/src/standard/elements/media-input.element.ts
@@ -16,7 +16,7 @@ import {
 } from "../../elements/index.js";
 
 export const MediaInput = Cluster(
-    { name: "MediaInput", id: 0x507 },
+    { name: "MediaInput", id: 0x507, classification: "application" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 1 }),
     Attribute(
         { name: "FeatureMap", id: 0xfffc, type: "FeatureMap" },

--- a/packages/model/src/standard/elements/media-playback.element.ts
+++ b/packages/model/src/standard/elements/media-playback.element.ts
@@ -17,7 +17,7 @@ import {
 } from "../../elements/index.js";
 
 export const MediaPlayback = Cluster(
-    { name: "MediaPlayback", id: 0x506 },
+    { name: "MediaPlayback", id: 0x506, classification: "application" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 2 }),
 
     Attribute(

--- a/packages/model/src/standard/elements/messages.element.ts
+++ b/packages/model/src/standard/elements/messages.element.ts
@@ -17,7 +17,7 @@ import {
 } from "../../elements/index.js";
 
 export const Messages = Cluster(
-    { name: "Messages", id: 0x97 },
+    { name: "Messages", id: 0x97, classification: "application" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 3 }),
 
     Attribute(

--- a/packages/model/src/standard/elements/microwave-oven-control.element.ts
+++ b/packages/model/src/standard/elements/microwave-oven-control.element.ts
@@ -15,7 +15,7 @@ import {
 } from "../../elements/index.js";
 
 export const MicrowaveOvenControl = Cluster(
-    { name: "MicrowaveOvenControl", id: 0x5f },
+    { name: "MicrowaveOvenControl", id: 0x5f, classification: "application" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 1 }),
 
     Attribute(

--- a/packages/model/src/standard/elements/microwave-oven-mode.element.ts
+++ b/packages/model/src/standard/elements/microwave-oven-mode.element.ts
@@ -16,7 +16,7 @@ import {
 } from "../../elements/index.js";
 
 export const MicrowaveOvenMode = Cluster(
-    { name: "MicrowaveOvenMode", id: 0x5e, type: "ModeBase" },
+    { name: "MicrowaveOvenMode", id: 0x5e, type: "ModeBase", classification: "application" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 2 }),
     Attribute(
         { name: "FeatureMap", id: 0xfffc, type: "FeatureMap" },

--- a/packages/model/src/standard/elements/microwave-oven.element.ts
+++ b/packages/model/src/standard/elements/microwave-oven.element.ts
@@ -10,7 +10,7 @@ import { MatterDefinition } from "../MatterDefinition.js";
 import { DeviceTypeElement as DeviceType, RequirementElement as Requirement } from "../../elements/index.js";
 
 export const MicrowaveOvenDt = DeviceType(
-    { name: "MicrowaveOven", id: 0x79 },
+    { name: "MicrowaveOven", id: 0x79, classification: "simple" },
     Requirement(
         { name: "Descriptor", id: 0x1d, element: "serverCluster" },
         Requirement({ name: "DeviceTypeList", default: [ { deviceType: 121, revision: 2 } ], element: "attribute" })

--- a/packages/model/src/standard/elements/mode-base.element.ts
+++ b/packages/model/src/standard/elements/mode-base.element.ts
@@ -16,7 +16,7 @@ import {
 } from "../../elements/index.js";
 
 export const ModeBase = Cluster(
-    { name: "ModeBase" },
+    { name: "ModeBase", classification: "application" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 2 }),
     Attribute(
         { name: "FeatureMap", id: 0xfffc, type: "FeatureMap" },

--- a/packages/model/src/standard/elements/mode-select-cluster.element.ts
+++ b/packages/model/src/standard/elements/mode-select-cluster.element.ts
@@ -16,7 +16,7 @@ import {
 } from "../../elements/index.js";
 
 export const ModeSelect = Cluster(
-    { name: "ModeSelect", id: 0x50 },
+    { name: "ModeSelect", id: 0x50, classification: "application" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 2 }),
     Attribute(
         { name: "FeatureMap", id: 0xfffc, type: "FeatureMap" },

--- a/packages/model/src/standard/elements/mode-select-device.element.ts
+++ b/packages/model/src/standard/elements/mode-select-device.element.ts
@@ -10,7 +10,7 @@ import { MatterDefinition } from "../MatterDefinition.js";
 import { DeviceTypeElement as DeviceType, RequirementElement as Requirement } from "../../elements/index.js";
 
 export const ModeSelectDt = DeviceType(
-    { name: "ModeSelect", id: 0x27 },
+    { name: "ModeSelect", id: 0x27, classification: "simple" },
     Requirement(
         { name: "Descriptor", id: 0x1d, element: "serverCluster" },
         Requirement({ name: "DeviceTypeList", default: [ { deviceType: 39, revision: 1 } ], element: "attribute" })

--- a/packages/model/src/standard/elements/mounted-dimmable-load-control.element.ts
+++ b/packages/model/src/standard/elements/mounted-dimmable-load-control.element.ts
@@ -10,7 +10,7 @@ import { MatterDefinition } from "../MatterDefinition.js";
 import { DeviceTypeElement as DeviceType, RequirementElement as Requirement } from "../../elements/index.js";
 
 export const MountedDimmableLoadControlDt = DeviceType(
-    { name: "MountedDimmableLoadControl", id: 0x110 },
+    { name: "MountedDimmableLoadControl", id: 0x110, classification: "simple" },
     Requirement(
         { name: "Descriptor", id: 0x1d, element: "serverCluster" },
         Requirement({ name: "DeviceTypeList", default: [ { deviceType: 272, revision: 2 } ], element: "attribute" })

--- a/packages/model/src/standard/elements/mounted-on-off-control.element.ts
+++ b/packages/model/src/standard/elements/mounted-on-off-control.element.ts
@@ -10,7 +10,7 @@ import { MatterDefinition } from "../MatterDefinition.js";
 import { DeviceTypeElement as DeviceType, RequirementElement as Requirement } from "../../elements/index.js";
 
 export const MountedOnOffControlDt = DeviceType(
-    { name: "MountedOnOffControl", id: 0x10f },
+    { name: "MountedOnOffControl", id: 0x10f, classification: "simple" },
     Requirement(
         { name: "Descriptor", id: 0x1d, element: "serverCluster" },
         Requirement({ name: "DeviceTypeList", default: [ { deviceType: 271, revision: 2 } ], element: "attribute" })

--- a/packages/model/src/standard/elements/network-commissioning.element.ts
+++ b/packages/model/src/standard/elements/network-commissioning.element.ts
@@ -16,7 +16,7 @@ import {
 } from "../../elements/index.js";
 
 export const NetworkCommissioning = Cluster(
-    { name: "NetworkCommissioning", id: 0x31 },
+    { name: "NetworkCommissioning", id: 0x31, classification: "node" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 2 }),
 
     Attribute(

--- a/packages/model/src/standard/elements/network-infrastructure-manager.element.ts
+++ b/packages/model/src/standard/elements/network-infrastructure-manager.element.ts
@@ -10,7 +10,7 @@ import { MatterDefinition } from "../MatterDefinition.js";
 import { DeviceTypeElement as DeviceType, RequirementElement as Requirement } from "../../elements/index.js";
 
 export const NetworkInfrastructureManagerDt = DeviceType(
-    { name: "NetworkInfrastructureManager", id: 0x90 },
+    { name: "NetworkInfrastructureManager", id: 0x90, classification: "simple" },
     Requirement(
         { name: "Descriptor", id: 0x1d, element: "serverCluster" },
         Requirement({ name: "DeviceTypeList", default: [ { deviceType: 144, revision: 2 } ], element: "attribute" })

--- a/packages/model/src/standard/elements/occupancy-sensing.element.ts
+++ b/packages/model/src/standard/elements/occupancy-sensing.element.ts
@@ -16,7 +16,7 @@ import {
 } from "../../elements/index.js";
 
 export const OccupancySensing = Cluster(
-    { name: "OccupancySensing", id: 0x406 },
+    { name: "OccupancySensing", id: 0x406, classification: "application" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 5 }),
 
     Attribute(

--- a/packages/model/src/standard/elements/occupancy-sensor.element.ts
+++ b/packages/model/src/standard/elements/occupancy-sensor.element.ts
@@ -10,7 +10,7 @@ import { MatterDefinition } from "../MatterDefinition.js";
 import { DeviceTypeElement as DeviceType, RequirementElement as Requirement } from "../../elements/index.js";
 
 export const OccupancySensorDt = DeviceType(
-    { name: "OccupancySensor", id: 0x107 },
+    { name: "OccupancySensor", id: 0x107, classification: "simple" },
     Requirement(
         { name: "Descriptor", id: 0x1d, element: "serverCluster" },
         Requirement({ name: "DeviceTypeList", default: [ { deviceType: 263, revision: 4 } ], element: "attribute" })

--- a/packages/model/src/standard/elements/on-off-light-switch.element.ts
+++ b/packages/model/src/standard/elements/on-off-light-switch.element.ts
@@ -10,7 +10,7 @@ import { MatterDefinition } from "../MatterDefinition.js";
 import { DeviceTypeElement as DeviceType, RequirementElement as Requirement } from "../../elements/index.js";
 
 export const OnOffLightSwitchDt = DeviceType(
-    { name: "OnOffLightSwitch", id: 0x103 },
+    { name: "OnOffLightSwitch", id: 0x103, classification: "simple" },
     Requirement(
         { name: "Descriptor", id: 0x1d, element: "serverCluster" },
         Requirement({ name: "DeviceTypeList", default: [ { deviceType: 259, revision: 3 } ], element: "attribute" })

--- a/packages/model/src/standard/elements/on-off-light.element.ts
+++ b/packages/model/src/standard/elements/on-off-light.element.ts
@@ -10,7 +10,7 @@ import { MatterDefinition } from "../MatterDefinition.js";
 import { DeviceTypeElement as DeviceType, RequirementElement as Requirement } from "../../elements/index.js";
 
 export const OnOffLightDt = DeviceType(
-    { name: "OnOffLight", id: 0x100 },
+    { name: "OnOffLight", id: 0x100, classification: "simple" },
     Requirement(
         { name: "Descriptor", id: 0x1d, element: "serverCluster" },
         Requirement({ name: "DeviceTypeList", default: [ { deviceType: 256, revision: 3 } ], element: "attribute" })

--- a/packages/model/src/standard/elements/on-off-plug-in-unit.element.ts
+++ b/packages/model/src/standard/elements/on-off-plug-in-unit.element.ts
@@ -10,7 +10,7 @@ import { MatterDefinition } from "../MatterDefinition.js";
 import { DeviceTypeElement as DeviceType, RequirementElement as Requirement } from "../../elements/index.js";
 
 export const OnOffPlugInUnitDt = DeviceType(
-    { name: "OnOffPlugInUnit", id: 0x10a },
+    { name: "OnOffPlugInUnit", id: 0x10a, classification: "simple" },
     Requirement(
         { name: "Descriptor", id: 0x1d, element: "serverCluster" },
         Requirement({ name: "DeviceTypeList", default: [ { deviceType: 266, revision: 4 } ], element: "attribute" })

--- a/packages/model/src/standard/elements/on-off-sensor.element.ts
+++ b/packages/model/src/standard/elements/on-off-sensor.element.ts
@@ -10,7 +10,7 @@ import { MatterDefinition } from "../MatterDefinition.js";
 import { DeviceTypeElement as DeviceType, RequirementElement as Requirement } from "../../elements/index.js";
 
 export const OnOffSensorDt = DeviceType(
-    { name: "OnOffSensor", id: 0x850 },
+    { name: "OnOffSensor", id: 0x850, classification: "simple" },
     Requirement(
         { name: "Descriptor", id: 0x1d, element: "serverCluster" },
         Requirement({ name: "DeviceTypeList", default: [ { deviceType: 2128, revision: 3 } ], element: "attribute" })

--- a/packages/model/src/standard/elements/on-off.element.ts
+++ b/packages/model/src/standard/elements/on-off.element.ts
@@ -16,7 +16,7 @@ import {
 } from "../../elements/index.js";
 
 export const OnOff = Cluster(
-    { name: "OnOff", id: 0x6 },
+    { name: "OnOff", id: 0x6, classification: "application" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 6 }),
 
     Attribute(

--- a/packages/model/src/standard/elements/operational-credentials.element.ts
+++ b/packages/model/src/standard/elements/operational-credentials.element.ts
@@ -16,7 +16,7 @@ import {
 } from "../../elements/index.js";
 
 export const OperationalCredentials = Cluster(
-    { name: "OperationalCredentials", id: 0x3e },
+    { name: "OperationalCredentials", id: 0x3e, classification: "node" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 2 }),
 
     Attribute(

--- a/packages/model/src/standard/elements/operational-state.element.ts
+++ b/packages/model/src/standard/elements/operational-state.element.ts
@@ -17,7 +17,7 @@ import {
 } from "../../elements/index.js";
 
 export const OperationalState = Cluster(
-    { name: "OperationalState", id: 0x60 },
+    { name: "OperationalState", id: 0x60, classification: "application" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 3 }),
 
     Attribute(

--- a/packages/model/src/standard/elements/ota-provider.element.ts
+++ b/packages/model/src/standard/elements/ota-provider.element.ts
@@ -10,7 +10,7 @@ import { MatterDefinition } from "../MatterDefinition.js";
 import { DeviceTypeElement as DeviceType, RequirementElement as Requirement } from "../../elements/index.js";
 
 export const OtaProviderDt = DeviceType(
-    { name: "OtaProvider", id: 0x14 },
+    { name: "OtaProvider", id: 0x14, classification: "utility" },
     Requirement(
         { name: "Descriptor", id: 0x1d, element: "serverCluster" },
         Requirement({ name: "DeviceTypeList", default: [ { deviceType: 20, revision: 1 } ], element: "attribute" })

--- a/packages/model/src/standard/elements/ota-requestor.element.ts
+++ b/packages/model/src/standard/elements/ota-requestor.element.ts
@@ -10,7 +10,7 @@ import { MatterDefinition } from "../MatterDefinition.js";
 import { DeviceTypeElement as DeviceType, RequirementElement as Requirement } from "../../elements/index.js";
 
 export const OtaRequestorDt = DeviceType(
-    { name: "OtaRequestor", id: 0x12 },
+    { name: "OtaRequestor", id: 0x12, classification: "utility" },
     Requirement(
         { name: "Descriptor", id: 0x1d, element: "serverCluster" },
         Requirement({ name: "DeviceTypeList", default: [ { deviceType: 18, revision: 1 } ], element: "attribute" })

--- a/packages/model/src/standard/elements/ota-software-update-provider.element.ts
+++ b/packages/model/src/standard/elements/ota-software-update-provider.element.ts
@@ -16,7 +16,7 @@ import {
 } from "../../elements/index.js";
 
 export const OtaSoftwareUpdateProvider = Cluster(
-    { name: "OtaSoftwareUpdateProvider", id: 0x29 },
+    { name: "OtaSoftwareUpdateProvider", id: 0x29, classification: "node" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 1 }),
 
     Command(

--- a/packages/model/src/standard/elements/ota-software-update-requestor.element.ts
+++ b/packages/model/src/standard/elements/ota-software-update-requestor.element.ts
@@ -17,7 +17,7 @@ import {
 } from "../../elements/index.js";
 
 export const OtaSoftwareUpdateRequestor = Cluster(
-    { name: "OtaSoftwareUpdateRequestor", id: 0x2a },
+    { name: "OtaSoftwareUpdateRequestor", id: 0x2a, classification: "node" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 1 }),
 
     Attribute(

--- a/packages/model/src/standard/elements/oven-cavity-operational-state.element.ts
+++ b/packages/model/src/standard/elements/oven-cavity-operational-state.element.ts
@@ -14,7 +14,7 @@ import {
 } from "../../elements/index.js";
 
 export const OvenCavityOperationalState = Cluster(
-    { name: "OvenCavityOperationalState", id: 0x48, type: "OperationalState" },
+    { name: "OvenCavityOperationalState", id: 0x48, type: "OperationalState", classification: "application" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 2 }),
     Command({ name: "Pause", id: 0x0, conformance: "X" }),
     Command({ name: "Stop", id: 0x1 }),

--- a/packages/model/src/standard/elements/oven-mode.element.ts
+++ b/packages/model/src/standard/elements/oven-mode.element.ts
@@ -15,7 +15,7 @@ import {
 } from "../../elements/index.js";
 
 export const OvenMode = Cluster(
-    { name: "OvenMode", id: 0x49, type: "ModeBase" },
+    { name: "OvenMode", id: 0x49, type: "ModeBase", classification: "application" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 2 }),
     Attribute(
         { name: "FeatureMap", id: 0xfffc, type: "FeatureMap" },

--- a/packages/model/src/standard/elements/oven.element.ts
+++ b/packages/model/src/standard/elements/oven.element.ts
@@ -10,7 +10,7 @@ import { MatterDefinition } from "../MatterDefinition.js";
 import { DeviceTypeElement as DeviceType, RequirementElement as Requirement } from "../../elements/index.js";
 
 export const OvenDt = DeviceType(
-    { name: "Oven", id: 0x7b },
+    { name: "Oven", id: 0x7b, classification: "simple" },
     Requirement(
         { name: "Descriptor", id: 0x1d, element: "serverCluster" },
         Requirement({ name: "DeviceTypeList", default: [ { deviceType: 123, revision: 2 } ], element: "attribute" })

--- a/packages/model/src/standard/elements/power-source-cluster.element.ts
+++ b/packages/model/src/standard/elements/power-source-cluster.element.ts
@@ -16,7 +16,7 @@ import {
 } from "../../elements/index.js";
 
 export const PowerSource = Cluster(
-    { name: "PowerSource", id: 0x2f },
+    { name: "PowerSource", id: 0x2f, classification: "node" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 3 }),
 
     Attribute(

--- a/packages/model/src/standard/elements/power-source-configuration.element.ts
+++ b/packages/model/src/standard/elements/power-source-configuration.element.ts
@@ -14,7 +14,7 @@ import {
 } from "../../elements/index.js";
 
 export const PowerSourceConfiguration = Cluster(
-    { name: "PowerSourceConfiguration", id: 0x2e },
+    { name: "PowerSourceConfiguration", id: 0x2e, classification: "node" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 1 }),
     Attribute(
         { name: "Sources", id: 0x0, type: "list", access: "R V", conformance: "M", constraint: "max 6", quality: "N" },

--- a/packages/model/src/standard/elements/power-source-device.element.ts
+++ b/packages/model/src/standard/elements/power-source-device.element.ts
@@ -10,7 +10,7 @@ import { MatterDefinition } from "../MatterDefinition.js";
 import { DeviceTypeElement as DeviceType, RequirementElement as Requirement } from "../../elements/index.js";
 
 export const PowerSourceDt = DeviceType(
-    { name: "PowerSource", id: 0x11 },
+    { name: "PowerSource", id: 0x11, classification: "utility" },
     Requirement(
         { name: "Descriptor", id: 0x1d, element: "serverCluster" },
         Requirement({ name: "DeviceTypeList", default: [ { deviceType: 17, revision: 1 } ], element: "attribute" })

--- a/packages/model/src/standard/elements/power-topology.element.ts
+++ b/packages/model/src/standard/elements/power-topology.element.ts
@@ -14,7 +14,7 @@ import {
 } from "../../elements/index.js";
 
 export const PowerTopology = Cluster(
-    { name: "PowerTopology", id: 0x9c },
+    { name: "PowerTopology", id: 0x9c, classification: "application" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 1 }),
 
     Attribute(

--- a/packages/model/src/standard/elements/pressure-measurement.element.ts
+++ b/packages/model/src/standard/elements/pressure-measurement.element.ts
@@ -14,7 +14,7 @@ import {
 } from "../../elements/index.js";
 
 export const PressureMeasurement = Cluster(
-    { name: "PressureMeasurement", id: 0x403 },
+    { name: "PressureMeasurement", id: 0x403, classification: "application" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 3 }),
     Attribute(
         { name: "FeatureMap", id: 0xfffc, type: "FeatureMap" },

--- a/packages/model/src/standard/elements/pressure-sensor.element.ts
+++ b/packages/model/src/standard/elements/pressure-sensor.element.ts
@@ -10,7 +10,7 @@ import { MatterDefinition } from "../MatterDefinition.js";
 import { DeviceTypeElement as DeviceType, RequirementElement as Requirement } from "../../elements/index.js";
 
 export const PressureSensorDt = DeviceType(
-    { name: "PressureSensor", id: 0x305 },
+    { name: "PressureSensor", id: 0x305, classification: "simple" },
     Requirement(
         { name: "Descriptor", id: 0x1d, element: "serverCluster" },
         Requirement({ name: "DeviceTypeList", default: [ { deviceType: 773, revision: 2 } ], element: "attribute" })

--- a/packages/model/src/standard/elements/pump-configuration-and-control.element.ts
+++ b/packages/model/src/standard/elements/pump-configuration-and-control.element.ts
@@ -16,7 +16,7 @@ import {
 } from "../../elements/index.js";
 
 export const PumpConfigurationAndControl = Cluster(
-    { name: "PumpConfigurationAndControl", id: 0x200 },
+    { name: "PumpConfigurationAndControl", id: 0x200, classification: "application" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 4 }),
 
     Attribute(

--- a/packages/model/src/standard/elements/pump-controller.element.ts
+++ b/packages/model/src/standard/elements/pump-controller.element.ts
@@ -10,7 +10,7 @@ import { MatterDefinition } from "../MatterDefinition.js";
 import { DeviceTypeElement as DeviceType, RequirementElement as Requirement } from "../../elements/index.js";
 
 export const PumpControllerDt = DeviceType(
-    { name: "PumpController", id: 0x304 },
+    { name: "PumpController", id: 0x304, classification: "simple" },
     Requirement(
         { name: "Descriptor", id: 0x1d, element: "serverCluster" },
         Requirement({ name: "DeviceTypeList", default: [ { deviceType: 772, revision: 4 } ], element: "attribute" })

--- a/packages/model/src/standard/elements/pump.element.ts
+++ b/packages/model/src/standard/elements/pump.element.ts
@@ -10,7 +10,7 @@ import { MatterDefinition } from "../MatterDefinition.js";
 import { DeviceTypeElement as DeviceType, RequirementElement as Requirement } from "../../elements/index.js";
 
 export const PumpDt = DeviceType(
-    { name: "Pump", id: 0x303 },
+    { name: "Pump", id: 0x303, classification: "simple" },
     Requirement(
         { name: "Descriptor", id: 0x1d, element: "serverCluster" },
         Requirement({ name: "DeviceTypeList", default: [ { deviceType: 771, revision: 3 } ], element: "attribute" })

--- a/packages/model/src/standard/elements/rain-sensor.element.ts
+++ b/packages/model/src/standard/elements/rain-sensor.element.ts
@@ -10,7 +10,7 @@ import { MatterDefinition } from "../MatterDefinition.js";
 import { DeviceTypeElement as DeviceType, RequirementElement as Requirement } from "../../elements/index.js";
 
 export const RainSensorDt = DeviceType(
-    { name: "RainSensor", id: 0x44 },
+    { name: "RainSensor", id: 0x44, classification: "simple" },
     Requirement(
         { name: "Descriptor", id: 0x1d, element: "serverCluster" },
         Requirement({ name: "DeviceTypeList", default: [ { deviceType: 68, revision: 1 } ], element: "attribute" })

--- a/packages/model/src/standard/elements/refrigerator-alarm.element.ts
+++ b/packages/model/src/standard/elements/refrigerator-alarm.element.ts
@@ -16,7 +16,7 @@ import {
 } from "../../elements/index.js";
 
 export const RefrigeratorAlarm = Cluster(
-    { name: "RefrigeratorAlarm", id: 0x57, type: "AlarmBase" },
+    { name: "RefrigeratorAlarm", id: 0x57, type: "AlarmBase", classification: "application" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 1 }),
     Attribute(
         { name: "FeatureMap", id: 0xfffc, type: "FeatureMap" },

--- a/packages/model/src/standard/elements/refrigerator-and-temperature-controlled-cabinet-mode.element.ts
+++ b/packages/model/src/standard/elements/refrigerator-and-temperature-controlled-cabinet-mode.element.ts
@@ -15,7 +15,10 @@ import {
 } from "../../elements/index.js";
 
 export const RefrigeratorAndTemperatureControlledCabinetMode = Cluster(
-    { name: "RefrigeratorAndTemperatureControlledCabinetMode", id: 0x52, type: "ModeBase" },
+    {
+        name: "RefrigeratorAndTemperatureControlledCabinetMode", id: 0x52, type: "ModeBase",
+        classification: "application"
+    },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 3 }),
     Attribute(
         { name: "FeatureMap", id: 0xfffc, type: "FeatureMap" },

--- a/packages/model/src/standard/elements/refrigerator-device.element.ts
+++ b/packages/model/src/standard/elements/refrigerator-device.element.ts
@@ -10,7 +10,7 @@ import { MatterDefinition } from "../MatterDefinition.js";
 import { DeviceTypeElement as DeviceType, RequirementElement as Requirement } from "../../elements/index.js";
 
 export const RefrigeratorDt = DeviceType(
-    { name: "Refrigerator", id: 0x70 },
+    { name: "Refrigerator", id: 0x70, classification: "simple" },
     Requirement(
         { name: "Descriptor", id: 0x1d, element: "serverCluster" },
         Requirement({ name: "DeviceTypeList", default: [ { deviceType: 112, revision: 2 } ], element: "attribute" })

--- a/packages/model/src/standard/elements/relative-humidity-measurement.element.ts
+++ b/packages/model/src/standard/elements/relative-humidity-measurement.element.ts
@@ -10,7 +10,7 @@ import { MatterDefinition } from "../MatterDefinition.js";
 import { ClusterElement as Cluster, AttributeElement as Attribute } from "../../elements/index.js";
 
 export const RelativeHumidityMeasurement = Cluster(
-    { name: "RelativeHumidityMeasurement", id: 0x405 },
+    { name: "RelativeHumidityMeasurement", id: 0x405, classification: "application" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 3 }),
     Attribute({
         name: "MeasuredValue", id: 0x0, type: "uint16", access: "R V", conformance: "M",

--- a/packages/model/src/standard/elements/resource-monitoring.element.ts
+++ b/packages/model/src/standard/elements/resource-monitoring.element.ts
@@ -16,7 +16,7 @@ import {
 } from "../../elements/index.js";
 
 export const ResourceMonitoring = Cluster(
-    { name: "ResourceMonitoring" },
+    { name: "ResourceMonitoring", classification: "application" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 1 }),
 
     Attribute(

--- a/packages/model/src/standard/elements/robotic-vacuum-cleaner.element.ts
+++ b/packages/model/src/standard/elements/robotic-vacuum-cleaner.element.ts
@@ -10,7 +10,7 @@ import { MatterDefinition } from "../MatterDefinition.js";
 import { DeviceTypeElement as DeviceType, RequirementElement as Requirement } from "../../elements/index.js";
 
 export const RoboticVacuumCleanerDt = DeviceType(
-    { name: "RoboticVacuumCleaner", id: 0x74 },
+    { name: "RoboticVacuumCleaner", id: 0x74, classification: "simple" },
     Requirement(
         { name: "Descriptor", id: 0x1d, element: "serverCluster" },
         Requirement({ name: "DeviceTypeList", default: [ { deviceType: 116, revision: 4 } ], element: "attribute" })

--- a/packages/model/src/standard/elements/room-air-conditioner-device.element.ts
+++ b/packages/model/src/standard/elements/room-air-conditioner-device.element.ts
@@ -10,7 +10,7 @@ import { MatterDefinition } from "../MatterDefinition.js";
 import { DeviceTypeElement as DeviceType, RequirementElement as Requirement } from "../../elements/index.js";
 
 export const RoomAirConditionerDt = DeviceType(
-    { name: "RoomAirConditioner", id: 0x72 },
+    { name: "RoomAirConditioner", id: 0x72, classification: "simple" },
     Requirement(
         { name: "Descriptor", id: 0x1d, element: "serverCluster" },
         Requirement({ name: "DeviceTypeList", default: [ { deviceType: 114, revision: 2 } ], element: "attribute" })

--- a/packages/model/src/standard/elements/root-node.element.ts
+++ b/packages/model/src/standard/elements/root-node.element.ts
@@ -14,7 +14,7 @@ import {
 } from "../../elements/index.js";
 
 export const RootNodeDt = DeviceType(
-    { name: "RootNode", id: 0x16 },
+    { name: "RootNode", id: 0x16, classification: "node" },
     Requirement(
         { name: "Descriptor", id: 0x1d, element: "serverCluster" },
         Requirement({ name: "DeviceTypeList", default: [ { deviceType: 22, revision: 3 } ], element: "attribute" })

--- a/packages/model/src/standard/elements/rvc-clean-mode.element.ts
+++ b/packages/model/src/standard/elements/rvc-clean-mode.element.ts
@@ -15,7 +15,7 @@ import {
 } from "../../elements/index.js";
 
 export const RvcCleanMode = Cluster(
-    { name: "RvcCleanMode", id: 0x55, type: "ModeBase" },
+    { name: "RvcCleanMode", id: 0x55, type: "ModeBase", classification: "application" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 4 }),
     Attribute(
         { name: "FeatureMap", id: 0xfffc, type: "FeatureMap" },

--- a/packages/model/src/standard/elements/rvc-operational-state.element.ts
+++ b/packages/model/src/standard/elements/rvc-operational-state.element.ts
@@ -16,7 +16,7 @@ import {
 } from "../../elements/index.js";
 
 export const RvcOperationalState = Cluster(
-    { name: "RvcOperationalState", id: 0x61, type: "OperationalState" },
+    { name: "RvcOperationalState", id: 0x61, type: "OperationalState", classification: "application" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 3 }),
     Command({ name: "Pause", id: 0x0 }),
     Command({ name: "Stop", id: 0x1, conformance: "X" }),

--- a/packages/model/src/standard/elements/rvc-run-mode.element.ts
+++ b/packages/model/src/standard/elements/rvc-run-mode.element.ts
@@ -15,7 +15,7 @@ import {
 } from "../../elements/index.js";
 
 export const RvcRunMode = Cluster(
-    { name: "RvcRunMode", id: 0x54, type: "ModeBase" },
+    { name: "RvcRunMode", id: 0x54, type: "ModeBase", classification: "application" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 3 }),
     Attribute(
         { name: "FeatureMap", id: 0xfffc, type: "FeatureMap" },

--- a/packages/model/src/standard/elements/scenes-management.element.ts
+++ b/packages/model/src/standard/elements/scenes-management.element.ts
@@ -16,7 +16,7 @@ import {
 } from "../../elements/index.js";
 
 export const ScenesManagement = Cluster(
-    { name: "ScenesManagement", id: 0x62 },
+    { name: "ScenesManagement", id: 0x62, classification: "application" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 1 }),
     Attribute(
         { name: "FeatureMap", id: 0xfffc, type: "FeatureMap" },

--- a/packages/model/src/standard/elements/secondary-network-interface.element.ts
+++ b/packages/model/src/standard/elements/secondary-network-interface.element.ts
@@ -10,7 +10,7 @@ import { MatterDefinition } from "../MatterDefinition.js";
 import { DeviceTypeElement as DeviceType, RequirementElement as Requirement } from "../../elements/index.js";
 
 export const SecondaryNetworkInterfaceDt = DeviceType(
-    { name: "SecondaryNetworkInterface", id: 0x19 },
+    { name: "SecondaryNetworkInterface", id: 0x19, classification: "utility" },
     Requirement(
         { name: "Descriptor", id: 0x1d, element: "serverCluster" },
         Requirement({ name: "DeviceTypeList", default: [ { deviceType: 25, revision: 1 } ], element: "attribute" })

--- a/packages/model/src/standard/elements/service-area.element.ts
+++ b/packages/model/src/standard/elements/service-area.element.ts
@@ -16,7 +16,7 @@ import {
 } from "../../elements/index.js";
 
 export const ServiceArea = Cluster(
-    { name: "ServiceArea", id: 0x150 },
+    { name: "ServiceArea", id: 0x150, classification: "application" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 2 }),
 
     Attribute(

--- a/packages/model/src/standard/elements/smoke-co-alarm-cluster.element.ts
+++ b/packages/model/src/standard/elements/smoke-co-alarm-cluster.element.ts
@@ -17,7 +17,7 @@ import {
 } from "../../elements/index.js";
 
 export const SmokeCoAlarm = Cluster(
-    { name: "SmokeCoAlarm", id: 0x5c },
+    { name: "SmokeCoAlarm", id: 0x5c, classification: "application" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 1 }),
     Attribute(
         { name: "FeatureMap", id: 0xfffc, type: "FeatureMap" },

--- a/packages/model/src/standard/elements/smoke-co-alarm-device.element.ts
+++ b/packages/model/src/standard/elements/smoke-co-alarm-device.element.ts
@@ -10,7 +10,7 @@ import { MatterDefinition } from "../MatterDefinition.js";
 import { DeviceTypeElement as DeviceType, RequirementElement as Requirement } from "../../elements/index.js";
 
 export const SmokeCoAlarmDt = DeviceType(
-    { name: "SmokeCoAlarm", id: 0x76 },
+    { name: "SmokeCoAlarm", id: 0x76, classification: "simple" },
     Requirement(
         { name: "Descriptor", id: 0x1d, element: "serverCluster" },
         Requirement({ name: "DeviceTypeList", default: [ { deviceType: 118, revision: 1 } ], element: "attribute" })

--- a/packages/model/src/standard/elements/software-diagnostics.element.ts
+++ b/packages/model/src/standard/elements/software-diagnostics.element.ts
@@ -17,7 +17,7 @@ import {
 } from "../../elements/index.js";
 
 export const SoftwareDiagnostics = Cluster(
-    { name: "SoftwareDiagnostics", id: 0x34, quality: "K" },
+    { name: "SoftwareDiagnostics", id: 0x34, classification: "node", quality: "K" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 1 }),
     Attribute(
         { name: "FeatureMap", id: 0xfffc, type: "FeatureMap" },

--- a/packages/model/src/standard/elements/solar-power.element.ts
+++ b/packages/model/src/standard/elements/solar-power.element.ts
@@ -10,7 +10,7 @@ import { MatterDefinition } from "../MatterDefinition.js";
 import { DeviceTypeElement as DeviceType, RequirementElement as Requirement } from "../../elements/index.js";
 
 export const SolarPowerDt = DeviceType(
-    { name: "SolarPower", id: 0x17 },
+    { name: "SolarPower", id: 0x17, classification: "simple" },
     Requirement(
         { name: "Descriptor", id: 0x1d, element: "serverCluster" },
         Requirement({ name: "DeviceTypeList", default: [ { deviceType: 23, revision: 1 } ], element: "attribute" })

--- a/packages/model/src/standard/elements/speaker.element.ts
+++ b/packages/model/src/standard/elements/speaker.element.ts
@@ -10,7 +10,7 @@ import { MatterDefinition } from "../MatterDefinition.js";
 import { DeviceTypeElement as DeviceType, RequirementElement as Requirement } from "../../elements/index.js";
 
 export const SpeakerDt = DeviceType(
-    { name: "Speaker", id: 0x22 },
+    { name: "Speaker", id: 0x22, classification: "simple" },
     Requirement(
         { name: "Descriptor", id: 0x1d, element: "serverCluster" },
         Requirement({ name: "DeviceTypeList", default: [ { deviceType: 34, revision: 1 } ], element: "attribute" })

--- a/packages/model/src/standard/elements/switch.element.ts
+++ b/packages/model/src/standard/elements/switch.element.ts
@@ -15,7 +15,7 @@ import {
 } from "../../elements/index.js";
 
 export const Switch = Cluster(
-    { name: "Switch", id: 0x3b },
+    { name: "Switch", id: 0x3b, classification: "application" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 2 }),
 
     Attribute(

--- a/packages/model/src/standard/elements/target-navigator.element.ts
+++ b/packages/model/src/standard/elements/target-navigator.element.ts
@@ -17,7 +17,7 @@ import {
 } from "../../elements/index.js";
 
 export const TargetNavigator = Cluster(
-    { name: "TargetNavigator", id: 0x505 },
+    { name: "TargetNavigator", id: 0x505, classification: "application" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 2 }),
     Attribute(
         { name: "TargetList", id: 0x0, type: "list", access: "R V", conformance: "M" },

--- a/packages/model/src/standard/elements/temperature-control.element.ts
+++ b/packages/model/src/standard/elements/temperature-control.element.ts
@@ -15,7 +15,7 @@ import {
 } from "../../elements/index.js";
 
 export const TemperatureControl = Cluster(
-    { name: "TemperatureControl", id: 0x56 },
+    { name: "TemperatureControl", id: 0x56, classification: "application" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 1 }),
 
     Attribute(

--- a/packages/model/src/standard/elements/temperature-controlled-cabinet.element.ts
+++ b/packages/model/src/standard/elements/temperature-controlled-cabinet.element.ts
@@ -14,7 +14,7 @@ import {
 } from "../../elements/index.js";
 
 export const TemperatureControlledCabinetDt = DeviceType(
-    { name: "TemperatureControlledCabinet", id: 0x71 },
+    { name: "TemperatureControlledCabinet", id: 0x71, classification: "simple" },
     Requirement(
         { name: "Descriptor", id: 0x1d, element: "serverCluster" },
         Requirement({ name: "DeviceTypeList", default: [ { deviceType: 113, revision: 5 } ], element: "attribute" })

--- a/packages/model/src/standard/elements/temperature-measurement.element.ts
+++ b/packages/model/src/standard/elements/temperature-measurement.element.ts
@@ -10,7 +10,7 @@ import { MatterDefinition } from "../MatterDefinition.js";
 import { ClusterElement as Cluster, AttributeElement as Attribute } from "../../elements/index.js";
 
 export const TemperatureMeasurement = Cluster(
-    { name: "TemperatureMeasurement", id: 0x402 },
+    { name: "TemperatureMeasurement", id: 0x402, classification: "application" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 4 }),
     Attribute({
         name: "MeasuredValue", id: 0x0, type: "temperature", access: "R V", conformance: "M",

--- a/packages/model/src/standard/elements/temperature-sensor.element.ts
+++ b/packages/model/src/standard/elements/temperature-sensor.element.ts
@@ -10,7 +10,7 @@ import { MatterDefinition } from "../MatterDefinition.js";
 import { DeviceTypeElement as DeviceType, RequirementElement as Requirement } from "../../elements/index.js";
 
 export const TemperatureSensorDt = DeviceType(
-    { name: "TemperatureSensor", id: 0x302 },
+    { name: "TemperatureSensor", id: 0x302, classification: "simple" },
     Requirement(
         { name: "Descriptor", id: 0x1d, element: "serverCluster" },
         Requirement({ name: "DeviceTypeList", default: [ { deviceType: 770, revision: 2 } ], element: "attribute" })

--- a/packages/model/src/standard/elements/thermostat-cluster.element.ts
+++ b/packages/model/src/standard/elements/thermostat-cluster.element.ts
@@ -16,7 +16,7 @@ import {
 } from "../../elements/index.js";
 
 export const Thermostat = Cluster(
-    { name: "Thermostat", id: 0x201 },
+    { name: "Thermostat", id: 0x201, classification: "application" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 9 }),
 
     Attribute(

--- a/packages/model/src/standard/elements/thermostat-controller.element.ts
+++ b/packages/model/src/standard/elements/thermostat-controller.element.ts
@@ -10,7 +10,7 @@ import { MatterDefinition } from "../MatterDefinition.js";
 import { DeviceTypeElement as DeviceType, RequirementElement as Requirement } from "../../elements/index.js";
 
 export const ThermostatControllerDt = DeviceType(
-    { name: "ThermostatController", id: 0x30a },
+    { name: "ThermostatController", id: 0x30a, classification: "simple" },
     Requirement(
         { name: "Descriptor", id: 0x1d, element: "serverCluster" },
         Requirement({ name: "DeviceTypeList", default: [ { deviceType: 778, revision: 1 } ], element: "attribute" })

--- a/packages/model/src/standard/elements/thermostat-device.element.ts
+++ b/packages/model/src/standard/elements/thermostat-device.element.ts
@@ -10,7 +10,7 @@ import { MatterDefinition } from "../MatterDefinition.js";
 import { DeviceTypeElement as DeviceType, RequirementElement as Requirement } from "../../elements/index.js";
 
 export const ThermostatDt = DeviceType(
-    { name: "Thermostat", id: 0x301 },
+    { name: "Thermostat", id: 0x301, classification: "simple" },
     Requirement(
         { name: "Descriptor", id: 0x1d, element: "serverCluster" },
         Requirement({ name: "DeviceTypeList", default: [ { deviceType: 769, revision: 4 } ], element: "attribute" })

--- a/packages/model/src/standard/elements/thermostat-user-interface-configuration.element.ts
+++ b/packages/model/src/standard/elements/thermostat-user-interface-configuration.element.ts
@@ -15,7 +15,7 @@ import {
 } from "../../elements/index.js";
 
 export const ThermostatUserInterfaceConfiguration = Cluster(
-    { name: "ThermostatUserInterfaceConfiguration", id: 0x204 },
+    { name: "ThermostatUserInterfaceConfiguration", id: 0x204, classification: "application" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 2 }),
     Attribute({ name: "TemperatureDisplayMode", id: 0x0, type: "TemperatureDisplayModeEnum", access: "RW VO", conformance: "M" }),
     Attribute({ name: "KeypadLockout", id: 0x1, type: "KeypadLockoutEnum", access: "RW VM", conformance: "M" }),

--- a/packages/model/src/standard/elements/thread-border-router-management.element.ts
+++ b/packages/model/src/standard/elements/thread-border-router-management.element.ts
@@ -15,7 +15,7 @@ import {
 } from "../../elements/index.js";
 
 export const ThreadBorderRouterManagement = Cluster(
-    { name: "ThreadBorderRouterManagement", id: 0x452 },
+    { name: "ThreadBorderRouterManagement", id: 0x452, classification: "application" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 1 }),
     Attribute(
         { name: "FeatureMap", id: 0xfffc, type: "FeatureMap" },

--- a/packages/model/src/standard/elements/thread-network-diagnostics.element.ts
+++ b/packages/model/src/standard/elements/thread-network-diagnostics.element.ts
@@ -17,7 +17,7 @@ import {
 } from "../../elements/index.js";
 
 export const ThreadNetworkDiagnostics = Cluster(
-    { name: "ThreadNetworkDiagnostics", id: 0x35, quality: "K" },
+    { name: "ThreadNetworkDiagnostics", id: 0x35, classification: "node", quality: "K" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 3 }),
 
     Attribute(

--- a/packages/model/src/standard/elements/thread-network-directory.element.ts
+++ b/packages/model/src/standard/elements/thread-network-directory.element.ts
@@ -16,7 +16,7 @@ import {
 } from "../../elements/index.js";
 
 export const ThreadNetworkDirectory = Cluster(
-    { name: "ThreadNetworkDirectory", id: 0x453 },
+    { name: "ThreadNetworkDirectory", id: 0x453, classification: "application" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 1 }),
     Attribute({
         name: "PreferredExtendedPanId", id: 0x0, type: "octstr", access: "RW VM", conformance: "M",

--- a/packages/model/src/standard/elements/time-format-localization.element.ts
+++ b/packages/model/src/standard/elements/time-format-localization.element.ts
@@ -15,7 +15,7 @@ import {
 } from "../../elements/index.js";
 
 export const TimeFormatLocalization = Cluster(
-    { name: "TimeFormatLocalization", id: 0x2c },
+    { name: "TimeFormatLocalization", id: 0x2c, classification: "node" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 1 }),
     Attribute(
         { name: "FeatureMap", id: 0xfffc, type: "FeatureMap" },

--- a/packages/model/src/standard/elements/time-synchronization.element.ts
+++ b/packages/model/src/standard/elements/time-synchronization.element.ts
@@ -17,7 +17,7 @@ import {
 } from "../../elements/index.js";
 
 export const TimeSynchronization = Cluster(
-    { name: "TimeSynchronization", id: 0x38 },
+    { name: "TimeSynchronization", id: 0x38, classification: "node" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 2 }),
 
     Attribute(

--- a/packages/model/src/standard/elements/unit-localization.element.ts
+++ b/packages/model/src/standard/elements/unit-localization.element.ts
@@ -15,7 +15,7 @@ import {
 } from "../../elements/index.js";
 
 export const UnitLocalization = Cluster(
-    { name: "UnitLocalization", id: 0x2d },
+    { name: "UnitLocalization", id: 0x2d, classification: "node" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 2 }),
     Attribute(
         { name: "FeatureMap", id: 0xfffc, type: "FeatureMap" },

--- a/packages/model/src/standard/elements/user-label.element.ts
+++ b/packages/model/src/standard/elements/user-label.element.ts
@@ -14,7 +14,7 @@ import {
 } from "../../elements/index.js";
 
 export const UserLabel = Cluster(
-    { name: "UserLabel", id: 0x41, type: "Label" },
+    { name: "UserLabel", id: 0x41, type: "Label", classification: "endpoint" },
 
     Attribute(
         {

--- a/packages/model/src/standard/elements/valve-configuration-and-control.element.ts
+++ b/packages/model/src/standard/elements/valve-configuration-and-control.element.ts
@@ -17,7 +17,7 @@ import {
 } from "../../elements/index.js";
 
 export const ValveConfigurationAndControl = Cluster(
-    { name: "ValveConfigurationAndControl", id: 0x81 },
+    { name: "ValveConfigurationAndControl", id: 0x81, classification: "application" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 1 }),
     Attribute(
         { name: "FeatureMap", id: 0xfffc, type: "FeatureMap" },

--- a/packages/model/src/standard/elements/video-remote-control.element.ts
+++ b/packages/model/src/standard/elements/video-remote-control.element.ts
@@ -10,7 +10,7 @@ import { MatterDefinition } from "../MatterDefinition.js";
 import { DeviceTypeElement as DeviceType, RequirementElement as Requirement } from "../../elements/index.js";
 
 export const VideoRemoteControlDt = DeviceType(
-    { name: "VideoRemoteControl", id: 0x2a },
+    { name: "VideoRemoteControl", id: 0x2a, classification: "simple" },
     Requirement(
         { name: "Descriptor", id: 0x1d, element: "serverCluster" },
         Requirement({ name: "DeviceTypeList", default: [ { deviceType: 42, revision: 2 } ], element: "attribute" })

--- a/packages/model/src/standard/elements/wake-on-lan.element.ts
+++ b/packages/model/src/standard/elements/wake-on-lan.element.ts
@@ -10,7 +10,7 @@ import { MatterDefinition } from "../MatterDefinition.js";
 import { ClusterElement as Cluster, AttributeElement as Attribute } from "../../elements/index.js";
 
 export const WakeOnLan = Cluster(
-    { name: "WakeOnLan", id: 0x503 },
+    { name: "WakeOnLan", id: 0x503, classification: "application" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 1 }),
     Attribute({
         name: "MacAddress", id: 0x0, type: "string", access: "R V", conformance: "O", constraint: "max 12",

--- a/packages/model/src/standard/elements/water-freeze-detector.element.ts
+++ b/packages/model/src/standard/elements/water-freeze-detector.element.ts
@@ -10,7 +10,7 @@ import { MatterDefinition } from "../MatterDefinition.js";
 import { DeviceTypeElement as DeviceType, RequirementElement as Requirement } from "../../elements/index.js";
 
 export const WaterFreezeDetectorDt = DeviceType(
-    { name: "WaterFreezeDetector", id: 0x41 },
+    { name: "WaterFreezeDetector", id: 0x41, classification: "simple" },
     Requirement(
         { name: "Descriptor", id: 0x1d, element: "serverCluster" },
         Requirement({ name: "DeviceTypeList", default: [ { deviceType: 65, revision: 1 } ], element: "attribute" })

--- a/packages/model/src/standard/elements/water-heater-management.element.ts
+++ b/packages/model/src/standard/elements/water-heater-management.element.ts
@@ -17,7 +17,7 @@ import {
 } from "../../elements/index.js";
 
 export const WaterHeaterManagement = Cluster(
-    { name: "WaterHeaterManagement", id: 0x94 },
+    { name: "WaterHeaterManagement", id: 0x94, classification: "application" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 2 }),
     Attribute(
         { name: "FeatureMap", id: 0xfffc, type: "FeatureMap" },

--- a/packages/model/src/standard/elements/water-heater-mode.element.ts
+++ b/packages/model/src/standard/elements/water-heater-mode.element.ts
@@ -15,7 +15,7 @@ import {
 } from "../../elements/index.js";
 
 export const WaterHeaterMode = Cluster(
-    { name: "WaterHeaterMode", id: 0x9e, type: "ModeBase" },
+    { name: "WaterHeaterMode", id: 0x9e, type: "ModeBase", classification: "application" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 1 }),
     Attribute(
         { name: "FeatureMap", id: 0xfffc, type: "FeatureMap" },

--- a/packages/model/src/standard/elements/water-heater.element.ts
+++ b/packages/model/src/standard/elements/water-heater.element.ts
@@ -10,7 +10,7 @@ import { MatterDefinition } from "../MatterDefinition.js";
 import { DeviceTypeElement as DeviceType, RequirementElement as Requirement } from "../../elements/index.js";
 
 export const WaterHeaterDt = DeviceType(
-    { name: "WaterHeater", id: 0x50f },
+    { name: "WaterHeater", id: 0x50f, classification: "simple" },
     Requirement(
         { name: "Descriptor", id: 0x1d, element: "serverCluster" },
         Requirement({ name: "DeviceTypeList", default: [ { deviceType: 1295, revision: 1 } ], element: "attribute" })

--- a/packages/model/src/standard/elements/water-leak-detector.element.ts
+++ b/packages/model/src/standard/elements/water-leak-detector.element.ts
@@ -10,7 +10,7 @@ import { MatterDefinition } from "../MatterDefinition.js";
 import { DeviceTypeElement as DeviceType, RequirementElement as Requirement } from "../../elements/index.js";
 
 export const WaterLeakDetectorDt = DeviceType(
-    { name: "WaterLeakDetector", id: 0x43 },
+    { name: "WaterLeakDetector", id: 0x43, classification: "simple" },
     Requirement(
         { name: "Descriptor", id: 0x1d, element: "serverCluster" },
         Requirement({ name: "DeviceTypeList", default: [ { deviceType: 67, revision: 1 } ], element: "attribute" })

--- a/packages/model/src/standard/elements/water-valve.element.ts
+++ b/packages/model/src/standard/elements/water-valve.element.ts
@@ -10,7 +10,7 @@ import { MatterDefinition } from "../MatterDefinition.js";
 import { DeviceTypeElement as DeviceType, RequirementElement as Requirement } from "../../elements/index.js";
 
 export const WaterValveDt = DeviceType(
-    { name: "WaterValve", id: 0x42 },
+    { name: "WaterValve", id: 0x42, classification: "simple" },
     Requirement(
         { name: "Descriptor", id: 0x1d, element: "serverCluster" },
         Requirement({ name: "DeviceTypeList", default: [ { deviceType: 66, revision: 1 } ], element: "attribute" })

--- a/packages/model/src/standard/elements/wi-fi-network-diagnostics.element.ts
+++ b/packages/model/src/standard/elements/wi-fi-network-diagnostics.element.ts
@@ -17,7 +17,7 @@ import {
 } from "../../elements/index.js";
 
 export const WiFiNetworkDiagnostics = Cluster(
-    { name: "WiFiNetworkDiagnostics", id: 0x36, quality: "K" },
+    { name: "WiFiNetworkDiagnostics", id: 0x36, classification: "node", quality: "K" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 1 }),
     Attribute(
         { name: "FeatureMap", id: 0xfffc, type: "FeatureMap" },

--- a/packages/model/src/standard/elements/wi-fi-network-management.element.ts
+++ b/packages/model/src/standard/elements/wi-fi-network-management.element.ts
@@ -15,7 +15,7 @@ import {
 } from "../../elements/index.js";
 
 export const WiFiNetworkManagement = Cluster(
-    { name: "WiFiNetworkManagement", id: 0x451 },
+    { name: "WiFiNetworkManagement", id: 0x451, classification: "application" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 1 }),
     Attribute({ name: "Ssid", id: 0x0, type: "octstr", access: "R V", conformance: "M", constraint: "1 to 32", quality: "X N" }),
     Attribute({ name: "PassphraseSurrogate", id: 0x1, type: "uint64", access: "R M", conformance: "M", quality: "X N" }),

--- a/packages/model/src/standard/elements/window-covering-cluster.element.ts
+++ b/packages/model/src/standard/elements/window-covering-cluster.element.ts
@@ -16,7 +16,7 @@ import {
 } from "../../elements/index.js";
 
 export const WindowCovering = Cluster(
-    { name: "WindowCovering", id: 0x102 },
+    { name: "WindowCovering", id: 0x102, classification: "application" },
     Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 6 }),
 
     Attribute(

--- a/packages/model/src/standard/elements/window-covering-controller.element.ts
+++ b/packages/model/src/standard/elements/window-covering-controller.element.ts
@@ -10,7 +10,7 @@ import { MatterDefinition } from "../MatterDefinition.js";
 import { DeviceTypeElement as DeviceType, RequirementElement as Requirement } from "../../elements/index.js";
 
 export const WindowCoveringControllerDt = DeviceType(
-    { name: "WindowCoveringController", id: 0x203 },
+    { name: "WindowCoveringController", id: 0x203, classification: "simple" },
     Requirement(
         { name: "Descriptor", id: 0x1d, element: "serverCluster" },
         Requirement({ name: "DeviceTypeList", default: [ { deviceType: 515, revision: 4 } ], element: "attribute" })

--- a/packages/model/src/standard/elements/window-covering-device.element.ts
+++ b/packages/model/src/standard/elements/window-covering-device.element.ts
@@ -10,7 +10,7 @@ import { MatterDefinition } from "../MatterDefinition.js";
 import { DeviceTypeElement as DeviceType, RequirementElement as Requirement } from "../../elements/index.js";
 
 export const WindowCoveringDt = DeviceType(
-    { name: "WindowCovering", id: 0x202 },
+    { name: "WindowCovering", id: 0x202, classification: "simple" },
     Requirement(
         { name: "Descriptor", id: 0x1d, element: "serverCluster" },
         Requirement({ name: "DeviceTypeList", default: [ { deviceType: 514, revision: 4 } ], element: "attribute" })

--- a/packages/model/src/standard/resources/access-control.resource.ts
+++ b/packages/model/src/standard/resources/access-control.resource.ts
@@ -10,7 +10,7 @@ import { Resource } from "#models/Resource.js";
 
 Resource.add(
     {
-        tag: "cluster", name: "AccessControl", classification: "node", pics: "ACL", xref: "core§9.10",
+        tag: "cluster", name: "AccessControl", pics: "ACL", xref: "core§9.10",
 
         details: "The Access Control Cluster exposes a data model view of a Node’s Access Control List (ACL), which " +
             "codifies the rules used to manage and enforce Access Control for the Node’s endpoints and their " +

--- a/packages/model/src/standard/resources/account-login.resource.ts
+++ b/packages/model/src/standard/resources/account-login.resource.ts
@@ -9,8 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "cluster", name: "AccountLogin", classification: "application", pics: "ALOGIN",
-    xref: "cluster§6.2",
+    tag: "cluster", name: "AccountLogin", pics: "ALOGIN", xref: "cluster§6.2",
 
     details: "This cluster provides commands that facilitate user account login on a Content App or a node. For " +
         "example, a Content App running on a Video Player device, which is represented as an endpoint (see " +

--- a/packages/model/src/standard/resources/actions.resource.ts
+++ b/packages/model/src/standard/resources/actions.resource.ts
@@ -10,7 +10,7 @@ import { Resource } from "#models/Resource.js";
 
 Resource.add(
     {
-        tag: "cluster", name: "Actions", classification: "application", pics: "ACT", xref: "core§9.14",
+        tag: "cluster", name: "Actions", pics: "ACT", xref: "core§9.14",
 
         details: "This cluster provides a standardized way for a Node (typically a Bridge, but could be any Node) to " +
             "expose logical grouping and actions." +

--- a/packages/model/src/standard/resources/administrator-commissioning.resource.ts
+++ b/packages/model/src/standard/resources/administrator-commissioning.resource.ts
@@ -9,8 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "cluster", name: "AdministratorCommissioning", classification: "node", pics: "CADMIN",
-    xref: "core§11.19",
+    tag: "cluster", name: "AdministratorCommissioning", pics: "CADMIN", xref: "core§11.19",
 
     details: "This cluster is used to trigger a Node to allow a new Administrator to commission it. It defines " +
         "Attributes, Commands and Responses needed for this purpose." +

--- a/packages/model/src/standard/resources/aggregator.resource.ts
+++ b/packages/model/src/standard/resources/aggregator.resource.ts
@@ -9,7 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "deviceType", name: "Aggregator", classification: "simple", xref: "device§11.2",
+    tag: "deviceType", name: "Aggregator", xref: "device§11.2",
 
     details: "This device type aggregates endpoints as a collection. Clusters on the endpoint indicating this " +
         "device type provide functionality for the collection of descendant endpoints present in the " +

--- a/packages/model/src/standard/resources/air-purifier.resource.ts
+++ b/packages/model/src/standard/resources/air-purifier.resource.ts
@@ -9,7 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "deviceType", name: "AirPurifier", classification: "simple", xref: "device§9.3",
+    tag: "deviceType", name: "AirPurifier", xref: "device§9.3",
     details: "An Air Purifier is a standalone device that is designed to clean the air in a room." +
         "\n" +
         "It is a device that has a fan to control the air speed while it is operating. Optionally, it can " +

--- a/packages/model/src/standard/resources/air-quality-sensor.resource.ts
+++ b/packages/model/src/standard/resources/air-quality-sensor.resource.ts
@@ -9,7 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "deviceType", name: "AirQualitySensor", classification: "simple", xref: "device§7.10",
+    tag: "deviceType", name: "AirQualitySensor", xref: "device§7.10",
     details: "This defines conformance for the Air Quality Sensor device type." +
         "\n" +
         "An air quality sensor is a device designed to monitor and measure various parameters related to the " +

--- a/packages/model/src/standard/resources/air-quality.resource.ts
+++ b/packages/model/src/standard/resources/air-quality.resource.ts
@@ -9,8 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "cluster", name: "AirQuality", classification: "application", pics: "AIRQUAL",
-    xref: "cluster§2.9",
+    tag: "cluster", name: "AirQuality", pics: "AIRQUAL", xref: "cluster§2.9",
     details: "This cluster provides an interface to air quality classification using distinct levels with " +
         "human-readable labels.",
 

--- a/packages/model/src/standard/resources/alarm-base.resource.ts
+++ b/packages/model/src/standard/resources/alarm-base.resource.ts
@@ -9,8 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "cluster", name: "AlarmBase", classification: "application", pics: "ALARM",
-    xref: "cluster§1.15",
+    tag: "cluster", name: "AlarmBase", pics: "ALARM", xref: "cluster§1.15",
     details: "This cluster is a base cluster from which clusters for particular alarms for a device type can be " +
         "derived. Each derivation shall define the values for the AlarmBitmap data type used in this cluster. " +
         "Each derivation shall define which alarms are latched.",

--- a/packages/model/src/standard/resources/application-basic.resource.ts
+++ b/packages/model/src/standard/resources/application-basic.resource.ts
@@ -9,8 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "cluster", name: "ApplicationBasic", classification: "application", pics: "APBSC",
-    xref: "cluster§6.3",
+    tag: "cluster", name: "ApplicationBasic", pics: "APBSC", xref: "cluster§6.3",
 
     details: "This cluster provides information about a Content App running on a Video Player device which is " +
         "represented as an endpoint (see Device Type Library document)." +

--- a/packages/model/src/standard/resources/application-launcher.resource.ts
+++ b/packages/model/src/standard/resources/application-launcher.resource.ts
@@ -9,8 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "cluster", name: "ApplicationLauncher", classification: "application", pics: "APPLAUNCHER",
-    xref: "cluster§6.4",
+    tag: "cluster", name: "ApplicationLauncher", pics: "APPLAUNCHER", xref: "cluster§6.4",
 
     details: "This cluster provides an interface for launching applications on a Video Player device such as a TV." +
         "\n" +

--- a/packages/model/src/standard/resources/audio-output.resource.ts
+++ b/packages/model/src/standard/resources/audio-output.resource.ts
@@ -9,8 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "cluster", name: "AudioOutput", classification: "application", pics: "AUDIOOUTPUT",
-    xref: "cluster§6.5",
+    tag: "cluster", name: "AudioOutput", pics: "AUDIOOUTPUT", xref: "cluster§6.5",
 
     details: "This cluster provides an interface for controlling the Output on a Video Player device such as a TV." +
         "\n" +

--- a/packages/model/src/standard/resources/base.resource.ts
+++ b/packages/model/src/standard/resources/base.resource.ts
@@ -9,7 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "deviceType", name: "Base", classification: "base", xref: "device§1.1",
+    tag: "deviceType", name: "Base", xref: "device§1.1",
 
     children: [
         {

--- a/packages/model/src/standard/resources/basic-information.resource.ts
+++ b/packages/model/src/standard/resources/basic-information.resource.ts
@@ -9,7 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "cluster", name: "BasicInformation", classification: "node", pics: "BINFO", xref: "core§11.1",
+    tag: "cluster", name: "BasicInformation", pics: "BINFO", xref: "core§11.1",
     details: "This cluster provides attributes and events for determining basic information about Nodes, which " +
         "supports both Commissioning and operational determination of Node characteristics, such as Vendor " +
         "ID, Product ID and serial number, which apply to the whole Node.",

--- a/packages/model/src/standard/resources/basic-video-player.resource.ts
+++ b/packages/model/src/standard/resources/basic-video-player.resource.ts
@@ -9,7 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "deviceType", name: "BasicVideoPlayer", classification: "simple", xref: "device§10.2",
+    tag: "deviceType", name: "BasicVideoPlayer", xref: "device§10.2",
 
     details: "This defines conformance to the Basic Video Player device type." +
         "\n" +

--- a/packages/model/src/standard/resources/battery-storage.resource.ts
+++ b/packages/model/src/standard/resources/battery-storage.resource.ts
@@ -9,7 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "deviceType", name: "BatteryStorage", classification: "simple", xref: "device§14.4",
+    tag: "deviceType", name: "BatteryStorage", xref: "device§14.4",
     details: "A Battery Storage device is a device that allows a DC battery, which can optionally be comprised of " +
         "a set parallel strings of battery packs and associated controller, and an AC inverter, to be " +
         "monitored and controlled by an Energy Management System in order to manage the peaks and troughs of " +

--- a/packages/model/src/standard/resources/binding.resource.ts
+++ b/packages/model/src/standard/resources/binding.resource.ts
@@ -9,7 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "cluster", name: "Binding", classification: "endpoint", pics: "BIND", xref: "core§9.6",
+    tag: "cluster", name: "Binding", pics: "BIND", xref: "core§9.6",
 
     details: "> [!NOTE]" +
         "\n" +

--- a/packages/model/src/standard/resources/boolean-state-configuration.resource.ts
+++ b/packages/model/src/standard/resources/boolean-state-configuration.resource.ts
@@ -10,8 +10,7 @@ import { Resource } from "#models/Resource.js";
 
 Resource.add(
     {
-        tag: "cluster", name: "BooleanStateConfiguration", classification: "application", pics: "BOOLCFG",
-        xref: "cluster§1.8",
+        tag: "cluster", name: "BooleanStateConfiguration", pics: "BOOLCFG", xref: "cluster§1.8",
         details: "This cluster is used to configure a boolean sensor, including optional state change alarm features " +
             "and configuration of the sensitivity level associated with the sensor.",
 

--- a/packages/model/src/standard/resources/boolean-state.resource.ts
+++ b/packages/model/src/standard/resources/boolean-state.resource.ts
@@ -9,8 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "cluster", name: "BooleanState", classification: "application", pics: "BOOL",
-    xref: "cluster§1.7",
+    tag: "cluster", name: "BooleanState", pics: "BOOL", xref: "cluster§1.7",
     details: "This cluster provides an interface to a boolean state.",
 
     children: [

--- a/packages/model/src/standard/resources/bridged-device-basic-information.resource.ts
+++ b/packages/model/src/standard/resources/bridged-device-basic-information.resource.ts
@@ -9,8 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "cluster", name: "BridgedDeviceBasicInformation", classification: "endpoint", pics: "BRBINFO",
-    xref: "core§9.13",
+    tag: "cluster", name: "BridgedDeviceBasicInformation", pics: "BRBINFO", xref: "core§9.13",
 
     details: "This cluster provides attributes and events for determining basic information about Bridged Nodes." +
         "\n" +

--- a/packages/model/src/standard/resources/bridged-node.resource.ts
+++ b/packages/model/src/standard/resources/bridged-node.resource.ts
@@ -9,7 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "deviceType", name: "BridgedNode", classification: "utility", xref: "device§2.5",
+    tag: "deviceType", name: "BridgedNode", xref: "device§2.5",
     details: "This defines conformance for a Bridged Node root endpoint. This endpoint is akin to a \"read me " +
         "first\" endpoint that describes itself and any other endpoints that make up the Bridged Node. A " +
         "Bridged Node endpoint represents a device on a foreign network, but is not the root endpoint of the " +

--- a/packages/model/src/standard/resources/casting-video-client.resource.ts
+++ b/packages/model/src/standard/resources/casting-video-client.resource.ts
@@ -9,7 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "deviceType", name: "CastingVideoClient", classification: "simple", xref: "device§10.6",
+    tag: "deviceType", name: "CastingVideoClient", xref: "device§10.6",
     details: "This defines conformance to the Casting Video Client device type." +
         "\n" +
         "A Casting Video Client is a client that can launch content on a Casting Video Player, for example, a " +

--- a/packages/model/src/standard/resources/casting-video-player.resource.ts
+++ b/packages/model/src/standard/resources/casting-video-player.resource.ts
@@ -9,7 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "deviceType", name: "CastingVideoPlayer", classification: "simple", xref: "device§10.3",
+    tag: "deviceType", name: "CastingVideoPlayer", xref: "device§10.3",
 
     details: "This defines conformance to the Casting Video Player device type." +
         "\n" +

--- a/packages/model/src/standard/resources/channel.resource.ts
+++ b/packages/model/src/standard/resources/channel.resource.ts
@@ -9,8 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "cluster", name: "Channel", classification: "application", pics: "CHANNEL",
-    xref: "cluster§6.6",
+    tag: "cluster", name: "Channel", pics: "CHANNEL", xref: "cluster§6.6",
 
     details: "This cluster provides an interface for controlling the current Channel on a device or endpoint." +
         "\n" +

--- a/packages/model/src/standard/resources/color-control.resource.ts
+++ b/packages/model/src/standard/resources/color-control.resource.ts
@@ -10,8 +10,7 @@ import { Resource } from "#models/Resource.js";
 
 Resource.add(
     {
-        tag: "cluster", name: "ColorControl", classification: "application", pics: "CC",
-        xref: "cluster§3.2",
+        tag: "cluster", name: "ColorControl", pics: "CC", xref: "cluster§3.2",
 
         details: "This cluster provides an interface for changing the color of a light. Color is specified according " +
             "to the CIE 1931 Color space. Color control is carried out in terms of x,y values, as defined by this " +

--- a/packages/model/src/standard/resources/color-dimmer-switch.resource.ts
+++ b/packages/model/src/standard/resources/color-dimmer-switch.resource.ts
@@ -9,7 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "deviceType", name: "ColorDimmerSwitch", classification: "simple", xref: "device§6.3",
+    tag: "deviceType", name: "ColorDimmerSwitch", xref: "device§6.3",
     details: "A Color Dimmer Switch is a controller device that, when bound to a lighting device such as an " +
         "Extended Color Light, is capable of being used to adjust the color of the light being emitted.",
 

--- a/packages/model/src/standard/resources/color-temperature-light.resource.ts
+++ b/packages/model/src/standard/resources/color-temperature-light.resource.ts
@@ -9,7 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "deviceType", name: "ColorTemperatureLight", classification: "simple", xref: "device§4.3",
+    tag: "deviceType", name: "ColorTemperatureLight", xref: "device§4.3",
     details: "A Color Temperature Light is a lighting device that is capable of being switched on or off, the " +
         "intensity of its light adjusted, and its color temperature adjusted by means of a bound controller " +
         "device such as a Color Dimmer Switch.",

--- a/packages/model/src/standard/resources/commissioner-control.resource.ts
+++ b/packages/model/src/standard/resources/commissioner-control.resource.ts
@@ -9,8 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "cluster", name: "CommissionerControl", classification: "node", pics: "CCTRL",
-    xref: "core§11.26",
+    tag: "cluster", name: "CommissionerControl", pics: "CCTRL", xref: "core§11.26",
 
     details: "The Commissioner Control Cluster supports the ability for clients to request the commissioning of " +
         "themselves or other nodes onto a fabric which the cluster server can commission onto. An example use " +

--- a/packages/model/src/standard/resources/concentration-measurement.resource.ts
+++ b/packages/model/src/standard/resources/concentration-measurement.resource.ts
@@ -9,8 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "cluster", name: "ConcentrationMeasurement", classification: "application", pics: "CONC",
-    xref: "cluster§2.10",
+    tag: "cluster", name: "ConcentrationMeasurement", pics: "CONC", xref: "cluster§2.10",
     details: "The server cluster provides an interface to concentration measurement functionality. This cluster " +
         "shall to be used via an alias to a specific substance (see Cluster IDs).",
 

--- a/packages/model/src/standard/resources/contact-sensor.resource.ts
+++ b/packages/model/src/standard/resources/contact-sensor.resource.ts
@@ -9,7 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "deviceType", name: "ContactSensor", classification: "simple", xref: "device§7.1",
+    tag: "deviceType", name: "ContactSensor", xref: "device§7.1",
     details: "This defines conformance to the Contact Sensor device type.",
     children: [
         { tag: "requirement", name: "Identify", xref: "device§7.1.4" },

--- a/packages/model/src/standard/resources/content-app-observer.resource.ts
+++ b/packages/model/src/standard/resources/content-app-observer.resource.ts
@@ -9,8 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "cluster", name: "ContentAppObserver", classification: "application", pics: "APPOBSERVER",
-    xref: "cluster§6.12",
+    tag: "cluster", name: "ContentAppObserver", pics: "APPOBSERVER", xref: "cluster§6.12",
 
     details: "This cluster provides an interface for sending targeted commands to an Observer of a Content App on " +
         "a Video Player device such as a Streaming Media Player, Smart TV or Smart Screen." +

--- a/packages/model/src/standard/resources/content-app.resource.ts
+++ b/packages/model/src/standard/resources/content-app.resource.ts
@@ -9,7 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "deviceType", name: "ContentApp", classification: "simple", xref: "device§10.5",
+    tag: "deviceType", name: "ContentApp", xref: "device§10.5",
     details: "This defines conformance to the Content App device type." +
         "\n" +
         "A Content App is usually an application built by a Content Provider. A Casting Video Player with a " +

--- a/packages/model/src/standard/resources/content-control.resource.ts
+++ b/packages/model/src/standard/resources/content-control.resource.ts
@@ -9,8 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "cluster", name: "ContentControl", classification: "application", pics: "CONCON",
-    xref: "cluster§6.13",
+    tag: "cluster", name: "ContentControl", pics: "CONCON", xref: "cluster§6.13",
 
     details: "This cluster is used for managing the content control (including \"parental control\") settings on a " +
         "media device such as a TV, or Set-top Box." +

--- a/packages/model/src/standard/resources/content-launcher.resource.ts
+++ b/packages/model/src/standard/resources/content-launcher.resource.ts
@@ -10,8 +10,7 @@ import { Resource } from "#models/Resource.js";
 
 Resource.add(
     {
-        tag: "cluster", name: "ContentLauncher", classification: "application", pics: "CONTENTLAUNCHER",
-        xref: "cluster§6.7",
+        tag: "cluster", name: "ContentLauncher", pics: "CONTENTLAUNCHER", xref: "cluster§6.7",
 
         details: "This cluster provides an interface for launching content on a Video Player device such as a " +
             "Streaming Media Player, Smart TV or Smart Screen." +

--- a/packages/model/src/standard/resources/control-bridge.resource.ts
+++ b/packages/model/src/standard/resources/control-bridge.resource.ts
@@ -9,7 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "deviceType", name: "ControlBridge", classification: "simple", xref: "device§6.4",
+    tag: "deviceType", name: "ControlBridge", xref: "device§6.4",
     details: "A Control Bridge is a controller device that, when bound to a lighting device such as an Extended " +
         "Color Light, is capable of being used to switch the device on or off, adjust the intensity of the " +
         "light being emitted and adjust the color of the light being emitted. In addition, a Control Bridge " +

--- a/packages/model/src/standard/resources/cook-surface.resource.ts
+++ b/packages/model/src/standard/resources/cook-surface.resource.ts
@@ -9,7 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "deviceType", name: "CookSurface", classification: "simple", xref: "device§13.7",
+    tag: "deviceType", name: "CookSurface", xref: "device§13.7",
     details: "A Cook Surface device type represents a heating object on a cooktop or other similar device. It " +
         "shall only be used when composed as part of another device type.",
     children: [

--- a/packages/model/src/standard/resources/cooktop.resource.ts
+++ b/packages/model/src/standard/resources/cooktop.resource.ts
@@ -9,7 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "deviceType", name: "Cooktop", classification: "simple", xref: "device§13.8",
+    tag: "deviceType", name: "Cooktop", xref: "device§13.8",
     details: "A cooktop is a cooking surface that heats food either by transferring currents from an " +
         "electromagnetic field located below the glass surface directly to the magnetic induction cookware " +
         "placed above or through traditional gas or electric burners.",

--- a/packages/model/src/standard/resources/descriptor.resource.ts
+++ b/packages/model/src/standard/resources/descriptor.resource.ts
@@ -9,7 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "cluster", name: "Descriptor", classification: "endpoint", pics: "DESC", xref: "core§9.5",
+    tag: "cluster", name: "Descriptor", pics: "DESC", xref: "core§9.5",
 
     details: "> [!NOTE]" +
         "\n" +

--- a/packages/model/src/standard/resources/device-energy-management-cluster.resource.ts
+++ b/packages/model/src/standard/resources/device-energy-management-cluster.resource.ts
@@ -10,8 +10,7 @@ import { Resource } from "#models/Resource.js";
 
 Resource.add(
     {
-        tag: "cluster", name: "DeviceEnergyManagement", classification: "application", pics: "DEM",
-        xref: "cluster§9.2",
+        tag: "cluster", name: "DeviceEnergyManagement", pics: "DEM", xref: "cluster§9.2",
 
         details: "This cluster allows a client to manage the power draw of a device. An example of such a client could " +
             "be an Energy Management System (EMS) which controls an Energy Smart Appliance (ESA)." +

--- a/packages/model/src/standard/resources/device-energy-management-device.resource.ts
+++ b/packages/model/src/standard/resources/device-energy-management-device.resource.ts
@@ -9,7 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "deviceType", name: "DeviceEnergyManagement", classification: "utility", xref: "device§2.7",
+    tag: "deviceType", name: "DeviceEnergyManagement", xref: "device§2.7",
     details: "A Device Energy Management device provides reporting and optionally adjustment of the electrical " +
         "power planned on being consumed or produced by the device.",
 

--- a/packages/model/src/standard/resources/device-energy-management-mode.resource.ts
+++ b/packages/model/src/standard/resources/device-energy-management-mode.resource.ts
@@ -9,8 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "cluster", name: "DeviceEnergyManagementMode", classification: "application", pics: "DEMM",
-    xref: "cluster§9.8",
+    tag: "cluster", name: "DeviceEnergyManagementMode", pics: "DEMM", xref: "cluster§9.8",
     details: "This cluster is derived from the Mode Base cluster and defines additional mode tags and namespaced " +
         "enumerated values for Device Energy Management devices.",
 

--- a/packages/model/src/standard/resources/diagnostic-logs.resource.ts
+++ b/packages/model/src/standard/resources/diagnostic-logs.resource.ts
@@ -9,7 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "cluster", name: "DiagnosticLogs", classification: "node", pics: "DLOG", xref: "core§11.11",
+    tag: "cluster", name: "DiagnosticLogs", pics: "DLOG", xref: "core§11.11",
     details: "This Cluster supports an interface to a Node. It provides commands for retrieving unstructured " +
         "diagnostic logs from a Node that may be used to aid in diagnostics. It will often be the case that " +
         "unstructured diagnostic logs will be Node-wide and not specific to any subset of Endpoints. When " +

--- a/packages/model/src/standard/resources/dimmable-light.resource.ts
+++ b/packages/model/src/standard/resources/dimmable-light.resource.ts
@@ -9,7 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "deviceType", name: "DimmableLight", classification: "simple", xref: "device§4.2",
+    tag: "deviceType", name: "DimmableLight", xref: "device§4.2",
     details: "A Dimmable Light is a lighting device that is capable of being switched on or off and the intensity " +
         "of its light adjusted by means of a bound controller device such as a Dimmer Switch or a Color " +
         "Dimmer Switch. In addition, a Dimmable Light device is also capable of being switched by means of a " +

--- a/packages/model/src/standard/resources/dimmable-plug-in-unit.resource.ts
+++ b/packages/model/src/standard/resources/dimmable-plug-in-unit.resource.ts
@@ -9,7 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "deviceType", name: "DimmablePlugInUnit", classification: "simple", xref: "device§5.2",
+    tag: "deviceType", name: "DimmablePlugInUnit", xref: "device§5.2",
 
     details: "A Dimmable Plug-In Unit is a device that provides power to another device that is plugged into it, " +
         "and is capable of being switched on or off and have its level adjusted. The Dimmable Plug-in Unit is " +

--- a/packages/model/src/standard/resources/dimmer-switch.resource.ts
+++ b/packages/model/src/standard/resources/dimmer-switch.resource.ts
@@ -9,7 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "deviceType", name: "DimmerSwitch", classification: "simple", xref: "device§6.2",
+    tag: "deviceType", name: "DimmerSwitch", xref: "device§6.2",
     details: "A Dimmer Switch is a controller device that, when bound to a lighting device such as a Dimmable " +
         "Light, is capable of being used to switch the device on or off and adjust the intensity of the light " +
         "being emitted.",

--- a/packages/model/src/standard/resources/dishwasher-alarm.resource.ts
+++ b/packages/model/src/standard/resources/dishwasher-alarm.resource.ts
@@ -9,8 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "cluster", name: "DishwasherAlarm", classification: "application", pics: "DISHALM",
-    xref: "cluster§8.4",
+    tag: "cluster", name: "DishwasherAlarm", pics: "DISHALM", xref: "cluster§8.4",
     details: "This cluster is a derived cluster of the Alarm Base cluster and provides the alarm definition " +
         "related to dishwasher devices.",
 

--- a/packages/model/src/standard/resources/dishwasher-mode.resource.ts
+++ b/packages/model/src/standard/resources/dishwasher-mode.resource.ts
@@ -9,8 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "cluster", name: "DishwasherMode", classification: "application", pics: "DISHM",
-    xref: "cluster§8.3",
+    tag: "cluster", name: "DishwasherMode", pics: "DISHM", xref: "cluster§8.3",
     details: "This cluster is derived from the Mode Base cluster and defines additional mode tags and namespaced " +
         "enumerated values for dishwasher devices.",
 

--- a/packages/model/src/standard/resources/dishwasher.resource.ts
+++ b/packages/model/src/standard/resources/dishwasher.resource.ts
@@ -9,7 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "deviceType", name: "Dishwasher", classification: "simple", xref: "device§13.5",
+    tag: "deviceType", name: "Dishwasher", xref: "device§13.5",
     details: "A dishwasher is a device that is generally installed in residential homes and is capable of washing " +
         "dishes, cutlery, and other items associate with food preparation and consumption. The device can be " +
         "permanently installed or portable and can have variety of filling and draining methods.",

--- a/packages/model/src/standard/resources/door-lock-cluster.resource.ts
+++ b/packages/model/src/standard/resources/door-lock-cluster.resource.ts
@@ -10,7 +10,7 @@ import { Resource } from "#models/Resource.js";
 
 Resource.add(
     {
-        tag: "cluster", name: "DoorLock", classification: "application", pics: "DRLK", xref: "cluster§5.2",
+        tag: "cluster", name: "DoorLock", pics: "DRLK", xref: "cluster§5.2",
         details: "The door lock cluster provides an interface to a generic way to secure a door. The physical object " +
             "that provides the locking functionality is abstracted from the cluster. The cluster has a small list " +
             "of mandatory attributes and functions and a list of optional features.",

--- a/packages/model/src/standard/resources/door-lock-controller.resource.ts
+++ b/packages/model/src/standard/resources/door-lock-controller.resource.ts
@@ -9,7 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "deviceType", name: "DoorLockController", classification: "simple", xref: "device§8.2",
+    tag: "deviceType", name: "DoorLockController", xref: "device§8.2",
     details: "A Door Lock Controller is a device capable of controlling a door lock.",
 
     children: [

--- a/packages/model/src/standard/resources/door-lock-device.resource.ts
+++ b/packages/model/src/standard/resources/door-lock-device.resource.ts
@@ -9,7 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "deviceType", name: "DoorLock", classification: "simple", xref: "device§8.1",
+    tag: "deviceType", name: "DoorLock", xref: "device§8.1",
     details: "A Door Lock is a device used to secure a door. It is possible to actuate a door lock either by means " +
         "of a manual or a remote method.",
 

--- a/packages/model/src/standard/resources/ecosystem-information.resource.ts
+++ b/packages/model/src/standard/resources/ecosystem-information.resource.ts
@@ -9,8 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "cluster", name: "EcosystemInformation", classification: "endpoint", pics: "ECOINFO",
-    xref: "core§9.17",
+    tag: "cluster", name: "EcosystemInformation", pics: "ECOINFO", xref: "core§9.17",
 
     details: "The Ecosystem Information Cluster provides extended device information for all the logical devices " +
         "represented by a Bridged Node. The Ecosystem Information Cluster presents the view of device name " +

--- a/packages/model/src/standard/resources/electrical-energy-measurement.resource.ts
+++ b/packages/model/src/standard/resources/electrical-energy-measurement.resource.ts
@@ -9,8 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "cluster", name: "ElectricalEnergyMeasurement", classification: "application", pics: "EEM",
-    xref: "cluster§2.12",
+    tag: "cluster", name: "ElectricalEnergyMeasurement", pics: "EEM", xref: "cluster§2.12",
     details: "This cluster provides a mechanism for querying data about the electrical energy imported or provided " +
         "by the server.",
 

--- a/packages/model/src/standard/resources/electrical-power-measurement.resource.ts
+++ b/packages/model/src/standard/resources/electrical-power-measurement.resource.ts
@@ -9,8 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "cluster", name: "ElectricalPowerMeasurement", classification: "application", pics: "EPM",
-    xref: "cluster§2.13",
+    tag: "cluster", name: "ElectricalPowerMeasurement", pics: "EPM", xref: "cluster§2.13",
     details: "This cluster provides a mechanism for querying data about electrical power as measured by the " +
         "server.",
 

--- a/packages/model/src/standard/resources/electrical-sensor.resource.ts
+++ b/packages/model/src/standard/resources/electrical-sensor.resource.ts
@@ -9,7 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "deviceType", name: "ElectricalSensor", classification: "utility", xref: "device§2.6",
+    tag: "deviceType", name: "ElectricalSensor", xref: "device§2.6",
     details: "An Electrical Sensor device measures the electrical power and/or energy being imported and/or " +
         "exported.",
     children: [

--- a/packages/model/src/standard/resources/energy-evse-cluster.resource.ts
+++ b/packages/model/src/standard/resources/energy-evse-cluster.resource.ts
@@ -10,8 +10,7 @@ import { Resource } from "#models/Resource.js";
 
 Resource.add(
     {
-        tag: "cluster", name: "EnergyEvse", classification: "application", pics: "EEVSE",
-        xref: "cluster§9.3",
+        tag: "cluster", name: "EnergyEvse", pics: "EEVSE", xref: "cluster§9.3",
 
         details: "Electric Vehicle Supply Equipment (EVSE) is equipment used to charge an Electric Vehicle (EV) or " +
             "Plug-In Hybrid Electric Vehicle. This cluster provides an interface to the functionality of Electric " +

--- a/packages/model/src/standard/resources/energy-evse-device.resource.ts
+++ b/packages/model/src/standard/resources/energy-evse-device.resource.ts
@@ -9,7 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "deviceType", name: "EnergyEvse", classification: "simple", xref: "device§14.1",
+    tag: "deviceType", name: "EnergyEvse", xref: "device§14.1",
     details: "An EVSE (Electric Vehicle Supply Equipment) is a device that allows an EV (Electric Vehicle) to be " +
         "connected to the mains electricity supply to allow it to be charged (or discharged in case of " +
         "Vehicle to Grid / Vehicle to Home applications).",

--- a/packages/model/src/standard/resources/energy-evse-mode.resource.ts
+++ b/packages/model/src/standard/resources/energy-evse-mode.resource.ts
@@ -9,8 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "cluster", name: "EnergyEvseMode", classification: "application", pics: "EEVSEM",
-    xref: "cluster§9.4",
+    tag: "cluster", name: "EnergyEvseMode", pics: "EEVSEM", xref: "cluster§9.4",
     details: "This cluster is derived from the Mode Base cluster and defines additional mode tags and namespaced " +
         "enumerated values for EVSE devices.",
 

--- a/packages/model/src/standard/resources/energy-preference.resource.ts
+++ b/packages/model/src/standard/resources/energy-preference.resource.ts
@@ -9,8 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "cluster", name: "EnergyPreference", classification: "application", pics: "EPREF",
-    xref: "cluster§9.7",
+    tag: "cluster", name: "EnergyPreference", pics: "EPREF", xref: "cluster§9.7",
     details: "This cluster provides an interface to specify preferences for how devices should consume energy." +
         "\n" +
         "NOTE Support for Energy Preference cluster is provisional.",

--- a/packages/model/src/standard/resources/ethernet-network-diagnostics.resource.ts
+++ b/packages/model/src/standard/resources/ethernet-network-diagnostics.resource.ts
@@ -9,8 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "cluster", name: "EthernetNetworkDiagnostics", classification: "node", pics: "DGETH",
-    xref: "core§11.16",
+    tag: "cluster", name: "EthernetNetworkDiagnostics", pics: "DGETH", xref: "core§11.16",
     details: "The Ethernet Network Diagnostics Cluster provides a means to acquire standardized diagnostics " +
         "metrics that may be used by a Node to assist a user or Administrator in diagnosing potential " +
         "problems. The Ethernet Network Diagnostics Cluster attempts to centralize all metrics that are " +

--- a/packages/model/src/standard/resources/extended-color-light.resource.ts
+++ b/packages/model/src/standard/resources/extended-color-light.resource.ts
@@ -9,7 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "deviceType", name: "ExtendedColorLight", classification: "simple", xref: "device§4.4",
+    tag: "deviceType", name: "ExtendedColorLight", xref: "device§4.4",
     details: "An Extended Color Light is a lighting device that is capable of being switched on or off, the " +
         "intensity of its light adjusted, and its color adjusted by means of a bound controller device such " +
         "as a Color Dimmer Switch or Control Bridge. The device supports adjustment of color by means of " +

--- a/packages/model/src/standard/resources/extractor-hood.resource.ts
+++ b/packages/model/src/standard/resources/extractor-hood.resource.ts
@@ -9,7 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "deviceType", name: "ExtractorHood", classification: "simple", xref: "device§13.10",
+    tag: "deviceType", name: "ExtractorHood", xref: "device§13.10",
 
     details: "An Extractor Hood is a device that is generally installed above a cooking surface in residential " +
         "kitchens. An Extractor Hood’s primary purpose is to reduce odors that arise during the cooking " +

--- a/packages/model/src/standard/resources/fan-control.resource.ts
+++ b/packages/model/src/standard/resources/fan-control.resource.ts
@@ -9,7 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "cluster", name: "FanControl", classification: "application", pics: "FAN", xref: "cluster§4.4",
+    tag: "cluster", name: "FanControl", pics: "FAN", xref: "cluster§4.4",
     details: "This cluster specifies an interface to control the speed of a fan.",
 
     children: [

--- a/packages/model/src/standard/resources/fan.resource.ts
+++ b/packages/model/src/standard/resources/fan.resource.ts
@@ -9,7 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "deviceType", name: "Fan", classification: "simple", xref: "device§9.2",
+    tag: "deviceType", name: "Fan", xref: "device§9.2",
     details: "A Fan device is typically standalone or mounted on a ceiling or wall and is used to circulate air in " +
         "a room.",
 

--- a/packages/model/src/standard/resources/fixed-label.resource.ts
+++ b/packages/model/src/standard/resources/fixed-label.resource.ts
@@ -9,7 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "cluster", name: "FixedLabel", classification: "endpoint", pics: "FLABEL", xref: "core§9.8",
+    tag: "cluster", name: "FixedLabel", pics: "FLABEL", xref: "core§9.8",
 
     details: "This cluster is derived from the Label cluster and provides a feature for the device to tag an " +
         "endpoint with zero or more read-only labels." +

--- a/packages/model/src/standard/resources/flow-measurement.resource.ts
+++ b/packages/model/src/standard/resources/flow-measurement.resource.ts
@@ -10,8 +10,7 @@ import { Resource } from "#models/Resource.js";
 
 Resource.add(
     {
-        tag: "cluster", name: "FlowMeasurement", classification: "application", pics: "FLW",
-        xref: "cluster§2.5",
+        tag: "cluster", name: "FlowMeasurement", pics: "FLW", xref: "cluster§2.5",
         details: "This cluster provides an interface to flow measurement functionality, including configuration and " +
             "provision of notifications of flow measurements.",
 

--- a/packages/model/src/standard/resources/flow-sensor.resource.ts
+++ b/packages/model/src/standard/resources/flow-sensor.resource.ts
@@ -9,7 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "deviceType", name: "FlowSensor", classification: "simple", xref: "device§7.6",
+    tag: "deviceType", name: "FlowSensor", xref: "device§7.6",
     details: "A Flow Sensor device measures and reports the flow rate of a fluid.",
     children: [
         { tag: "requirement", name: "FlowMeasurement", xref: "device§7.6.4" },

--- a/packages/model/src/standard/resources/general-commissioning.resource.ts
+++ b/packages/model/src/standard/resources/general-commissioning.resource.ts
@@ -9,8 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "cluster", name: "GeneralCommissioning", classification: "node", pics: "CGEN",
-    xref: "core§11.10",
+    tag: "cluster", name: "GeneralCommissioning", pics: "CGEN", xref: "core§11.10",
     details: "This cluster is used to manage basic commissioning lifecycle." +
         "\n" +
         "This cluster also represents responsibilities related to commissioning that don’t well fit other " +

--- a/packages/model/src/standard/resources/general-diagnostics.resource.ts
+++ b/packages/model/src/standard/resources/general-diagnostics.resource.ts
@@ -9,8 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "cluster", name: "GeneralDiagnostics", classification: "node", pics: "DGGEN",
-    xref: "core§11.12",
+    tag: "cluster", name: "GeneralDiagnostics", pics: "DGGEN", xref: "core§11.12",
     details: "The General Diagnostics Cluster, along with other diagnostics clusters, provide a means to acquire " +
         "standardized diagnostics metrics that may be used by a Node to assist a user or Administrator in " +
         "diagnosing potential problems. The General Diagnostics Cluster attempts to centralize all metrics " +

--- a/packages/model/src/standard/resources/generic-switch.resource.ts
+++ b/packages/model/src/standard/resources/generic-switch.resource.ts
@@ -9,7 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "deviceType", name: "GenericSwitch", classification: "simple", xref: "device§6.6",
+    tag: "deviceType", name: "GenericSwitch", xref: "device§6.6",
     details: "This defines conformance for the Generic Switch device type.",
     children: [
         { tag: "requirement", name: "Identify", xref: "device§6.6.4" },

--- a/packages/model/src/standard/resources/group-key-management.resource.ts
+++ b/packages/model/src/standard/resources/group-key-management.resource.ts
@@ -9,8 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "cluster", name: "GroupKeyManagement", classification: "node", pics: "GRPKEY",
-    xref: "core§11.2",
+    tag: "cluster", name: "GroupKeyManagement", pics: "GRPKEY", xref: "core§11.2",
 
     details: "The Group Key Management cluster manages group keys for the node. The cluster is scoped to the node " +
         "and is a singleton for the node. This cluster maintains a list of groups supported by the node. Each " +

--- a/packages/model/src/standard/resources/groups.resource.ts
+++ b/packages/model/src/standard/resources/groups.resource.ts
@@ -9,7 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "cluster", name: "Groups", classification: "endpoint", pics: "G", xref: "cluster§1.3",
+    tag: "cluster", name: "Groups", pics: "G", xref: "cluster§1.3",
 
     details: "The Groups cluster manages, per endpoint, the content of the node-wide Group Table that is part of " +
         "the underlying interaction layer." +

--- a/packages/model/src/standard/resources/heat-pump.resource.ts
+++ b/packages/model/src/standard/resources/heat-pump.resource.ts
@@ -9,7 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "deviceType", name: "HeatPump", classification: "simple", xref: "device§14.5",
+    tag: "deviceType", name: "HeatPump", xref: "device§14.5",
 
     details: "A Heat Pump device is a device that uses electrical energy to heat either spaces or water tanks " +
         "using ground, water or air as the heat source. These typically can heat the air or can pump water " +

--- a/packages/model/src/standard/resources/humidity-sensor.resource.ts
+++ b/packages/model/src/standard/resources/humidity-sensor.resource.ts
@@ -9,7 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "deviceType", name: "HumiditySensor", classification: "simple", xref: "device§7.7",
+    tag: "deviceType", name: "HumiditySensor", xref: "device§7.7",
     details: "A humidity sensor (in most cases a Relative humidity sensor) reports humidity measurements.",
     children: [
         { tag: "requirement", name: "Identify", xref: "device§7.7.4" },

--- a/packages/model/src/standard/resources/icd-management.resource.ts
+++ b/packages/model/src/standard/resources/icd-management.resource.ts
@@ -9,7 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "cluster", name: "IcdManagement", classification: "node", pics: "ICDM", xref: "core§9.16",
+    tag: "cluster", name: "IcdManagement", pics: "ICDM", xref: "core§9.16",
     details: "ICD Management Cluster enables configuration of the ICD’s behavior and ensuring that listed clients " +
         "can be notified when an intermittently connected device, ICD, is available for communication." +
         "\n" +

--- a/packages/model/src/standard/resources/identify.resource.ts
+++ b/packages/model/src/standard/resources/identify.resource.ts
@@ -9,7 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "cluster", name: "Identify", classification: "endpoint", pics: "I", xref: "cluster§1.2",
+    tag: "cluster", name: "Identify", pics: "I", xref: "cluster§1.2",
 
     details: "This cluster supports an endpoint identification state (e.g., flashing a light), that indicates to " +
         "an observer (e.g., an installer) which of several nodes and/or endpoints it is. It also supports a " +

--- a/packages/model/src/standard/resources/illuminance-measurement.resource.ts
+++ b/packages/model/src/standard/resources/illuminance-measurement.resource.ts
@@ -10,8 +10,7 @@ import { Resource } from "#models/Resource.js";
 
 Resource.add(
     {
-        tag: "cluster", name: "IlluminanceMeasurement", classification: "application", pics: "ILL",
-        xref: "cluster§2.2",
+        tag: "cluster", name: "IlluminanceMeasurement", pics: "ILL", xref: "cluster§2.2",
         details: "The Illuminance Measurement cluster provides an interface to illuminance measurement functionality, " +
             "including configuration and provision of notifications of illuminance measurements.",
 

--- a/packages/model/src/standard/resources/joint-fabric-administrator-cluster.resource.ts
+++ b/packages/model/src/standard/resources/joint-fabric-administrator-cluster.resource.ts
@@ -10,8 +10,7 @@ import { Resource } from "#models/Resource.js";
 
 Resource.add(
     {
-        tag: "cluster", name: "JointFabricAdministrator", classification: "node", pics: "JFPKI",
-        xref: "core§11.25",
+        tag: "cluster", name: "JointFabricAdministrator", pics: "JFPKI", xref: "core§11.25",
         details: "An instance of the Joint Fabric Administrator Cluster only applies to Joint Fabric Administrator " +
             "nodes fulfilling the role of Anchor CA." +
             "\n" +

--- a/packages/model/src/standard/resources/joint-fabric-administrator-device.resource.ts
+++ b/packages/model/src/standard/resources/joint-fabric-administrator-device.resource.ts
@@ -9,7 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "deviceType", name: "JointFabricAdministrator", classification: "utility", xref: "device§2.9",
+    tag: "deviceType", name: "JointFabricAdministrator", xref: "device§2.9",
 
     details: "A Joint Fabric Administrator device provides capabilities to manage the Joint Fabric Datastore and " +
         "issue an ICAC signed by the Joint Fabric Anchor Root CA." +

--- a/packages/model/src/standard/resources/joint-fabric-datastore.resource.ts
+++ b/packages/model/src/standard/resources/joint-fabric-datastore.resource.ts
@@ -9,8 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "cluster", name: "JointFabricDatastore", classification: "node", pics: "JFDS",
-    xref: "core§11.24",
+    tag: "cluster", name: "JointFabricDatastore", pics: "JFDS", xref: "core§11.24",
 
     details: "The Joint Fabric Datastore Cluster is a cluster that provides a mechanism for the Joint Fabric " +
         "Administrators to manage the set of Nodes, Groups, and Group membership among Nodes in the Joint " +

--- a/packages/model/src/standard/resources/keypad-input.resource.ts
+++ b/packages/model/src/standard/resources/keypad-input.resource.ts
@@ -9,8 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "cluster", name: "KeypadInput", classification: "application", pics: "KEYPADINPUT",
-    xref: "cluster§6.8",
+    tag: "cluster", name: "KeypadInput", pics: "KEYPADINPUT", xref: "cluster§6.8",
 
     details: "This cluster provides an interface for key code based input and control on a device like a Video " +
         "Player or an endpoint like a Content App. This may include text or action commands such as UP, DOWN, " +

--- a/packages/model/src/standard/resources/label.resource.ts
+++ b/packages/model/src/standard/resources/label.resource.ts
@@ -9,7 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "cluster", name: "Label", classification: "endpoint", pics: "LABEL", xref: "core§9.7",
+    tag: "cluster", name: "Label", pics: "LABEL", xref: "core§9.7",
     details: "This cluster provides a feature to tag an endpoint with zero or more labels. This is a base cluster " +
         "that requires a derived cluster to create an instance.",
 

--- a/packages/model/src/standard/resources/laundry-dryer-controls.resource.ts
+++ b/packages/model/src/standard/resources/laundry-dryer-controls.resource.ts
@@ -9,8 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "cluster", name: "LaundryDryerControls", classification: "application", pics: "DRYERCTRL",
-    xref: "cluster§8.9",
+    tag: "cluster", name: "LaundryDryerControls", pics: "DRYERCTRL", xref: "cluster§8.9",
     details: "This cluster provides a way to access options associated with the operation of a laundry dryer " +
         "device type.",
 

--- a/packages/model/src/standard/resources/laundry-dryer.resource.ts
+++ b/packages/model/src/standard/resources/laundry-dryer.resource.ts
@@ -9,7 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "deviceType", name: "LaundryDryer", classification: "simple", xref: "device§13.6",
+    tag: "deviceType", name: "LaundryDryer", xref: "device§13.6",
     details: "A Laundry Dryer represents a device that is capable of drying laundry items.",
 
     children: [

--- a/packages/model/src/standard/resources/laundry-washer-controls.resource.ts
+++ b/packages/model/src/standard/resources/laundry-washer-controls.resource.ts
@@ -9,8 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "cluster", name: "LaundryWasherControls", classification: "application", pics: "WASHERCTRL",
-    xref: "cluster§8.6",
+    tag: "cluster", name: "LaundryWasherControls", pics: "WASHERCTRL", xref: "cluster§8.6",
     details: "This cluster provides a way to access options associated with the operation of a laundry washer " +
         "device type.",
 

--- a/packages/model/src/standard/resources/laundry-washer-mode.resource.ts
+++ b/packages/model/src/standard/resources/laundry-washer-mode.resource.ts
@@ -9,8 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "cluster", name: "LaundryWasherMode", classification: "application", pics: "LWM",
-    xref: "cluster§8.5",
+    tag: "cluster", name: "LaundryWasherMode", pics: "LWM", xref: "cluster§8.5",
     details: "This cluster is derived from the Mode Base cluster and defines additional mode tags and namespaced " +
         "enumerated values for laundry washer as well as laundry dryer devices.",
 

--- a/packages/model/src/standard/resources/laundry-washer.resource.ts
+++ b/packages/model/src/standard/resources/laundry-washer.resource.ts
@@ -9,7 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "deviceType", name: "LaundryWasher", classification: "simple", xref: "device§13.1",
+    tag: "deviceType", name: "LaundryWasher", xref: "device§13.1",
     details: "A Laundry Washer represents a device that is capable of laundering consumer items. Any laundry " +
         "washer product may utilize this device type." +
         "\n" +

--- a/packages/model/src/standard/resources/level-control.resource.ts
+++ b/packages/model/src/standard/resources/level-control.resource.ts
@@ -9,8 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "cluster", name: "LevelControl", classification: "application", pics: "LVL",
-    xref: "cluster§1.6",
+    tag: "cluster", name: "LevelControl", pics: "LVL", xref: "cluster§1.6",
     details: "This cluster provides an interface for controlling a characteristic of a device that can be set to a " +
         "level, for example the brightness of a light, the degree of closure of a door, or the power output " +
         "of a heater.",

--- a/packages/model/src/standard/resources/light-sensor.resource.ts
+++ b/packages/model/src/standard/resources/light-sensor.resource.ts
@@ -9,7 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "deviceType", name: "LightSensor", classification: "simple", xref: "device§7.2",
+    tag: "deviceType", name: "LightSensor", xref: "device§7.2",
     details: "A Light Sensor device is a measurement and sensing device that is capable of measuring and reporting " +
         "the intensity of light (illuminance) to which the sensor is being subjected.",
     children: [

--- a/packages/model/src/standard/resources/localization-configuration.resource.ts
+++ b/packages/model/src/standard/resources/localization-configuration.resource.ts
@@ -9,8 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "cluster", name: "LocalizationConfiguration", classification: "node", pics: "LCFG",
-    xref: "core§11.3",
+    tag: "cluster", name: "LocalizationConfiguration", pics: "LCFG", xref: "core§11.3",
 
     details: "Nodes should be expected to be deployed to any and all regions of the world. These global regions " +
         "may have differing common languages, units of measurements, and numerical formatting standards. As " +

--- a/packages/model/src/standard/resources/low-power.resource.ts
+++ b/packages/model/src/standard/resources/low-power.resource.ts
@@ -9,8 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "cluster", name: "LowPower", classification: "application", pics: "LOWPOWER",
-    xref: "cluster§1.11",
+    tag: "cluster", name: "LowPower", pics: "LOWPOWER", xref: "cluster§1.11",
 
     details: "This cluster provides an interface for managing low power mode on a device." +
         "\n" +

--- a/packages/model/src/standard/resources/media-input.resource.ts
+++ b/packages/model/src/standard/resources/media-input.resource.ts
@@ -9,8 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "cluster", name: "MediaInput", classification: "application", pics: "MEDIAINPUT",
-    xref: "cluster§6.9",
+    tag: "cluster", name: "MediaInput", pics: "MEDIAINPUT", xref: "cluster§6.9",
 
     details: "This cluster provides an interface for controlling the Input Selector on a media device such as a " +
         "Video Player." +

--- a/packages/model/src/standard/resources/media-playback.resource.ts
+++ b/packages/model/src/standard/resources/media-playback.resource.ts
@@ -9,8 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "cluster", name: "MediaPlayback", classification: "application", pics: "MEDIAPLAYBACK",
-    xref: "cluster§6.10",
+    tag: "cluster", name: "MediaPlayback", pics: "MEDIAPLAYBACK", xref: "cluster§6.10",
     details: "This cluster provides an interface for controlling Media Playback (PLAY, PAUSE, etc) on a media " +
         "device such as a TV, Set-top Box, or Smart Speaker." +
         "\n" +

--- a/packages/model/src/standard/resources/messages.resource.ts
+++ b/packages/model/src/standard/resources/messages.resource.ts
@@ -9,7 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "cluster", name: "Messages", classification: "application", pics: "MESS", xref: "cluster§1.16",
+    tag: "cluster", name: "Messages", pics: "MESS", xref: "cluster§1.16",
     details: "This cluster provides an interface for passing messages to be presented by a device.",
 
     children: [

--- a/packages/model/src/standard/resources/microwave-oven-control.resource.ts
+++ b/packages/model/src/standard/resources/microwave-oven-control.resource.ts
@@ -9,8 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "cluster", name: "MicrowaveOvenControl", classification: "application", pics: "MWOCTRL",
-    xref: "cluster§8.13",
+    tag: "cluster", name: "MicrowaveOvenControl", pics: "MWOCTRL", xref: "cluster§8.13",
     details: "This cluster defines the requirements for the Microwave Oven Control cluster." +
         "\n" +
         "This cluster has dependencies with the Operational State and Microwave Oven Mode clusters. The " +

--- a/packages/model/src/standard/resources/microwave-oven-mode.resource.ts
+++ b/packages/model/src/standard/resources/microwave-oven-mode.resource.ts
@@ -9,8 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "cluster", name: "MicrowaveOvenMode", classification: "application", pics: "MWOM",
-    xref: "cluster§8.12",
+    tag: "cluster", name: "MicrowaveOvenMode", pics: "MWOM", xref: "cluster§8.12",
     details: "This cluster is derived from the Mode Base cluster and defines additional mode tags and namespaced " +
         "enumerated values for microwave oven devices.",
 

--- a/packages/model/src/standard/resources/microwave-oven.resource.ts
+++ b/packages/model/src/standard/resources/microwave-oven.resource.ts
@@ -9,7 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "deviceType", name: "MicrowaveOven", classification: "simple", xref: "device§13.11",
+    tag: "deviceType", name: "MicrowaveOven", xref: "device§13.11",
     details: "This defines conformance to the Microwave Oven device type." +
         "\n" +
         "A Microwave Oven is a device with the primary function of heating foods and beverages using a " +

--- a/packages/model/src/standard/resources/mode-base.resource.ts
+++ b/packages/model/src/standard/resources/mode-base.resource.ts
@@ -9,7 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "cluster", name: "ModeBase", classification: "application", pics: "MODB", xref: "cluster§1.10",
+    tag: "cluster", name: "ModeBase", pics: "MODB", xref: "cluster§1.10",
 
     details: "This cluster provides an interface for controlling a characteristic of a device that can be set to " +
         "one of several predefined values. For example, the light pattern of a disco ball, the mode of a " +

--- a/packages/model/src/standard/resources/mode-select-cluster.resource.ts
+++ b/packages/model/src/standard/resources/mode-select-cluster.resource.ts
@@ -9,7 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "cluster", name: "ModeSelect", classification: "application", pics: "MOD", xref: "cluster§1.9",
+    tag: "cluster", name: "ModeSelect", pics: "MOD", xref: "cluster§1.9",
 
     details: "This cluster provides an interface for controlling a characteristic of a device that can be set to " +
         "one of several predefined values. For example, the light pattern of a disco ball, the mode of a " +

--- a/packages/model/src/standard/resources/mode-select-device.resource.ts
+++ b/packages/model/src/standard/resources/mode-select-device.resource.ts
@@ -9,7 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "deviceType", name: "ModeSelect", classification: "simple", xref: "device§11.1",
+    tag: "deviceType", name: "ModeSelect", xref: "device§11.1",
     details: "This defines conformance to the Mode Select device type.",
     children: [{ tag: "requirement", name: "ModeSelect", xref: "device§11.1.4" }]
 });

--- a/packages/model/src/standard/resources/mounted-dimmable-load-control.resource.ts
+++ b/packages/model/src/standard/resources/mounted-dimmable-load-control.resource.ts
@@ -9,7 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "deviceType", name: "MountedDimmableLoadControl", classification: "simple", xref: "device§5.4",
+    tag: "deviceType", name: "MountedDimmableLoadControl", xref: "device§5.4",
 
     details: "A Mounted Dimmable Load Control is a fixed device that provides power to a load connected to it, and " +
         "is capable of being switched on or off and have its level adjusted. The Mounted Dimmable Load " +

--- a/packages/model/src/standard/resources/mounted-on-off-control.resource.ts
+++ b/packages/model/src/standard/resources/mounted-on-off-control.resource.ts
@@ -9,7 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "deviceType", name: "MountedOnOffControl", classification: "simple", xref: "device§5.3",
+    tag: "deviceType", name: "MountedOnOffControl", xref: "device§5.3",
 
     details: "A Mounted On/Off Control is a fixed device that provides power to another device or power circuit " +
         "that is connected to it, and is capable of switching that provided power on or off." +

--- a/packages/model/src/standard/resources/network-commissioning.resource.ts
+++ b/packages/model/src/standard/resources/network-commissioning.resource.ts
@@ -10,8 +10,7 @@ import { Resource } from "#models/Resource.js";
 
 Resource.add(
     {
-        tag: "cluster", name: "NetworkCommissioning", classification: "node", pics: "CNET",
-        xref: "core§11.9",
+        tag: "cluster", name: "NetworkCommissioning", pics: "CNET", xref: "core§11.9",
 
         details: "Network commissioning is part of the overall Node commissioning. The main goal of Network " +
             "Commissioning Cluster is to associate a Node with or manage a Node’s one or more network interfaces. " +

--- a/packages/model/src/standard/resources/network-infrastructure-manager.resource.ts
+++ b/packages/model/src/standard/resources/network-infrastructure-manager.resource.ts
@@ -9,8 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "deviceType", name: "NetworkInfrastructureManager", classification: "simple",
-    xref: "device§15.3",
+    tag: "deviceType", name: "NetworkInfrastructureManager", xref: "device§15.3",
 
     details: "A Network Infrastructure Manager provides interfaces that allow for the management of the Wi-Fi, " +
         "Thread, and Ethernet networks underlying a Matter deployment, realizing the Star Network Topology " +

--- a/packages/model/src/standard/resources/occupancy-sensing.resource.ts
+++ b/packages/model/src/standard/resources/occupancy-sensing.resource.ts
@@ -9,8 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "cluster", name: "OccupancySensing", classification: "application", pics: "OCC",
-    xref: "cluster§2.7",
+    tag: "cluster", name: "OccupancySensing", pics: "OCC", xref: "cluster§2.7",
     details: "The server cluster provides an interface to occupancy sensing functionality based on one or more " +
         "sensing modalities, including configuration and provision of notifications of occupancy status.",
 

--- a/packages/model/src/standard/resources/occupancy-sensor.resource.ts
+++ b/packages/model/src/standard/resources/occupancy-sensor.resource.ts
@@ -9,7 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "deviceType", name: "OccupancySensor", classification: "simple", xref: "device§7.3",
+    tag: "deviceType", name: "OccupancySensor", xref: "device§7.3",
     details: "An Occupancy Sensor is a measurement and sensing device that is capable of measuring and reporting " +
         "the occupancy state in a designated area.",
     children: [

--- a/packages/model/src/standard/resources/on-off-light-switch.resource.ts
+++ b/packages/model/src/standard/resources/on-off-light-switch.resource.ts
@@ -9,7 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "deviceType", name: "OnOffLightSwitch", classification: "simple", xref: "device§6.1",
+    tag: "deviceType", name: "OnOffLightSwitch", xref: "device§6.1",
     details: "An On/Off Light Switch is a controller device that, when bound to a lighting device such as an " +
         "On/Off Light, is capable of being used to switch the device on or off.",
 

--- a/packages/model/src/standard/resources/on-off-light.resource.ts
+++ b/packages/model/src/standard/resources/on-off-light.resource.ts
@@ -9,7 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "deviceType", name: "OnOffLight", classification: "simple", xref: "device§4.1",
+    tag: "deviceType", name: "OnOffLight", xref: "device§4.1",
     details: "The On/Off Light is a lighting device that is capable of being switched on or off by means of a " +
         "bound controller device such as an On/Off Light Switch or a Dimmer Switch. In addition, an on/off " +
         "light is also capable of being switched by means of a bound occupancy sensor.",

--- a/packages/model/src/standard/resources/on-off-plug-in-unit.resource.ts
+++ b/packages/model/src/standard/resources/on-off-plug-in-unit.resource.ts
@@ -9,7 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "deviceType", name: "OnOffPlugInUnit", classification: "simple", xref: "device§5.1",
+    tag: "deviceType", name: "OnOffPlugInUnit", xref: "device§5.1",
 
     details: "An On/Off Plug-in Unit is a device that provides power to another device that is plugged into it, " +
         "and is capable of switching that provided power on or off." +

--- a/packages/model/src/standard/resources/on-off-sensor.resource.ts
+++ b/packages/model/src/standard/resources/on-off-sensor.resource.ts
@@ -9,7 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "deviceType", name: "OnOffSensor", classification: "simple", xref: "device§7.8",
+    tag: "deviceType", name: "OnOffSensor", xref: "device§7.8",
     details: "An On/Off Sensor is a measurement and sensing device that, when bound to a lighting device such as a " +
         "Dimmable Light, is capable of being used to switch the device on or off.",
 

--- a/packages/model/src/standard/resources/on-off.resource.ts
+++ b/packages/model/src/standard/resources/on-off.resource.ts
@@ -9,7 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "cluster", name: "OnOff", classification: "application", pics: "OO", xref: "cluster§1.5",
+    tag: "cluster", name: "OnOff", pics: "OO", xref: "cluster§1.5",
     details: "Attributes and commands for turning devices on and off.",
 
     children: [

--- a/packages/model/src/standard/resources/operational-credentials.resource.ts
+++ b/packages/model/src/standard/resources/operational-credentials.resource.ts
@@ -9,8 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "cluster", name: "OperationalCredentials", classification: "node", pics: "OPCREDS",
-    xref: "core§11.18",
+    tag: "cluster", name: "OperationalCredentials", pics: "OPCREDS", xref: "core§11.18",
     details: "This cluster is used to add or remove Node Operational credentials on a Commissionee or " +
         "already-configured Node, as well as manage the associated Fabrics.",
 

--- a/packages/model/src/standard/resources/operational-state.resource.ts
+++ b/packages/model/src/standard/resources/operational-state.resource.ts
@@ -9,8 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "cluster", name: "OperationalState", classification: "application", pics: "OPSTATE",
-    xref: "cluster§1.14",
+    tag: "cluster", name: "OperationalState", pics: "OPSTATE", xref: "cluster§1.14",
 
     details: "This cluster supports remotely monitoring and, where supported, changing the operational state of " +
         "any device where a state machine is a part of the operation." +

--- a/packages/model/src/standard/resources/ota-provider.resource.ts
+++ b/packages/model/src/standard/resources/ota-provider.resource.ts
@@ -9,7 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "deviceType", name: "OtaProvider", classification: "utility", xref: "device§2.4",
+    tag: "deviceType", name: "OtaProvider", xref: "device§2.4",
     details: "An OTA Provider is a node that is capable of providing an OTA software update to other nodes on the " +
         "same fabric.",
     children: [

--- a/packages/model/src/standard/resources/ota-requestor.resource.ts
+++ b/packages/model/src/standard/resources/ota-requestor.resource.ts
@@ -9,7 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "deviceType", name: "OtaRequestor", classification: "utility", xref: "device§2.3",
+    tag: "deviceType", name: "OtaRequestor", xref: "device§2.3",
     details: "An OTA Requestor is a device that is capable of receiving an OTA software update.",
     children: [
         { tag: "requirement", name: "OtaSoftwareUpdateRequestor", xref: "device§2.3.3" },

--- a/packages/model/src/standard/resources/ota-software-update-provider.resource.ts
+++ b/packages/model/src/standard/resources/ota-software-update-provider.resource.ts
@@ -10,8 +10,7 @@ import { Resource } from "#models/Resource.js";
 
 Resource.add(
     {
-        tag: "cluster", name: "OtaSoftwareUpdateProvider", classification: "node", pics: "OTAP",
-        xref: "core§11.20.6",
+        tag: "cluster", name: "OtaSoftwareUpdateProvider", pics: "OTAP", xref: "core§11.20.6",
 
         children: [
             {

--- a/packages/model/src/standard/resources/ota-software-update-requestor.resource.ts
+++ b/packages/model/src/standard/resources/ota-software-update-requestor.resource.ts
@@ -9,8 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "cluster", name: "OtaSoftwareUpdateRequestor", classification: "node", pics: "OTAR",
-    xref: "core§11.20.7",
+    tag: "cluster", name: "OtaSoftwareUpdateRequestor", pics: "OTAR", xref: "core§11.20.7",
 
     children: [
         {

--- a/packages/model/src/standard/resources/oven-cavity-operational-state.resource.ts
+++ b/packages/model/src/standard/resources/oven-cavity-operational-state.resource.ts
@@ -9,8 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "cluster", name: "OvenCavityOperationalState", classification: "application",
-    pics: "OVENOPSTATE", xref: "cluster§8.10",
+    tag: "cluster", name: "OvenCavityOperationalState", pics: "OVENOPSTATE", xref: "cluster§8.10",
     details: "This cluster is derived from the Operational State cluster and provides an interface for monitoring " +
         "the operational state of an oven.",
 

--- a/packages/model/src/standard/resources/oven-mode.resource.ts
+++ b/packages/model/src/standard/resources/oven-mode.resource.ts
@@ -9,8 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "cluster", name: "OvenMode", classification: "application", pics: "OTCCM",
-    xref: "cluster§8.11",
+    tag: "cluster", name: "OvenMode", pics: "OTCCM", xref: "cluster§8.11",
     details: "This cluster is derived from the Mode Base cluster and defines additional mode tags and namespaced " +
         "enumerated values for oven devices.",
 

--- a/packages/model/src/standard/resources/oven.resource.ts
+++ b/packages/model/src/standard/resources/oven.resource.ts
@@ -9,7 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "deviceType", name: "Oven", classification: "simple", xref: "device§13.9",
+    tag: "deviceType", name: "Oven", xref: "device§13.9",
     details: "An oven represents a device that contains one or more cabinets, and optionally a single cooktop, " +
         "that are all capable of heating food. Examples of consumer products implementing this device type " +
         "include ovens, wall ovens, convection ovens, etc.",

--- a/packages/model/src/standard/resources/power-source-cluster.resource.ts
+++ b/packages/model/src/standard/resources/power-source-cluster.resource.ts
@@ -9,7 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "cluster", name: "PowerSource", classification: "node", pics: "PS", xref: "core§11.7",
+    tag: "cluster", name: "PowerSource", pics: "PS", xref: "core§11.7",
     details: "This cluster is used to describe the configuration and capabilities of a physical power source that " +
         "provides power to one or more endpoints on a node. In case the node has multiple power sources, each " +
         "shall be described by its own cluster instance. Each instance of this cluster may be associated with " +

--- a/packages/model/src/standard/resources/power-source-configuration.resource.ts
+++ b/packages/model/src/standard/resources/power-source-configuration.resource.ts
@@ -9,8 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "cluster", name: "PowerSourceConfiguration", classification: "node", pics: "PSCFG",
-    xref: "core§11.6",
+    tag: "cluster", name: "PowerSourceConfiguration", pics: "PSCFG", xref: "core§11.6",
     details: "This cluster is used to describe the configuration and capabilities of a Device’s power system. It " +
         "provides an ordering overview as well as linking to the one or more endpoints each supporting a " +
         "Power Source cluster.",

--- a/packages/model/src/standard/resources/power-source-device.resource.ts
+++ b/packages/model/src/standard/resources/power-source-device.resource.ts
@@ -9,6 +9,6 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "deviceType", name: "PowerSource", classification: "utility", xref: "device§2.2",
+    tag: "deviceType", name: "PowerSource", xref: "device§2.2",
     children: [{ tag: "requirement", name: "PowerSource", xref: "device§2.2.3" }]
 });

--- a/packages/model/src/standard/resources/power-topology.resource.ts
+++ b/packages/model/src/standard/resources/power-topology.resource.ts
@@ -9,8 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "cluster", name: "PowerTopology", classification: "application", pics: "PWRTL",
-    xref: "core§11.8",
+    tag: "cluster", name: "PowerTopology", pics: "PWRTL", xref: "core§11.8",
     details: "The Power Topology Cluster provides a mechanism for expressing how power is flowing between " +
         "endpoints.",
 

--- a/packages/model/src/standard/resources/pressure-measurement.resource.ts
+++ b/packages/model/src/standard/resources/pressure-measurement.resource.ts
@@ -10,8 +10,7 @@ import { Resource } from "#models/Resource.js";
 
 Resource.add(
     {
-        tag: "cluster", name: "PressureMeasurement", classification: "application", pics: "PRS",
-        xref: "cluster§2.4",
+        tag: "cluster", name: "PressureMeasurement", pics: "PRS", xref: "cluster§2.4",
         details: "This cluster provides an interface to pressure measurement functionality, including configuration " +
             "and provision of notifications of pressure measurements.",
 

--- a/packages/model/src/standard/resources/pressure-sensor.resource.ts
+++ b/packages/model/src/standard/resources/pressure-sensor.resource.ts
@@ -9,7 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "deviceType", name: "PressureSensor", classification: "simple", xref: "device§7.5",
+    tag: "deviceType", name: "PressureSensor", xref: "device§7.5",
     details: "A Pressure Sensor device measures and reports the pressure of a fluid.",
     children: [
         { tag: "requirement", name: "PressureMeasurement", xref: "device§7.5.4" },

--- a/packages/model/src/standard/resources/pump-configuration-and-control.resource.ts
+++ b/packages/model/src/standard/resources/pump-configuration-and-control.resource.ts
@@ -10,8 +10,7 @@ import { Resource } from "#models/Resource.js";
 
 Resource.add(
     {
-        tag: "cluster", name: "PumpConfigurationAndControl", classification: "application", pics: "PCC",
-        xref: "cluster§4.2",
+        tag: "cluster", name: "PumpConfigurationAndControl", pics: "PCC", xref: "cluster§4.2",
 
         details: "The Pump Configuration and Control cluster provides an interface for the setup and control of pump " +
             "devices, and the automatic reporting of pump status information. Note that control of pump speed is " +

--- a/packages/model/src/standard/resources/pump-controller.resource.ts
+++ b/packages/model/src/standard/resources/pump-controller.resource.ts
@@ -9,7 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "deviceType", name: "PumpController", classification: "simple", xref: "device§6.5",
+    tag: "deviceType", name: "PumpController", xref: "device§6.5",
     details: "A Pump Controller device is capable of configuring and controlling a Pump device.",
 
     children: [

--- a/packages/model/src/standard/resources/pump.resource.ts
+++ b/packages/model/src/standard/resources/pump.resource.ts
@@ -9,7 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "deviceType", name: "Pump", classification: "simple", xref: "device§5.5",
+    tag: "deviceType", name: "Pump", xref: "device§5.5",
     details: "A Pump device is a pump that may have variable speed. It may have optional built-in sensors and a " +
         "regulation mechanism. It is typically used for pumping fluids like water.",
 

--- a/packages/model/src/standard/resources/rain-sensor.resource.ts
+++ b/packages/model/src/standard/resources/rain-sensor.resource.ts
@@ -9,7 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "deviceType", name: "RainSensor", classification: "simple", xref: "device§7.13",
+    tag: "deviceType", name: "RainSensor", xref: "device§7.13",
     details: "This defines conformance to the Rain Sensor device type.",
     children: [
         { tag: "requirement", name: "Identify", xref: "device§7.13.4" },

--- a/packages/model/src/standard/resources/refrigerator-alarm.resource.ts
+++ b/packages/model/src/standard/resources/refrigerator-alarm.resource.ts
@@ -9,8 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "cluster", name: "RefrigeratorAlarm", classification: "application", pics: "REFALM",
-    xref: "cluster§8.8",
+    tag: "cluster", name: "RefrigeratorAlarm", pics: "REFALM", xref: "cluster§8.8",
     details: "This cluster is a derived cluster of Alarm Base cluster and provides the alarm definition related to " +
         "refrigerator and temperature controlled cabinet devices.",
 

--- a/packages/model/src/standard/resources/refrigerator-and-temperature-controlled-cabinet-mode.resource.ts
+++ b/packages/model/src/standard/resources/refrigerator-and-temperature-controlled-cabinet-mode.resource.ts
@@ -9,8 +9,8 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "cluster", name: "RefrigeratorAndTemperatureControlledCabinetMode",
-    classification: "application", pics: "TCCM", xref: "cluster§8.7",
+    tag: "cluster", name: "RefrigeratorAndTemperatureControlledCabinetMode", pics: "TCCM",
+    xref: "cluster§8.7",
     details: "This cluster is derived from the Mode Base cluster and defines additional mode tags and namespaced " +
         "enumerated values for refrigerator and temperature controlled cabinet devices.",
 

--- a/packages/model/src/standard/resources/refrigerator-device.resource.ts
+++ b/packages/model/src/standard/resources/refrigerator-device.resource.ts
@@ -9,7 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "deviceType", name: "Refrigerator", classification: "simple", xref: "device§13.2",
+    tag: "deviceType", name: "Refrigerator", xref: "device§13.2",
     details: "A refrigerator represents a device that contains one or more cabinets that are capable of chilling " +
         "or freezing food. Examples of consumer products that may make use of this device type include " +
         "refrigerators, freezers, and wine coolers.",

--- a/packages/model/src/standard/resources/relative-humidity-measurement.resource.ts
+++ b/packages/model/src/standard/resources/relative-humidity-measurement.resource.ts
@@ -10,8 +10,7 @@ import { Resource } from "#models/Resource.js";
 
 Resource.add(
     {
-        tag: "cluster", name: "RelativeHumidityMeasurement", classification: "application", pics: "RH",
-        xref: "cluster§2.6",
+        tag: "cluster", name: "RelativeHumidityMeasurement", pics: "RH", xref: "cluster§2.6",
         details: "This is a base cluster. The server cluster provides an interface to water content measurement " +
             "functionality. The measurement is reportable and may be configured for reporting. Water content " +
             "measurements currently is, but are not limited to relative humidity.",

--- a/packages/model/src/standard/resources/resource-monitoring.resource.ts
+++ b/packages/model/src/standard/resources/resource-monitoring.resource.ts
@@ -9,8 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "cluster", name: "ResourceMonitoring", classification: "application", pics: "REPM",
-    xref: "cluster§2.8",
+    tag: "cluster", name: "ResourceMonitoring", pics: "REPM", xref: "cluster§2.8",
 
     details: "This generic cluster provides an interface to the current condition of a resource. A resource is a " +
         "component of a device that is designed to be replaced, refilled, or emptied when exhausted or full. " +

--- a/packages/model/src/standard/resources/robotic-vacuum-cleaner.resource.ts
+++ b/packages/model/src/standard/resources/robotic-vacuum-cleaner.resource.ts
@@ -9,7 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "deviceType", name: "RoboticVacuumCleaner", classification: "simple", xref: "device§12.1",
+    tag: "deviceType", name: "RoboticVacuumCleaner", xref: "device§12.1",
     details: "This defines conformance for the Robotic Vacuum Cleaner device type.",
 
     children: [

--- a/packages/model/src/standard/resources/room-air-conditioner-device.resource.ts
+++ b/packages/model/src/standard/resources/room-air-conditioner-device.resource.ts
@@ -9,7 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "deviceType", name: "RoomAirConditioner", classification: "simple", xref: "device§13.3",
+    tag: "deviceType", name: "RoomAirConditioner", xref: "device§13.3",
     details: "This defines conformance to the Room Air Conditioner device type." +
         "\n" +
         "A Room Air Conditioner is a device with the primary function of controlling the air temperature in a " +

--- a/packages/model/src/standard/resources/root-node.resource.ts
+++ b/packages/model/src/standard/resources/root-node.resource.ts
@@ -9,7 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "deviceType", name: "RootNode", classification: "node", xref: "device§2.1",
+    tag: "deviceType", name: "RootNode", xref: "device§2.1",
 
     details: "This defines conformance for a root node endpoint (see System Model specification). This endpoint is " +
         "akin to a \"read me first\" endpoint that describes itself and the other endpoints that make up the " +

--- a/packages/model/src/standard/resources/rvc-clean-mode.resource.ts
+++ b/packages/model/src/standard/resources/rvc-clean-mode.resource.ts
@@ -9,8 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "cluster", name: "RvcCleanMode", classification: "application", pics: "RVCCLEANM",
-    xref: "cluster§7.3",
+    tag: "cluster", name: "RvcCleanMode", pics: "RVCCLEANM", xref: "cluster§7.3",
     details: "This cluster is derived from the Mode Base cluster and defines additional mode tags and namespaced " +
         "enumerated values for the cleaning type of robotic vacuum cleaner devices.",
 

--- a/packages/model/src/standard/resources/rvc-operational-state.resource.ts
+++ b/packages/model/src/standard/resources/rvc-operational-state.resource.ts
@@ -9,8 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "cluster", name: "RvcOperationalState", classification: "application", pics: "RVCOPSTATE",
-    xref: "cluster§7.4",
+    tag: "cluster", name: "RvcOperationalState", pics: "RVCOPSTATE", xref: "cluster§7.4",
     details: "This cluster is derived from the Operational State cluster and provides an interface for monitoring " +
         "the operational state of a robotic vacuum cleaner.",
 

--- a/packages/model/src/standard/resources/rvc-run-mode.resource.ts
+++ b/packages/model/src/standard/resources/rvc-run-mode.resource.ts
@@ -9,8 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "cluster", name: "RvcRunMode", classification: "application", pics: "RVCRUNM",
-    xref: "cluster§7.2",
+    tag: "cluster", name: "RvcRunMode", pics: "RVCRUNM", xref: "cluster§7.2",
     details: "This cluster is derived from the Mode Base cluster and defines additional mode tags and namespaced " +
         "enumerated values for the running modes of robotic vacuum cleaner devices.",
 

--- a/packages/model/src/standard/resources/scenes-management.resource.ts
+++ b/packages/model/src/standard/resources/scenes-management.resource.ts
@@ -9,8 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "cluster", name: "ScenesManagement", classification: "application", pics: "S",
-    xref: "cluster§1.4",
+    tag: "cluster", name: "ScenesManagement", pics: "S", xref: "cluster§1.4",
 
     details: "The Scenes Management cluster provides attributes and commands for setting up and recalling scenes. " +
         "Each scene corresponds to a set of stored values of specified attributes for one or more clusters on " +

--- a/packages/model/src/standard/resources/secondary-network-interface.resource.ts
+++ b/packages/model/src/standard/resources/secondary-network-interface.resource.ts
@@ -9,7 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "deviceType", name: "SecondaryNetworkInterface", classification: "utility", xref: "device§2.8",
+    tag: "deviceType", name: "SecondaryNetworkInterface", xref: "device§2.8",
 
     details: "A Secondary Network Interface device provides an additional network interface supported by the Node, " +
         "supplementing the primary interface hosted by the Root Node endpoint." +

--- a/packages/model/src/standard/resources/service-area.resource.ts
+++ b/packages/model/src/standard/resources/service-area.resource.ts
@@ -9,8 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "cluster", name: "ServiceArea", classification: "application", pics: "SEAR",
-    xref: "cluster§1.17",
+    tag: "cluster", name: "ServiceArea", pics: "SEAR", xref: "cluster§1.17",
 
     details: "This cluster provides an interface for controlling the areas where a device should operate, for " +
         "reporting the status at each area, and for querying the current area." +

--- a/packages/model/src/standard/resources/smoke-co-alarm-cluster.resource.ts
+++ b/packages/model/src/standard/resources/smoke-co-alarm-cluster.resource.ts
@@ -9,8 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "cluster", name: "SmokeCoAlarm", classification: "application", pics: "SMOKECO",
-    xref: "cluster§2.11",
+    tag: "cluster", name: "SmokeCoAlarm", pics: "SMOKECO", xref: "cluster§2.11",
     details: "This cluster provides an interface for observing and managing the state of smoke and CO alarms.",
 
     children: [

--- a/packages/model/src/standard/resources/smoke-co-alarm-device.resource.ts
+++ b/packages/model/src/standard/resources/smoke-co-alarm-device.resource.ts
@@ -9,7 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "deviceType", name: "SmokeCoAlarm", classification: "simple", xref: "device§7.9",
+    tag: "deviceType", name: "SmokeCoAlarm", xref: "device§7.9",
 
     details: "A Smoke CO Alarm device is capable of sensing smoke, carbon monoxide or both. It is capable of " +
         "issuing a visual and audible alert to indicate elevated concentration of smoke or carbon monoxide." +

--- a/packages/model/src/standard/resources/software-diagnostics.resource.ts
+++ b/packages/model/src/standard/resources/software-diagnostics.resource.ts
@@ -9,8 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "cluster", name: "SoftwareDiagnostics", classification: "node", pics: "DGSW",
-    xref: "core§11.13",
+    tag: "cluster", name: "SoftwareDiagnostics", pics: "DGSW", xref: "core§11.13",
     details: "The Software Diagnostics Cluster provides a means to acquire standardized diagnostics metrics that " +
         "may be used by a Node to assist a user or Administrator in diagnosing potential problems. The " +
         "Software Diagnostics Cluster attempts to centralize all metrics that are relevant to the software " +

--- a/packages/model/src/standard/resources/solar-power.resource.ts
+++ b/packages/model/src/standard/resources/solar-power.resource.ts
@@ -9,7 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "deviceType", name: "SolarPower", classification: "simple", xref: "device§14.3",
+    tag: "deviceType", name: "SolarPower", xref: "device§14.3",
     details: "A Solar Power device is a device that allows a solar panel array, which can optionally be comprised " +
         "of a set parallel strings of solar panels, and its associated controller and, if appropriate, " +
         "inverter, to be monitored and controlled by an Energy Management System.",

--- a/packages/model/src/standard/resources/speaker.resource.ts
+++ b/packages/model/src/standard/resources/speaker.resource.ts
@@ -9,7 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "deviceType", name: "Speaker", classification: "simple", xref: "device§10.4",
+    tag: "deviceType", name: "Speaker", xref: "device§10.4",
 
     details: "This defines conformance to the Speaker device type. This feature controls the speaker volume of the " +
         "device." +

--- a/packages/model/src/standard/resources/switch.resource.ts
+++ b/packages/model/src/standard/resources/switch.resource.ts
@@ -9,7 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "cluster", name: "Switch", classification: "application", pics: "SWTCH", xref: "cluster§1.13",
+    tag: "cluster", name: "Switch", pics: "SWTCH", xref: "cluster§1.13",
 
     details: "This cluster exposes interactions with a switch device, for the purpose of using those interactions " +
         "by other devices." +

--- a/packages/model/src/standard/resources/target-navigator.resource.ts
+++ b/packages/model/src/standard/resources/target-navigator.resource.ts
@@ -9,8 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "cluster", name: "TargetNavigator", classification: "application", pics: "TGTNAV",
-    xref: "cluster§6.11",
+    tag: "cluster", name: "TargetNavigator", pics: "TGTNAV", xref: "cluster§6.11",
 
     details: "This cluster provides an interface for UX navigation within a set of targets on a device or " +
         "endpoint." +

--- a/packages/model/src/standard/resources/temperature-control.resource.ts
+++ b/packages/model/src/standard/resources/temperature-control.resource.ts
@@ -10,8 +10,7 @@ import { Resource } from "#models/Resource.js";
 
 Resource.add(
     {
-        tag: "cluster", name: "TemperatureControl", classification: "application", pics: "TCTL",
-        xref: "cluster§8.2",
+        tag: "cluster", name: "TemperatureControl", pics: "TCTL", xref: "cluster§8.2",
 
         details: "This cluster provides an interface to the setpoint temperature on devices such as washers, " +
             "refrigerators, and water heaters. The setpoint temperature is the temperature to which a device " +

--- a/packages/model/src/standard/resources/temperature-controlled-cabinet.resource.ts
+++ b/packages/model/src/standard/resources/temperature-controlled-cabinet.resource.ts
@@ -9,8 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "deviceType", name: "TemperatureControlledCabinet", classification: "simple",
-    xref: "device§13.4",
+    tag: "deviceType", name: "TemperatureControlledCabinet", xref: "device§13.4",
     details: "A Temperature Controlled Cabinet only exists composed as part of another device type. It represents " +
         "a single cabinet that is capable of having its temperature controlled. Such a cabinet may be " +
         "chilling or freezing food, for example as part of a refrigerator, freezer, wine chiller, or other " +

--- a/packages/model/src/standard/resources/temperature-measurement.resource.ts
+++ b/packages/model/src/standard/resources/temperature-measurement.resource.ts
@@ -9,8 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "cluster", name: "TemperatureMeasurement", classification: "application", pics: "TMP",
-    xref: "cluster§2.3",
+    tag: "cluster", name: "TemperatureMeasurement", pics: "TMP", xref: "cluster§2.3",
     details: "This cluster provides an interface to temperature measurement functionality, including configuration " +
         "and provision of notifications of temperature measurements.",
 

--- a/packages/model/src/standard/resources/temperature-sensor.resource.ts
+++ b/packages/model/src/standard/resources/temperature-sensor.resource.ts
@@ -9,7 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "deviceType", name: "TemperatureSensor", classification: "simple", xref: "device§7.4",
+    tag: "deviceType", name: "TemperatureSensor", xref: "device§7.4",
     details: "A Temperature Sensor device reports measurements of temperature.",
     children: [
         { tag: "requirement", name: "TemperatureMeasurement", xref: "device§7.4.4" },

--- a/packages/model/src/standard/resources/thermostat-cluster.resource.ts
+++ b/packages/model/src/standard/resources/thermostat-cluster.resource.ts
@@ -10,8 +10,7 @@ import { Resource } from "#models/Resource.js";
 
 Resource.add(
     {
-        tag: "cluster", name: "Thermostat", classification: "application", pics: "TSTAT",
-        xref: "cluster§4.3",
+        tag: "cluster", name: "Thermostat", pics: "TSTAT", xref: "cluster§4.3",
         details: "This cluster provides an interface to the functionality of a thermostat.",
 
         children: [

--- a/packages/model/src/standard/resources/thermostat-controller.resource.ts
+++ b/packages/model/src/standard/resources/thermostat-controller.resource.ts
@@ -9,7 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "deviceType", name: "ThermostatController", classification: "simple", xref: "device§9.4",
+    tag: "deviceType", name: "ThermostatController", xref: "device§9.4",
     details: "A Thermostat Controller is a device capable of controlling a Thermostat.",
 
     children: [

--- a/packages/model/src/standard/resources/thermostat-device.resource.ts
+++ b/packages/model/src/standard/resources/thermostat-device.resource.ts
@@ -9,7 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "deviceType", name: "Thermostat", classification: "simple", xref: "device§9.1",
+    tag: "deviceType", name: "Thermostat", xref: "device§9.1",
     details: "A Thermostat device is capable of having either built-in or separate sensors for temperature, " +
         "humidity or occupancy. It allows the desired temperature to be set either remotely or locally. The " +
         "thermostat is capable of sending heating and/or cooling requirement notifications to a " +

--- a/packages/model/src/standard/resources/thermostat-user-interface-configuration.resource.ts
+++ b/packages/model/src/standard/resources/thermostat-user-interface-configuration.resource.ts
@@ -9,8 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "cluster", name: "ThermostatUserInterfaceConfiguration", classification: "application",
-    pics: "TSUIC", xref: "cluster§4.5",
+    tag: "cluster", name: "ThermostatUserInterfaceConfiguration", pics: "TSUIC", xref: "cluster§4.5",
     details: "This cluster provides an interface to allow configuration of the user interface for a thermostat, or " +
         "a thermostat controller device, that supports a keypad and LCD screen.",
 

--- a/packages/model/src/standard/resources/thread-border-router-management.resource.ts
+++ b/packages/model/src/standard/resources/thread-border-router-management.resource.ts
@@ -9,8 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "cluster", name: "ThreadBorderRouterManagement", classification: "application", pics: "TBRM",
-    xref: "cluster§10.3",
+    tag: "cluster", name: "ThreadBorderRouterManagement", pics: "TBRM", xref: "cluster§10.3",
     details: "This cluster provides an interface for managing a Thread Border Router and the Thread network that " +
         "it belongs to. Privileged nodes within the same fabric as a Thread Border Router can use these " +
         "interfaces to request and set credentials information to the Thread network.",

--- a/packages/model/src/standard/resources/thread-network-diagnostics.resource.ts
+++ b/packages/model/src/standard/resources/thread-network-diagnostics.resource.ts
@@ -9,8 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "cluster", name: "ThreadNetworkDiagnostics", classification: "node", pics: "DGTHREAD",
-    xref: "core§11.14",
+    tag: "cluster", name: "ThreadNetworkDiagnostics", pics: "DGTHREAD", xref: "core§11.14",
     details: "The Thread Network Diagnostics Cluster provides a means to acquire standardized diagnostics metrics " +
         "that may be used by a Node to assist a user or Administrator in diagnosing potential problems. The " +
         "Thread Network Diagnostics Cluster attempts to centralize all metrics that are relevant to a " +

--- a/packages/model/src/standard/resources/thread-network-directory.resource.ts
+++ b/packages/model/src/standard/resources/thread-network-directory.resource.ts
@@ -9,8 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "cluster", name: "ThreadNetworkDirectory", classification: "application", pics: "THNETDIR",
-    xref: "cluster§10.4",
+    tag: "cluster", name: "ThreadNetworkDirectory", pics: "THNETDIR", xref: "cluster§10.4",
     details: "This cluster stores a list of Thread networks (including the credentials required to access each " +
         "network), as well as a designation of the user’s preferred network, to facilitate the sharing of " +
         "Thread networks across fabrics.",

--- a/packages/model/src/standard/resources/time-format-localization.resource.ts
+++ b/packages/model/src/standard/resources/time-format-localization.resource.ts
@@ -9,8 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "cluster", name: "TimeFormatLocalization", classification: "node", pics: "LTIME",
-    xref: "core§11.4",
+    tag: "cluster", name: "TimeFormatLocalization", pics: "LTIME", xref: "core§11.4",
 
     details: "Nodes should be expected to be deployed to any and all regions of the world. These global regions " +
         "may have differing preferences for how dates and times are conveyed. As such, Nodes that visually or " +

--- a/packages/model/src/standard/resources/time-synchronization.resource.ts
+++ b/packages/model/src/standard/resources/time-synchronization.resource.ts
@@ -9,8 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "cluster", name: "TimeSynchronization", classification: "node", pics: "TIMESYNC",
-    xref: "core§11.17",
+    tag: "cluster", name: "TimeSynchronization", pics: "TIMESYNC", xref: "core§11.17",
 
     details: "Accurate time is required for a number of reasons, including scheduling, display and validating " +
         "security materials." +

--- a/packages/model/src/standard/resources/unit-localization.resource.ts
+++ b/packages/model/src/standard/resources/unit-localization.resource.ts
@@ -9,7 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "cluster", name: "UnitLocalization", classification: "node", pics: "LUNIT", xref: "core§11.5",
+    tag: "cluster", name: "UnitLocalization", pics: "LUNIT", xref: "core§11.5",
 
     details: "Nodes should be expected to be deployed to any and all regions of the world. These global regions " +
         "may have differing preferences for the units in which values are conveyed in communication to a " +

--- a/packages/model/src/standard/resources/user-label.resource.ts
+++ b/packages/model/src/standard/resources/user-label.resource.ts
@@ -9,7 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "cluster", name: "UserLabel", classification: "endpoint", pics: "ULABEL", xref: "core§9.9",
+    tag: "cluster", name: "UserLabel", pics: "ULABEL", xref: "core§9.9",
     details: "This cluster is derived from the Label cluster and provides a feature to tag an endpoint with zero " +
         "or more writable labels.",
     children: [{

--- a/packages/model/src/standard/resources/valve-configuration-and-control.resource.ts
+++ b/packages/model/src/standard/resources/valve-configuration-and-control.resource.ts
@@ -9,8 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "cluster", name: "ValveConfigurationAndControl", classification: "application", pics: "VALCC",
-    xref: "cluster§4.6",
+    tag: "cluster", name: "ValveConfigurationAndControl", pics: "VALCC", xref: "cluster§4.6",
     details: "This cluster is used to configure a valve.",
 
     children: [

--- a/packages/model/src/standard/resources/video-remote-control.resource.ts
+++ b/packages/model/src/standard/resources/video-remote-control.resource.ts
@@ -9,7 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "deviceType", name: "VideoRemoteControl", classification: "simple", xref: "device§10.7",
+    tag: "deviceType", name: "VideoRemoteControl", xref: "device§10.7",
     details: "This defines conformance to the Video Remote Control device type." +
         "\n" +
         "A Video Remote Control is a client that can control a Video Player, for example, a traditional " +

--- a/packages/model/src/standard/resources/wake-on-lan.resource.ts
+++ b/packages/model/src/standard/resources/wake-on-lan.resource.ts
@@ -9,8 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "cluster", name: "WakeOnLan", classification: "application", pics: "WAKEONLAN",
-    xref: "cluster§1.12",
+    tag: "cluster", name: "WakeOnLan", pics: "WAKEONLAN", xref: "cluster§1.12",
 
     details: "This cluster provides an interface for managing low power mode on a device that supports the Wake On " +
         "LAN or Wake On Wireless LAN (WLAN) protocol (see [Wake On LAN])." +

--- a/packages/model/src/standard/resources/water-freeze-detector.resource.ts
+++ b/packages/model/src/standard/resources/water-freeze-detector.resource.ts
@@ -9,7 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "deviceType", name: "WaterFreezeDetector", classification: "simple", xref: "device§7.11",
+    tag: "deviceType", name: "WaterFreezeDetector", xref: "device§7.11",
     details: "This defines conformance to the Water Freeze Detector device type.",
     children: [
         { tag: "requirement", name: "Identify", xref: "device§7.11.4" },

--- a/packages/model/src/standard/resources/water-heater-management.resource.ts
+++ b/packages/model/src/standard/resources/water-heater-management.resource.ts
@@ -10,8 +10,7 @@ import { Resource } from "#models/Resource.js";
 
 Resource.add(
     {
-        tag: "cluster", name: "WaterHeaterManagement", classification: "application", pics: "EWATERHTR",
-        xref: "cluster§9.5",
+        tag: "cluster", name: "WaterHeaterManagement", pics: "EWATERHTR", xref: "cluster§9.5",
 
         details: "This cluster is used to allow clients to control the operation of a hot water heating appliance so " +
             "that it can be used with energy management." +

--- a/packages/model/src/standard/resources/water-heater-mode.resource.ts
+++ b/packages/model/src/standard/resources/water-heater-mode.resource.ts
@@ -9,8 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "cluster", name: "WaterHeaterMode", classification: "application", pics: "WHM",
-    xref: "cluster§9.6",
+    tag: "cluster", name: "WaterHeaterMode", pics: "WHM", xref: "cluster§9.6",
     details: "This cluster is derived from the Mode Base cluster and defines additional mode tags and namespaced " +
         "enumerated values for water heater devices.",
 

--- a/packages/model/src/standard/resources/water-heater.resource.ts
+++ b/packages/model/src/standard/resources/water-heater.resource.ts
@@ -9,7 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "deviceType", name: "WaterHeater", classification: "simple", xref: "device§14.2",
+    tag: "deviceType", name: "WaterHeater", xref: "device§14.2",
     details: "A water heater is a device that is generally installed in properties to heat water for showers, " +
         "baths etc.",
 

--- a/packages/model/src/standard/resources/water-leak-detector.resource.ts
+++ b/packages/model/src/standard/resources/water-leak-detector.resource.ts
@@ -9,7 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "deviceType", name: "WaterLeakDetector", classification: "simple", xref: "device§7.12",
+    tag: "deviceType", name: "WaterLeakDetector", xref: "device§7.12",
     details: "This defines conformance to the Water Leak Detector device type.",
     children: [
         { tag: "requirement", name: "Identify", xref: "device§7.12.4" },

--- a/packages/model/src/standard/resources/water-valve.resource.ts
+++ b/packages/model/src/standard/resources/water-valve.resource.ts
@@ -9,7 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "deviceType", name: "WaterValve", classification: "simple", xref: "device§5.6",
+    tag: "deviceType", name: "WaterValve", xref: "device§5.6",
     details: "This defines conformance to the Water Valve device type.",
 
     children: [

--- a/packages/model/src/standard/resources/wi-fi-network-diagnostics.resource.ts
+++ b/packages/model/src/standard/resources/wi-fi-network-diagnostics.resource.ts
@@ -9,8 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "cluster", name: "WiFiNetworkDiagnostics", classification: "node", pics: "DGWIFI",
-    xref: "core§11.15",
+    tag: "cluster", name: "WiFiNetworkDiagnostics", pics: "DGWIFI", xref: "core§11.15",
     details: "The Wi-Fi Network Diagnostics Cluster provides a means to acquire standardized diagnostics metrics " +
         "that may be used by a Node to assist a user or Administrator in diagnosing potential problems. The " +
         "Wi-Fi Network Diagnostics Cluster attempts to centralize all metrics that are relevant to a " +

--- a/packages/model/src/standard/resources/wi-fi-network-management.resource.ts
+++ b/packages/model/src/standard/resources/wi-fi-network-management.resource.ts
@@ -9,8 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "cluster", name: "WiFiNetworkManagement", classification: "application", pics: "WIFINM",
-    xref: "cluster§10.2",
+    tag: "cluster", name: "WiFiNetworkManagement", pics: "WIFINM", xref: "cluster§10.2",
     details: "This cluster provides an interface for getting information about the Wi-Fi network that a Network " +
         "Infrastructure Manager device type provides. Privileged nodes within the same fabric as a Network " +
         "Infrastructure Manager can use these interfaces to request information related to the Wi-Fi Network " +

--- a/packages/model/src/standard/resources/window-covering-cluster.resource.ts
+++ b/packages/model/src/standard/resources/window-covering-cluster.resource.ts
@@ -10,8 +10,7 @@ import { Resource } from "#models/Resource.js";
 
 Resource.add(
     {
-        tag: "cluster", name: "WindowCovering", classification: "application", pics: "WNCV",
-        xref: "cluster§5.3",
+        tag: "cluster", name: "WindowCovering", pics: "WNCV", xref: "cluster§5.3",
         details: "The window covering cluster provides an interface for controlling and adjusting automatic window " +
             "coverings such as drapery motors, automatic shades, curtains and blinds.",
 

--- a/packages/model/src/standard/resources/window-covering-controller.resource.ts
+++ b/packages/model/src/standard/resources/window-covering-controller.resource.ts
@@ -9,7 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "deviceType", name: "WindowCoveringController", classification: "simple", xref: "device§8.4",
+    tag: "deviceType", name: "WindowCoveringController", xref: "device§8.4",
     details: "A Window Covering Controller is a device that controls an automatic window covering.",
 
     children: [

--- a/packages/model/src/standard/resources/window-covering-device.resource.ts
+++ b/packages/model/src/standard/resources/window-covering-device.resource.ts
@@ -9,7 +9,7 @@
 import { Resource } from "#models/Resource.js";
 
 Resource.add({
-    tag: "deviceType", name: "WindowCovering", classification: "simple", xref: "device§8.3",
+    tag: "deviceType", name: "WindowCovering", xref: "device§8.3",
     details: "This defines conformance to the Window Covering device type.",
     children: [
         { tag: "requirement", name: "Identify", xref: "device§8.3.4" },

--- a/packages/model/test/models/ResourceTest.ts
+++ b/packages/model/test/models/ResourceTest.ts
@@ -32,7 +32,6 @@ const LandingGearResource = new Resource({
     asOf: "1.1",
     until: "1.2",
     matchTo: { id: 1234 },
-    classification: "application",
     pics: "PLNWHL",
     description: "You need this to land",
     details: "You usually also need this to take off",
@@ -80,7 +79,7 @@ describe("Resource", () => {
             (cluster as any)[key] = LandingGearResource[key as keyof Resource];
         }
         expect(cluster.resource).deep.equals(LandingGearResource);
-        expect(Object.keys(cluster.resource!).length).equals(9);
+        expect(Object.keys(cluster.resource!).length).equals(8);
     });
 
     it("sets locally from resource", () => {

--- a/packages/node/src/devices/air-purifier.ts
+++ b/packages/node/src/devices/air-purifier.ts
@@ -100,4 +100,5 @@ export const AirPurifierDeviceDefinition = MutableEndpoint({
     )
 });
 
+Object.freeze(AirPurifierDeviceDefinition);
 export const AirPurifierDevice: AirPurifierDevice = AirPurifierDeviceDefinition;

--- a/packages/node/src/devices/air-quality-sensor.ts
+++ b/packages/node/src/devices/air-quality-sensor.ts
@@ -196,4 +196,5 @@ export const AirQualitySensorDeviceDefinition = MutableEndpoint({
     )
 });
 
+Object.freeze(AirQualitySensorDeviceDefinition);
 export const AirQualitySensorDevice: AirQualitySensorDevice = AirQualitySensorDeviceDefinition;

--- a/packages/node/src/devices/basic-video-player.ts
+++ b/packages/node/src/devices/basic-video-player.ts
@@ -150,4 +150,5 @@ export const BasicVideoPlayerDeviceDefinition = MutableEndpoint({
     )
 });
 
+Object.freeze(BasicVideoPlayerDeviceDefinition);
 export const BasicVideoPlayerDevice: BasicVideoPlayerDevice = BasicVideoPlayerDeviceDefinition;

--- a/packages/node/src/devices/battery-storage.ts
+++ b/packages/node/src/devices/battery-storage.ts
@@ -44,4 +44,5 @@ export const BatteryStorageDeviceDefinition = MutableEndpoint({
     behaviors: SupportedBehaviors()
 });
 
+Object.freeze(BatteryStorageDeviceDefinition);
 export const BatteryStorageDevice: BatteryStorageDevice = BatteryStorageDeviceDefinition;

--- a/packages/node/src/devices/casting-video-client.ts
+++ b/packages/node/src/devices/casting-video-client.ts
@@ -210,4 +210,5 @@ export const CastingVideoClientDeviceDefinition = MutableEndpoint({
     behaviors: SupportedBehaviors()
 });
 
+Object.freeze(CastingVideoClientDeviceDefinition);
 export const CastingVideoClientDevice: CastingVideoClientDevice = CastingVideoClientDeviceDefinition;

--- a/packages/node/src/devices/casting-video-player.ts
+++ b/packages/node/src/devices/casting-video-player.ts
@@ -184,4 +184,5 @@ export const CastingVideoPlayerDeviceDefinition = MutableEndpoint({
     )
 });
 
+Object.freeze(CastingVideoPlayerDeviceDefinition);
 export const CastingVideoPlayerDevice: CastingVideoPlayerDevice = CastingVideoPlayerDeviceDefinition;

--- a/packages/node/src/devices/color-dimmer-switch.ts
+++ b/packages/node/src/devices/color-dimmer-switch.ts
@@ -105,4 +105,5 @@ export const ColorDimmerSwitchDeviceDefinition = MutableEndpoint({
     behaviors: SupportedBehaviors(ColorDimmerSwitchRequirements.server.mandatory.Identify)
 });
 
+Object.freeze(ColorDimmerSwitchDeviceDefinition);
 export const ColorDimmerSwitchDevice: ColorDimmerSwitchDevice = ColorDimmerSwitchDeviceDefinition;

--- a/packages/node/src/devices/color-temperature-light.ts
+++ b/packages/node/src/devices/color-temperature-light.ts
@@ -127,4 +127,5 @@ export const ColorTemperatureLightDeviceDefinition = MutableEndpoint({
     )
 });
 
+Object.freeze(ColorTemperatureLightDeviceDefinition);
 export const ColorTemperatureLightDevice: ColorTemperatureLightDevice = ColorTemperatureLightDeviceDefinition;

--- a/packages/node/src/devices/contact-sensor.ts
+++ b/packages/node/src/devices/contact-sensor.ts
@@ -64,4 +64,5 @@ export const ContactSensorDeviceDefinition = MutableEndpoint({
     )
 });
 
+Object.freeze(ContactSensorDeviceDefinition);
 export const ContactSensorDevice: ContactSensorDevice = ContactSensorDeviceDefinition;

--- a/packages/node/src/devices/content-app.ts
+++ b/packages/node/src/devices/content-app.ts
@@ -145,4 +145,5 @@ export const ContentAppDeviceDefinition = MutableEndpoint({
     )
 });
 
+Object.freeze(ContentAppDeviceDefinition);
 export const ContentAppDevice: ContentAppDevice = ContentAppDeviceDefinition;

--- a/packages/node/src/devices/control-bridge.ts
+++ b/packages/node/src/devices/control-bridge.ts
@@ -131,4 +131,5 @@ export const ControlBridgeDeviceDefinition = MutableEndpoint({
     behaviors: SupportedBehaviors(ControlBridgeRequirements.server.mandatory.Identify)
 });
 
+Object.freeze(ControlBridgeDeviceDefinition);
 export const ControlBridgeDevice: ControlBridgeDevice = ControlBridgeDeviceDefinition;

--- a/packages/node/src/devices/cook-surface.ts
+++ b/packages/node/src/devices/cook-surface.ts
@@ -68,4 +68,5 @@ export const CookSurfaceDeviceDefinition = MutableEndpoint({
     behaviors: SupportedBehaviors()
 });
 
+Object.freeze(CookSurfaceDeviceDefinition);
 export const CookSurfaceDevice: CookSurfaceDevice = CookSurfaceDeviceDefinition;

--- a/packages/node/src/devices/cooktop.ts
+++ b/packages/node/src/devices/cooktop.ts
@@ -50,4 +50,5 @@ export const CooktopDeviceDefinition = MutableEndpoint({
     behaviors: SupportedBehaviors(CooktopRequirements.server.mandatory.OnOff)
 });
 
+Object.freeze(CooktopDeviceDefinition);
 export const CooktopDevice: CooktopDevice = CooktopDeviceDefinition;

--- a/packages/node/src/devices/dimmable-light.ts
+++ b/packages/node/src/devices/dimmable-light.ts
@@ -115,4 +115,5 @@ export const DimmableLightDeviceDefinition = MutableEndpoint({
     )
 });
 
+Object.freeze(DimmableLightDeviceDefinition);
 export const DimmableLightDevice: DimmableLightDevice = DimmableLightDeviceDefinition;

--- a/packages/node/src/devices/dimmable-plug-in-unit.ts
+++ b/packages/node/src/devices/dimmable-plug-in-unit.ts
@@ -126,4 +126,5 @@ export const DimmablePlugInUnitDeviceDefinition = MutableEndpoint({
     )
 });
 
+Object.freeze(DimmablePlugInUnitDeviceDefinition);
 export const DimmablePlugInUnitDevice: DimmablePlugInUnitDevice = DimmablePlugInUnitDeviceDefinition;

--- a/packages/node/src/devices/dimmer-switch.ts
+++ b/packages/node/src/devices/dimmer-switch.ts
@@ -91,4 +91,5 @@ export const DimmerSwitchDeviceDefinition = MutableEndpoint({
     behaviors: SupportedBehaviors(DimmerSwitchRequirements.server.mandatory.Identify)
 });
 
+Object.freeze(DimmerSwitchDeviceDefinition);
 export const DimmerSwitchDevice: DimmerSwitchDevice = DimmerSwitchDeviceDefinition;

--- a/packages/node/src/devices/dishwasher.ts
+++ b/packages/node/src/devices/dishwasher.ts
@@ -97,4 +97,5 @@ export const DishwasherDeviceDefinition = MutableEndpoint({
     behaviors: SupportedBehaviors(DishwasherRequirements.server.mandatory.OperationalState)
 });
 
+Object.freeze(DishwasherDeviceDefinition);
 export const DishwasherDevice: DishwasherDevice = DishwasherDeviceDefinition;

--- a/packages/node/src/devices/door-lock-controller.ts
+++ b/packages/node/src/devices/door-lock-controller.ts
@@ -76,4 +76,5 @@ export const DoorLockControllerDeviceDefinition = MutableEndpoint({
     behaviors: SupportedBehaviors()
 });
 
+Object.freeze(DoorLockControllerDeviceDefinition);
 export const DoorLockControllerDevice: DoorLockControllerDevice = DoorLockControllerDeviceDefinition;

--- a/packages/node/src/devices/door-lock.ts
+++ b/packages/node/src/devices/door-lock.ts
@@ -73,4 +73,5 @@ export const DoorLockDeviceDefinition = MutableEndpoint({
     )
 });
 
+Object.freeze(DoorLockDeviceDefinition);
 export const DoorLockDevice: DoorLockDevice = DoorLockDeviceDefinition;

--- a/packages/node/src/devices/energy-evse.ts
+++ b/packages/node/src/devices/energy-evse.ts
@@ -74,4 +74,5 @@ export const EnergyEvseDeviceDefinition = MutableEndpoint({
     )
 });
 
+Object.freeze(EnergyEvseDeviceDefinition);
 export const EnergyEvseDevice: EnergyEvseDevice = EnergyEvseDeviceDefinition;

--- a/packages/node/src/devices/extended-color-light.ts
+++ b/packages/node/src/devices/extended-color-light.ts
@@ -129,4 +129,5 @@ export const ExtendedColorLightDeviceDefinition = MutableEndpoint({
     )
 });
 
+Object.freeze(ExtendedColorLightDeviceDefinition);
 export const ExtendedColorLightDevice: ExtendedColorLightDevice = ExtendedColorLightDeviceDefinition;

--- a/packages/node/src/devices/extractor-hood.ts
+++ b/packages/node/src/devices/extractor-hood.ts
@@ -93,4 +93,5 @@ export const ExtractorHoodDeviceDefinition = MutableEndpoint({
     behaviors: SupportedBehaviors(ExtractorHoodRequirements.server.mandatory.FanControl)
 });
 
+Object.freeze(ExtractorHoodDeviceDefinition);
 export const ExtractorHoodDevice: ExtractorHoodDevice = ExtractorHoodDeviceDefinition;

--- a/packages/node/src/devices/fan.ts
+++ b/packages/node/src/devices/fan.ts
@@ -71,4 +71,5 @@ export const FanDeviceDefinition = MutableEndpoint({
     )
 });
 
+Object.freeze(FanDeviceDefinition);
 export const FanDevice: FanDevice = FanDeviceDefinition;

--- a/packages/node/src/devices/flow-sensor.ts
+++ b/packages/node/src/devices/flow-sensor.ts
@@ -51,4 +51,5 @@ export const FlowSensorDeviceDefinition = MutableEndpoint({
     )
 });
 
+Object.freeze(FlowSensorDeviceDefinition);
 export const FlowSensorDevice: FlowSensorDevice = FlowSensorDeviceDefinition;

--- a/packages/node/src/devices/generic-switch.ts
+++ b/packages/node/src/devices/generic-switch.ts
@@ -51,4 +51,5 @@ export const GenericSwitchDeviceDefinition = MutableEndpoint({
     behaviors: SupportedBehaviors(GenericSwitchRequirements.server.mandatory.Identify)
 });
 
+Object.freeze(GenericSwitchDeviceDefinition);
 export const GenericSwitchDevice: GenericSwitchDevice = GenericSwitchDeviceDefinition;

--- a/packages/node/src/devices/heat-pump.ts
+++ b/packages/node/src/devices/heat-pump.ts
@@ -58,4 +58,5 @@ export const HeatPumpDeviceDefinition = MutableEndpoint({
     behaviors: SupportedBehaviors()
 });
 
+Object.freeze(HeatPumpDeviceDefinition);
 export const HeatPumpDevice: HeatPumpDevice = HeatPumpDeviceDefinition;

--- a/packages/node/src/devices/humidity-sensor.ts
+++ b/packages/node/src/devices/humidity-sensor.ts
@@ -55,4 +55,5 @@ export const HumiditySensorDeviceDefinition = MutableEndpoint({
     )
 });
 
+Object.freeze(HumiditySensorDeviceDefinition);
 export const HumiditySensorDevice: HumiditySensorDevice = HumiditySensorDeviceDefinition;

--- a/packages/node/src/devices/laundry-dryer.ts
+++ b/packages/node/src/devices/laundry-dryer.ts
@@ -99,4 +99,5 @@ export const LaundryDryerDeviceDefinition = MutableEndpoint({
     behaviors: SupportedBehaviors(LaundryDryerRequirements.server.mandatory.OperationalState)
 });
 
+Object.freeze(LaundryDryerDeviceDefinition);
 export const LaundryDryerDevice: LaundryDryerDevice = LaundryDryerDeviceDefinition;

--- a/packages/node/src/devices/laundry-washer.ts
+++ b/packages/node/src/devices/laundry-washer.ts
@@ -102,4 +102,5 @@ export const LaundryWasherDeviceDefinition = MutableEndpoint({
     behaviors: SupportedBehaviors(LaundryWasherRequirements.server.mandatory.OperationalState)
 });
 
+Object.freeze(LaundryWasherDeviceDefinition);
 export const LaundryWasherDevice: LaundryWasherDevice = LaundryWasherDeviceDefinition;

--- a/packages/node/src/devices/light-sensor.ts
+++ b/packages/node/src/devices/light-sensor.ts
@@ -54,4 +54,5 @@ export const LightSensorDeviceDefinition = MutableEndpoint({
     )
 });
 
+Object.freeze(LightSensorDeviceDefinition);
 export const LightSensorDevice: LightSensorDevice = LightSensorDeviceDefinition;

--- a/packages/node/src/devices/microwave-oven.ts
+++ b/packages/node/src/devices/microwave-oven.ts
@@ -94,4 +94,5 @@ export const MicrowaveOvenDeviceDefinition = MutableEndpoint({
     )
 });
 
+Object.freeze(MicrowaveOvenDeviceDefinition);
 export const MicrowaveOvenDevice: MicrowaveOvenDevice = MicrowaveOvenDeviceDefinition;

--- a/packages/node/src/devices/mode-select.ts
+++ b/packages/node/src/devices/mode-select.ts
@@ -40,4 +40,5 @@ export const ModeSelectDeviceDefinition = MutableEndpoint({
     behaviors: SupportedBehaviors(ModeSelectRequirements.server.mandatory.ModeSelect)
 });
 
+Object.freeze(ModeSelectDeviceDefinition);
 export const ModeSelectDevice: ModeSelectDevice = ModeSelectDeviceDefinition;

--- a/packages/node/src/devices/mounted-dimmable-load-control.ts
+++ b/packages/node/src/devices/mounted-dimmable-load-control.ts
@@ -128,4 +128,5 @@ export const MountedDimmableLoadControlDeviceDefinition = MutableEndpoint({
     )
 });
 
+Object.freeze(MountedDimmableLoadControlDeviceDefinition);
 export const MountedDimmableLoadControlDevice: MountedDimmableLoadControlDevice = MountedDimmableLoadControlDeviceDefinition;

--- a/packages/node/src/devices/mounted-on-off-control.ts
+++ b/packages/node/src/devices/mounted-on-off-control.ts
@@ -126,4 +126,5 @@ export const MountedOnOffControlDeviceDefinition = MutableEndpoint({
     )
 });
 
+Object.freeze(MountedOnOffControlDeviceDefinition);
 export const MountedOnOffControlDevice: MountedOnOffControlDevice = MountedOnOffControlDeviceDefinition;

--- a/packages/node/src/devices/network-infrastructure-manager.ts
+++ b/packages/node/src/devices/network-infrastructure-manager.ts
@@ -97,4 +97,5 @@ export const NetworkInfrastructureManagerDeviceDefinition = MutableEndpoint({
     )
 });
 
+Object.freeze(NetworkInfrastructureManagerDeviceDefinition);
 export const NetworkInfrastructureManagerDevice: NetworkInfrastructureManagerDevice = NetworkInfrastructureManagerDeviceDefinition;

--- a/packages/node/src/devices/occupancy-sensor.ts
+++ b/packages/node/src/devices/occupancy-sensor.ts
@@ -67,4 +67,5 @@ export const OccupancySensorDeviceDefinition = MutableEndpoint({
     behaviors: SupportedBehaviors(OccupancySensorRequirements.server.mandatory.Identify)
 });
 
+Object.freeze(OccupancySensorDeviceDefinition);
 export const OccupancySensorDevice: OccupancySensorDevice = OccupancySensorDeviceDefinition;

--- a/packages/node/src/devices/on-off-light-switch.ts
+++ b/packages/node/src/devices/on-off-light-switch.ts
@@ -83,4 +83,5 @@ export const OnOffLightSwitchDeviceDefinition = MutableEndpoint({
     behaviors: SupportedBehaviors(OnOffLightSwitchRequirements.server.mandatory.Identify)
 });
 
+Object.freeze(OnOffLightSwitchDeviceDefinition);
 export const OnOffLightSwitchDevice: OnOffLightSwitchDevice = OnOffLightSwitchDeviceDefinition;

--- a/packages/node/src/devices/on-off-light.ts
+++ b/packages/node/src/devices/on-off-light.ts
@@ -115,4 +115,5 @@ export const OnOffLightDeviceDefinition = MutableEndpoint({
     )
 });
 
+Object.freeze(OnOffLightDeviceDefinition);
 export const OnOffLightDevice: OnOffLightDevice = OnOffLightDeviceDefinition;

--- a/packages/node/src/devices/on-off-plug-in-unit.ts
+++ b/packages/node/src/devices/on-off-plug-in-unit.ts
@@ -125,4 +125,5 @@ export const OnOffPlugInUnitDeviceDefinition = MutableEndpoint({
     )
 });
 
+Object.freeze(OnOffPlugInUnitDeviceDefinition);
 export const OnOffPlugInUnitDevice: OnOffPlugInUnitDevice = OnOffPlugInUnitDeviceDefinition;

--- a/packages/node/src/devices/on-off-sensor.ts
+++ b/packages/node/src/devices/on-off-sensor.ts
@@ -105,4 +105,5 @@ export const OnOffSensorDeviceDefinition = MutableEndpoint({
     behaviors: SupportedBehaviors(OnOffSensorRequirements.server.mandatory.Identify)
 });
 
+Object.freeze(OnOffSensorDeviceDefinition);
 export const OnOffSensorDevice: OnOffSensorDevice = OnOffSensorDeviceDefinition;

--- a/packages/node/src/devices/oven.ts
+++ b/packages/node/src/devices/oven.ts
@@ -42,4 +42,5 @@ export const OvenDeviceDefinition = MutableEndpoint({
     behaviors: SupportedBehaviors()
 });
 
+Object.freeze(OvenDeviceDefinition);
 export const OvenDevice: OvenDevice = OvenDeviceDefinition;

--- a/packages/node/src/devices/pressure-sensor.ts
+++ b/packages/node/src/devices/pressure-sensor.ts
@@ -53,4 +53,5 @@ export const PressureSensorDeviceDefinition = MutableEndpoint({
     )
 });
 
+Object.freeze(PressureSensorDeviceDefinition);
 export const PressureSensorDevice: PressureSensorDevice = PressureSensorDeviceDefinition;

--- a/packages/node/src/devices/pump-controller.ts
+++ b/packages/node/src/devices/pump-controller.ts
@@ -139,4 +139,5 @@ export const PumpControllerDeviceDefinition = MutableEndpoint({
     behaviors: SupportedBehaviors(PumpControllerRequirements.server.mandatory.Identify)
 });
 
+Object.freeze(PumpControllerDeviceDefinition);
 export const PumpControllerDevice: PumpControllerDevice = PumpControllerDeviceDefinition;

--- a/packages/node/src/devices/pump.ts
+++ b/packages/node/src/devices/pump.ts
@@ -185,4 +185,5 @@ export const PumpDeviceDefinition = MutableEndpoint({
     behaviors: SupportedBehaviors(PumpRequirements.server.mandatory.OnOff, PumpRequirements.server.mandatory.Identify)
 });
 
+Object.freeze(PumpDeviceDefinition);
 export const PumpDevice: PumpDevice = PumpDeviceDefinition;

--- a/packages/node/src/devices/rain-sensor.ts
+++ b/packages/node/src/devices/rain-sensor.ts
@@ -64,4 +64,5 @@ export const RainSensorDeviceDefinition = MutableEndpoint({
     )
 });
 
+Object.freeze(RainSensorDeviceDefinition);
 export const RainSensorDevice: RainSensorDevice = RainSensorDeviceDefinition;

--- a/packages/node/src/devices/refrigerator.ts
+++ b/packages/node/src/devices/refrigerator.ts
@@ -70,4 +70,5 @@ export const RefrigeratorDeviceDefinition = MutableEndpoint({
     behaviors: SupportedBehaviors()
 });
 
+Object.freeze(RefrigeratorDeviceDefinition);
 export const RefrigeratorDevice: RefrigeratorDevice = RefrigeratorDeviceDefinition;

--- a/packages/node/src/devices/robotic-vacuum-cleaner.ts
+++ b/packages/node/src/devices/robotic-vacuum-cleaner.ts
@@ -86,4 +86,5 @@ export const RoboticVacuumCleanerDeviceDefinition = MutableEndpoint({
     )
 });
 
+Object.freeze(RoboticVacuumCleanerDeviceDefinition);
 export const RoboticVacuumCleanerDevice: RoboticVacuumCleanerDevice = RoboticVacuumCleanerDeviceDefinition;

--- a/packages/node/src/devices/room-air-conditioner.ts
+++ b/packages/node/src/devices/room-air-conditioner.ts
@@ -132,4 +132,5 @@ export const RoomAirConditionerDeviceDefinition = MutableEndpoint({
     )
 });
 
+Object.freeze(RoomAirConditionerDeviceDefinition);
 export const RoomAirConditionerDevice: RoomAirConditionerDevice = RoomAirConditionerDeviceDefinition;

--- a/packages/node/src/devices/smoke-co-alarm.ts
+++ b/packages/node/src/devices/smoke-co-alarm.ts
@@ -108,4 +108,5 @@ export const SmokeCoAlarmDeviceDefinition = MutableEndpoint({
     behaviors: SupportedBehaviors(SmokeCoAlarmRequirements.server.mandatory.Identify)
 });
 
+Object.freeze(SmokeCoAlarmDeviceDefinition);
 export const SmokeCoAlarmDevice: SmokeCoAlarmDevice = SmokeCoAlarmDeviceDefinition;

--- a/packages/node/src/devices/solar-power.ts
+++ b/packages/node/src/devices/solar-power.ts
@@ -42,4 +42,5 @@ export const SolarPowerDeviceDefinition = MutableEndpoint({
     behaviors: SupportedBehaviors()
 });
 
+Object.freeze(SolarPowerDeviceDefinition);
 export const SolarPowerDevice: SolarPowerDevice = SolarPowerDeviceDefinition;

--- a/packages/node/src/devices/speaker.ts
+++ b/packages/node/src/devices/speaker.ts
@@ -62,4 +62,5 @@ export const SpeakerDeviceDefinition = MutableEndpoint({
     )
 });
 
+Object.freeze(SpeakerDeviceDefinition);
 export const SpeakerDevice: SpeakerDevice = SpeakerDeviceDefinition;

--- a/packages/node/src/devices/temperature-controlled-cabinet.ts
+++ b/packages/node/src/devices/temperature-controlled-cabinet.ts
@@ -98,4 +98,5 @@ export const TemperatureControlledCabinetDeviceDefinition = MutableEndpoint({
     behaviors: SupportedBehaviors()
 });
 
+Object.freeze(TemperatureControlledCabinetDeviceDefinition);
 export const TemperatureControlledCabinetDevice: TemperatureControlledCabinetDevice = TemperatureControlledCabinetDeviceDefinition;

--- a/packages/node/src/devices/temperature-sensor.ts
+++ b/packages/node/src/devices/temperature-sensor.ts
@@ -53,4 +53,5 @@ export const TemperatureSensorDeviceDefinition = MutableEndpoint({
     )
 });
 
+Object.freeze(TemperatureSensorDeviceDefinition);
 export const TemperatureSensorDevice: TemperatureSensorDevice = TemperatureSensorDeviceDefinition;

--- a/packages/node/src/devices/thermostat-controller.ts
+++ b/packages/node/src/devices/thermostat-controller.ts
@@ -69,4 +69,5 @@ export const ThermostatControllerDeviceDefinition = MutableEndpoint({
     behaviors: SupportedBehaviors()
 });
 
+Object.freeze(ThermostatControllerDeviceDefinition);
 export const ThermostatControllerDevice: ThermostatControllerDevice = ThermostatControllerDeviceDefinition;

--- a/packages/node/src/devices/thermostat.ts
+++ b/packages/node/src/devices/thermostat.ts
@@ -142,4 +142,5 @@ export const ThermostatDeviceDefinition = MutableEndpoint({
     behaviors: SupportedBehaviors(ThermostatRequirements.server.mandatory.Identify)
 });
 
+Object.freeze(ThermostatDeviceDefinition);
 export const ThermostatDevice: ThermostatDevice = ThermostatDeviceDefinition;

--- a/packages/node/src/devices/video-remote-control.ts
+++ b/packages/node/src/devices/video-remote-control.ts
@@ -171,4 +171,5 @@ export const VideoRemoteControlDeviceDefinition = MutableEndpoint({
     behaviors: SupportedBehaviors()
 });
 
+Object.freeze(VideoRemoteControlDeviceDefinition);
 export const VideoRemoteControlDevice: VideoRemoteControlDevice = VideoRemoteControlDeviceDefinition;

--- a/packages/node/src/devices/water-freeze-detector.ts
+++ b/packages/node/src/devices/water-freeze-detector.ts
@@ -64,4 +64,5 @@ export const WaterFreezeDetectorDeviceDefinition = MutableEndpoint({
     )
 });
 
+Object.freeze(WaterFreezeDetectorDeviceDefinition);
 export const WaterFreezeDetectorDevice: WaterFreezeDetectorDevice = WaterFreezeDetectorDeviceDefinition;

--- a/packages/node/src/devices/water-heater.ts
+++ b/packages/node/src/devices/water-heater.ts
@@ -81,4 +81,5 @@ export const WaterHeaterDeviceDefinition = MutableEndpoint({
     )
 });
 
+Object.freeze(WaterHeaterDeviceDefinition);
 export const WaterHeaterDevice: WaterHeaterDevice = WaterHeaterDeviceDefinition;

--- a/packages/node/src/devices/water-leak-detector.ts
+++ b/packages/node/src/devices/water-leak-detector.ts
@@ -64,4 +64,5 @@ export const WaterLeakDetectorDeviceDefinition = MutableEndpoint({
     )
 });
 
+Object.freeze(WaterLeakDetectorDeviceDefinition);
 export const WaterLeakDetectorDevice: WaterLeakDetectorDevice = WaterLeakDetectorDeviceDefinition;

--- a/packages/node/src/devices/water-valve.ts
+++ b/packages/node/src/devices/water-valve.ts
@@ -79,4 +79,5 @@ export const WaterValveDeviceDefinition = MutableEndpoint({
     )
 });
 
+Object.freeze(WaterValveDeviceDefinition);
 export const WaterValveDevice: WaterValveDevice = WaterValveDeviceDefinition;

--- a/packages/node/src/devices/window-covering-controller.ts
+++ b/packages/node/src/devices/window-covering-controller.ts
@@ -74,4 +74,5 @@ export const WindowCoveringControllerDeviceDefinition = MutableEndpoint({
     behaviors: SupportedBehaviors()
 });
 
+Object.freeze(WindowCoveringControllerDeviceDefinition);
 export const WindowCoveringControllerDevice: WindowCoveringControllerDevice = WindowCoveringControllerDeviceDefinition;

--- a/packages/node/src/devices/window-covering.ts
+++ b/packages/node/src/devices/window-covering.ts
@@ -62,4 +62,5 @@ export const WindowCoveringDeviceDefinition = MutableEndpoint({
     behaviors: SupportedBehaviors(WindowCoveringRequirements.server.mandatory.Identify)
 });
 
+Object.freeze(WindowCoveringDeviceDefinition);
 export const WindowCoveringDevice: WindowCoveringDevice = WindowCoveringDeviceDefinition;

--- a/packages/node/src/endpoint/properties/ClientNodeEndpoints.ts
+++ b/packages/node/src/endpoint/properties/ClientNodeEndpoints.ts
@@ -26,7 +26,7 @@ export class ClientNodeEndpoints extends Endpoints {
             id: `ep${endpointId}`,
             number: endpointId,
             type: EndpointType({
-                name: "ClientEndpoint",
+                name: "Unknown",
                 deviceType: EndpointType.UNKNOWN_DEVICE_TYPE,
                 deviceRevision: EndpointType.UNKNOWN_DEVICE_REVISION,
                 ...type,

--- a/packages/node/src/endpoints/aggregator.ts
+++ b/packages/node/src/endpoints/aggregator.ts
@@ -74,4 +74,5 @@ export const AggregatorEndpointDefinition = MutableEndpoint({
     )
 });
 
+Object.freeze(AggregatorEndpointDefinition);
 export const AggregatorEndpoint: AggregatorEndpoint = AggregatorEndpointDefinition;

--- a/packages/node/src/endpoints/bridged-node.ts
+++ b/packages/node/src/endpoints/bridged-node.ts
@@ -103,4 +103,5 @@ export const BridgedNodeEndpointDefinition = MutableEndpoint({
     )
 });
 
+Object.freeze(BridgedNodeEndpointDefinition);
 export const BridgedNodeEndpoint: BridgedNodeEndpoint = BridgedNodeEndpointDefinition;

--- a/packages/node/src/endpoints/device-energy-management.ts
+++ b/packages/node/src/endpoints/device-energy-management.ts
@@ -62,4 +62,5 @@ export const DeviceEnergyManagementEndpointDefinition = MutableEndpoint({
     behaviors: SupportedBehaviors()
 });
 
+Object.freeze(DeviceEnergyManagementEndpointDefinition);
 export const DeviceEnergyManagementEndpoint: DeviceEnergyManagementEndpoint = DeviceEnergyManagementEndpointDefinition;

--- a/packages/node/src/endpoints/electrical-sensor.ts
+++ b/packages/node/src/endpoints/electrical-sensor.ts
@@ -71,4 +71,5 @@ export const ElectricalSensorEndpointDefinition = MutableEndpoint({
     behaviors: SupportedBehaviors()
 });
 
+Object.freeze(ElectricalSensorEndpointDefinition);
 export const ElectricalSensorEndpoint: ElectricalSensorEndpoint = ElectricalSensorEndpointDefinition;

--- a/packages/node/src/endpoints/joint-fabric-administrator.ts
+++ b/packages/node/src/endpoints/joint-fabric-administrator.ts
@@ -67,4 +67,5 @@ export const JointFabricAdministratorEndpointDefinition = MutableEndpoint({
     )
 });
 
+Object.freeze(JointFabricAdministratorEndpointDefinition);
 export const JointFabricAdministratorEndpoint: JointFabricAdministratorEndpoint = JointFabricAdministratorEndpointDefinition;

--- a/packages/node/src/endpoints/ota-provider.ts
+++ b/packages/node/src/endpoints/ota-provider.ts
@@ -62,4 +62,5 @@ export const OtaProviderEndpointDefinition = MutableEndpoint({
     behaviors: SupportedBehaviors(OtaProviderRequirements.server.mandatory.OtaSoftwareUpdateProvider)
 });
 
+Object.freeze(OtaProviderEndpointDefinition);
 export const OtaProviderEndpoint: OtaProviderEndpoint = OtaProviderEndpointDefinition;

--- a/packages/node/src/endpoints/ota-requestor.ts
+++ b/packages/node/src/endpoints/ota-requestor.ts
@@ -59,4 +59,5 @@ export const OtaRequestorEndpointDefinition = MutableEndpoint({
     behaviors: SupportedBehaviors(OtaRequestorRequirements.server.mandatory.OtaSoftwareUpdateRequestor)
 });
 
+Object.freeze(OtaRequestorEndpointDefinition);
 export const OtaRequestorEndpoint: OtaRequestorEndpoint = OtaRequestorEndpointDefinition;

--- a/packages/node/src/endpoints/power-source.ts
+++ b/packages/node/src/endpoints/power-source.ts
@@ -43,4 +43,5 @@ export const PowerSourceEndpointDefinition = MutableEndpoint({
     behaviors: SupportedBehaviors()
 });
 
+Object.freeze(PowerSourceEndpointDefinition);
 export const PowerSourceEndpoint: PowerSourceEndpoint = PowerSourceEndpointDefinition;

--- a/packages/node/src/endpoints/root.ts
+++ b/packages/node/src/endpoints/root.ts
@@ -265,4 +265,5 @@ export const RootEndpointDefinition = MutableEndpoint({
     )
 });
 
+Object.freeze(RootEndpointDefinition);
 export const RootEndpoint: RootEndpoint = RootEndpointDefinition;

--- a/packages/node/src/endpoints/secondary-network-interface.ts
+++ b/packages/node/src/endpoints/secondary-network-interface.ts
@@ -90,4 +90,5 @@ export const SecondaryNetworkInterfaceEndpointDefinition = MutableEndpoint({
     behaviors: SupportedBehaviors()
 });
 
+Object.freeze(SecondaryNetworkInterfaceEndpointDefinition);
 export const SecondaryNetworkInterfaceEndpoint: SecondaryNetworkInterfaceEndpoint = SecondaryNetworkInterfaceEndpointDefinition;

--- a/packages/node/src/node/ClientNode.ts
+++ b/packages/node/src/node/ClientNode.ts
@@ -12,6 +12,8 @@ import { NetworkRuntime } from "#behavior/system/network/NetworkRuntime.js";
 import { Agent } from "#endpoint/Agent.js";
 import { ClientNodeEndpoints } from "#endpoint/properties/ClientNodeEndpoints.js";
 import { EndpointInitializer } from "#endpoint/properties/EndpointInitializer.js";
+import { EndpointType } from "#endpoint/type/EndpointType.js";
+import { MutableEndpoint } from "#endpoint/type/MutableEndpoint.js";
 import { Diagnostic, Identity, Lifecycle, Logger, MaybePromise } from "#general";
 import { Matter, MatterModel } from "#model";
 import { Interactable, OccurrenceManager, PeerAddress } from "#protocol";
@@ -39,7 +41,9 @@ export class ClientNode extends Node<ClientNode.RootEndpoint> {
         const opts = {
             ...options,
             number: 0,
-            type: ClientNode.RootEndpoint,
+
+            // Create an unfrozen type so we can set the revision when we see the descriptor
+            type: MutableEndpoint(ClientNode.RootEndpoint),
         };
 
         super(opts);
@@ -234,7 +238,12 @@ export namespace ClientNode {
         matter?: MatterModel;
     }
 
-    export const RootEndpoint = Node.CommonRootEndpoint.with(CommissioningClient, NetworkClient);
+    export const RootEndpoint = MutableEndpoint({
+        ...Node.CommonRootEndpoint,
+        deviceRevision: EndpointType.UNKNOWN_DEVICE_REVISION,
+    }).with(CommissioningClient, NetworkClient);
 
     export interface RootEndpoint extends Identity<typeof RootEndpoint> {}
 }
+
+Object.freeze(ClientNode.RootEndpoint);

--- a/packages/node/src/node/ServerNode.ts
+++ b/packages/node/src/node/ServerNode.ts
@@ -215,3 +215,5 @@ export namespace ServerNode {
 
     export interface RootEndpoint extends Identity<typeof RootEndpoint> {}
 }
+
+Object.freeze(ServerNode.RootEndpoint);

--- a/packages/node/test/node/ClientNodeTest.ts
+++ b/packages/node/test/node/ClientNodeTest.ts
@@ -297,11 +297,11 @@ describe("ClientNode", () => {
         expect(payload).deep.equals({ softwareVersion: 12 });
     });
 
-    it("handles shutdown event and reestablishes connection", () => {
+    it("removes node after leave event", () => {
         // TODO
     });
 
-    it("removes node after leave event", () => {
+    it("handles shutdown event and reestablishes connection", () => {
         // TODO
     });
 

--- a/packages/protocol/src/action/client/subscription/ClientSubscriptionHandler.ts
+++ b/packages/protocol/src/action/client/subscription/ClientSubscriptionHandler.ts
@@ -119,11 +119,9 @@ async function* processReports(
         const decoded = DecodedDataReport(report);
 
         if (decoded.subscriptionId === undefined) {
-            logger.debug(
-                "Ignoring data report for incorrect subscription id",
-                Diagnostic.strong(decoded.subscriptionId),
-            );
+            logger.debug("Ignoring data report with missing subscription id");
             await sendInvalid(messenger, decoded.subscriptionId);
+            continue;
         }
 
         if (decoded.subscriptionId !== subscriptionId) {

--- a/support/codegen/src/endpoints/EndpointFile.ts
+++ b/support/codegen/src/endpoints/EndpointFile.ts
@@ -110,6 +110,8 @@ export class EndpointFile extends TsFile {
         definition.atom("deviceRevision", this.model.revision);
         this.addDeviceClass(definition);
 
+        this.atom(`Object.freeze(${this.definitionName}Definition)`);
+
         this.addImport("!node/endpoint/properties/SupportedBehaviors.js", "SupportedBehaviors");
         definition.atom(`requirements: ${this.requirementsName}`);
         const behaviors = definition.expressions("behaviors: SupportedBehaviors(", ")");

--- a/support/codegen/src/mom/spec/translate-cluster.ts
+++ b/support/codegen/src/mom/spec/translate-cluster.ts
@@ -178,7 +178,7 @@ function translateMetadata(definition: ClusterReference, children: Array<Cluster
     }
 
     function translateClassification() {
-        const classifications = translateTable("classfication", definition.classifications, {
+        const classifications = translateTable("classification", definition.classifications, {
             hierarchy: Optional(Str),
             role: Optional(LowerIdentifier),
             scope: Optional(Alias(LowerIdentifier, "context")),


### PR DESCRIPTION
* Ensure we use an application type for `endpoint.type.deviceType` if there are utility types listed first in `deviceTypeList`.  Not sure that would ever happen but can't find anything in spec that precludes it

* Moves cluster and endpoint `classification` field from resources to the element so we can use it operationally

* Freezes endpoint types so they can't accidentally mutate when configuring client nodes