### PR TITLE
Update package name in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The main work (all changes without a GitHub username in brackets in the below li
 
 ## __WORK IN PROGRESS__
 
-- @project-chip/matter.js
+- @matter/protocol
   - Improve handling of errors when peers are closed or when removing not-connected nodes
 
 ## 0.16.1 (2026-01-13)


### PR DESCRIPTION
Updated package name from @project-chip/matter.js to @matter/protocol in the changelog.