### PR TITLE
Properly dispose of peers during destruction

### DIFF
--- a/packages/node/src/node/ServerNode.ts
+++ b/packages/node/src/node/ServerNode.ts
@@ -105,6 +105,10 @@ export class ServerNode<T extends ServerNode.RootEndpoint = ServerNode.RootEndpo
     }
 
     override async [Construction.destruct]() {
+        if (this.#peers) {
+            await this.#peers.close();
+        }
+
         await super[Construction.destruct]();
         await ServerEnvironment.close(this);
     }
@@ -159,8 +163,13 @@ export class ServerNode<T extends ServerNode.RootEndpoint = ServerNode.RootEndpo
      */
     get peers() {
         if (!this.#peers) {
-            this.#peers = new Peers(this);
-            this.#peers.initialize();
+            try {
+                this.#peers = new Peers(this);
+                this.#peers.initialize();
+            } catch (e) {
+                this.#peers = undefined;
+                throw e;
+            }
         }
 
         return this.#peers;

--- a/packages/node/src/node/client/Peers.ts
+++ b/packages/node/src/node/client/Peers.ts
@@ -29,6 +29,7 @@ import {
     Seconds,
     Time,
     Timestamp,
+    UninitializedDependencyError,
 } from "#general";
 import { ClientGroup } from "#node/ClientGroup.js";
 import { InteractionServer } from "#node/server/InteractionServer.js";
@@ -77,7 +78,14 @@ export class Peers extends EndpointContainer<ClientNode> {
     initialize() {
         const factory = this.owner.env.get(ClientNodeFactory);
 
-        const clientStores = this.owner.env.get(ServerNodeStore).clientStores;
+        const clientStores = this.owner.env.maybeGet(ServerNodeStore)?.clientStores;
+        if (clientStores === undefined) {
+            throw new UninitializedDependencyError(
+                "Peers",
+                "are not available because ServerNode initialization is incomplete",
+            );
+        }
+
         // Group nodes have an in-memory only store, so all nodes restored here are ClientNode
         for (const id of clientStores.knownIds) {
             this.add(


### PR DESCRIPTION
Also makes the error clearer when accessing peers too early