### PR TITLE
Delete external change listener on datasource close

### DIFF
--- a/packages/node/src/behavior/internal/BehaviorBacking.ts
+++ b/packages/node/src/behavior/internal/BehaviorBacking.ts
@@ -155,6 +155,9 @@ export abstract class BehaviorBacking {
                 result = MaybePromise.then(result, () => this.#invokeClose(agent));
             }
 
+            this.#datasource?.close();
+            this.#datasource = undefined;
+
             return result;
         });
     }


### PR DESCRIPTION
Not sure if this would have been problematic but do it just to be safe.