### PR TITLE
Improve subpath import resolution and compatibility for Bun.js

### DIFF
--- a/packages/cli-tool/package.json
+++ b/packages/cli-tool/package.json
@@ -31,12 +31,72 @@
         "matter": "bin/matter.js"
     },
     "imports": {
-        "#tools": "@matter/tools",
-        "#general": "@matter/general",
-        "#model": "@matter/model",
-        "#types": "@matter/types",
-        "#protocol": "@matter/protocol",
-        "#node": "@matter/node",
+        "#tools": {
+            "types": "@matter/tools",
+            "import": {
+                "types": "@matter/tools/dist/esm/index.d.ts",
+                "default": "@matter/tools/dist/esm/index.js"
+            },
+            "require": {
+                "types": "@matter/tools/dist/cjs/index.d.ts",
+                "default": "@matter/tools/dist/cjs/index.js"
+            }
+        },
+        "#general": {
+            "types": "@matter/general",
+            "import": {
+                "types": "@matter/general/dist/esm/index.d.ts",
+                "default": "@matter/general/dist/esm/index.js"
+            },
+            "require": {
+                "types": "@matter/general/dist/cjs/index.d.ts",
+                "default": "@matter/general/dist/cjs/index.js"
+            }
+        },
+        "#model": {
+            "types": "@matter/model",
+            "import": {
+                "types": "@matter/model/dist/esm/index.d.ts",
+                "default": "@matter/model/dist/esm/index.js"
+            },
+            "require": {
+                "types": "@matter/model/dist/cjs/index.d.ts",
+                "default": "@matter/model/dist/cjs/index.js"
+            }
+        },
+        "#types": {
+            "types": "@matter/types",
+            "import": {
+                "types": "@matter/types/dist/esm/index.d.ts",
+                "default": "@matter/types/dist/esm/index.js"
+            },
+            "require": {
+                "types": "@matter/types/dist/cjs/index.d.ts",
+                "default": "@matter/types/dist/cjs/index.js"
+            }
+        },
+        "#protocol": {
+            "types": "@matter/protocol",
+            "import": {
+                "types": "@matter/protocol/dist/esm/index.d.ts",
+                "default": "@matter/protocol/dist/esm/index.js"
+            },
+            "require": {
+                "types": "@matter/protocol/dist/cjs/index.d.ts",
+                "default": "@matter/protocol/dist/cjs/index.js"
+            }
+        },
+        "#node": {
+            "types": "@matter/node",
+            "import": {
+                "types": "@matter/node/dist/esm/index.d.ts",
+                "default": "@matter/node/dist/esm/index.js"
+            },
+            "require": {
+                "types": "@matter/node/dist/cjs/index.d.ts",
+                "default": "@matter/node/dist/cjs/index.js"
+            }
+        },
         "#package": "./package.json",
         "#*": "./src/*"
     },

