### PR TITLE
Add option to allocate peer IDs sequentially

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ The main work (all changes without a GitHub username in brackets in the below li
 	## __WORK IN PROGRESS__
 -->
 
+## __WORK IN PROGRESS__
+
+- @matter/node
+    - Feature: We now allocate node IDs as sequential numbers; the old behavior of randomized node behavior is available if you set `ControllerBehavior` state property `nodeIdAssignment` to `"random"`
+
 ## 0.16.8 (2026-01-30)
 
 - @matter/node

--- a/packages/node/src/behavior/system/commissioning/CommissioningClient.ts
+++ b/packages/node/src/behavior/system/commissioning/CommissioningClient.ts
@@ -182,7 +182,7 @@ export class CommissioningClient extends Behavior {
         const commissioner = node.env.get(ControllerCommissioner);
 
         const identityService = node.env.get(IdentityService);
-        const address = identityService.assignNodeAddress(node, fabric.fabricIndex, opts.nodeId);
+        const address = await identityService.assignNodeAddress(node, fabric.fabricIndex, opts.nodeId);
 
         const commissioningOptions: LocatedNodeCommissioningOptions = {
             addresses: addresses.map(ServerAddress),

--- a/packages/node/src/behavior/system/controller/ControllerBehavior.ts
+++ b/packages/node/src/behavior/system/controller/ControllerBehavior.ts
@@ -194,6 +194,21 @@ export namespace ControllerBehavior {
         ip?: boolean = undefined;
 
         /**
+         * Node ID assignment strategy.
+         */
+        nodeIdAssignment: "sequential" | "random" = "sequential";
+
+        /**
+         * Next assigned ID when {@link nodeIdAssignment} is "sequential".
+         *
+         * matter.js increments this value automatically after allocating a new node ID.  This means that the
+         * "sequential" strategy does not reuse IDs from decommissioned nodes.
+         *
+         * If there is a conflict with an existing ID, matter.js increments this value until it identifies a free ID.
+         */
+        nextNodeId?: NodeId;
+
+        /**
          * Contains the label of the admin fabric which is set for all commissioned devices
          */
         adminFabricLabel = "matter.js";

--- a/packages/node/src/node/client/NodePeerAddressStore.ts
+++ b/packages/node/src/node/client/NodePeerAddressStore.ts
@@ -5,6 +5,7 @@
  */
 
 import { RemoteDescriptor } from "#behavior/system/commissioning/RemoteDescriptor.js";
+import { ControllerBehavior } from "#behavior/system/controller/ControllerBehavior.js";
 import { Crypto, ServerAddress, ServerAddressUdp } from "#general";
 import type { ClientNode } from "#node/ClientNode.js";
 import { IdentityService } from "#node/server/IdentityService.js";
@@ -35,15 +36,27 @@ export class NodePeerAddressStore extends PeerAddressStore {
         identityService.releaseNodeAddress = this.deletePeer.bind(this);
     }
 
-    assignNewAddress(node: ClientNode, fabricIndex: FabricIndex, nodeId?: NodeId) {
+    async assignNewAddress(node: ClientNode, fabricIndex: FabricIndex, nodeId?: NodeId) {
+        const useSequentialIds = node.owner?.state.controller.nodeIdAssignment !== "random";
+        let nextNodeId: NodeId = node.owner?.state.controller.nextNodeId ?? NodeId(1);
+
         while (nodeId === undefined) {
-            nodeId = NodeId.randomOperationalNodeId(this.#owner.env.get(Crypto));
+            if (useSequentialIds) {
+                nodeId = nextNodeId;
+                nextNodeId++;
+            } else {
+                nodeId = NodeId.randomOperationalNodeId(this.#owner.env.get(Crypto));
+            }
             if (this.#assignedAddresses.has({ fabricIndex, nodeId })) {
                 nodeId = undefined;
             }
         }
 
         const address = PeerAddress({ fabricIndex, nodeId });
+
+        if (useSequentialIds) {
+            await node.owner?.setStateOf(ControllerBehavior, { nextNodeId });
+        }
 
         this.#assignedAddresses.set(address, node);
 

--- a/packages/node/src/node/server/IdentityService.ts
+++ b/packages/node/src/node/server/IdentityService.ts
@@ -62,7 +62,7 @@ export class IdentityService {
     /**
      * Assign a peer address.
      */
-    assignNodeAddress(_node: ClientNode, _fabricIndex: FabricIndex, _nodeId?: NodeId): PeerAddress {
+    async assignNodeAddress(_node: ClientNode, _fabricIndex: FabricIndex, _nodeId?: NodeId): Promise<PeerAddress> {
         throw new InternalError("Client node ID assignment is not initialized");
     }
 

--- a/packages/protocol/src/peer/ControllerCommissioner.ts
+++ b/packages/protocol/src/peer/ControllerCommissioner.ts
@@ -390,7 +390,7 @@ export class ControllerCommissioner {
     /** Validate if a Peer Address is already known and commissioned */
     #assertPeerAddress(address: PeerAddress) {
         if (this.#context.peers.has(address)) {
-            throw new NodeIdConflictError(`Node ID ${address.nodeId} is already commissioned and can not be reused.`);
+            throw new NodeIdConflictError(`Node ID ${address.nodeId} is already commissioned and can not be reused`);
         }
     }
 


### PR DESCRIPTION
Here's a proposal to allocate peer IDs sequentially, with an option to set to random