### PR TITLE
Make ClientNode initialize sync again

### DIFF
--- a/packages/node/src/node/ClientNode.ts
+++ b/packages/node/src/node/ClientNode.ts
@@ -79,9 +79,9 @@ export class ClientNode extends Node<ClientNode.RootEndpoint> {
         return this.env.get(ServerNodeStore).clientStores.storeForNode(this);
     }
 
-    override async initialize() {
+    // This needs to be sync to ensure a sync initialization
+    override initialize() {
         const store = this.store;
-        await store.construction;
 
         this.env.set(ClientNodeStore, store);
 
@@ -92,7 +92,7 @@ export class ClientNode extends Node<ClientNode.RootEndpoint> {
 
         initializer.structure.loadCache();
 
-        await super.initialize();
+        return super.initialize();
     }
 
     override get owner(): ServerNode | undefined {

--- a/packages/node/src/node/client/Peers.ts
+++ b/packages/node/src/node/client/Peers.ts
@@ -216,6 +216,14 @@ export class Peers extends EndpointContainer<ClientNode> {
 
         let node = this.get(peerAddress);
         if (!node) {
+            if (options.id !== undefined) {
+                // We want to initialize a node with a provided id. This could be an injected node, so ensure the
+                // ClientNodeStore is constructed. Without id the storage is empty anyway because id is newly assigned
+                // TODO: Remove when we remove legacy controller
+                const store = this.owner.env.get(ServerNodeStore).clientStores.storeForNode(options.id);
+                await store.construction;
+            }
+
             // We do not have that node till now, also not persisted, so create it
             const factory = this.owner.env.get(ClientNodeFactory);
             node = factory.create(options, peerAddress);

--- a/packages/node/src/node/server/ServerEnvironment.ts
+++ b/packages/node/src/node/server/ServerEnvironment.ts
@@ -26,17 +26,12 @@ export namespace ServerEnvironment {
         const { env } = node;
 
         // Install support services
-        if (!env.has(ServerNodeStore)) {
-            // TODO Remove the "if" once the legacy controller is removed
-            const store = await ServerNodeStore.create(env, node.id);
-            env.set(ServerNodeStore, store);
-        }
+        const store = await ServerNodeStore.create(env, node.id);
+        env.set(ServerNodeStore, store);
+
         env.set(EndpointInitializer, new ServerEndpointInitializer(env));
         env.set(IdentityService, new IdentityService(node));
-        if (!env.has(PeerAddressStore)) {
-            // TODO Remove the "if" once the legacy controller is removed
-            env.set(PeerAddressStore, new NodePeerAddressStore(node));
-        }
+        env.set(PeerAddressStore, new NodePeerAddressStore(node));
         env.set(ChangeNotificationService, new ChangeNotificationService(node));
 
         // Ensure these are fully initialized

--- a/packages/node/src/storage/client/ClientNodeStores.ts
+++ b/packages/node/src/storage/client/ClientNodeStores.ts
@@ -72,19 +72,23 @@ export class ClientNodeStores {
     }
 
     /**
-     * Obtain the store for a single {@link ClientNode}.
+     * Get the store for a single {@link ClientNode} or peer Id.
      *
-     * These stores are cached internally by ID.
+     * These stores are cached internally by Id.
      */
-    storeForNode(node: ClientNode): ClientNodeStore {
+    storeForNode(nodeOrId: ClientNode | string): ClientNodeStore {
         this.#construction.assert();
 
-        const store = this.#stores[node.id];
+        if (typeof nodeOrId !== "string") {
+            nodeOrId = nodeOrId.id;
+        }
+
+        const store = this.#stores[nodeOrId];
         if (store) {
             return store;
         }
 
-        return this.#createNodeStore(node.id);
+        return this.#createNodeStore(nodeOrId);
     }
 
     storeForGroup(node: ClientGroup): ClientNodeStore {


### PR DESCRIPTION
... and remove two If's that can go away already.

Only in the case that we do a "forAddress" with a provided id we ensure that client storage is initialized