--- a/packages/main/package.json
+++ b/packages/main/package.json
@@ -29,11 +29,83 @@
         "embed-examples": "embedme **/README.md"
     },
     "imports": {
-        "#general": "@matter/general",
-        "#platform": "@matter/main/platform",
-        "#model": "@matter/model",
-        "#types": "@matter/types",
-        "#protocol": "@matter/protocol",
+        "#general": {
+            "types": "@matter/general",
+            "import": {
+                "types": "@matter/general/dist/esm/index.d.ts",
+                "default": "@matter/general/dist/esm/index.js"
+            },
+            "require": {
+                "types": "@matter/general/dist/cjs/index.d.ts",
+                "default": "@matter/general/dist/cjs/index.js"
+            }
+        },
+        "#platform": {
+            "types": "@matter/main/platform",
+            "node": {
+                "import": {
+                    "types": "./dist/esm/platform/nodejs.d.ts",
+                    "default": "./dist/esm/platform/nodejs.js"
+                },
+                "require": {
+                    "types": "./dist/cjs/platform/nodejs.d.ts",
+                    "default": "./dist/cjs/platform/nodejs.js"
+                }
+            },
+            "react-native": {
+                "import": {
+                    "types": "./dist/esm/platform/react-native.d.ts",
+                    "default": "./dist/esm/platform/react-native.js"
+                },
+                "require": {
+                    "types": "./dist/cjs/platform/react-native.d.ts",
+                    "default": "./dist/cjs/platform/react-native.js"
+                }
+            },
+            "default": {
+                "import": {
+                    "types": "./dist/esm/platform/default.d.ts",
+                    "default": "./dist/esm/platform/default.js"
+                },
+                "require": {
+                    "types": "./dist/cjs/platform/default.d.ts",
+                    "default": "./dist/cjs/platform/default.js"
+                }
+            }
+        },
+        "#model": {
+            "types": "@matter/model",
+            "import": {
+                "types": "@matter/model/dist/esm/index.d.ts",
+                "default": "@matter/model/dist/esm/index.js"
+            },
+            "require": {
+                "types": "@matter/model/dist/cjs/index.d.ts",
+                "default": "@matter/model/dist/cjs/index.js"
+            }
+        },
+        "#types": {
+            "types": "@matter/types",
+            "import": {
+                "types": "@matter/types/dist/esm/index.d.ts",
+                "default": "@matter/types/dist/esm/index.js"
+            },
+            "require": {
+                "types": "@matter/types/dist/cjs/index.d.ts",
+                "default": "@matter/types/dist/cjs/index.js"
+            }
+        },
+        "#protocol": {
+            "types": "@matter/protocol",
+            "import": {
+                "types": "@matter/protocol/dist/esm/index.d.ts",
+                "default": "@matter/protocol/dist/esm/index.js"
+            },
+            "require": {
+                "types": "@matter/protocol/dist/cjs/index.d.ts",
+                "default": "@matter/protocol/dist/cjs/index.js"
+            }
+        },
         "#clusters/*": "@matter/types/clusters/*",
         "#behaviors/*": "@matter/node/behaviors/*",
         "#endpoints/*": "@matter/node/endpoints/*",

--- a/packages/matter.js/package.json
+++ b/packages/matter.js/package.json
@@ -32,12 +32,72 @@
         "embed-examples": "embedme **/README.md"
     },
     "imports": {
-        "#general": "@matter/general",
-        "#model": "@matter/model",
-        "#types": "@matter/types",
-        "#clusters": "@matter/types/clusters",
-        "#protocol": "@matter/protocol",
-        "#node": "@matter/node",
+        "#general": {
+            "types": "@matter/general",
+            "import": {
+                "types": "@matter/general/dist/esm/index.d.ts",
+                "default": "@matter/general/dist/esm/index.js"
+            },
+            "require": {
+                "types": "@matter/general/dist/cjs/index.d.ts",
+                "default": "@matter/general/dist/cjs/index.js"
+            }
+        },
+        "#model": {
+            "types": "@matter/model",
+            "import": {
+                "types": "@matter/model/dist/esm/index.d.ts",
+                "default": "@matter/model/dist/esm/index.js"
+            },
+            "require": {
+                "types": "@matter/model/dist/cjs/index.d.ts",
+                "default": "@matter/model/dist/cjs/index.js"
+            }
+        },
+        "#types": {
+            "types": "@matter/types",
+            "import": {
+                "types": "@matter/types/dist/esm/index.d.ts",
+                "default": "@matter/types/dist/esm/index.js"
+            },
+            "require": {
+                "types": "@matter/types/dist/cjs/index.d.ts",
+                "default": "@matter/types/dist/cjs/index.js"
+            }
+        },
+        "#clusters": {
+            "types": "@matter/types/clusters",
+            "import": {
+                "types": "@matter/types/dist/esm/clusters/index.d.ts",
+                "default": "@matter/types/dist/esm/clusters/index.js"
+            },
+            "require": {
+                "types": "@matter/types/dist/cjs/clusters/index.d.ts",
+                "default": "@matter/types/dist/cjs/clusters/index.js"
+            }
+        },
+        "#protocol": {
+            "types": "@matter/protocol",
+            "import": {
+                "types": "@matter/protocol/dist/esm/index.d.ts",
+                "default": "@matter/protocol/dist/esm/index.js"
+            },
+            "require": {
+                "types": "@matter/protocol/dist/cjs/index.d.ts",
+                "default": "@matter/protocol/dist/cjs/index.js"
+            }
+        },
+        "#node": {
+            "types": "@matter/node",
+            "import": {
+                "types": "@matter/node/dist/esm/index.d.ts",
+                "default": "@matter/node/dist/esm/index.js"
+            },
+            "require": {
+                "types": "@matter/node/dist/cjs/index.d.ts",
+                "default": "@matter/node/dist/cjs/index.js"
+            }
+        },
         "#behaviors/*": "@matter/node/behaviors/*",
         "#devices/*": "@matter/node/devices/*",
         "#endpoints/*": "@matter/node/endpoints/*",

--- a/packages/model/package.json
+++ b/packages/model/package.json
@@ -57,7 +57,6 @@
                 "default": "./dist/cjs/index.js"
             }
         },
