### PR TITLE
Prepare NPM trusted publishing

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -5,6 +5,7 @@ name: Automatic Labeled NPM Release
 permissions:
   contents: write
   pull-requests: write
+  id-token: write  # Required for OIDC
 
 on:
   pull_request:
@@ -120,8 +121,7 @@ jobs:
         env:
           PRERELEASE: ${{ contains(steps.version.outputs.result, '-') }}
         run: |
-          npm config set //registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}
-          npm whoami
+          npm install -g npm@latest
           
           if [[ "$PRERELEASE" == "true" ]]; then
             npm publish --workspaces --tag dev


### PR DESCRIPTION
This PR adjusts the GHA we use to publish the npmjs packages for NPM Trusted publishing.

Please do not set to automerge. I will merge once I finished the setup for all packages on npm.

Note: For the future we need to publish new packages once manually in order to configure them for trusted publishing.

Docs: https://docs.npmjs.com/trusted-publishers/#configuring-trusted-publishing