### PR TITLE
Optimize Nightly release - tweak FS

### DIFF
--- a/.github/workflows/nightly-dev-release.yml
+++ b/.github/workflows/nightly-dev-release.yml
@@ -31,6 +31,7 @@ jobs:
       uses: easimon/maximize-build-space@v10
       with:
         remove-dotnet: 'true'
+        remove-android: 'true'
 
     - name: Checkout code
       uses: actions/checkout@v6


### PR DESCRIPTION
The nightlies sometimes fail not because installing stuff, but just while installing anything needed and unpacking the caches for test runs. so not too much we can do ourself (except switch to docker tests), so try this here for now