-
         "./resources": {
             "import": {
                 "types": "./dist/esm/standard/resources/index.d.ts",
@@ -70,8 +69,28 @@
         }
     },
     "imports": {
-        "#general": "@matter/general",
-        "#model": "@matter/model",
+        "#general": {
+            "types": "@matter/general",
+            "import": {
+                "types": "@matter/general/dist/esm/index.d.ts",
+                "default": "@matter/general/dist/esm/index.js"
+            },
+            "require": {
+                "types": "@matter/general/dist/cjs/index.d.ts",
+                "default": "@matter/general/dist/cjs/index.js"
+            }
+        },
+        "#model": {
+            "types": "@matter/model",
+            "import": {
+                "types": "@matter/model/dist/esm/index.d.ts",
+                "default": "@matter/model/dist/esm/index.js"
+            },
+            "require": {
+                "types": "@matter/model/dist/cjs/index.d.ts",
+                "default": "@matter/model/dist/cjs/index.js"
+            }
+        },
         "#*": "./src/*"
     },
     "types": "dist/esm/index.d.ts",

--- a/packages/mqtt/package.json
+++ b/packages/mqtt/package.json
@@ -44,7 +44,17 @@
         "LICENSE"
     ],
     "imports": {
-        "#general": "@matter/general"
+        "#general": {
+            "types": "@matter/general",
+            "import": {
+                "types": "@matter/general/dist/esm/index.d.ts",
+                "default": "@matter/general/dist/esm/index.js"
+            },
+            "require": {
+                "types": "@matter/general/dist/cjs/index.d.ts",
+                "default": "@matter/general/dist/cjs/index.js"
+            }
+        }
     },
     "type": "module",
     "main": "dist/cjs/index.js",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -31,10 +31,50 @@
         "embed-examples": "embedme **/README.md"
     },
     "imports": {
-        "#general": "@matter/general",
-        "#model": "@matter/model",
-        "#types": "@matter/types",
-        "#protocol": "@matter/protocol",
+        "#general": {
+            "types": "@matter/general",
+            "import": {
+                "types": "@matter/general/dist/esm/index.d.ts",
+                "default": "@matter/general/dist/esm/index.js"
+            },
+            "require": {
+                "types": "@matter/general/dist/cjs/index.d.ts",
+                "default": "@matter/general/dist/cjs/index.js"
+            }
+        },
+        "#model": {
+            "types": "@matter/model",
+            "import": {
+                "types": "@matter/model/dist/esm/index.d.ts",
+                "default": "@matter/model/dist/esm/index.js"
+            },
+            "require": {
+                "types": "@matter/model/dist/cjs/index.d.ts",
+                "default": "@matter/model/dist/cjs/index.js"
+            }
+        },
+        "#types": {
+            "types": "@matter/types",
+            "import": {
+                "types": "@matter/types/dist/esm/index.d.ts",
+                "default": "@matter/types/dist/esm/index.js"
+            },
+            "require": {
+                "types": "@matter/types/dist/cjs/index.d.ts",
+                "default": "@matter/types/dist/cjs/index.js"
+            }
+        },
+        "#protocol": {
+            "types": "@matter/protocol",
+            "import": {
+                "types": "@matter/protocol/dist/esm/index.d.ts",
+                "default": "@matter/protocol/dist/esm/index.js"
+            },
+            "require": {
+                "types": "@matter/protocol/dist/cjs/index.d.ts",
+                "default": "@matter/protocol/dist/cjs/index.js"
+            }
+        },
         "#clusters/*": "@matter/types/clusters/*",
         "#behaviors/*": "./src/behaviors/*/index.js",
         "#endpoints/*": "./src/endpoints/*.js",

--- a/packages/nodejs-ble/package.json
+++ b/packages/nodejs-ble/package.json
@@ -49,9 +49,39 @@
         "LICENSE"
     ],
     "imports": {
-        "#general": "@matter/general",
-        "#protocol": "@matter/protocol",
-        "#types": "@matter/types"
+        "#general": {
+            "types": "@matter/general",
+            "import": {
+                "types": "@matter/general/dist/esm/index.d.ts",
+                "default": "@matter/general/dist/esm/index.js"
+            },
+            "require": {
+                "types": "@matter/general/dist/cjs/index.d.ts",
+                "default": "@matter/general/dist/cjs/index.js"
+            }
+        },
+        "#protocol": {
+            "types": "@matter/protocol",
+            "import": {
+                "types": "@matter/protocol/dist/esm/index.d.ts",
+                "default": "@matter/protocol/dist/esm/index.js"
+            },
+            "require": {
+                "types": "@matter/protocol/dist/cjs/index.d.ts",
+                "default": "@matter/protocol/dist/cjs/index.js"
+            }
+        },
+        "#types": {
+            "types": "@matter/types",
+            "import": {
+                "types": "@matter/types/dist/esm/index.d.ts",
+                "default": "@matter/types/dist/esm/index.js"
+            },
+            "require": {
+                "types": "@matter/types/dist/cjs/index.d.ts",
+                "default": "@matter/types/dist/cjs/index.js"
+            }
+        }
     },
     "type": "module",
     "main": "dist/cjs/index.js",

