### PR TITLE
Fix resumption record deletion + CADMIN/1.16

### DIFF
--- a/packages/node/src/node/ServerNode.ts
+++ b/packages/node/src/node/ServerNode.ts
@@ -110,8 +110,7 @@ export class ServerNode<T extends ServerNode.RootEndpoint = ServerNode.RootEndpo
     }
 
     override async prepareRuntimeShutdown() {
-        const sessions = this.env.get(SessionManager);
-        await sessions.close();
+        await this.env.get(SessionManager).closeAllSessions();
     }
 
     /**

--- a/packages/protocol/src/session/SessionManager.ts
+++ b/packages/protocol/src/session/SessionManager.ts
@@ -688,9 +688,20 @@ export class SessionManager {
             await this.#construction;
         }
 
+        this.#observers.close();
+
+        await this.closeAllSessions();
+    }
+
+    async clear() {
+        await this.closeAllSessions();
+        await this.#context.storage.clear();
+        this.#resumptionRecords.clear();
+    }
+
+    async closeAllSessions() {
         await this.#subscriptionUpdateMutex;
 
-        this.#observers.close();
         await this.#storeResumptionRecords();
         const closePromises = this.#sessions.map(async session => {
             await session?.end(false);
@@ -707,12 +718,6 @@ export class SessionManager {
         await MatterAggregateError.allSettled(closePromises, "Error closing sessions").catch(error =>
             logger.error(error),
         );
-    }
-
-    async clear() {
-        await this.close();
-        await this.#context.storage.clear();
-        this.#resumptionRecords.clear();
     }
 
     updateAllSubscriptions() {

--- a/packages/testing/src/chip/matter-js-pics.properties
+++ b/packages/testing/src/chip/matter-js-pics.properties
@@ -13,6 +13,9 @@ WNCV.S.F03=1
 # We need to turn off calibration because the test expect a different behavior then we do in default implementation
 WNCV.S.M.Calibration=0
 
+# We support CADMIN "Basic" feature
+CADMIN.S.F00=1
+
 # We support "Hue/Saturation" feature and want to run tests for that too
 CC.S.F00=1
 

--- a/support/chip-testing/test/core/CADMIN.test.ts
+++ b/support/chip-testing/test/core/CADMIN.test.ts
@@ -53,6 +53,17 @@ describe("CADMIN", () => {
         ),
     );
 
+    // CADMIN/1.16 waits for timeouts for two operations on BasicInformation NodeLabel which ends up being roughly
+    // fourty seconds.  Reduce to 4 since we know that 2s. per is more than generous for local comms
+    before(() =>
+        chip.testFor("CADMIN/1.16").edit(
+            edit.insert({
+                after: "      PICS: BINFO.S.A0005",
+                lines: "      timeout: 2",
+            }),
+        ),
+    );
+
     // CHIP expects general error code 0xb when the proper response is NodeOperationalCertStatus.TableFull
     //
     // For now we just patch the test to convert 0xb (whatever that is) to 0x587, which appears to be an internal
@@ -73,6 +84,11 @@ describe("CADMIN", () => {
         // These are joint fabric
         "CADMIN/1.27",
         "CADMIN/1.28",
+
+        // TODO - results in test failing on step 12 with usual "The test expects no error but the "FAILURE" error
+        // occured [sic]."  However, this occurs after successful commissioning and there are no errors in the logs from
+        // CHIP. So going to be interesting to diagnose
+        "CADMIN/1.16",
     );
 
     chip("CADMIN/1.19").beforeTest(subject => {


### PR DESCRIPTION
Fixes two places that were preventing proper resumption record deletion:

  - On clear we were "closing" the session manager, which removed its observer of session delete, but then continuing to use it, so subsequent sessions wouldn't properly remove resumption records

  - On shutdown we were also closing but then continuing to use with a similar effect

Previously we weren't running CADMIN/1.16 which crashed in two separate places due to the bugs above.  However, I've left disabled because it now exits with an error on step 12 even though the logs report that commissioning succeeded with no subsequent errors.