### PR TITLE
Handle changes to fixed attributes

### DIFF
--- a/packages/node/src/behavior/internal/ClientBehaviorBacking.ts
+++ b/packages/node/src/behavior/internal/ClientBehaviorBacking.ts
@@ -5,8 +5,9 @@
  */
 
 import { GlobalAttributeState } from "#behavior/cluster/ClusterState.js";
+import { DatasourceCache } from "#endpoint/index.js";
 import { SupportedElements } from "#endpoint/properties/Behaviors.js";
-import { camelize } from "#general";
+import { camelize, MaybePromise } from "#general";
 import { ClusterModel } from "#model";
 import { AttributeId, CommandId } from "#types";
 import { BehaviorBacking } from "./BehaviorBacking.js";
@@ -53,5 +54,13 @@ export class ClientBehaviorBacking extends BehaviorBacking {
         const options = super.datasourceOptions;
         options.primaryKey = "id";
         return options;
+    }
+
+    override close(): MaybePromise {
+        // Prepare the store for reuse in the case of reset
+        (this.store as DatasourceCache).reclaimValues?.();
+
+        // Omit the agent to skip disposal logic as client behaviors have none
+        super.close();
     }
 }

--- a/packages/node/src/behavior/state/managed/Datasource.ts
+++ b/packages/node/src/behavior/state/managed/Datasource.ts
@@ -230,6 +230,11 @@ export namespace Datasource {
         externalChangeListener?: (changes: Val.Struct) => Promise<void>;
 
         /**
+         * Callback installed by the store that releases the values from the datasource when invoked.
+         */
+        releaseValues?: () => Val.Struct;
+
+        /**
          * The current version of the data.
          */
         version: number;
@@ -471,6 +476,14 @@ function configureExternalChanges(internals: Internals) {
                 }
             }
         }
+    };
+
+    store.releaseValues = () => {
+        const { values } = internals;
+
+        internals.values = {};
+
+        return values;
     };
 }
 

--- a/packages/node/src/node/client/Peers.ts
+++ b/packages/node/src/node/client/Peers.ts
@@ -131,6 +131,10 @@ export class Peers extends EndpointContainer<ClientNode> {
         return this.owner.env.get(ClientStructureEvents).clusterInstalled(type);
     }
 
+    /**
+     * Emits when fixed attributes
+     */
+
     override get(id: number | string | PeerAddress) {
         if (typeof id !== "string" && typeof id !== "number") {
             const address = PeerAddress(id);

--- a/packages/node/src/node/server/ServerEndpointInitializer.ts
+++ b/packages/node/src/node/server/ServerEndpointInitializer.ts
@@ -32,7 +32,7 @@ export class ServerEndpointInitializer extends EndpointInitializer {
 
         // DescriptorServer is mandatory but we don't include it in generated device types
         if (!(DescriptorServer.id in endpoint.behaviors.supported)) {
-            endpoint.behaviors.inject(DescriptorServer);
+            endpoint.behaviors.inject(DescriptorServer, undefined, false);
         }
     }
 

--- a/packages/node/src/storage/EndpointStore.ts
+++ b/packages/node/src/storage/EndpointStore.ts
@@ -115,10 +115,17 @@ export class EndpointStore {
     }
 
     /**
-     * Remove all persisted information for the {@link Endpoint}
+     * Remove all persisted information for the {@link Endpoint}.
      */
     erase() {
         return this.storage.clearAll();
+    }
+
+    /**
+     * Remove all persisted information for a single behavior on the {@link Endpoint}.
+     */
+    eraseStoreForBehavior(behaviorId: string) {
+        return this.storage.createContext(behaviorId).clearAll();
     }
 
     protected get storage() {

--- a/packages/node/test/node/ClientNodeTest.ts
+++ b/packages/node/test/node/ClientNodeTest.ts
@@ -77,7 +77,7 @@ describe("ClientNode", () => {
         expect(peer1).not.undefined;
 
         // Validate the root endpoint
-        expect(Object.keys(peer1.state)).deep.equals(Object.keys(PEER1_STATE));
+        expect(Object.keys(peer1.state).sort()).deep.equals(Object.keys(PEER1_STATE).sort());
         for (const key in peer1.state) {
             const actual = (peer1.state as Record<string, unknown>)[key];
             const expected = (PEER1_STATE as Record<string, unknown>)[key];


### PR DESCRIPTION
Specifically key structural attributes including features, commands, attributes and servers.

For now we attempt to do a "live swap" of the relevant behaviors.  This is a little sketchy but should work OK for known elements at least.

Also modifies structural eventing to push the events until after all structural updates are applied.