### PR TITLE
Throw an error for feature mismatches

### DIFF
--- a/packages/node/src/behavior/cluster/ClusterBehavior.ts
+++ b/packages/node/src/behavior/cluster/ClusterBehavior.ts
@@ -56,6 +56,10 @@ export class ClusterBehavior extends Behavior {
         return this.cluster.supportedFeatures;
     }
 
+    override get type() {
+        return this.constructor as ClusterBehavior.Type;
+    }
+
     /**
      * Every cluster behavior has an associated ClusterType defined statically.
      */

--- a/packages/node/src/behavior/cluster/ClusterBehaviorType.ts
+++ b/packages/node/src/behavior/cluster/ClusterBehaviorType.ts
@@ -110,6 +110,11 @@ export function ClusterBehaviorType<const C extends ClusterType>({
     // Decorate the class
     ClassSemantics.of(type).mutableModel = schema;
 
+    // If the schema was overridden, it won't change with class semantics so override explicitly if necessary
+    if (type.schema !== schema) {
+        Object.defineProperty(type, "schema", { value: schema });
+    }
+
     // Mutation of schema will almost certainly result in logic errors so ensure that can't happen
     schema.finalize();
 

--- a/packages/node/src/behaviors/scenes-management/ScenesManagementServer.ts
+++ b/packages/node/src/behaviors/scenes-management/ScenesManagementServer.ts
@@ -845,8 +845,8 @@ export class ScenesManagementServer extends ScenesManagementBase {
      * @param applyFunc Function that applies scene values for that cluster
      */
     implementScenes<T extends ClusterBehavior>(behavior: T, applyFunc: ScenesManagementServer.ApplySceneValuesFunc<T>) {
-        const type = behavior.type as ClusterBehavior.Type;
-        if (!ClusterBehavior.is(type) || !type.schema || !type.schema.id) {
+        const { type } = behavior;
+        if (!type.schema.id) {
             return;
         }
         const clusterName = camelize(type.schema.name);


### PR DESCRIPTION
Prevents the case where endpoint initialization results in a feature map that does not match the schema.

Fixes #1209