--- a/packages/nodejs-shell/package.json
+++ b/packages/nodejs-shell/package.json
@@ -34,13 +34,83 @@
         "matter-shell": "dist/cjs/app.js"
     },
     "imports": {
-        "#general": "@matter/general",
-        "#model": "@matter/model",
-        "#node": "@matter/node",
-        "#nodejs": "@matter/nodejs",
-        "#nodejs-ble": "@matter/nodejs-ble",
-        "#protocol": "@matter/protocol",
-        "#types": "@matter/types"
+        "#general": {
+            "types": "@matter/general",
+            "import": {
+                "types": "@matter/general/dist/esm/index.d.ts",
+                "default": "@matter/general/dist/esm/index.js"
+            },
+            "require": {
+                "types": "@matter/general/dist/cjs/index.d.ts",
+                "default": "@matter/general/dist/cjs/index.js"
+            }
+        },
+        "#model": {
+            "types": "@matter/model",
+            "import": {
+                "types": "@matter/model/dist/esm/index.d.ts",
+                "default": "@matter/model/dist/esm/index.js"
+            },
+            "require": {
+                "types": "@matter/model/dist/cjs/index.d.ts",
+                "default": "@matter/model/dist/cjs/index.js"
+            }
+        },
+        "#node": {
+            "types": "@matter/node",
+            "import": {
+                "types": "@matter/node/dist/esm/index.d.ts",
+                "default": "@matter/node/dist/esm/index.js"
+            },
+            "require": {
+                "types": "@matter/node/dist/cjs/index.d.ts",
+                "default": "@matter/node/dist/cjs/index.js"
+            }
+        },
+        "#nodejs": {
+            "types": "@matter/nodejs",
+            "import": {
+                "types": "@matter/nodejs/dist/esm/index.d.ts",
+                "default": "@matter/nodejs/dist/esm/index.js"
+            },
+            "require": {
+                "types": "@matter/nodejs/dist/cjs/index.d.ts",
+                "default": "@matter/nodejs/dist/cjs/index.js"
+            }
+        },
+        "#nodejs-ble": {
+            "types": "@matter/nodejs-ble",
+            "import": {
+                "types": "@matter/nodejs-ble/dist/esm/index.d.ts",
+                "default": "@matter/nodejs-ble/dist/esm/index.js"
+            },
+            "require": {
+                "types": "@matter/nodejs-ble/dist/cjs/index.d.ts",
+                "default": "@matter/nodejs-ble/dist/cjs/index.js"
+            }
+        },
+        "#protocol": {
+            "types": "@matter/protocol",
+            "import": {
+                "types": "@matter/protocol/dist/esm/index.d.ts",
+                "default": "@matter/protocol/dist/esm/index.js"
+            },
+            "require": {
+                "types": "@matter/protocol/dist/cjs/index.d.ts",
+                "default": "@matter/protocol/dist/cjs/index.js"
+            }
+        },
+        "#types": {
+            "types": "@matter/types",
+            "import": {
+                "types": "@matter/types/dist/esm/index.d.ts",
+                "default": "@matter/types/dist/esm/index.js"
+            },
+            "require": {
+                "types": "@matter/types/dist/cjs/index.d.ts",
+                "default": "@matter/types/dist/cjs/index.js"
+            }
+        }
     },
     "dependencies": {
         "@matter/general": "*",

--- a/packages/nodejs-ws/package.json
+++ b/packages/nodejs-ws/package.json
@@ -50,9 +50,39 @@
         "LICENSE"
     ],
     "imports": {
-        "#general": "@matter/general",
-        "#nodejs": "@matter/nodejs",
-        "#node": "@matter/node"
+        "#general": {
+            "types": "@matter/general",
+            "import": {
+                "types": "@matter/general/dist/esm/index.d.ts",
+                "default": "@matter/general/dist/esm/index.js"
+            },
+            "require": {
+                "types": "@matter/general/dist/cjs/index.d.ts",
+                "default": "@matter/general/dist/cjs/index.js"
+            }
+        },
+        "#nodejs": {
+            "types": "@matter/nodejs",
+            "import": {
+                "types": "@matter/nodejs/dist/esm/index.d.ts",
+                "default": "@matter/nodejs/dist/esm/index.js"
+            },
+            "require": {
+                "types": "@matter/nodejs/dist/cjs/index.d.ts",
+                "default": "@matter/nodejs/dist/cjs/index.js"
+            }
+        },
+        "#node": {
+            "types": "@matter/node",
+            "import": {
+                "types": "@matter/node/dist/esm/index.d.ts",
+                "default": "@matter/node/dist/esm/index.js"
+            },
+            "require": {
+                "types": "@matter/node/dist/cjs/index.d.ts",
+                "default": "@matter/node/dist/cjs/index.js"
+            }
+        }
     },
     "type": "module",
     "main": "dist/cjs/index.js",

