### PR TITLE
Forget IP addresses when discovering operational address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Enhancement: Add protection against out-of-order mDNS goodbye packets (TTL=0) that could incorrectly remove recently discovered devices
     - Enhancement: Add minimum TTL protection for PTR records to prevent DoS attacks with very short TTLs
     - Enhancement: Add RFC 6762 §7.3 compliant duplicate question suppression to MdnsServer
+    - Enhancement: When forcing an MDNS update for an operational device, ensure we also get new IP addresses
     - Fix: Correctly handle multi-message write interactions (server and client) according to Matter specification
     - Fix: Correctly handle multi-message invoke responses (server and client) according to Matter specification
 


### PR DESCRIPTION
... to ensure we get new IPs and not just a SRV "confirmation"

The idea might also require adjustments to #3075 ?