### PR TITLE
Adjust PASE Server responses when ignoring new exchanges

### DIFF
--- a/packages/protocol/src/common/FailsafeContext.ts
+++ b/packages/protocol/src/common/FailsafeContext.ts
@@ -185,7 +185,7 @@ export abstract class FailsafeContext {
 
     async removePaseSession() {
         const session = this.#sessions.getPaseSession();
-        if (session) {
+        if (session !== undefined) {
             await session.close(true);
         }
     }

--- a/packages/protocol/src/session/SessionManager.ts
+++ b/packages/protocol/src/session/SessionManager.ts
@@ -421,7 +421,7 @@ export class SessionManager {
 
         return [...this.#sessions].find(
             session => NodeSession.is(session) && session.isPase && !session.closingAfterExchangeFinished,
-        ) as NodeSession;
+        );
     }
 
     forFabric(fabric: Fabric) {


### PR DESCRIPTION
I validated a bit in Matetr SDK code and there InvalidParam is returned instead of ignored