--- a/packages/nodejs/package.json
+++ b/packages/nodejs/package.json
@@ -36,11 +36,51 @@
         "embed-examples": "embedme **/README.md"
     },
     "imports": {
-        "#general": "@matter/general",
-        "#types": "@matter/types",
+        "#general": {
+            "types": "@matter/general",
+            "import": {
+                "types": "@matter/general/dist/esm/index.d.ts",
+                "default": "@matter/general/dist/esm/index.js"
+            },
+            "require": {
+                "types": "@matter/general/dist/cjs/index.d.ts",
+                "default": "@matter/general/dist/cjs/index.js"
+            }
+        },
+        "#types": {
+            "types": "@matter/types",
+            "import": {
+                "types": "@matter/types/dist/esm/index.d.ts",
+                "default": "@matter/types/dist/esm/index.js"
+            },
+            "require": {
+                "types": "@matter/types/dist/cjs/index.d.ts",
+                "default": "@matter/types/dist/cjs/index.js"
+            }
+        },
         "#clusters/*": "@matter/types/clusters/*",
-        "#node": "@matter/node",
-        "#protocol": "@matter/protocol",
+        "#node": {
+            "types": "@matter/node",
+            "import": {
+                "types": "@matter/node/dist/esm/index.d.ts",
+                "default": "@matter/node/dist/esm/index.js"
+            },
+            "require": {
+                "types": "@matter/node/dist/cjs/index.d.ts",
+                "default": "@matter/node/dist/cjs/index.js"
+            }
+        },
+        "#protocol": {
+            "types": "@matter/protocol",
+            "import": {
+                "types": "@matter/protocol/dist/esm/index.d.ts",
+                "default": "@matter/protocol/dist/esm/index.js"
+            },
+            "require": {
+                "types": "@matter/protocol/dist/cjs/index.d.ts",
+                "default": "@matter/protocol/dist/cjs/index.js"
+            }
+        },
         "#*": "./src/*"
     },
     "dependencies": {

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -33,9 +33,39 @@
         "embed-examples": "embedme **/README.md"
     },
     "imports": {
-        "#general": "@matter/general",
-        "#model": "@matter/model",
-        "#types": "@matter/types",
+        "#general": {
+            "types": "@matter/general",
+            "import": {
+                "types": "@matter/general/dist/esm/index.d.ts",
+                "default": "@matter/general/dist/esm/index.js"
+            },
+            "require": {
+                "types": "@matter/general/dist/cjs/index.d.ts",
+                "default": "@matter/general/dist/cjs/index.js"
+            }
+        },
+        "#model": {
+            "types": "@matter/model",
+            "import": {
+                "types": "@matter/model/dist/esm/index.d.ts",
+                "default": "@matter/model/dist/esm/index.js"
+            },
+            "require": {
+                "types": "@matter/model/dist/cjs/index.d.ts",
+                "default": "@matter/model/dist/cjs/index.js"
+            }
+        },
+        "#types": {
+            "types": "@matter/types",
+            "import": {
+                "types": "@matter/types/dist/esm/index.d.ts",
+                "default": "@matter/types/dist/esm/index.js"
+            },
+            "require": {
+                "types": "@matter/types/dist/cjs/index.d.ts",
+                "default": "@matter/types/dist/cjs/index.js"
+            }
+        },
         "#clusters/*": "@matter/types/clusters/*",
         "#*": "./src/*"
     },

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -82,8 +82,28 @@
         }
     },
     "imports": {
-        "#general": "@matter/general",
-        "#model": "@matter/model",
+        "#general": {
+            "types": "@matter/general",
+            "import": {
+                "types": "@matter/general/dist/esm/index.d.ts",
+                "default": "@matter/general/dist/esm/index.js"
+            },
+            "require": {
+                "types": "@matter/general/dist/cjs/index.d.ts",
+                "default": "@matter/general/dist/cjs/index.js"
+            }
+        },
+        "#model": {
+            "types": "@matter/model",
+            "import": {
+                "types": "@matter/model/dist/esm/index.d.ts",
+                "default": "@matter/model/dist/esm/index.js"
+            },
+            "require": {
+                "types": "@matter/model/dist/cjs/index.d.ts",
+                "default": "@matter/model/dist/cjs/index.js"
+            }
+        },
         "#*": "./src/*"
     },
     "types": "dist/esm/index.d.ts",


### PR DESCRIPTION
## Summary
This PR tries to fix subpath import resolution, specifically when running in Bun.js environments.
Previously, subpath imports were often used CommonJS (CJS) instead of ESM.

## The Problem
<img width="1895" height="405" alt="image" src="https://github.com/user-attachments/assets/73ca6c6d-d116-41c5-9975-70942d4db68b" />

1. Module Format Mismatch: Bun.js uses subpath imports like `#general` as CommonJS module in ESM project.
2. Resolution Failure: Bun.js does not detect `#platform` as `@matter/main/platforms/nodejs.js`.

## Changes
Updated the `imports` field to use conditional mappings in `package.json` and modified build script to redirect `./dist/esm|cjs/` to `./` recursively.

This modification is ugly for reading, but I haven't found other solutions to fix subpath imports in Bun.js.
Consider other way if we found other *simple* methods to fix subpath import in Bun.js.