### PR TITLE
Maintain internal index of disk storage

### DIFF
--- a/packages/nodejs/src/storage/StorageBackendDisk.ts
+++ b/packages/nodejs/src/storage/StorageBackendDisk.ts
@@ -346,9 +346,10 @@ export class StorageBackendDisk extends Storage {
         }
 
         if (index.keys) {
-            for (const key of index.keys) {
-                await this.#rm(this.buildStorageKey(contexts, key), index, key);
-            }
+            await MatterAggregateError.allSettled(
+                [...index.keys].map(key => this.#rm(this.buildStorageKey(contexts, key), index, key)),
+                `Error deleting keys of storage context ${contexts.join(".")}`,
+            );
         }
     }
 }


### PR DESCRIPTION
This is a proposed alternative to #2880...  It increases the size of StorageBackendDisk.ts by roughly the same number of lines but is hopefully more performant as it reduces the number of O(n) scans over storage files to 1.

Only tested to the extent that tests in StorageBackendDiskTest.ts pass, so if coverage there is incomplete this requires more testing.