### PR TITLE
Clears all sessions on UpdateNoc

### DIFF
--- a/packages/node/src/behaviors/operational-credentials/OperationalCredentialsServer.ts
+++ b/packages/node/src/behaviors/operational-credentials/OperationalCredentialsServer.ts
@@ -365,6 +365,9 @@ export class OperationalCredentialsServer extends OperationalCredentialsBehavior
             // update FabricManager and Resumption records but leave the current session intact
             await timedOp.replaceFabric(updatedFabric);
 
+            // close all sessions found to the old fabric and just leave the one with this exchange open to deliver response
+            await timedOp.associatedFabric.replaced(this.context.exchange);
+
             return {
                 statusCode: OperationalCredentials.NodeOperationalCertStatus.Ok,
                 fabricIndex: updatedFabric.fabricIndex,

--- a/packages/protocol/src/fabric/Fabric.ts
+++ b/packages/protocol/src/fabric/Fabric.ts
@@ -378,6 +378,20 @@ export class Fabric {
     }
 
     /**
+     * Handles actions when a fabric got replaced.
+     *
+     * It flushes subscriptions to ensure fabric updates are reported and closes sessions.
+     */
+    async replaced(currentExchange?: MessageExchange) {
+        for (const session of [...this.#sessions]) {
+            await session.initiateClose(async () => {
+                await session.closeSubscriptions(true);
+            });
+            await session.initiateForceClose(currentExchange);
+        }
+    }
+
+    /**
      * Gracefully exit the fabric.
      *
      * Devices should use this to cleanly exit a fabric.  It flushes subscriptions to ensure the "leave" event emits


### PR DESCRIPTION
After replacing the Fabric we need to close all sessions but ensure response delivery on the current exchange.