### PR TITLE
Always consider client behaviors "supported"

### DIFF
--- a/packages/node/src/behavior/cluster/ClientBehavior.ts
+++ b/packages/node/src/behavior/cluster/ClientBehavior.ts
@@ -1,0 +1,40 @@
+/**
+ * @license
+ * Copyright 2022-2025 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Behavior } from "#behavior/Behavior.js";
+import type { ClusterType } from "#types";
+import { ClusterBehavior } from "./ClusterBehavior.js";
+
+const isClient = Symbol("is-client");
+
+type ClientBehaviorType = { [isClient]?: boolean };
+
+/**
+ * Client view of a {@link ClusterBehavior}.
+ *
+ * You may use a client behavior to access the type-safe version of a behavior without knowing details of the underlying
+ * implementation such as the base class or supported features.
+ *
+ * For appropriate type safety {@link cluster} must be specify all cluster elements, and those that are not mandatory
+ * without features must be marked as optional.
+ */
+export function ClientBehavior<const T extends ClusterType>(cluster: T): ClusterBehavior.Type<T> {
+    const behavior = ClusterBehavior.for(cluster, undefined, `${cluster.name}Client`);
+
+    (behavior as ClientBehaviorType)[isClient] = true;
+
+    return behavior;
+}
+
+export namespace ClientBehavior {
+    /**
+     * Determine whether a behavior is a client.
+     */
+    export function is(type: Behavior.Type) {
+        // Use hasOwn so any derivation voids the client assertion
+        return (type as ClientBehaviorType)[isClient] && Object.hasOwn(type, isClient);
+    }
+}

--- a/packages/node/src/behavior/cluster/ClusterBehavior.ts
+++ b/packages/node/src/behavior/cluster/ClusterBehavior.ts
@@ -13,6 +13,7 @@ import { Behavior } from "../Behavior.js";
 import type { BehaviorBacking } from "../internal/BehaviorBacking.js";
 import type { RootSupervisor } from "../supervision/RootSupervisor.js";
 import { NetworkBehavior } from "../system/network/NetworkBehavior.js";
+import { ClientBehavior } from "./ClientBehavior.js";
 import { ExtensionInterfaceOf, createType, type ClusterOf } from "./ClusterBehaviorUtil.js";
 import type { ClusterEvents } from "./ClusterEvents.js";
 import { ClusterInterface } from "./ClusterInterface.js";
