### PR TITLE
Return a copy of the value when accessing local attr data

### DIFF
--- a/packages/matter.js/src/cluster/client/InteractionClient.ts
+++ b/packages/matter.js/src/cluster/client/InteractionClient.ts
@@ -6,6 +6,7 @@
 
 import { AccessControl } from "#clusters";
 import {
+    deepCopy,
     Diagnostic,
     Duration,
     ImplementationError,
@@ -523,7 +524,7 @@ export class InteractionClient {
         const { id: attributeId } = attribute;
 
         if (this.#interaction instanceof ClientNodeInteraction) {
-            return this.#interaction.localStateFor(endpointId)?.[clusterId]?.[attributeId] as
+            return deepCopy(this.#interaction.localStateFor(endpointId)?.[clusterId]?.[attributeId]) as
                 | AttributeJsType<A>
                 | undefined;
         }

--- a/packages/matter.js/src/device/PairedNode.ts
+++ b/packages/matter.js/src/device/PairedNode.ts
@@ -1244,7 +1244,7 @@ export class PairedNode {
 
             const endpoint = this.#endpoints.get(endpointId);
             if (endpoint === undefined) {
-                // Should not happen or endpoint was invalid and that's why not created, then we ignore it
+                // Should not happen, or endpoint was invalid and that's why not created, then we ignore it
                 continue;
             }
             endpoint.getChildEndpoints().forEach(child => {

--- a/packages/node/src/endpoint/properties/EndpointContainer.ts
+++ b/packages/node/src/endpoint/properties/EndpointContainer.ts
@@ -119,7 +119,7 @@ export class EndpointContainer<T extends Endpoint = Endpoint>
     }
 
     /**
-     * Confirm availability of an ID amongst the endpoint's children.
+     * Confirm the availability of an ID amongst the endpoint's children.
      */
     assertIdAvailable(id: string, endpoint: Endpoint) {
         const other = this.get(id);

--- a/packages/node/src/node/ClientNode.ts
+++ b/packages/node/src/node/ClientNode.ts
@@ -49,7 +49,7 @@ export class ClientNode extends Node<ClientNode.RootEndpoint> {
 
         super(opts);
 
-        // Block the OccurrenceManager from parent environment so we don't attempt to record events from peers
+        // Block the OccurrenceManager from the parent environment so we don't attempt to record events from peers
         this.env.close(OccurrenceManager);
 
         this.env.set(Node, this);


### PR DESCRIPTION
... to stay backward compatible. From new state API it is a managed value which can not be modified, formerly that was possible