@@ -181,7 +182,7 @@ export class ClusterBehavior extends Behavior {
         //
         // Further, we know the "Client" classes can have no extension methods or properties, so we don't need to do an
         // exact class match for type safety
-        if (other.name.endsWith("Client") && otherCluster.id === this.cluster.id) {
+        if (ClientBehavior.is(other) && otherCluster.id === this.cluster.id) {
             return true;
         }
 

--- a/packages/node/src/behavior/cluster/index.ts
+++ b/packages/node/src/behavior/cluster/index.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+export * from "./ClientBehavior.js";
 export * from "./ClusterBehavior.js";
 export * from "./ClusterBehaviorUtil.js";
 export * from "./ClusterEvents.js";

--- a/packages/node/src/behavior/internal/BehaviorBacking.ts
+++ b/packages/node/src/behavior/internal/BehaviorBacking.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { ClientBehavior } from "#behavior/cluster/ClientBehavior.js";
 import { OnlineEvent } from "#behavior/Events.js";
 import { Migration } from "#behavior/state/migrations/Migration.js";
 import type { Agent } from "#endpoint/Agent.js";
@@ -184,7 +185,7 @@ export abstract class BehaviorBacking {
      */
     createBehavior(agent: Agent, type: Behavior.Type) {
         const behavior = new this.#type(agent, this);
-        if (behavior instanceof type) {
+        if (behavior instanceof type || ClientBehavior.is(type)) {
             return behavior;
         }
 

--- a/packages/node/src/behaviors/access-control/AccessControlClient.ts
+++ b/packages/node/src/behaviors/access-control/AccessControlClient.ts
@@ -7,10 +7,10 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { AccessControl } from "#clusters/access-control";
-import { ClusterBehavior } from "../../behavior/cluster/ClusterBehavior.js";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const AccessControlClientConstructor = ClusterBehavior.for(AccessControl.Complete);
+export const AccessControlClientConstructor = ClientBehavior(AccessControl.Complete);
 export interface AccessControlClient extends InstanceType<typeof AccessControlClientConstructor> {}
 export interface AccessControlClientConstructor extends Identity<typeof AccessControlClientConstructor> {}
 export const AccessControlClient: AccessControlClientConstructor = AccessControlClientConstructor;

--- a/packages/node/src/behaviors/account-login/AccountLoginClient.ts
+++ b/packages/node/src/behaviors/account-login/AccountLoginClient.ts
@@ -6,10 +6,11 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import { AccountLoginBehavior } from "./AccountLoginBehavior.js";
+import { AccountLogin } from "#clusters/account-login";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const AccountLoginClientConstructor = AccountLoginBehavior;
-export interface AccountLoginClient extends AccountLoginBehavior {}
+export const AccountLoginClientConstructor = ClientBehavior(AccountLogin.Complete);
+export interface AccountLoginClient extends InstanceType<typeof AccountLoginClientConstructor> {}
 export interface AccountLoginClientConstructor extends Identity<typeof AccountLoginClientConstructor> {}
 export const AccountLoginClient: AccountLoginClientConstructor = AccountLoginClientConstructor;

--- a/packages/node/src/behaviors/actions/ActionsClient.ts
+++ b/packages/node/src/behaviors/actions/ActionsClient.ts
@@ -6,10 +6,11 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import { ActionsBehavior } from "./ActionsBehavior.js";
+import { Actions } from "#clusters/actions";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const ActionsClientConstructor = ActionsBehavior;
-export interface ActionsClient extends ActionsBehavior {}
+export const ActionsClientConstructor = ClientBehavior(Actions.Complete);
+export interface ActionsClient extends InstanceType<typeof ActionsClientConstructor> {}
 export interface ActionsClientConstructor extends Identity<typeof ActionsClientConstructor> {}
 export const ActionsClient: ActionsClientConstructor = ActionsClientConstructor;

--- a/packages/node/src/behaviors/activated-carbon-filter-monitoring/ActivatedCarbonFilterMonitoringClient.ts
+++ b/packages/node/src/behaviors/activated-carbon-filter-monitoring/ActivatedCarbonFilterMonitoringClient.ts
@@ -7,11 +7,10 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { ActivatedCarbonFilterMonitoring } from "#clusters/activated-carbon-filter-monitoring";
-import { ClusterBehavior } from "../../behavior/cluster/ClusterBehavior.js";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const ActivatedCarbonFilterMonitoringClientConstructor = ClusterBehavior
-    .for(ActivatedCarbonFilterMonitoring.Complete);
+export const ActivatedCarbonFilterMonitoringClientConstructor = ClientBehavior(ActivatedCarbonFilterMonitoring.Complete);
 export interface ActivatedCarbonFilterMonitoringClient extends InstanceType<typeof ActivatedCarbonFilterMonitoringClientConstructor> {}
 export interface ActivatedCarbonFilterMonitoringClientConstructor extends Identity<typeof ActivatedCarbonFilterMonitoringClientConstructor> {}
 export const ActivatedCarbonFilterMonitoringClient: ActivatedCarbonFilterMonitoringClientConstructor = ActivatedCarbonFilterMonitoringClientConstructor;

--- a/packages/node/src/behaviors/administrator-commissioning/AdministratorCommissioningClient.ts
+++ b/packages/node/src/behaviors/administrator-commissioning/AdministratorCommissioningClient.ts
@@ -7,10 +7,10 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { AdministratorCommissioning } from "#clusters/administrator-commissioning";
-import { ClusterBehavior } from "../../behavior/cluster/ClusterBehavior.js";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const AdministratorCommissioningClientConstructor = ClusterBehavior.for(AdministratorCommissioning.Complete);
+export const AdministratorCommissioningClientConstructor = ClientBehavior(AdministratorCommissioning.Complete);
 export interface AdministratorCommissioningClient extends InstanceType<typeof AdministratorCommissioningClientConstructor> {}
 export interface AdministratorCommissioningClientConstructor extends Identity<typeof AdministratorCommissioningClientConstructor> {}
 export const AdministratorCommissioningClient: AdministratorCommissioningClientConstructor = AdministratorCommissioningClientConstructor;

--- a/packages/node/src/behaviors/air-quality/AirQualityClient.ts
+++ b/packages/node/src/behaviors/air-quality/AirQualityClient.ts
@@ -6,10 +6,11 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import { AirQualityBehavior } from "./AirQualityBehavior.js";
+import { AirQuality } from "#clusters/air-quality";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const AirQualityClientConstructor = AirQualityBehavior;
-export interface AirQualityClient extends AirQualityBehavior {}
+export const AirQualityClientConstructor = ClientBehavior(AirQuality.Complete);
+export interface AirQualityClient extends InstanceType<typeof AirQualityClientConstructor> {}
 export interface AirQualityClientConstructor extends Identity<typeof AirQualityClientConstructor> {}
 export const AirQualityClient: AirQualityClientConstructor = AirQualityClientConstructor;

--- a/packages/node/src/behaviors/application-basic/ApplicationBasicClient.ts
+++ b/packages/node/src/behaviors/application-basic/ApplicationBasicClient.ts
@@ -6,10 +6,11 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import { ApplicationBasicBehavior } from "./ApplicationBasicBehavior.js";
+import { ApplicationBasic } from "#clusters/application-basic";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const ApplicationBasicClientConstructor = ApplicationBasicBehavior;
-export interface ApplicationBasicClient extends ApplicationBasicBehavior {}
+export const ApplicationBasicClientConstructor = ClientBehavior(ApplicationBasic.Complete);
+export interface ApplicationBasicClient extends InstanceType<typeof ApplicationBasicClientConstructor> {}
 export interface ApplicationBasicClientConstructor extends Identity<typeof ApplicationBasicClientConstructor> {}
 export const ApplicationBasicClient: ApplicationBasicClientConstructor = ApplicationBasicClientConstructor;

--- a/packages/node/src/behaviors/application-launcher/ApplicationLauncherClient.ts
+++ b/packages/node/src/behaviors/application-launcher/ApplicationLauncherClient.ts
@@ -7,10 +7,10 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { ApplicationLauncher } from "#clusters/application-launcher";
-import { ClusterBehavior } from "../../behavior/cluster/ClusterBehavior.js";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const ApplicationLauncherClientConstructor = ClusterBehavior.for(ApplicationLauncher.Complete);
+export const ApplicationLauncherClientConstructor = ClientBehavior(ApplicationLauncher.Complete);
 export interface ApplicationLauncherClient extends InstanceType<typeof ApplicationLauncherClientConstructor> {}
 export interface ApplicationLauncherClientConstructor extends Identity<typeof ApplicationLauncherClientConstructor> {}
 export const ApplicationLauncherClient: ApplicationLauncherClientConstructor = ApplicationLauncherClientConstructor;

--- a/packages/node/src/behaviors/audio-output/AudioOutputClient.ts
+++ b/packages/node/src/behaviors/audio-output/AudioOutputClient.ts
@@ -7,10 +7,10 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { AudioOutput } from "#clusters/audio-output";
-import { ClusterBehavior } from "../../behavior/cluster/ClusterBehavior.js";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const AudioOutputClientConstructor = ClusterBehavior.for(AudioOutput.Complete);
+export const AudioOutputClientConstructor = ClientBehavior(AudioOutput.Complete);
 export interface AudioOutputClient extends InstanceType<typeof AudioOutputClientConstructor> {}
 export interface AudioOutputClientConstructor extends Identity<typeof AudioOutputClientConstructor> {}
 export const AudioOutputClient: AudioOutputClientConstructor = AudioOutputClientConstructor;

--- a/packages/node/src/behaviors/basic-information/BasicInformationClient.ts
+++ b/packages/node/src/behaviors/basic-information/BasicInformationClient.ts
@@ -6,10 +6,11 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import { BasicInformationBehavior } from "./BasicInformationBehavior.js";
+import { BasicInformation } from "#clusters/basic-information";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const BasicInformationClientConstructor = BasicInformationBehavior;
-export interface BasicInformationClient extends BasicInformationBehavior {}
+export const BasicInformationClientConstructor = ClientBehavior(BasicInformation.Complete);
+export interface BasicInformationClient extends InstanceType<typeof BasicInformationClientConstructor> {}
 export interface BasicInformationClientConstructor extends Identity<typeof BasicInformationClientConstructor> {}
 export const BasicInformationClient: BasicInformationClientConstructor = BasicInformationClientConstructor;

--- a/packages/node/src/behaviors/binding/BindingClient.ts
+++ b/packages/node/src/behaviors/binding/BindingClient.ts
@@ -6,10 +6,11 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import { BindingBehavior } from "./BindingBehavior.js";
+import { Binding } from "#clusters/binding";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const BindingClientConstructor = BindingBehavior;
-export interface BindingClient extends BindingBehavior {}
+export const BindingClientConstructor = ClientBehavior(Binding.Complete);
+export interface BindingClient extends InstanceType<typeof BindingClientConstructor> {}
 export interface BindingClientConstructor extends Identity<typeof BindingClientConstructor> {}
 export const BindingClient: BindingClientConstructor = BindingClientConstructor;

--- a/packages/node/src/behaviors/boolean-state-configuration/BooleanStateConfigurationClient.ts
+++ b/packages/node/src/behaviors/boolean-state-configuration/BooleanStateConfigurationClient.ts
@@ -7,10 +7,10 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { BooleanStateConfiguration } from "#clusters/boolean-state-configuration";
-import { ClusterBehavior } from "../../behavior/cluster/ClusterBehavior.js";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const BooleanStateConfigurationClientConstructor = ClusterBehavior.for(BooleanStateConfiguration.Complete);
+export const BooleanStateConfigurationClientConstructor = ClientBehavior(BooleanStateConfiguration.Complete);
 export interface BooleanStateConfigurationClient extends InstanceType<typeof BooleanStateConfigurationClientConstructor> {}
 export interface BooleanStateConfigurationClientConstructor extends Identity<typeof BooleanStateConfigurationClientConstructor> {}
 export const BooleanStateConfigurationClient: BooleanStateConfigurationClientConstructor = BooleanStateConfigurationClientConstructor;

--- a/packages/node/src/behaviors/boolean-state/BooleanStateClient.ts
+++ b/packages/node/src/behaviors/boolean-state/BooleanStateClient.ts
@@ -6,10 +6,11 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import { BooleanStateBehavior } from "./BooleanStateBehavior.js";
+import { BooleanState } from "#clusters/boolean-state";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const BooleanStateClientConstructor = BooleanStateBehavior;
-export interface BooleanStateClient extends BooleanStateBehavior {}
+export const BooleanStateClientConstructor = ClientBehavior(BooleanState.Complete);
+export interface BooleanStateClient extends InstanceType<typeof BooleanStateClientConstructor> {}
 export interface BooleanStateClientConstructor extends Identity<typeof BooleanStateClientConstructor> {}
 export const BooleanStateClient: BooleanStateClientConstructor = BooleanStateClientConstructor;

--- a/packages/node/src/behaviors/bridged-device-basic-information/BridgedDeviceBasicInformationClient.ts
+++ b/packages/node/src/behaviors/bridged-device-basic-information/BridgedDeviceBasicInformationClient.ts
@@ -7,11 +7,10 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { BridgedDeviceBasicInformation } from "#clusters/bridged-device-basic-information";
-import { ClusterBehavior } from "../../behavior/cluster/ClusterBehavior.js";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const BridgedDeviceBasicInformationClientConstructor = ClusterBehavior
-    .for(BridgedDeviceBasicInformation.Complete);
+export const BridgedDeviceBasicInformationClientConstructor = ClientBehavior(BridgedDeviceBasicInformation.Complete);
 export interface BridgedDeviceBasicInformationClient extends InstanceType<typeof BridgedDeviceBasicInformationClientConstructor> {}
 export interface BridgedDeviceBasicInformationClientConstructor extends Identity<typeof BridgedDeviceBasicInformationClientConstructor> {}
 export const BridgedDeviceBasicInformationClient: BridgedDeviceBasicInformationClientConstructor = BridgedDeviceBasicInformationClientConstructor;

--- a/packages/node/src/behaviors/carbon-dioxide-concentration-measurement/CarbonDioxideConcentrationMeasurementClient.ts
+++ b/packages/node/src/behaviors/carbon-dioxide-concentration-measurement/CarbonDioxideConcentrationMeasurementClient.ts
@@ -7,11 +7,12 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { CarbonDioxideConcentrationMeasurement } from "#clusters/carbon-dioxide-concentration-measurement";
-import { ClusterBehavior } from "../../behavior/cluster/ClusterBehavior.js";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const CarbonDioxideConcentrationMeasurementClientConstructor = ClusterBehavior
-    .for(CarbonDioxideConcentrationMeasurement.Complete);
+export const CarbonDioxideConcentrationMeasurementClientConstructor = ClientBehavior(
+    CarbonDioxideConcentrationMeasurement.Complete
+);
 export interface CarbonDioxideConcentrationMeasurementClient extends InstanceType<typeof CarbonDioxideConcentrationMeasurementClientConstructor> {}
 export interface CarbonDioxideConcentrationMeasurementClientConstructor extends Identity<typeof CarbonDioxideConcentrationMeasurementClientConstructor> {}
 export const CarbonDioxideConcentrationMeasurementClient: CarbonDioxideConcentrationMeasurementClientConstructor = CarbonDioxideConcentrationMeasurementClientConstructor;

--- a/packages/node/src/behaviors/carbon-monoxide-concentration-measurement/CarbonMonoxideConcentrationMeasurementClient.ts
+++ b/packages/node/src/behaviors/carbon-monoxide-concentration-measurement/CarbonMonoxideConcentrationMeasurementClient.ts
@@ -7,11 +7,12 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { CarbonMonoxideConcentrationMeasurement } from "#clusters/carbon-monoxide-concentration-measurement";
-import { ClusterBehavior } from "../../behavior/cluster/ClusterBehavior.js";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const CarbonMonoxideConcentrationMeasurementClientConstructor = ClusterBehavior
-    .for(CarbonMonoxideConcentrationMeasurement.Complete);
+export const CarbonMonoxideConcentrationMeasurementClientConstructor = ClientBehavior(
+    CarbonMonoxideConcentrationMeasurement.Complete
+);
 export interface CarbonMonoxideConcentrationMeasurementClient extends InstanceType<typeof CarbonMonoxideConcentrationMeasurementClientConstructor> {}
 export interface CarbonMonoxideConcentrationMeasurementClientConstructor extends Identity<typeof CarbonMonoxideConcentrationMeasurementClientConstructor> {}
 export const CarbonMonoxideConcentrationMeasurementClient: CarbonMonoxideConcentrationMeasurementClientConstructor = CarbonMonoxideConcentrationMeasurementClientConstructor;

--- a/packages/node/src/behaviors/channel/ChannelClient.ts
+++ b/packages/node/src/behaviors/channel/ChannelClient.ts
@@ -7,10 +7,10 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { Channel } from "#clusters/channel";
-import { ClusterBehavior } from "../../behavior/cluster/ClusterBehavior.js";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const ChannelClientConstructor = ClusterBehavior.for(Channel.Complete);
+export const ChannelClientConstructor = ClientBehavior(Channel.Complete);
 export interface ChannelClient extends InstanceType<typeof ChannelClientConstructor> {}
 export interface ChannelClientConstructor extends Identity<typeof ChannelClientConstructor> {}
 export const ChannelClient: ChannelClientConstructor = ChannelClientConstructor;

--- a/packages/node/src/behaviors/color-control/ColorControlClient.ts
+++ b/packages/node/src/behaviors/color-control/ColorControlClient.ts
@@ -7,10 +7,10 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { ColorControl } from "#clusters/color-control";
-import { ClusterBehavior } from "../../behavior/cluster/ClusterBehavior.js";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const ColorControlClientConstructor = ClusterBehavior.for(ColorControl.Complete);
+export const ColorControlClientConstructor = ClientBehavior(ColorControl.Complete);
 export interface ColorControlClient extends InstanceType<typeof ColorControlClientConstructor> {}
 export interface ColorControlClientConstructor extends Identity<typeof ColorControlClientConstructor> {}
 export const ColorControlClient: ColorControlClientConstructor = ColorControlClientConstructor;

--- a/packages/node/src/behaviors/commissioner-control/CommissionerControlClient.ts
+++ b/packages/node/src/behaviors/commissioner-control/CommissionerControlClient.ts
@@ -6,10 +6,11 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import { CommissionerControlBehavior } from "./CommissionerControlBehavior.js";
+import { CommissionerControl } from "#clusters/commissioner-control";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const CommissionerControlClientConstructor = CommissionerControlBehavior;
-export interface CommissionerControlClient extends CommissionerControlBehavior {}
+export const CommissionerControlClientConstructor = ClientBehavior(CommissionerControl.Complete);
+export interface CommissionerControlClient extends InstanceType<typeof CommissionerControlClientConstructor> {}
 export interface CommissionerControlClientConstructor extends Identity<typeof CommissionerControlClientConstructor> {}
 export const CommissionerControlClient: CommissionerControlClientConstructor = CommissionerControlClientConstructor;

--- a/packages/node/src/behaviors/content-app-observer/ContentAppObserverClient.ts
+++ b/packages/node/src/behaviors/content-app-observer/ContentAppObserverClient.ts
@@ -6,10 +6,11 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import { ContentAppObserverBehavior } from "./ContentAppObserverBehavior.js";
+import { ContentAppObserver } from "#clusters/content-app-observer";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const ContentAppObserverClientConstructor = ContentAppObserverBehavior;
-export interface ContentAppObserverClient extends ContentAppObserverBehavior {}
+export const ContentAppObserverClientConstructor = ClientBehavior(ContentAppObserver.Complete);
+export interface ContentAppObserverClient extends InstanceType<typeof ContentAppObserverClientConstructor> {}
 export interface ContentAppObserverClientConstructor extends Identity<typeof ContentAppObserverClientConstructor> {}
 export const ContentAppObserverClient: ContentAppObserverClientConstructor = ContentAppObserverClientConstructor;

--- a/packages/node/src/behaviors/content-control/ContentControlClient.ts
+++ b/packages/node/src/behaviors/content-control/ContentControlClient.ts
@@ -7,10 +7,10 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { ContentControl } from "#clusters/content-control";
-import { ClusterBehavior } from "../../behavior/cluster/ClusterBehavior.js";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const ContentControlClientConstructor = ClusterBehavior.for(ContentControl.Complete);
+export const ContentControlClientConstructor = ClientBehavior(ContentControl.Complete);
 export interface ContentControlClient extends InstanceType<typeof ContentControlClientConstructor> {}
 export interface ContentControlClientConstructor extends Identity<typeof ContentControlClientConstructor> {}
 export const ContentControlClient: ContentControlClientConstructor = ContentControlClientConstructor;

--- a/packages/node/src/behaviors/content-launcher/ContentLauncherClient.ts
+++ b/packages/node/src/behaviors/content-launcher/ContentLauncherClient.ts
@@ -7,10 +7,10 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { ContentLauncher } from "#clusters/content-launcher";
-import { ClusterBehavior } from "../../behavior/cluster/ClusterBehavior.js";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const ContentLauncherClientConstructor = ClusterBehavior.for(ContentLauncher.Complete);
+export const ContentLauncherClientConstructor = ClientBehavior(ContentLauncher.Complete);
 export interface ContentLauncherClient extends InstanceType<typeof ContentLauncherClientConstructor> {}
 export interface ContentLauncherClientConstructor extends Identity<typeof ContentLauncherClientConstructor> {}
 export const ContentLauncherClient: ContentLauncherClientConstructor = ContentLauncherClientConstructor;

--- a/packages/node/src/behaviors/descriptor/DescriptorClient.ts
+++ b/packages/node/src/behaviors/descriptor/DescriptorClient.ts
@@ -7,10 +7,10 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { Descriptor } from "#clusters/descriptor";
-import { ClusterBehavior } from "../../behavior/cluster/ClusterBehavior.js";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const DescriptorClientConstructor = ClusterBehavior.for(Descriptor.Complete);
+export const DescriptorClientConstructor = ClientBehavior(Descriptor.Complete);
 export interface DescriptorClient extends InstanceType<typeof DescriptorClientConstructor> {}
 export interface DescriptorClientConstructor extends Identity<typeof DescriptorClientConstructor> {}
 export const DescriptorClient: DescriptorClientConstructor = DescriptorClientConstructor;

--- a/packages/node/src/behaviors/device-energy-management-mode/DeviceEnergyManagementModeClient.ts
+++ b/packages/node/src/behaviors/device-energy-management-mode/DeviceEnergyManagementModeClient.ts
@@ -6,10 +6,11 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import { DeviceEnergyManagementModeBehavior } from "./DeviceEnergyManagementModeBehavior.js";
+import { DeviceEnergyManagementMode } from "#clusters/device-energy-management-mode";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const DeviceEnergyManagementModeClientConstructor = DeviceEnergyManagementModeBehavior;
-export interface DeviceEnergyManagementModeClient extends DeviceEnergyManagementModeBehavior {}
+export const DeviceEnergyManagementModeClientConstructor = ClientBehavior(DeviceEnergyManagementMode.Complete);
+export interface DeviceEnergyManagementModeClient extends InstanceType<typeof DeviceEnergyManagementModeClientConstructor> {}
 export interface DeviceEnergyManagementModeClientConstructor extends Identity<typeof DeviceEnergyManagementModeClientConstructor> {}
 export const DeviceEnergyManagementModeClient: DeviceEnergyManagementModeClientConstructor = DeviceEnergyManagementModeClientConstructor;

--- a/packages/node/src/behaviors/device-energy-management/DeviceEnergyManagementClient.ts
+++ b/packages/node/src/behaviors/device-energy-management/DeviceEnergyManagementClient.ts
@@ -7,10 +7,10 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { DeviceEnergyManagement } from "#clusters/device-energy-management";
-import { ClusterBehavior } from "../../behavior/cluster/ClusterBehavior.js";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const DeviceEnergyManagementClientConstructor = ClusterBehavior.for(DeviceEnergyManagement.Complete);
+export const DeviceEnergyManagementClientConstructor = ClientBehavior(DeviceEnergyManagement.Complete);
 export interface DeviceEnergyManagementClient extends InstanceType<typeof DeviceEnergyManagementClientConstructor> {}
 export interface DeviceEnergyManagementClientConstructor extends Identity<typeof DeviceEnergyManagementClientConstructor> {}
 export const DeviceEnergyManagementClient: DeviceEnergyManagementClientConstructor = DeviceEnergyManagementClientConstructor;

--- a/packages/node/src/behaviors/diagnostic-logs/DiagnosticLogsClient.ts
+++ b/packages/node/src/behaviors/diagnostic-logs/DiagnosticLogsClient.ts
@@ -6,10 +6,11 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import { DiagnosticLogsBehavior } from "./DiagnosticLogsBehavior.js";
+import { DiagnosticLogs } from "#clusters/diagnostic-logs";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const DiagnosticLogsClientConstructor = DiagnosticLogsBehavior;
-export interface DiagnosticLogsClient extends DiagnosticLogsBehavior {}
+export const DiagnosticLogsClientConstructor = ClientBehavior(DiagnosticLogs.Complete);
+export interface DiagnosticLogsClient extends InstanceType<typeof DiagnosticLogsClientConstructor> {}
 export interface DiagnosticLogsClientConstructor extends Identity<typeof DiagnosticLogsClientConstructor> {}
 export const DiagnosticLogsClient: DiagnosticLogsClientConstructor = DiagnosticLogsClientConstructor;

--- a/packages/node/src/behaviors/dishwasher-alarm/DishwasherAlarmClient.ts
+++ b/packages/node/src/behaviors/dishwasher-alarm/DishwasherAlarmClient.ts
@@ -7,10 +7,10 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { DishwasherAlarm } from "#clusters/dishwasher-alarm";
-import { ClusterBehavior } from "../../behavior/cluster/ClusterBehavior.js";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const DishwasherAlarmClientConstructor = ClusterBehavior.for(DishwasherAlarm.Complete);
+export const DishwasherAlarmClientConstructor = ClientBehavior(DishwasherAlarm.Complete);
 export interface DishwasherAlarmClient extends InstanceType<typeof DishwasherAlarmClientConstructor> {}
 export interface DishwasherAlarmClientConstructor extends Identity<typeof DishwasherAlarmClientConstructor> {}
 export const DishwasherAlarmClient: DishwasherAlarmClientConstructor = DishwasherAlarmClientConstructor;

--- a/packages/node/src/behaviors/dishwasher-mode/DishwasherModeClient.ts
+++ b/packages/node/src/behaviors/dishwasher-mode/DishwasherModeClient.ts
@@ -6,10 +6,11 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import { DishwasherModeBehavior } from "./DishwasherModeBehavior.js";
+import { DishwasherMode } from "#clusters/dishwasher-mode";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const DishwasherModeClientConstructor = DishwasherModeBehavior;
-export interface DishwasherModeClient extends DishwasherModeBehavior {}
+export const DishwasherModeClientConstructor = ClientBehavior(DishwasherMode.Complete);
+export interface DishwasherModeClient extends InstanceType<typeof DishwasherModeClientConstructor> {}
 export interface DishwasherModeClientConstructor extends Identity<typeof DishwasherModeClientConstructor> {}
 export const DishwasherModeClient: DishwasherModeClientConstructor = DishwasherModeClientConstructor;

--- a/packages/node/src/behaviors/door-lock/DoorLockClient.ts
+++ b/packages/node/src/behaviors/door-lock/DoorLockClient.ts
@@ -7,10 +7,10 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { DoorLock } from "#clusters/door-lock";
-import { ClusterBehavior } from "../../behavior/cluster/ClusterBehavior.js";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const DoorLockClientConstructor = ClusterBehavior.for(DoorLock.Complete);
+export const DoorLockClientConstructor = ClientBehavior(DoorLock.Complete);
 export interface DoorLockClient extends InstanceType<typeof DoorLockClientConstructor> {}
 export interface DoorLockClientConstructor extends Identity<typeof DoorLockClientConstructor> {}
 export const DoorLockClient: DoorLockClientConstructor = DoorLockClientConstructor;

--- a/packages/node/src/behaviors/ecosystem-information/EcosystemInformationClient.ts
+++ b/packages/node/src/behaviors/ecosystem-information/EcosystemInformationClient.ts
@@ -6,10 +6,11 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import { EcosystemInformationBehavior } from "./EcosystemInformationBehavior.js";
+import { EcosystemInformation } from "#clusters/ecosystem-information";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const EcosystemInformationClientConstructor = EcosystemInformationBehavior;
-export interface EcosystemInformationClient extends EcosystemInformationBehavior {}
+export const EcosystemInformationClientConstructor = ClientBehavior(EcosystemInformation.Complete);
+export interface EcosystemInformationClient extends InstanceType<typeof EcosystemInformationClientConstructor> {}
 export interface EcosystemInformationClientConstructor extends Identity<typeof EcosystemInformationClientConstructor> {}
 export const EcosystemInformationClient: EcosystemInformationClientConstructor = EcosystemInformationClientConstructor;

--- a/packages/node/src/behaviors/electrical-energy-measurement/ElectricalEnergyMeasurementClient.ts
+++ b/packages/node/src/behaviors/electrical-energy-measurement/ElectricalEnergyMeasurementClient.ts
@@ -7,10 +7,10 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { ElectricalEnergyMeasurement } from "#clusters/electrical-energy-measurement";
-import { ClusterBehavior } from "../../behavior/cluster/ClusterBehavior.js";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const ElectricalEnergyMeasurementClientConstructor = ClusterBehavior.for(ElectricalEnergyMeasurement.Complete);
+export const ElectricalEnergyMeasurementClientConstructor = ClientBehavior(ElectricalEnergyMeasurement.Complete);
 export interface ElectricalEnergyMeasurementClient extends InstanceType<typeof ElectricalEnergyMeasurementClientConstructor> {}
 export interface ElectricalEnergyMeasurementClientConstructor extends Identity<typeof ElectricalEnergyMeasurementClientConstructor> {}
 export const ElectricalEnergyMeasurementClient: ElectricalEnergyMeasurementClientConstructor = ElectricalEnergyMeasurementClientConstructor;

--- a/packages/node/src/behaviors/electrical-power-measurement/ElectricalPowerMeasurementClient.ts
+++ b/packages/node/src/behaviors/electrical-power-measurement/ElectricalPowerMeasurementClient.ts
@@ -7,10 +7,10 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { ElectricalPowerMeasurement } from "#clusters/electrical-power-measurement";
-import { ClusterBehavior } from "../../behavior/cluster/ClusterBehavior.js";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const ElectricalPowerMeasurementClientConstructor = ClusterBehavior.for(ElectricalPowerMeasurement.Complete);
+export const ElectricalPowerMeasurementClientConstructor = ClientBehavior(ElectricalPowerMeasurement.Complete);
 export interface ElectricalPowerMeasurementClient extends InstanceType<typeof ElectricalPowerMeasurementClientConstructor> {}
 export interface ElectricalPowerMeasurementClientConstructor extends Identity<typeof ElectricalPowerMeasurementClientConstructor> {}
 export const ElectricalPowerMeasurementClient: ElectricalPowerMeasurementClientConstructor = ElectricalPowerMeasurementClientConstructor;

--- a/packages/node/src/behaviors/energy-evse-mode/EnergyEvseModeClient.ts
+++ b/packages/node/src/behaviors/energy-evse-mode/EnergyEvseModeClient.ts
@@ -6,10 +6,11 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import { EnergyEvseModeBehavior } from "./EnergyEvseModeBehavior.js";
+import { EnergyEvseMode } from "#clusters/energy-evse-mode";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const EnergyEvseModeClientConstructor = EnergyEvseModeBehavior;
-export interface EnergyEvseModeClient extends EnergyEvseModeBehavior {}
+export const EnergyEvseModeClientConstructor = ClientBehavior(EnergyEvseMode.Complete);
+export interface EnergyEvseModeClient extends InstanceType<typeof EnergyEvseModeClientConstructor> {}
 export interface EnergyEvseModeClientConstructor extends Identity<typeof EnergyEvseModeClientConstructor> {}
 export const EnergyEvseModeClient: EnergyEvseModeClientConstructor = EnergyEvseModeClientConstructor;

--- a/packages/node/src/behaviors/energy-evse/EnergyEvseClient.ts
+++ b/packages/node/src/behaviors/energy-evse/EnergyEvseClient.ts
@@ -7,10 +7,10 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { EnergyEvse } from "#clusters/energy-evse";
-import { ClusterBehavior } from "../../behavior/cluster/ClusterBehavior.js";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const EnergyEvseClientConstructor = ClusterBehavior.for(EnergyEvse.Complete);
+export const EnergyEvseClientConstructor = ClientBehavior(EnergyEvse.Complete);
 export interface EnergyEvseClient extends InstanceType<typeof EnergyEvseClientConstructor> {}
 export interface EnergyEvseClientConstructor extends Identity<typeof EnergyEvseClientConstructor> {}
 export const EnergyEvseClient: EnergyEvseClientConstructor = EnergyEvseClientConstructor;

--- a/packages/node/src/behaviors/energy-preference/EnergyPreferenceClient.ts
+++ b/packages/node/src/behaviors/energy-preference/EnergyPreferenceClient.ts
@@ -7,10 +7,10 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { EnergyPreference } from "#clusters/energy-preference";
-import { ClusterBehavior } from "../../behavior/cluster/ClusterBehavior.js";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const EnergyPreferenceClientConstructor = ClusterBehavior.for(EnergyPreference.Complete);
+export const EnergyPreferenceClientConstructor = ClientBehavior(EnergyPreference.Complete);
 export interface EnergyPreferenceClient extends InstanceType<typeof EnergyPreferenceClientConstructor> {}
 export interface EnergyPreferenceClientConstructor extends Identity<typeof EnergyPreferenceClientConstructor> {}
 export const EnergyPreferenceClient: EnergyPreferenceClientConstructor = EnergyPreferenceClientConstructor;

--- a/packages/node/src/behaviors/ethernet-network-diagnostics/EthernetNetworkDiagnosticsClient.ts
+++ b/packages/node/src/behaviors/ethernet-network-diagnostics/EthernetNetworkDiagnosticsClient.ts
@@ -7,10 +7,10 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { EthernetNetworkDiagnostics } from "#clusters/ethernet-network-diagnostics";
-import { ClusterBehavior } from "../../behavior/cluster/ClusterBehavior.js";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const EthernetNetworkDiagnosticsClientConstructor = ClusterBehavior.for(EthernetNetworkDiagnostics.Complete);
+export const EthernetNetworkDiagnosticsClientConstructor = ClientBehavior(EthernetNetworkDiagnostics.Complete);
 export interface EthernetNetworkDiagnosticsClient extends InstanceType<typeof EthernetNetworkDiagnosticsClientConstructor> {}
 export interface EthernetNetworkDiagnosticsClientConstructor extends Identity<typeof EthernetNetworkDiagnosticsClientConstructor> {}
 export const EthernetNetworkDiagnosticsClient: EthernetNetworkDiagnosticsClientConstructor = EthernetNetworkDiagnosticsClientConstructor;

--- a/packages/node/src/behaviors/fan-control/FanControlClient.ts
+++ b/packages/node/src/behaviors/fan-control/FanControlClient.ts
@@ -7,10 +7,10 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { FanControl } from "#clusters/fan-control";
-import { ClusterBehavior } from "../../behavior/cluster/ClusterBehavior.js";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const FanControlClientConstructor = ClusterBehavior.for(FanControl.Complete);
+export const FanControlClientConstructor = ClientBehavior(FanControl.Complete);
 export interface FanControlClient extends InstanceType<typeof FanControlClientConstructor> {}
 export interface FanControlClientConstructor extends Identity<typeof FanControlClientConstructor> {}
 export const FanControlClient: FanControlClientConstructor = FanControlClientConstructor;

--- a/packages/node/src/behaviors/fixed-label/FixedLabelClient.ts
+++ b/packages/node/src/behaviors/fixed-label/FixedLabelClient.ts
@@ -6,10 +6,11 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import { FixedLabelBehavior } from "./FixedLabelBehavior.js";
+import { FixedLabel } from "#clusters/fixed-label";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const FixedLabelClientConstructor = FixedLabelBehavior;
-export interface FixedLabelClient extends FixedLabelBehavior {}
+export const FixedLabelClientConstructor = ClientBehavior(FixedLabel.Complete);
+export interface FixedLabelClient extends InstanceType<typeof FixedLabelClientConstructor> {}
 export interface FixedLabelClientConstructor extends Identity<typeof FixedLabelClientConstructor> {}
 export const FixedLabelClient: FixedLabelClientConstructor = FixedLabelClientConstructor;

--- a/packages/node/src/behaviors/flow-measurement/FlowMeasurementClient.ts
+++ b/packages/node/src/behaviors/flow-measurement/FlowMeasurementClient.ts
@@ -6,10 +6,11 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import { FlowMeasurementBehavior } from "./FlowMeasurementBehavior.js";
+import { FlowMeasurement } from "#clusters/flow-measurement";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const FlowMeasurementClientConstructor = FlowMeasurementBehavior;
-export interface FlowMeasurementClient extends FlowMeasurementBehavior {}
+export const FlowMeasurementClientConstructor = ClientBehavior(FlowMeasurement.Complete);
+export interface FlowMeasurementClient extends InstanceType<typeof FlowMeasurementClientConstructor> {}
 export interface FlowMeasurementClientConstructor extends Identity<typeof FlowMeasurementClientConstructor> {}
 export const FlowMeasurementClient: FlowMeasurementClientConstructor = FlowMeasurementClientConstructor;

--- a/packages/node/src/behaviors/formaldehyde-concentration-measurement/FormaldehydeConcentrationMeasurementClient.ts
+++ b/packages/node/src/behaviors/formaldehyde-concentration-measurement/FormaldehydeConcentrationMeasurementClient.ts
@@ -7,11 +7,12 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { FormaldehydeConcentrationMeasurement } from "#clusters/formaldehyde-concentration-measurement";
-import { ClusterBehavior } from "../../behavior/cluster/ClusterBehavior.js";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const FormaldehydeConcentrationMeasurementClientConstructor = ClusterBehavior
-    .for(FormaldehydeConcentrationMeasurement.Complete);
+export const FormaldehydeConcentrationMeasurementClientConstructor = ClientBehavior(
+    FormaldehydeConcentrationMeasurement.Complete
+);
 export interface FormaldehydeConcentrationMeasurementClient extends InstanceType<typeof FormaldehydeConcentrationMeasurementClientConstructor> {}
 export interface FormaldehydeConcentrationMeasurementClientConstructor extends Identity<typeof FormaldehydeConcentrationMeasurementClientConstructor> {}
 export const FormaldehydeConcentrationMeasurementClient: FormaldehydeConcentrationMeasurementClientConstructor = FormaldehydeConcentrationMeasurementClientConstructor;

--- a/packages/node/src/behaviors/general-commissioning/GeneralCommissioningClient.ts
+++ b/packages/node/src/behaviors/general-commissioning/GeneralCommissioningClient.ts
@@ -7,10 +7,10 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { GeneralCommissioning } from "#clusters/general-commissioning";
-import { ClusterBehavior } from "../../behavior/cluster/ClusterBehavior.js";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const GeneralCommissioningClientConstructor = ClusterBehavior.for(GeneralCommissioning.Complete);
+export const GeneralCommissioningClientConstructor = ClientBehavior(GeneralCommissioning.Complete);
 export interface GeneralCommissioningClient extends InstanceType<typeof GeneralCommissioningClientConstructor> {}
 export interface GeneralCommissioningClientConstructor extends Identity<typeof GeneralCommissioningClientConstructor> {}
 export const GeneralCommissioningClient: GeneralCommissioningClientConstructor = GeneralCommissioningClientConstructor;

--- a/packages/node/src/behaviors/general-diagnostics/GeneralDiagnosticsClient.ts
+++ b/packages/node/src/behaviors/general-diagnostics/GeneralDiagnosticsClient.ts
@@ -7,10 +7,10 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { GeneralDiagnostics } from "#clusters/general-diagnostics";
-import { ClusterBehavior } from "../../behavior/cluster/ClusterBehavior.js";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const GeneralDiagnosticsClientConstructor = ClusterBehavior.for(GeneralDiagnostics.Complete);
+export const GeneralDiagnosticsClientConstructor = ClientBehavior(GeneralDiagnostics.Complete);
 export interface GeneralDiagnosticsClient extends InstanceType<typeof GeneralDiagnosticsClientConstructor> {}
 export interface GeneralDiagnosticsClientConstructor extends Identity<typeof GeneralDiagnosticsClientConstructor> {}
 export const GeneralDiagnosticsClient: GeneralDiagnosticsClientConstructor = GeneralDiagnosticsClientConstructor;

--- a/packages/node/src/behaviors/group-key-management/GroupKeyManagementClient.ts
+++ b/packages/node/src/behaviors/group-key-management/GroupKeyManagementClient.ts
@@ -6,10 +6,11 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import { GroupKeyManagementBehavior } from "./GroupKeyManagementBehavior.js";
+import { GroupKeyManagement } from "#clusters/group-key-management";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const GroupKeyManagementClientConstructor = GroupKeyManagementBehavior;
-export interface GroupKeyManagementClient extends GroupKeyManagementBehavior {}
+export const GroupKeyManagementClientConstructor = ClientBehavior(GroupKeyManagement.Complete);
+export interface GroupKeyManagementClient extends InstanceType<typeof GroupKeyManagementClientConstructor> {}
 export interface GroupKeyManagementClientConstructor extends Identity<typeof GroupKeyManagementClientConstructor> {}
 export const GroupKeyManagementClient: GroupKeyManagementClientConstructor = GroupKeyManagementClientConstructor;

--- a/packages/node/src/behaviors/groups/GroupsClient.ts
+++ b/packages/node/src/behaviors/groups/GroupsClient.ts
@@ -6,10 +6,11 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import { GroupsBehavior } from "./GroupsBehavior.js";
+import { Groups } from "#clusters/groups";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const GroupsClientConstructor = GroupsBehavior;
-export interface GroupsClient extends GroupsBehavior {}
+export const GroupsClientConstructor = ClientBehavior(Groups.Complete);
+export interface GroupsClient extends InstanceType<typeof GroupsClientConstructor> {}
 export interface GroupsClientConstructor extends Identity<typeof GroupsClientConstructor> {}
 export const GroupsClient: GroupsClientConstructor = GroupsClientConstructor;

--- a/packages/node/src/behaviors/hepa-filter-monitoring/HepaFilterMonitoringClient.ts
+++ b/packages/node/src/behaviors/hepa-filter-monitoring/HepaFilterMonitoringClient.ts
@@ -7,10 +7,10 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { HepaFilterMonitoring } from "#clusters/hepa-filter-monitoring";
-import { ClusterBehavior } from "../../behavior/cluster/ClusterBehavior.js";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const HepaFilterMonitoringClientConstructor = ClusterBehavior.for(HepaFilterMonitoring.Complete);
+export const HepaFilterMonitoringClientConstructor = ClientBehavior(HepaFilterMonitoring.Complete);
 export interface HepaFilterMonitoringClient extends InstanceType<typeof HepaFilterMonitoringClientConstructor> {}
 export interface HepaFilterMonitoringClientConstructor extends Identity<typeof HepaFilterMonitoringClientConstructor> {}
 export const HepaFilterMonitoringClient: HepaFilterMonitoringClientConstructor = HepaFilterMonitoringClientConstructor;

--- a/packages/node/src/behaviors/icd-management/IcdManagementClient.ts
+++ b/packages/node/src/behaviors/icd-management/IcdManagementClient.ts
@@ -7,10 +7,10 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { IcdManagement } from "#clusters/icd-management";
-import { ClusterBehavior } from "../../behavior/cluster/ClusterBehavior.js";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const IcdManagementClientConstructor = ClusterBehavior.for(IcdManagement.Complete);
+export const IcdManagementClientConstructor = ClientBehavior(IcdManagement.Complete);
 export interface IcdManagementClient extends InstanceType<typeof IcdManagementClientConstructor> {}
 export interface IcdManagementClientConstructor extends Identity<typeof IcdManagementClientConstructor> {}
 export const IcdManagementClient: IcdManagementClientConstructor = IcdManagementClientConstructor;

--- a/packages/node/src/behaviors/identify/IdentifyClient.ts
+++ b/packages/node/src/behaviors/identify/IdentifyClient.ts
@@ -6,10 +6,11 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import { IdentifyBehavior } from "./IdentifyBehavior.js";
+import { Identify } from "#clusters/identify";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const IdentifyClientConstructor = IdentifyBehavior;
-export interface IdentifyClient extends IdentifyBehavior {}
+export const IdentifyClientConstructor = ClientBehavior(Identify.Complete);
+export interface IdentifyClient extends InstanceType<typeof IdentifyClientConstructor> {}
 export interface IdentifyClientConstructor extends Identity<typeof IdentifyClientConstructor> {}
 export const IdentifyClient: IdentifyClientConstructor = IdentifyClientConstructor;

--- a/packages/node/src/behaviors/illuminance-measurement/IlluminanceMeasurementClient.ts
+++ b/packages/node/src/behaviors/illuminance-measurement/IlluminanceMeasurementClient.ts
@@ -6,10 +6,11 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import { IlluminanceMeasurementBehavior } from "./IlluminanceMeasurementBehavior.js";
+import { IlluminanceMeasurement } from "#clusters/illuminance-measurement";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const IlluminanceMeasurementClientConstructor = IlluminanceMeasurementBehavior;
-export interface IlluminanceMeasurementClient extends IlluminanceMeasurementBehavior {}
+export const IlluminanceMeasurementClientConstructor = ClientBehavior(IlluminanceMeasurement.Complete);
+export interface IlluminanceMeasurementClient extends InstanceType<typeof IlluminanceMeasurementClientConstructor> {}
 export interface IlluminanceMeasurementClientConstructor extends Identity<typeof IlluminanceMeasurementClientConstructor> {}
 export const IlluminanceMeasurementClient: IlluminanceMeasurementClientConstructor = IlluminanceMeasurementClientConstructor;

--- a/packages/node/src/behaviors/joint-fabric-administrator/JointFabricAdministratorClient.ts
+++ b/packages/node/src/behaviors/joint-fabric-administrator/JointFabricAdministratorClient.ts
@@ -6,10 +6,11 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import { JointFabricAdministratorBehavior } from "./JointFabricAdministratorBehavior.js";
+import { JointFabricAdministrator } from "#clusters/joint-fabric-administrator";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const JointFabricAdministratorClientConstructor = JointFabricAdministratorBehavior;
-export interface JointFabricAdministratorClient extends JointFabricAdministratorBehavior {}
+export const JointFabricAdministratorClientConstructor = ClientBehavior(JointFabricAdministrator.Complete);
+export interface JointFabricAdministratorClient extends InstanceType<typeof JointFabricAdministratorClientConstructor> {}
 export interface JointFabricAdministratorClientConstructor extends Identity<typeof JointFabricAdministratorClientConstructor> {}
 export const JointFabricAdministratorClient: JointFabricAdministratorClientConstructor = JointFabricAdministratorClientConstructor;

--- a/packages/node/src/behaviors/joint-fabric-datastore/JointFabricDatastoreClient.ts
+++ b/packages/node/src/behaviors/joint-fabric-datastore/JointFabricDatastoreClient.ts
@@ -6,10 +6,11 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import { JointFabricDatastoreBehavior } from "./JointFabricDatastoreBehavior.js";
+import { JointFabricDatastore } from "#clusters/joint-fabric-datastore";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const JointFabricDatastoreClientConstructor = JointFabricDatastoreBehavior;
-export interface JointFabricDatastoreClient extends JointFabricDatastoreBehavior {}
+export const JointFabricDatastoreClientConstructor = ClientBehavior(JointFabricDatastore.Complete);
+export interface JointFabricDatastoreClient extends InstanceType<typeof JointFabricDatastoreClientConstructor> {}
 export interface JointFabricDatastoreClientConstructor extends Identity<typeof JointFabricDatastoreClientConstructor> {}
 export const JointFabricDatastoreClient: JointFabricDatastoreClientConstructor = JointFabricDatastoreClientConstructor;

--- a/packages/node/src/behaviors/keypad-input/KeypadInputClient.ts
+++ b/packages/node/src/behaviors/keypad-input/KeypadInputClient.ts
@@ -6,10 +6,11 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import { KeypadInputBehavior } from "./KeypadInputBehavior.js";
+import { KeypadInput } from "#clusters/keypad-input";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const KeypadInputClientConstructor = KeypadInputBehavior;
-export interface KeypadInputClient extends KeypadInputBehavior {}
+export const KeypadInputClientConstructor = ClientBehavior(KeypadInput.Complete);
+export interface KeypadInputClient extends InstanceType<typeof KeypadInputClientConstructor> {}
 export interface KeypadInputClientConstructor extends Identity<typeof KeypadInputClientConstructor> {}
 export const KeypadInputClient: KeypadInputClientConstructor = KeypadInputClientConstructor;

--- a/packages/node/src/behaviors/laundry-dryer-controls/LaundryDryerControlsClient.ts
+++ b/packages/node/src/behaviors/laundry-dryer-controls/LaundryDryerControlsClient.ts
@@ -6,10 +6,11 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import { LaundryDryerControlsBehavior } from "./LaundryDryerControlsBehavior.js";
+import { LaundryDryerControls } from "#clusters/laundry-dryer-controls";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const LaundryDryerControlsClientConstructor = LaundryDryerControlsBehavior;
-export interface LaundryDryerControlsClient extends LaundryDryerControlsBehavior {}
+export const LaundryDryerControlsClientConstructor = ClientBehavior(LaundryDryerControls.Complete);
+export interface LaundryDryerControlsClient extends InstanceType<typeof LaundryDryerControlsClientConstructor> {}
 export interface LaundryDryerControlsClientConstructor extends Identity<typeof LaundryDryerControlsClientConstructor> {}
 export const LaundryDryerControlsClient: LaundryDryerControlsClientConstructor = LaundryDryerControlsClientConstructor;

--- a/packages/node/src/behaviors/laundry-washer-controls/LaundryWasherControlsClient.ts
+++ b/packages/node/src/behaviors/laundry-washer-controls/LaundryWasherControlsClient.ts
@@ -7,10 +7,10 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { LaundryWasherControls } from "#clusters/laundry-washer-controls";
-import { ClusterBehavior } from "../../behavior/cluster/ClusterBehavior.js";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const LaundryWasherControlsClientConstructor = ClusterBehavior.for(LaundryWasherControls.Complete);
+export const LaundryWasherControlsClientConstructor = ClientBehavior(LaundryWasherControls.Complete);
 export interface LaundryWasherControlsClient extends InstanceType<typeof LaundryWasherControlsClientConstructor> {}
 export interface LaundryWasherControlsClientConstructor extends Identity<typeof LaundryWasherControlsClientConstructor> {}
 export const LaundryWasherControlsClient: LaundryWasherControlsClientConstructor = LaundryWasherControlsClientConstructor;

--- a/packages/node/src/behaviors/laundry-washer-mode/LaundryWasherModeClient.ts
+++ b/packages/node/src/behaviors/laundry-washer-mode/LaundryWasherModeClient.ts
@@ -6,10 +6,11 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import { LaundryWasherModeBehavior } from "./LaundryWasherModeBehavior.js";
+import { LaundryWasherMode } from "#clusters/laundry-washer-mode";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const LaundryWasherModeClientConstructor = LaundryWasherModeBehavior;
-export interface LaundryWasherModeClient extends LaundryWasherModeBehavior {}
+export const LaundryWasherModeClientConstructor = ClientBehavior(LaundryWasherMode.Complete);
+export interface LaundryWasherModeClient extends InstanceType<typeof LaundryWasherModeClientConstructor> {}
 export interface LaundryWasherModeClientConstructor extends Identity<typeof LaundryWasherModeClientConstructor> {}
 export const LaundryWasherModeClient: LaundryWasherModeClientConstructor = LaundryWasherModeClientConstructor;

--- a/packages/node/src/behaviors/level-control/LevelControlClient.ts
+++ b/packages/node/src/behaviors/level-control/LevelControlClient.ts
@@ -7,10 +7,10 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { LevelControl } from "#clusters/level-control";
-import { ClusterBehavior } from "../../behavior/cluster/ClusterBehavior.js";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const LevelControlClientConstructor = ClusterBehavior.for(LevelControl.Complete);
+export const LevelControlClientConstructor = ClientBehavior(LevelControl.Complete);
 export interface LevelControlClient extends InstanceType<typeof LevelControlClientConstructor> {}
 export interface LevelControlClientConstructor extends Identity<typeof LevelControlClientConstructor> {}
 export const LevelControlClient: LevelControlClientConstructor = LevelControlClientConstructor;

--- a/packages/node/src/behaviors/localization-configuration/LocalizationConfigurationClient.ts
+++ b/packages/node/src/behaviors/localization-configuration/LocalizationConfigurationClient.ts
@@ -6,10 +6,11 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import { LocalizationConfigurationBehavior } from "./LocalizationConfigurationBehavior.js";
+import { LocalizationConfiguration } from "#clusters/localization-configuration";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const LocalizationConfigurationClientConstructor = LocalizationConfigurationBehavior;
-export interface LocalizationConfigurationClient extends LocalizationConfigurationBehavior {}
+export const LocalizationConfigurationClientConstructor = ClientBehavior(LocalizationConfiguration.Complete);
+export interface LocalizationConfigurationClient extends InstanceType<typeof LocalizationConfigurationClientConstructor> {}
 export interface LocalizationConfigurationClientConstructor extends Identity<typeof LocalizationConfigurationClientConstructor> {}
 export const LocalizationConfigurationClient: LocalizationConfigurationClientConstructor = LocalizationConfigurationClientConstructor;

--- a/packages/node/src/behaviors/low-power/LowPowerClient.ts
+++ b/packages/node/src/behaviors/low-power/LowPowerClient.ts
@@ -6,10 +6,11 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import { LowPowerBehavior } from "./LowPowerBehavior.js";
+import { LowPower } from "#clusters/low-power";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const LowPowerClientConstructor = LowPowerBehavior;
-export interface LowPowerClient extends LowPowerBehavior {}
+export const LowPowerClientConstructor = ClientBehavior(LowPower.Complete);
+export interface LowPowerClient extends InstanceType<typeof LowPowerClientConstructor> {}
 export interface LowPowerClientConstructor extends Identity<typeof LowPowerClientConstructor> {}
 export const LowPowerClient: LowPowerClientConstructor = LowPowerClientConstructor;

--- a/packages/node/src/behaviors/media-input/MediaInputClient.ts
+++ b/packages/node/src/behaviors/media-input/MediaInputClient.ts
@@ -7,10 +7,10 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { MediaInput } from "#clusters/media-input";
-import { ClusterBehavior } from "../../behavior/cluster/ClusterBehavior.js";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const MediaInputClientConstructor = ClusterBehavior.for(MediaInput.Complete);
+export const MediaInputClientConstructor = ClientBehavior(MediaInput.Complete);
 export interface MediaInputClient extends InstanceType<typeof MediaInputClientConstructor> {}
 export interface MediaInputClientConstructor extends Identity<typeof MediaInputClientConstructor> {}
 export const MediaInputClient: MediaInputClientConstructor = MediaInputClientConstructor;

--- a/packages/node/src/behaviors/media-playback/MediaPlaybackClient.ts
+++ b/packages/node/src/behaviors/media-playback/MediaPlaybackClient.ts
@@ -7,10 +7,10 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { MediaPlayback } from "#clusters/media-playback";
-import { ClusterBehavior } from "../../behavior/cluster/ClusterBehavior.js";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const MediaPlaybackClientConstructor = ClusterBehavior.for(MediaPlayback.Complete);
+export const MediaPlaybackClientConstructor = ClientBehavior(MediaPlayback.Complete);
 export interface MediaPlaybackClient extends InstanceType<typeof MediaPlaybackClientConstructor> {}
 export interface MediaPlaybackClientConstructor extends Identity<typeof MediaPlaybackClientConstructor> {}
 export const MediaPlaybackClient: MediaPlaybackClientConstructor = MediaPlaybackClientConstructor;

--- a/packages/node/src/behaviors/messages/MessagesClient.ts
+++ b/packages/node/src/behaviors/messages/MessagesClient.ts
@@ -6,10 +6,11 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import { MessagesBehavior } from "./MessagesBehavior.js";
+import { Messages } from "#clusters/messages";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const MessagesClientConstructor = MessagesBehavior;
-export interface MessagesClient extends MessagesBehavior {}
+export const MessagesClientConstructor = ClientBehavior(Messages.Complete);
+export interface MessagesClient extends InstanceType<typeof MessagesClientConstructor> {}
 export interface MessagesClientConstructor extends Identity<typeof MessagesClientConstructor> {}
 export const MessagesClient: MessagesClientConstructor = MessagesClientConstructor;

--- a/packages/node/src/behaviors/microwave-oven-control/MicrowaveOvenControlClient.ts
+++ b/packages/node/src/behaviors/microwave-oven-control/MicrowaveOvenControlClient.ts
@@ -7,10 +7,10 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { MicrowaveOvenControl } from "#clusters/microwave-oven-control";
-import { ClusterBehavior } from "../../behavior/cluster/ClusterBehavior.js";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const MicrowaveOvenControlClientConstructor = ClusterBehavior.for(MicrowaveOvenControl.Complete);
+export const MicrowaveOvenControlClientConstructor = ClientBehavior(MicrowaveOvenControl.Complete);
 export interface MicrowaveOvenControlClient extends InstanceType<typeof MicrowaveOvenControlClientConstructor> {}
 export interface MicrowaveOvenControlClientConstructor extends Identity<typeof MicrowaveOvenControlClientConstructor> {}
 export const MicrowaveOvenControlClient: MicrowaveOvenControlClientConstructor = MicrowaveOvenControlClientConstructor;

--- a/packages/node/src/behaviors/microwave-oven-mode/MicrowaveOvenModeClient.ts
+++ b/packages/node/src/behaviors/microwave-oven-mode/MicrowaveOvenModeClient.ts
@@ -6,10 +6,11 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import { MicrowaveOvenModeBehavior } from "./MicrowaveOvenModeBehavior.js";
+import { MicrowaveOvenMode } from "#clusters/microwave-oven-mode";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const MicrowaveOvenModeClientConstructor = MicrowaveOvenModeBehavior;
-export interface MicrowaveOvenModeClient extends MicrowaveOvenModeBehavior {}
+export const MicrowaveOvenModeClientConstructor = ClientBehavior(MicrowaveOvenMode.Complete);
+export interface MicrowaveOvenModeClient extends InstanceType<typeof MicrowaveOvenModeClientConstructor> {}
 export interface MicrowaveOvenModeClientConstructor extends Identity<typeof MicrowaveOvenModeClientConstructor> {}
 export const MicrowaveOvenModeClient: MicrowaveOvenModeClientConstructor = MicrowaveOvenModeClientConstructor;

--- a/packages/node/src/behaviors/mode-select/ModeSelectClient.ts
+++ b/packages/node/src/behaviors/mode-select/ModeSelectClient.ts
@@ -7,10 +7,10 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { ModeSelect } from "#clusters/mode-select";
-import { ClusterBehavior } from "../../behavior/cluster/ClusterBehavior.js";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const ModeSelectClientConstructor = ClusterBehavior.for(ModeSelect.Complete);
+export const ModeSelectClientConstructor = ClientBehavior(ModeSelect.Complete);
 export interface ModeSelectClient extends InstanceType<typeof ModeSelectClientConstructor> {}
 export interface ModeSelectClientConstructor extends Identity<typeof ModeSelectClientConstructor> {}
 export const ModeSelectClient: ModeSelectClientConstructor = ModeSelectClientConstructor;

--- a/packages/node/src/behaviors/network-commissioning/NetworkCommissioningClient.ts
+++ b/packages/node/src/behaviors/network-commissioning/NetworkCommissioningClient.ts
@@ -7,10 +7,10 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { NetworkCommissioning } from "#clusters/network-commissioning";
-import { ClusterBehavior } from "../../behavior/cluster/ClusterBehavior.js";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const NetworkCommissioningClientConstructor = ClusterBehavior.for(NetworkCommissioning.Complete);
+export const NetworkCommissioningClientConstructor = ClientBehavior(NetworkCommissioning.Complete);
 export interface NetworkCommissioningClient extends InstanceType<typeof NetworkCommissioningClientConstructor> {}
 export interface NetworkCommissioningClientConstructor extends Identity<typeof NetworkCommissioningClientConstructor> {}
 export const NetworkCommissioningClient: NetworkCommissioningClientConstructor = NetworkCommissioningClientConstructor;

--- a/packages/node/src/behaviors/nitrogen-dioxide-concentration-measurement/NitrogenDioxideConcentrationMeasurementClient.ts
+++ b/packages/node/src/behaviors/nitrogen-dioxide-concentration-measurement/NitrogenDioxideConcentrationMeasurementClient.ts
@@ -7,11 +7,12 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { NitrogenDioxideConcentrationMeasurement } from "#clusters/nitrogen-dioxide-concentration-measurement";
-import { ClusterBehavior } from "../../behavior/cluster/ClusterBehavior.js";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const NitrogenDioxideConcentrationMeasurementClientConstructor = ClusterBehavior
-    .for(NitrogenDioxideConcentrationMeasurement.Complete);
+export const NitrogenDioxideConcentrationMeasurementClientConstructor = ClientBehavior(
+    NitrogenDioxideConcentrationMeasurement.Complete
+);
 export interface NitrogenDioxideConcentrationMeasurementClient extends InstanceType<typeof NitrogenDioxideConcentrationMeasurementClientConstructor> {}
 export interface NitrogenDioxideConcentrationMeasurementClientConstructor extends Identity<typeof NitrogenDioxideConcentrationMeasurementClientConstructor> {}
 export const NitrogenDioxideConcentrationMeasurementClient: NitrogenDioxideConcentrationMeasurementClientConstructor = NitrogenDioxideConcentrationMeasurementClientConstructor;

--- a/packages/node/src/behaviors/occupancy-sensing/OccupancySensingClient.ts
+++ b/packages/node/src/behaviors/occupancy-sensing/OccupancySensingClient.ts
@@ -7,10 +7,10 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { OccupancySensing } from "#clusters/occupancy-sensing";
-import { ClusterBehavior } from "../../behavior/cluster/ClusterBehavior.js";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const OccupancySensingClientConstructor = ClusterBehavior.for(OccupancySensing.Complete);
+export const OccupancySensingClientConstructor = ClientBehavior(OccupancySensing.Complete);
 export interface OccupancySensingClient extends InstanceType<typeof OccupancySensingClientConstructor> {}
 export interface OccupancySensingClientConstructor extends Identity<typeof OccupancySensingClientConstructor> {}
 export const OccupancySensingClient: OccupancySensingClientConstructor = OccupancySensingClientConstructor;

--- a/packages/node/src/behaviors/on-off/OnOffClient.ts
+++ b/packages/node/src/behaviors/on-off/OnOffClient.ts
@@ -7,10 +7,10 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { OnOff } from "#clusters/on-off";
-import { ClusterBehavior } from "../../behavior/cluster/ClusterBehavior.js";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const OnOffClientConstructor = ClusterBehavior.for(OnOff.Complete);
+export const OnOffClientConstructor = ClientBehavior(OnOff.Complete);
 export interface OnOffClient extends InstanceType<typeof OnOffClientConstructor> {}
 export interface OnOffClientConstructor extends Identity<typeof OnOffClientConstructor> {}
 export const OnOffClient: OnOffClientConstructor = OnOffClientConstructor;

--- a/packages/node/src/behaviors/operational-credentials/OperationalCredentialsClient.ts
+++ b/packages/node/src/behaviors/operational-credentials/OperationalCredentialsClient.ts
@@ -6,10 +6,11 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import { OperationalCredentialsBehavior } from "./OperationalCredentialsBehavior.js";
+import { OperationalCredentials } from "#clusters/operational-credentials";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const OperationalCredentialsClientConstructor = OperationalCredentialsBehavior;
-export interface OperationalCredentialsClient extends OperationalCredentialsBehavior {}
+export const OperationalCredentialsClientConstructor = ClientBehavior(OperationalCredentials.Complete);
+export interface OperationalCredentialsClient extends InstanceType<typeof OperationalCredentialsClientConstructor> {}
 export interface OperationalCredentialsClientConstructor extends Identity<typeof OperationalCredentialsClientConstructor> {}
 export const OperationalCredentialsClient: OperationalCredentialsClientConstructor = OperationalCredentialsClientConstructor;

--- a/packages/node/src/behaviors/operational-state/OperationalStateClient.ts
+++ b/packages/node/src/behaviors/operational-state/OperationalStateClient.ts
@@ -6,10 +6,11 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import { OperationalStateBehavior } from "./OperationalStateBehavior.js";
+import { OperationalState } from "#clusters/operational-state";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const OperationalStateClientConstructor = OperationalStateBehavior;
-export interface OperationalStateClient extends OperationalStateBehavior {}
+export const OperationalStateClientConstructor = ClientBehavior(OperationalState.Complete);
+export interface OperationalStateClient extends InstanceType<typeof OperationalStateClientConstructor> {}
 export interface OperationalStateClientConstructor extends Identity<typeof OperationalStateClientConstructor> {}
 export const OperationalStateClient: OperationalStateClientConstructor = OperationalStateClientConstructor;

--- a/packages/node/src/behaviors/ota-software-update-provider/OtaSoftwareUpdateProviderClient.ts
+++ b/packages/node/src/behaviors/ota-software-update-provider/OtaSoftwareUpdateProviderClient.ts
@@ -6,10 +6,11 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import { OtaSoftwareUpdateProviderBehavior } from "./OtaSoftwareUpdateProviderBehavior.js";
+import { OtaSoftwareUpdateProvider } from "#clusters/ota-software-update-provider";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const OtaSoftwareUpdateProviderClientConstructor = OtaSoftwareUpdateProviderBehavior;
-export interface OtaSoftwareUpdateProviderClient extends OtaSoftwareUpdateProviderBehavior {}
+export const OtaSoftwareUpdateProviderClientConstructor = ClientBehavior(OtaSoftwareUpdateProvider.Complete);
+export interface OtaSoftwareUpdateProviderClient extends InstanceType<typeof OtaSoftwareUpdateProviderClientConstructor> {}
 export interface OtaSoftwareUpdateProviderClientConstructor extends Identity<typeof OtaSoftwareUpdateProviderClientConstructor> {}
 export const OtaSoftwareUpdateProviderClient: OtaSoftwareUpdateProviderClientConstructor = OtaSoftwareUpdateProviderClientConstructor;

--- a/packages/node/src/behaviors/ota-software-update-requestor/OtaSoftwareUpdateRequestorClient.ts
+++ b/packages/node/src/behaviors/ota-software-update-requestor/OtaSoftwareUpdateRequestorClient.ts
@@ -6,10 +6,11 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import { OtaSoftwareUpdateRequestorBehavior } from "./OtaSoftwareUpdateRequestorBehavior.js";
+import { OtaSoftwareUpdateRequestor } from "#clusters/ota-software-update-requestor";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const OtaSoftwareUpdateRequestorClientConstructor = OtaSoftwareUpdateRequestorBehavior;
-export interface OtaSoftwareUpdateRequestorClient extends OtaSoftwareUpdateRequestorBehavior {}
+export const OtaSoftwareUpdateRequestorClientConstructor = ClientBehavior(OtaSoftwareUpdateRequestor.Complete);
+export interface OtaSoftwareUpdateRequestorClient extends InstanceType<typeof OtaSoftwareUpdateRequestorClientConstructor> {}
 export interface OtaSoftwareUpdateRequestorClientConstructor extends Identity<typeof OtaSoftwareUpdateRequestorClientConstructor> {}
 export const OtaSoftwareUpdateRequestorClient: OtaSoftwareUpdateRequestorClientConstructor = OtaSoftwareUpdateRequestorClientConstructor;

--- a/packages/node/src/behaviors/oven-cavity-operational-state/OvenCavityOperationalStateClient.ts
+++ b/packages/node/src/behaviors/oven-cavity-operational-state/OvenCavityOperationalStateClient.ts
@@ -6,10 +6,11 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import { OvenCavityOperationalStateBehavior } from "./OvenCavityOperationalStateBehavior.js";
+import { OvenCavityOperationalState } from "#clusters/oven-cavity-operational-state";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const OvenCavityOperationalStateClientConstructor = OvenCavityOperationalStateBehavior;
-export interface OvenCavityOperationalStateClient extends OvenCavityOperationalStateBehavior {}
+export const OvenCavityOperationalStateClientConstructor = ClientBehavior(OvenCavityOperationalState.Complete);
+export interface OvenCavityOperationalStateClient extends InstanceType<typeof OvenCavityOperationalStateClientConstructor> {}
 export interface OvenCavityOperationalStateClientConstructor extends Identity<typeof OvenCavityOperationalStateClientConstructor> {}
 export const OvenCavityOperationalStateClient: OvenCavityOperationalStateClientConstructor = OvenCavityOperationalStateClientConstructor;

--- a/packages/node/src/behaviors/oven-mode/OvenModeClient.ts
+++ b/packages/node/src/behaviors/oven-mode/OvenModeClient.ts
@@ -6,10 +6,11 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import { OvenModeBehavior } from "./OvenModeBehavior.js";
+import { OvenMode } from "#clusters/oven-mode";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const OvenModeClientConstructor = OvenModeBehavior;
-export interface OvenModeClient extends OvenModeBehavior {}
+export const OvenModeClientConstructor = ClientBehavior(OvenMode.Complete);
+export interface OvenModeClient extends InstanceType<typeof OvenModeClientConstructor> {}
 export interface OvenModeClientConstructor extends Identity<typeof OvenModeClientConstructor> {}
 export const OvenModeClient: OvenModeClientConstructor = OvenModeClientConstructor;

--- a/packages/node/src/behaviors/ozone-concentration-measurement/OzoneConcentrationMeasurementClient.ts
+++ b/packages/node/src/behaviors/ozone-concentration-measurement/OzoneConcentrationMeasurementClient.ts
@@ -7,11 +7,10 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { OzoneConcentrationMeasurement } from "#clusters/ozone-concentration-measurement";
-import { ClusterBehavior } from "../../behavior/cluster/ClusterBehavior.js";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const OzoneConcentrationMeasurementClientConstructor = ClusterBehavior
-    .for(OzoneConcentrationMeasurement.Complete);
+export const OzoneConcentrationMeasurementClientConstructor = ClientBehavior(OzoneConcentrationMeasurement.Complete);
 export interface OzoneConcentrationMeasurementClient extends InstanceType<typeof OzoneConcentrationMeasurementClientConstructor> {}
 export interface OzoneConcentrationMeasurementClientConstructor extends Identity<typeof OzoneConcentrationMeasurementClientConstructor> {}
 export const OzoneConcentrationMeasurementClient: OzoneConcentrationMeasurementClientConstructor = OzoneConcentrationMeasurementClientConstructor;

--- a/packages/node/src/behaviors/pm1-concentration-measurement/Pm1ConcentrationMeasurementClient.ts
+++ b/packages/node/src/behaviors/pm1-concentration-measurement/Pm1ConcentrationMeasurementClient.ts
@@ -7,10 +7,10 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { Pm1ConcentrationMeasurement } from "#clusters/pm1-concentration-measurement";
-import { ClusterBehavior } from "../../behavior/cluster/ClusterBehavior.js";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const Pm1ConcentrationMeasurementClientConstructor = ClusterBehavior.for(Pm1ConcentrationMeasurement.Complete);
+export const Pm1ConcentrationMeasurementClientConstructor = ClientBehavior(Pm1ConcentrationMeasurement.Complete);
 export interface Pm1ConcentrationMeasurementClient extends InstanceType<typeof Pm1ConcentrationMeasurementClientConstructor> {}
 export interface Pm1ConcentrationMeasurementClientConstructor extends Identity<typeof Pm1ConcentrationMeasurementClientConstructor> {}
 export const Pm1ConcentrationMeasurementClient: Pm1ConcentrationMeasurementClientConstructor = Pm1ConcentrationMeasurementClientConstructor;

--- a/packages/node/src/behaviors/pm10-concentration-measurement/Pm10ConcentrationMeasurementClient.ts
+++ b/packages/node/src/behaviors/pm10-concentration-measurement/Pm10ConcentrationMeasurementClient.ts
@@ -7,10 +7,10 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { Pm10ConcentrationMeasurement } from "#clusters/pm10-concentration-measurement";
-import { ClusterBehavior } from "../../behavior/cluster/ClusterBehavior.js";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const Pm10ConcentrationMeasurementClientConstructor = ClusterBehavior.for(Pm10ConcentrationMeasurement.Complete);
+export const Pm10ConcentrationMeasurementClientConstructor = ClientBehavior(Pm10ConcentrationMeasurement.Complete);
 export interface Pm10ConcentrationMeasurementClient extends InstanceType<typeof Pm10ConcentrationMeasurementClientConstructor> {}
 export interface Pm10ConcentrationMeasurementClientConstructor extends Identity<typeof Pm10ConcentrationMeasurementClientConstructor> {}
 export const Pm10ConcentrationMeasurementClient: Pm10ConcentrationMeasurementClientConstructor = Pm10ConcentrationMeasurementClientConstructor;

--- a/packages/node/src/behaviors/pm25-concentration-measurement/Pm25ConcentrationMeasurementClient.ts
+++ b/packages/node/src/behaviors/pm25-concentration-measurement/Pm25ConcentrationMeasurementClient.ts
@@ -7,10 +7,10 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { Pm25ConcentrationMeasurement } from "#clusters/pm25-concentration-measurement";
-import { ClusterBehavior } from "../../behavior/cluster/ClusterBehavior.js";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const Pm25ConcentrationMeasurementClientConstructor = ClusterBehavior.for(Pm25ConcentrationMeasurement.Complete);
+export const Pm25ConcentrationMeasurementClientConstructor = ClientBehavior(Pm25ConcentrationMeasurement.Complete);
 export interface Pm25ConcentrationMeasurementClient extends InstanceType<typeof Pm25ConcentrationMeasurementClientConstructor> {}
 export interface Pm25ConcentrationMeasurementClientConstructor extends Identity<typeof Pm25ConcentrationMeasurementClientConstructor> {}
 export const Pm25ConcentrationMeasurementClient: Pm25ConcentrationMeasurementClientConstructor = Pm25ConcentrationMeasurementClientConstructor;

--- a/packages/node/src/behaviors/power-source-configuration/PowerSourceConfigurationClient.ts
+++ b/packages/node/src/behaviors/power-source-configuration/PowerSourceConfigurationClient.ts
@@ -6,10 +6,11 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import { PowerSourceConfigurationBehavior } from "./PowerSourceConfigurationBehavior.js";
+import { PowerSourceConfiguration } from "#clusters/power-source-configuration";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const PowerSourceConfigurationClientConstructor = PowerSourceConfigurationBehavior;
-export interface PowerSourceConfigurationClient extends PowerSourceConfigurationBehavior {}
+export const PowerSourceConfigurationClientConstructor = ClientBehavior(PowerSourceConfiguration.Complete);
+export interface PowerSourceConfigurationClient extends InstanceType<typeof PowerSourceConfigurationClientConstructor> {}
 export interface PowerSourceConfigurationClientConstructor extends Identity<typeof PowerSourceConfigurationClientConstructor> {}
 export const PowerSourceConfigurationClient: PowerSourceConfigurationClientConstructor = PowerSourceConfigurationClientConstructor;

--- a/packages/node/src/behaviors/power-source/PowerSourceClient.ts
+++ b/packages/node/src/behaviors/power-source/PowerSourceClient.ts
@@ -7,10 +7,10 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { PowerSource } from "#clusters/power-source";
-import { ClusterBehavior } from "../../behavior/cluster/ClusterBehavior.js";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const PowerSourceClientConstructor = ClusterBehavior.for(PowerSource.Complete);
+export const PowerSourceClientConstructor = ClientBehavior(PowerSource.Complete);
 export interface PowerSourceClient extends InstanceType<typeof PowerSourceClientConstructor> {}
 export interface PowerSourceClientConstructor extends Identity<typeof PowerSourceClientConstructor> {}
 export const PowerSourceClient: PowerSourceClientConstructor = PowerSourceClientConstructor;

--- a/packages/node/src/behaviors/power-topology/PowerTopologyClient.ts
+++ b/packages/node/src/behaviors/power-topology/PowerTopologyClient.ts
@@ -7,10 +7,10 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { PowerTopology } from "#clusters/power-topology";
-import { ClusterBehavior } from "../../behavior/cluster/ClusterBehavior.js";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const PowerTopologyClientConstructor = ClusterBehavior.for(PowerTopology.Complete);
+export const PowerTopologyClientConstructor = ClientBehavior(PowerTopology.Complete);
 export interface PowerTopologyClient extends InstanceType<typeof PowerTopologyClientConstructor> {}
 export interface PowerTopologyClientConstructor extends Identity<typeof PowerTopologyClientConstructor> {}
 export const PowerTopologyClient: PowerTopologyClientConstructor = PowerTopologyClientConstructor;

--- a/packages/node/src/behaviors/pressure-measurement/PressureMeasurementClient.ts
+++ b/packages/node/src/behaviors/pressure-measurement/PressureMeasurementClient.ts
@@ -7,10 +7,10 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { PressureMeasurement } from "#clusters/pressure-measurement";
-import { ClusterBehavior } from "../../behavior/cluster/ClusterBehavior.js";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const PressureMeasurementClientConstructor = ClusterBehavior.for(PressureMeasurement.Complete);
+export const PressureMeasurementClientConstructor = ClientBehavior(PressureMeasurement.Complete);
 export interface PressureMeasurementClient extends InstanceType<typeof PressureMeasurementClientConstructor> {}
 export interface PressureMeasurementClientConstructor extends Identity<typeof PressureMeasurementClientConstructor> {}
 export const PressureMeasurementClient: PressureMeasurementClientConstructor = PressureMeasurementClientConstructor;

--- a/packages/node/src/behaviors/pump-configuration-and-control/PumpConfigurationAndControlClient.ts
+++ b/packages/node/src/behaviors/pump-configuration-and-control/PumpConfigurationAndControlClient.ts
@@ -7,10 +7,10 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { PumpConfigurationAndControl } from "#clusters/pump-configuration-and-control";
-import { ClusterBehavior } from "../../behavior/cluster/ClusterBehavior.js";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const PumpConfigurationAndControlClientConstructor = ClusterBehavior.for(PumpConfigurationAndControl.Complete);
+export const PumpConfigurationAndControlClientConstructor = ClientBehavior(PumpConfigurationAndControl.Complete);
 export interface PumpConfigurationAndControlClient extends InstanceType<typeof PumpConfigurationAndControlClientConstructor> {}
 export interface PumpConfigurationAndControlClientConstructor extends Identity<typeof PumpConfigurationAndControlClientConstructor> {}
 export const PumpConfigurationAndControlClient: PumpConfigurationAndControlClientConstructor = PumpConfigurationAndControlClientConstructor;

--- a/packages/node/src/behaviors/radon-concentration-measurement/RadonConcentrationMeasurementClient.ts
+++ b/packages/node/src/behaviors/radon-concentration-measurement/RadonConcentrationMeasurementClient.ts
@@ -7,11 +7,10 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { RadonConcentrationMeasurement } from "#clusters/radon-concentration-measurement";
-import { ClusterBehavior } from "../../behavior/cluster/ClusterBehavior.js";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const RadonConcentrationMeasurementClientConstructor = ClusterBehavior
-    .for(RadonConcentrationMeasurement.Complete);
+export const RadonConcentrationMeasurementClientConstructor = ClientBehavior(RadonConcentrationMeasurement.Complete);
 export interface RadonConcentrationMeasurementClient extends InstanceType<typeof RadonConcentrationMeasurementClientConstructor> {}
 export interface RadonConcentrationMeasurementClientConstructor extends Identity<typeof RadonConcentrationMeasurementClientConstructor> {}
 export const RadonConcentrationMeasurementClient: RadonConcentrationMeasurementClientConstructor = RadonConcentrationMeasurementClientConstructor;

--- a/packages/node/src/behaviors/refrigerator-alarm/RefrigeratorAlarmClient.ts
+++ b/packages/node/src/behaviors/refrigerator-alarm/RefrigeratorAlarmClient.ts
@@ -7,10 +7,10 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { RefrigeratorAlarm } from "#clusters/refrigerator-alarm";
-import { ClusterBehavior } from "../../behavior/cluster/ClusterBehavior.js";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const RefrigeratorAlarmClientConstructor = ClusterBehavior.for(RefrigeratorAlarm.Complete);
+export const RefrigeratorAlarmClientConstructor = ClientBehavior(RefrigeratorAlarm.Complete);
 export interface RefrigeratorAlarmClient extends InstanceType<typeof RefrigeratorAlarmClientConstructor> {}
 export interface RefrigeratorAlarmClientConstructor extends Identity<typeof RefrigeratorAlarmClientConstructor> {}
 export const RefrigeratorAlarmClient: RefrigeratorAlarmClientConstructor = RefrigeratorAlarmClientConstructor;

--- a/packages/node/src/behaviors/refrigerator-and-temperature-controlled-cabinet-mode/RefrigeratorAndTemperatureControlledCabinetModeClient.ts
+++ b/packages/node/src/behaviors/refrigerator-and-temperature-controlled-cabinet-mode/RefrigeratorAndTemperatureControlledCabinetModeClient.ts
@@ -7,11 +7,14 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import {
-    RefrigeratorAndTemperatureControlledCabinetModeBehavior
-} from "./RefrigeratorAndTemperatureControlledCabinetModeBehavior.js";
+    RefrigeratorAndTemperatureControlledCabinetMode
+} from "#clusters/refrigerator-and-temperature-controlled-cabinet-mode";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const RefrigeratorAndTemperatureControlledCabinetModeClientConstructor = RefrigeratorAndTemperatureControlledCabinetModeBehavior;
-export interface RefrigeratorAndTemperatureControlledCabinetModeClient extends RefrigeratorAndTemperatureControlledCabinetModeBehavior {}
+export const RefrigeratorAndTemperatureControlledCabinetModeClientConstructor = ClientBehavior(
+    RefrigeratorAndTemperatureControlledCabinetMode.Complete
+);
+export interface RefrigeratorAndTemperatureControlledCabinetModeClient extends InstanceType<typeof RefrigeratorAndTemperatureControlledCabinetModeClientConstructor> {}
 export interface RefrigeratorAndTemperatureControlledCabinetModeClientConstructor extends Identity<typeof RefrigeratorAndTemperatureControlledCabinetModeClientConstructor> {}
 export const RefrigeratorAndTemperatureControlledCabinetModeClient: RefrigeratorAndTemperatureControlledCabinetModeClientConstructor = RefrigeratorAndTemperatureControlledCabinetModeClientConstructor;

--- a/packages/node/src/behaviors/relative-humidity-measurement/RelativeHumidityMeasurementClient.ts
+++ b/packages/node/src/behaviors/relative-humidity-measurement/RelativeHumidityMeasurementClient.ts
@@ -6,10 +6,11 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import { RelativeHumidityMeasurementBehavior } from "./RelativeHumidityMeasurementBehavior.js";
+import { RelativeHumidityMeasurement } from "#clusters/relative-humidity-measurement";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const RelativeHumidityMeasurementClientConstructor = RelativeHumidityMeasurementBehavior;
-export interface RelativeHumidityMeasurementClient extends RelativeHumidityMeasurementBehavior {}
+export const RelativeHumidityMeasurementClientConstructor = ClientBehavior(RelativeHumidityMeasurement.Complete);
+export interface RelativeHumidityMeasurementClient extends InstanceType<typeof RelativeHumidityMeasurementClientConstructor> {}
 export interface RelativeHumidityMeasurementClientConstructor extends Identity<typeof RelativeHumidityMeasurementClientConstructor> {}
 export const RelativeHumidityMeasurementClient: RelativeHumidityMeasurementClientConstructor = RelativeHumidityMeasurementClientConstructor;

--- a/packages/node/src/behaviors/rvc-clean-mode/RvcCleanModeClient.ts
+++ b/packages/node/src/behaviors/rvc-clean-mode/RvcCleanModeClient.ts
@@ -6,10 +6,11 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import { RvcCleanModeBehavior } from "./RvcCleanModeBehavior.js";
+import { RvcCleanMode } from "#clusters/rvc-clean-mode";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const RvcCleanModeClientConstructor = RvcCleanModeBehavior;
-export interface RvcCleanModeClient extends RvcCleanModeBehavior {}
+export const RvcCleanModeClientConstructor = ClientBehavior(RvcCleanMode.Complete);
+export interface RvcCleanModeClient extends InstanceType<typeof RvcCleanModeClientConstructor> {}
 export interface RvcCleanModeClientConstructor extends Identity<typeof RvcCleanModeClientConstructor> {}
 export const RvcCleanModeClient: RvcCleanModeClientConstructor = RvcCleanModeClientConstructor;

--- a/packages/node/src/behaviors/rvc-operational-state/RvcOperationalStateClient.ts
+++ b/packages/node/src/behaviors/rvc-operational-state/RvcOperationalStateClient.ts
@@ -6,10 +6,11 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import { RvcOperationalStateBehavior } from "./RvcOperationalStateBehavior.js";
+import { RvcOperationalState } from "#clusters/rvc-operational-state";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const RvcOperationalStateClientConstructor = RvcOperationalStateBehavior;
-export interface RvcOperationalStateClient extends RvcOperationalStateBehavior {}
+export const RvcOperationalStateClientConstructor = ClientBehavior(RvcOperationalState.Complete);
+export interface RvcOperationalStateClient extends InstanceType<typeof RvcOperationalStateClientConstructor> {}
 export interface RvcOperationalStateClientConstructor extends Identity<typeof RvcOperationalStateClientConstructor> {}
 export const RvcOperationalStateClient: RvcOperationalStateClientConstructor = RvcOperationalStateClientConstructor;

--- a/packages/node/src/behaviors/rvc-run-mode/RvcRunModeClient.ts
+++ b/packages/node/src/behaviors/rvc-run-mode/RvcRunModeClient.ts
@@ -6,10 +6,11 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import { RvcRunModeBehavior } from "./RvcRunModeBehavior.js";
+import { RvcRunMode } from "#clusters/rvc-run-mode";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const RvcRunModeClientConstructor = RvcRunModeBehavior;
-export interface RvcRunModeClient extends RvcRunModeBehavior {}
+export const RvcRunModeClientConstructor = ClientBehavior(RvcRunMode.Complete);
+export interface RvcRunModeClient extends InstanceType<typeof RvcRunModeClientConstructor> {}
 export interface RvcRunModeClientConstructor extends Identity<typeof RvcRunModeClientConstructor> {}
 export const RvcRunModeClient: RvcRunModeClientConstructor = RvcRunModeClientConstructor;

--- a/packages/node/src/behaviors/scenes-management/ScenesManagementClient.ts
+++ b/packages/node/src/behaviors/scenes-management/ScenesManagementClient.ts
@@ -6,10 +6,11 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import { ScenesManagementBehavior } from "./ScenesManagementBehavior.js";
+import { ScenesManagement } from "#clusters/scenes-management";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const ScenesManagementClientConstructor = ScenesManagementBehavior;
-export interface ScenesManagementClient extends ScenesManagementBehavior {}
+export const ScenesManagementClientConstructor = ClientBehavior(ScenesManagement.Complete);
+export interface ScenesManagementClient extends InstanceType<typeof ScenesManagementClientConstructor> {}
 export interface ScenesManagementClientConstructor extends Identity<typeof ScenesManagementClientConstructor> {}
 export const ScenesManagementClient: ScenesManagementClientConstructor = ScenesManagementClientConstructor;

--- a/packages/node/src/behaviors/service-area/ServiceAreaClient.ts
+++ b/packages/node/src/behaviors/service-area/ServiceAreaClient.ts
@@ -7,10 +7,10 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { ServiceArea } from "#clusters/service-area";
-import { ClusterBehavior } from "../../behavior/cluster/ClusterBehavior.js";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const ServiceAreaClientConstructor = ClusterBehavior.for(ServiceArea.Complete);
+export const ServiceAreaClientConstructor = ClientBehavior(ServiceArea.Complete);
 export interface ServiceAreaClient extends InstanceType<typeof ServiceAreaClientConstructor> {}
 export interface ServiceAreaClientConstructor extends Identity<typeof ServiceAreaClientConstructor> {}
 export const ServiceAreaClient: ServiceAreaClientConstructor = ServiceAreaClientConstructor;

--- a/packages/node/src/behaviors/smoke-co-alarm/SmokeCoAlarmClient.ts
+++ b/packages/node/src/behaviors/smoke-co-alarm/SmokeCoAlarmClient.ts
@@ -7,10 +7,10 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { SmokeCoAlarm } from "#clusters/smoke-co-alarm";
-import { ClusterBehavior } from "../../behavior/cluster/ClusterBehavior.js";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const SmokeCoAlarmClientConstructor = ClusterBehavior.for(SmokeCoAlarm.Complete);
+export const SmokeCoAlarmClientConstructor = ClientBehavior(SmokeCoAlarm.Complete);
 export interface SmokeCoAlarmClient extends InstanceType<typeof SmokeCoAlarmClientConstructor> {}
 export interface SmokeCoAlarmClientConstructor extends Identity<typeof SmokeCoAlarmClientConstructor> {}
 export const SmokeCoAlarmClient: SmokeCoAlarmClientConstructor = SmokeCoAlarmClientConstructor;

--- a/packages/node/src/behaviors/software-diagnostics/SoftwareDiagnosticsClient.ts
+++ b/packages/node/src/behaviors/software-diagnostics/SoftwareDiagnosticsClient.ts
@@ -7,10 +7,10 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { SoftwareDiagnostics } from "#clusters/software-diagnostics";
-import { ClusterBehavior } from "../../behavior/cluster/ClusterBehavior.js";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const SoftwareDiagnosticsClientConstructor = ClusterBehavior.for(SoftwareDiagnostics.Complete);
+export const SoftwareDiagnosticsClientConstructor = ClientBehavior(SoftwareDiagnostics.Complete);
 export interface SoftwareDiagnosticsClient extends InstanceType<typeof SoftwareDiagnosticsClientConstructor> {}
 export interface SoftwareDiagnosticsClientConstructor extends Identity<typeof SoftwareDiagnosticsClientConstructor> {}
 export const SoftwareDiagnosticsClient: SoftwareDiagnosticsClientConstructor = SoftwareDiagnosticsClientConstructor;

--- a/packages/node/src/behaviors/switch/SwitchClient.ts
+++ b/packages/node/src/behaviors/switch/SwitchClient.ts
@@ -7,10 +7,10 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { Switch } from "#clusters/switch";
-import { ClusterBehavior } from "../../behavior/cluster/ClusterBehavior.js";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const SwitchClientConstructor = ClusterBehavior.for(Switch.Complete);
+export const SwitchClientConstructor = ClientBehavior(Switch.Complete);
 export interface SwitchClient extends InstanceType<typeof SwitchClientConstructor> {}
 export interface SwitchClientConstructor extends Identity<typeof SwitchClientConstructor> {}
 export const SwitchClient: SwitchClientConstructor = SwitchClientConstructor;

--- a/packages/node/src/behaviors/target-navigator/TargetNavigatorClient.ts
+++ b/packages/node/src/behaviors/target-navigator/TargetNavigatorClient.ts
@@ -6,10 +6,11 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import { TargetNavigatorBehavior } from "./TargetNavigatorBehavior.js";
+import { TargetNavigator } from "#clusters/target-navigator";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const TargetNavigatorClientConstructor = TargetNavigatorBehavior;
-export interface TargetNavigatorClient extends TargetNavigatorBehavior {}
+export const TargetNavigatorClientConstructor = ClientBehavior(TargetNavigator.Complete);
+export interface TargetNavigatorClient extends InstanceType<typeof TargetNavigatorClientConstructor> {}
 export interface TargetNavigatorClientConstructor extends Identity<typeof TargetNavigatorClientConstructor> {}
 export const TargetNavigatorClient: TargetNavigatorClientConstructor = TargetNavigatorClientConstructor;

--- a/packages/node/src/behaviors/temperature-control/TemperatureControlClient.ts
+++ b/packages/node/src/behaviors/temperature-control/TemperatureControlClient.ts
@@ -7,10 +7,10 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { TemperatureControl } from "#clusters/temperature-control";
-import { ClusterBehavior } from "../../behavior/cluster/ClusterBehavior.js";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const TemperatureControlClientConstructor = ClusterBehavior.for(TemperatureControl.Complete);
+export const TemperatureControlClientConstructor = ClientBehavior(TemperatureControl.Complete);
 export interface TemperatureControlClient extends InstanceType<typeof TemperatureControlClientConstructor> {}
 export interface TemperatureControlClientConstructor extends Identity<typeof TemperatureControlClientConstructor> {}
 export const TemperatureControlClient: TemperatureControlClientConstructor = TemperatureControlClientConstructor;

--- a/packages/node/src/behaviors/temperature-measurement/TemperatureMeasurementClient.ts
+++ b/packages/node/src/behaviors/temperature-measurement/TemperatureMeasurementClient.ts
@@ -6,10 +6,11 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import { TemperatureMeasurementBehavior } from "./TemperatureMeasurementBehavior.js";
+import { TemperatureMeasurement } from "#clusters/temperature-measurement";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const TemperatureMeasurementClientConstructor = TemperatureMeasurementBehavior;
-export interface TemperatureMeasurementClient extends TemperatureMeasurementBehavior {}
+export const TemperatureMeasurementClientConstructor = ClientBehavior(TemperatureMeasurement.Complete);
+export interface TemperatureMeasurementClient extends InstanceType<typeof TemperatureMeasurementClientConstructor> {}
 export interface TemperatureMeasurementClientConstructor extends Identity<typeof TemperatureMeasurementClientConstructor> {}
 export const TemperatureMeasurementClient: TemperatureMeasurementClientConstructor = TemperatureMeasurementClientConstructor;

--- a/packages/node/src/behaviors/thermostat-user-interface-configuration/ThermostatUserInterfaceConfigurationClient.ts
+++ b/packages/node/src/behaviors/thermostat-user-interface-configuration/ThermostatUserInterfaceConfigurationClient.ts
@@ -6,10 +6,13 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import { ThermostatUserInterfaceConfigurationBehavior } from "./ThermostatUserInterfaceConfigurationBehavior.js";
+import { ThermostatUserInterfaceConfiguration } from "#clusters/thermostat-user-interface-configuration";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const ThermostatUserInterfaceConfigurationClientConstructor = ThermostatUserInterfaceConfigurationBehavior;
-export interface ThermostatUserInterfaceConfigurationClient extends ThermostatUserInterfaceConfigurationBehavior {}
+export const ThermostatUserInterfaceConfigurationClientConstructor = ClientBehavior(
+    ThermostatUserInterfaceConfiguration.Complete
+);
+export interface ThermostatUserInterfaceConfigurationClient extends InstanceType<typeof ThermostatUserInterfaceConfigurationClientConstructor> {}
 export interface ThermostatUserInterfaceConfigurationClientConstructor extends Identity<typeof ThermostatUserInterfaceConfigurationClientConstructor> {}
 export const ThermostatUserInterfaceConfigurationClient: ThermostatUserInterfaceConfigurationClientConstructor = ThermostatUserInterfaceConfigurationClientConstructor;

--- a/packages/node/src/behaviors/thermostat/ThermostatClient.ts
+++ b/packages/node/src/behaviors/thermostat/ThermostatClient.ts
@@ -7,10 +7,10 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { Thermostat } from "#clusters/thermostat";
-import { ClusterBehavior } from "../../behavior/cluster/ClusterBehavior.js";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const ThermostatClientConstructor = ClusterBehavior.for(Thermostat.Complete);
+export const ThermostatClientConstructor = ClientBehavior(Thermostat.Complete);
 export interface ThermostatClient extends InstanceType<typeof ThermostatClientConstructor> {}
 export interface ThermostatClientConstructor extends Identity<typeof ThermostatClientConstructor> {}
 export const ThermostatClient: ThermostatClientConstructor = ThermostatClientConstructor;

--- a/packages/node/src/behaviors/thread-border-router-management/ThreadBorderRouterManagementClient.ts
+++ b/packages/node/src/behaviors/thread-border-router-management/ThreadBorderRouterManagementClient.ts
@@ -7,10 +7,10 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { ThreadBorderRouterManagement } from "#clusters/thread-border-router-management";
-import { ClusterBehavior } from "../../behavior/cluster/ClusterBehavior.js";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const ThreadBorderRouterManagementClientConstructor = ClusterBehavior.for(ThreadBorderRouterManagement.Complete);
+export const ThreadBorderRouterManagementClientConstructor = ClientBehavior(ThreadBorderRouterManagement.Complete);
 export interface ThreadBorderRouterManagementClient extends InstanceType<typeof ThreadBorderRouterManagementClientConstructor> {}
 export interface ThreadBorderRouterManagementClientConstructor extends Identity<typeof ThreadBorderRouterManagementClientConstructor> {}
 export const ThreadBorderRouterManagementClient: ThreadBorderRouterManagementClientConstructor = ThreadBorderRouterManagementClientConstructor;

--- a/packages/node/src/behaviors/thread-network-diagnostics/ThreadNetworkDiagnosticsClient.ts
+++ b/packages/node/src/behaviors/thread-network-diagnostics/ThreadNetworkDiagnosticsClient.ts
@@ -7,10 +7,10 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { ThreadNetworkDiagnostics } from "#clusters/thread-network-diagnostics";
-import { ClusterBehavior } from "../../behavior/cluster/ClusterBehavior.js";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const ThreadNetworkDiagnosticsClientConstructor = ClusterBehavior.for(ThreadNetworkDiagnostics.Complete);
+export const ThreadNetworkDiagnosticsClientConstructor = ClientBehavior(ThreadNetworkDiagnostics.Complete);
 export interface ThreadNetworkDiagnosticsClient extends InstanceType<typeof ThreadNetworkDiagnosticsClientConstructor> {}
 export interface ThreadNetworkDiagnosticsClientConstructor extends Identity<typeof ThreadNetworkDiagnosticsClientConstructor> {}
 export const ThreadNetworkDiagnosticsClient: ThreadNetworkDiagnosticsClientConstructor = ThreadNetworkDiagnosticsClientConstructor;

--- a/packages/node/src/behaviors/thread-network-directory/ThreadNetworkDirectoryClient.ts
+++ b/packages/node/src/behaviors/thread-network-directory/ThreadNetworkDirectoryClient.ts
@@ -6,10 +6,11 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import { ThreadNetworkDirectoryBehavior } from "./ThreadNetworkDirectoryBehavior.js";
+import { ThreadNetworkDirectory } from "#clusters/thread-network-directory";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const ThreadNetworkDirectoryClientConstructor = ThreadNetworkDirectoryBehavior;
-export interface ThreadNetworkDirectoryClient extends ThreadNetworkDirectoryBehavior {}
+export const ThreadNetworkDirectoryClientConstructor = ClientBehavior(ThreadNetworkDirectory.Complete);
+export interface ThreadNetworkDirectoryClient extends InstanceType<typeof ThreadNetworkDirectoryClientConstructor> {}
 export interface ThreadNetworkDirectoryClientConstructor extends Identity<typeof ThreadNetworkDirectoryClientConstructor> {}
 export const ThreadNetworkDirectoryClient: ThreadNetworkDirectoryClientConstructor = ThreadNetworkDirectoryClientConstructor;

--- a/packages/node/src/behaviors/time-format-localization/TimeFormatLocalizationClient.ts
+++ b/packages/node/src/behaviors/time-format-localization/TimeFormatLocalizationClient.ts
@@ -7,10 +7,10 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { TimeFormatLocalization } from "#clusters/time-format-localization";
-import { ClusterBehavior } from "../../behavior/cluster/ClusterBehavior.js";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const TimeFormatLocalizationClientConstructor = ClusterBehavior.for(TimeFormatLocalization.Complete);
+export const TimeFormatLocalizationClientConstructor = ClientBehavior(TimeFormatLocalization.Complete);
 export interface TimeFormatLocalizationClient extends InstanceType<typeof TimeFormatLocalizationClientConstructor> {}
 export interface TimeFormatLocalizationClientConstructor extends Identity<typeof TimeFormatLocalizationClientConstructor> {}
 export const TimeFormatLocalizationClient: TimeFormatLocalizationClientConstructor = TimeFormatLocalizationClientConstructor;

--- a/packages/node/src/behaviors/time-synchronization/TimeSynchronizationClient.ts
+++ b/packages/node/src/behaviors/time-synchronization/TimeSynchronizationClient.ts
@@ -7,10 +7,10 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { TimeSynchronization } from "#clusters/time-synchronization";
-import { ClusterBehavior } from "../../behavior/cluster/ClusterBehavior.js";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const TimeSynchronizationClientConstructor = ClusterBehavior.for(TimeSynchronization.Complete);
+export const TimeSynchronizationClientConstructor = ClientBehavior(TimeSynchronization.Complete);
 export interface TimeSynchronizationClient extends InstanceType<typeof TimeSynchronizationClientConstructor> {}
 export interface TimeSynchronizationClientConstructor extends Identity<typeof TimeSynchronizationClientConstructor> {}
 export const TimeSynchronizationClient: TimeSynchronizationClientConstructor = TimeSynchronizationClientConstructor;

--- a/packages/node/src/behaviors/total-volatile-organic-compounds-concentration-measurement/TotalVolatileOrganicCompoundsConcentrationMeasurementClient.ts
+++ b/packages/node/src/behaviors/total-volatile-organic-compounds-concentration-measurement/TotalVolatileOrganicCompoundsConcentrationMeasurementClient.ts
@@ -9,11 +9,12 @@
 import {
     TotalVolatileOrganicCompoundsConcentrationMeasurement
 } from "#clusters/total-volatile-organic-compounds-concentration-measurement";
-import { ClusterBehavior } from "../../behavior/cluster/ClusterBehavior.js";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const TotalVolatileOrganicCompoundsConcentrationMeasurementClientConstructor = ClusterBehavior
-    .for(TotalVolatileOrganicCompoundsConcentrationMeasurement.Complete);
+export const TotalVolatileOrganicCompoundsConcentrationMeasurementClientConstructor = ClientBehavior(
+    TotalVolatileOrganicCompoundsConcentrationMeasurement.Complete
+);
 export interface TotalVolatileOrganicCompoundsConcentrationMeasurementClient extends InstanceType<typeof TotalVolatileOrganicCompoundsConcentrationMeasurementClientConstructor> {}
 export interface TotalVolatileOrganicCompoundsConcentrationMeasurementClientConstructor extends Identity<typeof TotalVolatileOrganicCompoundsConcentrationMeasurementClientConstructor> {}
 export const TotalVolatileOrganicCompoundsConcentrationMeasurementClient: TotalVolatileOrganicCompoundsConcentrationMeasurementClientConstructor = TotalVolatileOrganicCompoundsConcentrationMeasurementClientConstructor;

--- a/packages/node/src/behaviors/unit-localization/UnitLocalizationClient.ts
+++ b/packages/node/src/behaviors/unit-localization/UnitLocalizationClient.ts
@@ -7,10 +7,10 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { UnitLocalization } from "#clusters/unit-localization";
-import { ClusterBehavior } from "../../behavior/cluster/ClusterBehavior.js";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const UnitLocalizationClientConstructor = ClusterBehavior.for(UnitLocalization.Complete);
+export const UnitLocalizationClientConstructor = ClientBehavior(UnitLocalization.Complete);
 export interface UnitLocalizationClient extends InstanceType<typeof UnitLocalizationClientConstructor> {}
 export interface UnitLocalizationClientConstructor extends Identity<typeof UnitLocalizationClientConstructor> {}
 export const UnitLocalizationClient: UnitLocalizationClientConstructor = UnitLocalizationClientConstructor;

--- a/packages/node/src/behaviors/user-label/UserLabelClient.ts
+++ b/packages/node/src/behaviors/user-label/UserLabelClient.ts
@@ -6,10 +6,11 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import { UserLabelBehavior } from "./UserLabelBehavior.js";
+import { UserLabel } from "#clusters/user-label";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const UserLabelClientConstructor = UserLabelBehavior;
-export interface UserLabelClient extends UserLabelBehavior {}
+export const UserLabelClientConstructor = ClientBehavior(UserLabel.Complete);
+export interface UserLabelClient extends InstanceType<typeof UserLabelClientConstructor> {}
 export interface UserLabelClientConstructor extends Identity<typeof UserLabelClientConstructor> {}
 export const UserLabelClient: UserLabelClientConstructor = UserLabelClientConstructor;

--- a/packages/node/src/behaviors/valve-configuration-and-control/ValveConfigurationAndControlClient.ts
+++ b/packages/node/src/behaviors/valve-configuration-and-control/ValveConfigurationAndControlClient.ts
@@ -7,10 +7,10 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { ValveConfigurationAndControl } from "#clusters/valve-configuration-and-control";
-import { ClusterBehavior } from "../../behavior/cluster/ClusterBehavior.js";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const ValveConfigurationAndControlClientConstructor = ClusterBehavior.for(ValveConfigurationAndControl.Complete);
+export const ValveConfigurationAndControlClientConstructor = ClientBehavior(ValveConfigurationAndControl.Complete);
 export interface ValveConfigurationAndControlClient extends InstanceType<typeof ValveConfigurationAndControlClientConstructor> {}
 export interface ValveConfigurationAndControlClientConstructor extends Identity<typeof ValveConfigurationAndControlClientConstructor> {}
 export const ValveConfigurationAndControlClient: ValveConfigurationAndControlClientConstructor = ValveConfigurationAndControlClientConstructor;

--- a/packages/node/src/behaviors/wake-on-lan/WakeOnLanClient.ts
+++ b/packages/node/src/behaviors/wake-on-lan/WakeOnLanClient.ts
@@ -6,10 +6,11 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import { WakeOnLanBehavior } from "./WakeOnLanBehavior.js";
+import { WakeOnLan } from "#clusters/wake-on-lan";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const WakeOnLanClientConstructor = WakeOnLanBehavior;
-export interface WakeOnLanClient extends WakeOnLanBehavior {}
+export const WakeOnLanClientConstructor = ClientBehavior(WakeOnLan.Complete);
+export interface WakeOnLanClient extends InstanceType<typeof WakeOnLanClientConstructor> {}
 export interface WakeOnLanClientConstructor extends Identity<typeof WakeOnLanClientConstructor> {}
 export const WakeOnLanClient: WakeOnLanClientConstructor = WakeOnLanClientConstructor;

--- a/packages/node/src/behaviors/water-heater-management/WaterHeaterManagementClient.ts
+++ b/packages/node/src/behaviors/water-heater-management/WaterHeaterManagementClient.ts
@@ -7,10 +7,10 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { WaterHeaterManagement } from "#clusters/water-heater-management";
-import { ClusterBehavior } from "../../behavior/cluster/ClusterBehavior.js";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const WaterHeaterManagementClientConstructor = ClusterBehavior.for(WaterHeaterManagement.Complete);
+export const WaterHeaterManagementClientConstructor = ClientBehavior(WaterHeaterManagement.Complete);
 export interface WaterHeaterManagementClient extends InstanceType<typeof WaterHeaterManagementClientConstructor> {}
 export interface WaterHeaterManagementClientConstructor extends Identity<typeof WaterHeaterManagementClientConstructor> {}
 export const WaterHeaterManagementClient: WaterHeaterManagementClientConstructor = WaterHeaterManagementClientConstructor;

--- a/packages/node/src/behaviors/water-heater-mode/WaterHeaterModeClient.ts
+++ b/packages/node/src/behaviors/water-heater-mode/WaterHeaterModeClient.ts
@@ -6,10 +6,11 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import { WaterHeaterModeBehavior } from "./WaterHeaterModeBehavior.js";
+import { WaterHeaterMode } from "#clusters/water-heater-mode";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const WaterHeaterModeClientConstructor = WaterHeaterModeBehavior;
-export interface WaterHeaterModeClient extends WaterHeaterModeBehavior {}
+export const WaterHeaterModeClientConstructor = ClientBehavior(WaterHeaterMode.Complete);
+export interface WaterHeaterModeClient extends InstanceType<typeof WaterHeaterModeClientConstructor> {}
 export interface WaterHeaterModeClientConstructor extends Identity<typeof WaterHeaterModeClientConstructor> {}
 export const WaterHeaterModeClient: WaterHeaterModeClientConstructor = WaterHeaterModeClientConstructor;

--- a/packages/node/src/behaviors/water-tank-level-monitoring/WaterTankLevelMonitoringClient.ts
+++ b/packages/node/src/behaviors/water-tank-level-monitoring/WaterTankLevelMonitoringClient.ts
@@ -7,10 +7,10 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { WaterTankLevelMonitoring } from "#clusters/water-tank-level-monitoring";
-import { ClusterBehavior } from "../../behavior/cluster/ClusterBehavior.js";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const WaterTankLevelMonitoringClientConstructor = ClusterBehavior.for(WaterTankLevelMonitoring.Complete);
+export const WaterTankLevelMonitoringClientConstructor = ClientBehavior(WaterTankLevelMonitoring.Complete);
 export interface WaterTankLevelMonitoringClient extends InstanceType<typeof WaterTankLevelMonitoringClientConstructor> {}
 export interface WaterTankLevelMonitoringClientConstructor extends Identity<typeof WaterTankLevelMonitoringClientConstructor> {}
 export const WaterTankLevelMonitoringClient: WaterTankLevelMonitoringClientConstructor = WaterTankLevelMonitoringClientConstructor;

--- a/packages/node/src/behaviors/wi-fi-network-diagnostics/WiFiNetworkDiagnosticsClient.ts
+++ b/packages/node/src/behaviors/wi-fi-network-diagnostics/WiFiNetworkDiagnosticsClient.ts
@@ -7,10 +7,10 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { WiFiNetworkDiagnostics } from "#clusters/wi-fi-network-diagnostics";
-import { ClusterBehavior } from "../../behavior/cluster/ClusterBehavior.js";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const WiFiNetworkDiagnosticsClientConstructor = ClusterBehavior.for(WiFiNetworkDiagnostics.Complete);
+export const WiFiNetworkDiagnosticsClientConstructor = ClientBehavior(WiFiNetworkDiagnostics.Complete);
 export interface WiFiNetworkDiagnosticsClient extends InstanceType<typeof WiFiNetworkDiagnosticsClientConstructor> {}
 export interface WiFiNetworkDiagnosticsClientConstructor extends Identity<typeof WiFiNetworkDiagnosticsClientConstructor> {}
 export const WiFiNetworkDiagnosticsClient: WiFiNetworkDiagnosticsClientConstructor = WiFiNetworkDiagnosticsClientConstructor;

--- a/packages/node/src/behaviors/wi-fi-network-management/WiFiNetworkManagementClient.ts
+++ b/packages/node/src/behaviors/wi-fi-network-management/WiFiNetworkManagementClient.ts
@@ -6,10 +6,11 @@
 
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
-import { WiFiNetworkManagementBehavior } from "./WiFiNetworkManagementBehavior.js";
+import { WiFiNetworkManagement } from "#clusters/wi-fi-network-management";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const WiFiNetworkManagementClientConstructor = WiFiNetworkManagementBehavior;
-export interface WiFiNetworkManagementClient extends WiFiNetworkManagementBehavior {}
+export const WiFiNetworkManagementClientConstructor = ClientBehavior(WiFiNetworkManagement.Complete);
+export interface WiFiNetworkManagementClient extends InstanceType<typeof WiFiNetworkManagementClientConstructor> {}
 export interface WiFiNetworkManagementClientConstructor extends Identity<typeof WiFiNetworkManagementClientConstructor> {}
 export const WiFiNetworkManagementClient: WiFiNetworkManagementClientConstructor = WiFiNetworkManagementClientConstructor;

--- a/packages/node/src/behaviors/window-covering/WindowCoveringClient.ts
+++ b/packages/node/src/behaviors/window-covering/WindowCoveringClient.ts
@@ -7,10 +7,10 @@
 /*** THIS FILE IS GENERATED, DO NOT EDIT ***/
 
 import { WindowCovering } from "#clusters/window-covering";
-import { ClusterBehavior } from "../../behavior/cluster/ClusterBehavior.js";
+import { ClientBehavior } from "../../behavior/cluster/ClientBehavior.js";
 import { Identity } from "#general";
 
-export const WindowCoveringClientConstructor = ClusterBehavior.for(WindowCovering.Complete);
+export const WindowCoveringClientConstructor = ClientBehavior(WindowCovering.Complete);
 export interface WindowCoveringClient extends InstanceType<typeof WindowCoveringClientConstructor> {}
 export interface WindowCoveringClientConstructor extends Identity<typeof WindowCoveringClientConstructor> {}
 export const WindowCoveringClient: WindowCoveringClientConstructor = WindowCoveringClientConstructor;

--- a/packages/node/src/node/client/ClientEndpointInitializer.ts
+++ b/packages/node/src/node/client/ClientEndpointInitializer.ts
@@ -12,7 +12,7 @@ import { ServerBehaviorBacking } from "#behavior/internal/ServerBehaviorBacking.
 import { Endpoint } from "#endpoint/Endpoint.js";
 import { EndpointInitializer } from "#endpoint/properties/EndpointInitializer.js";
 import { FeatureBitmap } from "#model";
-import { ClientBehavior } from "#node/client/ClientBehavior.js";
+import { PeerBehavior } from "#node/client/PeerBehavior.js";
 import type { ClientNode } from "#node/ClientNode.js";
 import { ClientNodeStore } from "#storage/client/ClientNodeStore.js";
 import { NodeStore } from "#storage/NodeStore.js";
@@ -84,7 +84,7 @@ export class ClientEndpointInitializer extends EndpointInitializer {
             commands.push(cmd.requestId);
         }
 
-        return ClientBehavior({
+        return PeerBehavior({
             id: cluster.id,
             revision: cluster.revision,
             features,

--- a/packages/node/src/node/client/ClientStructure.ts
+++ b/packages/node/src/node/client/ClientStructure.ts
@@ -26,8 +26,8 @@ import { ReadScope, type Read, type ReadResult } from "#protocol";
 import { DatasourceCache } from "#storage/client/DatasourceCache.js";
 import { ClientNodeStore } from "#storage/index.js";
 import type { AttributeId, ClusterId, ClusterType, CommandId, EndpointNumber } from "#types";
-import { ClientBehavior } from "./ClientBehavior.js";
 import { ClientEventEmitter } from "./ClientEventEmitter.js";
+import { PeerBehavior } from "./PeerBehavior.js";
 
 const DEVICE_TYPE_LIST_ATTR_ID = Descriptor.Cluster.attributes.deviceTypeList.id;
 const SERVER_LIST_ATTR_ID = Descriptor.Cluster.attributes.serverList.id;
@@ -295,7 +295,7 @@ export class ClientStructure {
                 cluster.attributes !== undefined &&
                 cluster.commands !== undefined
             ) {
-                cluster.behavior = ClientBehavior(cluster as ClientBehavior.ClusterShape);
+                cluster.behavior = PeerBehavior(cluster as PeerBehavior.ClusterShape);
                 endpoint.endpoint.behaviors.require(cluster.behavior);
             }
         }
@@ -437,7 +437,7 @@ interface EndpointStructure {
     clusters: Record<ClusterId, ClusterStructure>;
 }
 
-interface ClusterStructure extends Partial<ClientBehavior.ClusterShape> {
+interface ClusterStructure extends Partial<PeerBehavior.ClusterShape> {
     id: ClusterId;
     behavior?: ClusterBehavior.Type;
     store: Datasource.ExternallyMutableStore;

--- a/packages/node/src/node/client/PeerBehavior.ts
+++ b/packages/node/src/node/client/PeerBehavior.ts
@@ -33,7 +33,7 @@ const cache = {} as Record<string, ClusterBehavior.Type>;
 /**
  * Obtain a {@link ClusterBehavior.Type} for a remote cluster.
  */
-export function ClientBehavior(shape: ClientBehavior.ClusterShape): ClusterBehavior.Type {
+export function PeerBehavior(shape: PeerBehavior.ClusterShape): ClusterBehavior.Type {
     const analysis = ShapeAnalysis(shape);
 
     const fingerprint = createFingerprint(analysis);
@@ -55,7 +55,7 @@ export function ClientBehavior(shape: ClientBehavior.ClusterShape): ClusterBehav
     return type;
 }
 
-export namespace ClientBehavior {
+export namespace PeerBehavior {
     export interface ClusterShape {
         id: ClusterId;
         revision: number;
@@ -250,7 +250,7 @@ function createUnknownName(prefix: string, id: number) {
 
 interface ShapeAnalysis {
     schema: ClusterModel & { id: ClusterId };
-    shape: ClientBehavior.ClusterShape;
+    shape: PeerBehavior.ClusterShape;
     attrSupportOverrides: Map<AttributeModel, boolean>;
     extraAttrs: Set<number>;
     commandSupportOverrides: Map<CommandModel, boolean>;
@@ -260,7 +260,7 @@ interface ShapeAnalysis {
 /**
  * Analyze the cluster shape to determine how we should override the behavior and schema.
  */
-function ShapeAnalysis(shape: ClientBehavior.ClusterShape): ShapeAnalysis {
+function ShapeAnalysis(shape: PeerBehavior.ClusterShape): ShapeAnalysis {
     const standardCluster = Matter.get(ClusterModel, shape.id);
     const schema =
         standardCluster ??


### PR DESCRIPTION
Generates client behavior in a way that we can identify the class.  Then since we know the class interface is a superset of any implementation of the relevant cluster, always return the behavior implementation for the client.

This allows for convenient "mostly typed" access to behaviors regardless of underlying class or enabled cluster features.