### PR TITLE
Add proper types to DerCodec

### DIFF
--- a/packages/general/src/codec/DerCodec.ts
+++ b/packages/general/src/codec/DerCodec.ts
@@ -9,16 +9,6 @@ import { DataReader } from "../util/DataReader.js";
 import { toHex } from "../util/Number.js";
 import { isObject } from "../util/Type.js";
 
-export enum DerKey {
-    ObjectId = "_objectId",
-    TagId = "_tag",
-    Bytes = "_bytes",
-    Elements = "_elements",
-    BitsPadding = "_padding",
-    TypeOverride = "_type",
-    RawData = "_raw",
-}
-
 export class DerError extends UnexpectedDataError {}
 
 export enum DerType {
@@ -46,33 +36,87 @@ const enum DerClass {
     ContextSpecific = 0x80,
     Private = 0xc0,
 }
-export const ObjectId = (objectId: string) => ({
-    [DerKey.TagId]: DerType.ObjectIdentifier as number,
-    [DerKey.Bytes]: Bytes.fromHex(objectId),
+
+export interface ObjectId {
+    _tag: DerType.ObjectIdentifier;
+    _bytes: Bytes;
+}
+
+export const ObjectId = (objectId: string): ObjectId => ({
+    _tag: DerType.ObjectIdentifier as number,
+    _bytes: Bytes.fromHex(objectId),
 });
-export const DerObject = (objectId: string, content: any = {}) => ({
-    [DerKey.ObjectId]: ObjectId(objectId),
+
+export interface DerObject {
+    readonly _tag?: undefined;
+    readonly _objectId: ObjectId;
+    readonly [field: string]: unknown;
+}
+
+export const DerObject = (objectId: string, content: Record<string, unknown> = {}): DerObject => ({
+    _objectId: ObjectId(objectId),
     ...content,
 });
-export const DerBitString = (data: Bytes, padding = 0) => ({
-    [DerKey.TagId]: DerType.BitString as number,
-    [DerKey.Bytes]: data,
-    [DerKey.BitsPadding]: padding,
+
+export interface DerTagged {
+    _tag: number;
+    _bytes: Bytes;
+}
+
+export interface DerBitString extends DerTagged {
+    _tag: DerType.BitString;
+    _bytes: Bytes;
+    _padding: number;
+}
+
+export const DerBitString = (data: Bytes, padding = 0): DerBitString => ({
+    _tag: DerType.BitString,
+    _bytes: data,
+    _padding: padding,
 });
-export const ContextTagged = (tagId: number, value?: any) => ({
-    [DerKey.TagId]: tagId | DerClass.ContextSpecific | CONSTRUCTED,
-    [DerKey.Bytes]: value === undefined ? new Uint8Array(0) : DerCodec.encode(value),
+
+export const ContextTagged = (tagId: number, value?: any): DerTagged => ({
+    _tag: tagId | DerClass.ContextSpecific | CONSTRUCTED,
+    _bytes: value === undefined ? new Uint8Array(0) : DerCodec.encode(value),
 });
-export const ContextTaggedBytes = (tagId: number, value: Bytes) => ({
-    [DerKey.TagId]: tagId | DerClass.ContextSpecific,
-    [DerKey.Bytes]: value,
+
+export const ContextTaggedBytes = (tagId: number, value: Bytes): DerTagged => ({
+    _tag: tagId | DerClass.ContextSpecific,
+    _bytes: value,
 });
-export const DatatypeOverride = (type: DerType, value: any) => ({
-    [DerKey.TypeOverride]: type,
-    [DerKey.RawData]: value,
-});
-export const RawBytes = (bytes: Bytes) => ({
-    [DerKey.Bytes]: bytes,
+
+export type DatatypeOverride =
+    | {
+          _tag?: undefined;
+          _type: DerType.Integer;
+          _raw: Bytes;
+      }
+    | {
+          _tag?: undefined;
+          _type: DerType.BitString;
+          _raw: number;
+      }
+    | {
+          _tag?: undefined;
+          _type: DerType.PrintableString | DerType.IA5String;
+          _raw: string;
+      };
+
+export const DatatypeOverride = <T extends DatatypeOverride["_type"]>(
+    type: T,
+    value: (DatatypeOverride & { _type: T })["_raw"],
+) =>
+    ({
+        _type: type,
+        _raw: value,
+    }) as DatatypeOverride;
+
+export interface RawBytes {
+    _bytes: Bytes;
+}
+
+export const RawBytes = (bytes: Bytes): RawBytes => ({
+    _bytes: bytes,
 });
 
 /**
@@ -80,7 +124,7 @@ export const RawBytes = (bytes: Bytes) => ({
  *
  * This allows to avoid e.g. round tripping a 256-bit number through a bigint when encoding.
  */
-export const DerRawUint = (number: Bytes) => {
+export const DerRawUint = (number: Bytes): DerTagged => {
     const numberData = Bytes.of(number);
 
     if (numberData[0] & 0x80) {
@@ -101,20 +145,60 @@ export const DerRawUint = (number: Bytes) => {
     }
 
     return {
-        [DerKey.TagId]: DerType.Integer,
-        [DerKey.Bytes]: number,
+        _tag: DerType.Integer,
+        _bytes: number,
     };
 };
 
 export type DerNode = {
-    [DerKey.TagId]: number;
-    [DerKey.Bytes]: Bytes;
-    [DerKey.Elements]?: DerNode[];
-    [DerKey.BitsPadding]?: number;
+    _tag: number;
+    _bytes: Bytes;
+    _elements?: DerNode[];
+    _padding?: number;
 };
 
+/**
+ * Arrays define a DER set.
+ */
+export type DerSetDefinition = Array<DerNodeDefinition>;
+
+/**
+ * Objects without special fields define an "object".
+ *
+ * Under this somewhat strange construct, the field name is effectively just documentation.  The object order and
+ * ObjectID of the referenced node define the actual serialized format.
+ */
+export type DerSequenceDefinition = {
+    _tag?: undefined;
+    _type?: undefined;
+    _bytes?: undefined;
+    _objectId?: ObjectId;
+    [field: string]: DerNodeDefinition;
+};
+
+/**
+ * Input to {@link DerCodec.encode}.
+ *
+ * This is a lenient mapping of native JS types we accept on encoding.  We map each of these to a {@link DerNode} and
+ * then encode.
+ */
+export type DerNodeDefinition =
+    | string
+    | number
+    | bigint
+    | Date
+    | boolean
+    | Bytes
+    | undefined
+    | DerNode
+    | DerSetDefinition
+    | DerSequenceDefinition
+    | DerObject
+    | RawBytes
+    | DatatypeOverride;
+
 export class DerCodec {
-    static encode(value: unknown): Bytes {
+    static encode(value: DerNodeDefinition): Bytes {
         if (Array.isArray(value)) {
             return this.#encodeArray(value);
         } else if (Bytes.isBytes(value)) {
@@ -130,8 +214,8 @@ export class DerCodec {
         } else if (value === undefined) {
             return new Uint8Array(0);
         } else if (isObject(value)) {
-            if (value[DerKey.TagId] !== undefined) {
-                const { [DerKey.TagId]: tagId, [DerKey.BitsPadding]: bitsPadding, [DerKey.Bytes]: bytes } = value;
+            if (value._tag !== undefined) {
+                const { _tag: tagId, _padding: bitsPadding, _bytes: bytes } = value;
                 if (typeof tagId !== "number") {
                     throw new DerError("Tag ID is non-numeric");
                 }
@@ -145,35 +229,27 @@ export class DerCodec {
                     tagId,
                     bitsPadding === undefined ? bytes : Bytes.concat(Uint8Array.of(bitsPadding), Bytes.of(bytes)),
                 );
-            } else if (value[DerKey.TypeOverride] !== undefined && value[DerKey.RawData] !== undefined) {
-                if (value[DerKey.TypeOverride] === DerType.Integer && Bytes.isBytes(value[DerKey.RawData])) {
-                    return this.#encodeInteger(value[DerKey.RawData]);
-                } else if (
-                    value[DerKey.TypeOverride] === DerType.BitString &&
-                    typeof value[DerKey.RawData] === "number"
-                ) {
-                    return this.#encodeBitString(value[DerKey.RawData]);
-                } else if (
-                    value[DerKey.TypeOverride] === DerType.PrintableString &&
-                    typeof value[DerKey.RawData] === "string"
-                ) {
-                    return this.#encodePrintableString(value[DerKey.RawData]);
-                } else if (
-                    value[DerKey.TypeOverride] === DerType.IA5String &&
-                    typeof value[DerKey.RawData] === "string"
-                ) {
-                    return this.#encodeIA5String(value[DerKey.RawData]);
+            } else if (value._type !== undefined && value._raw !== undefined) {
+                if (value._type === DerType.Integer && Bytes.isBytes(value._raw)) {
+                    return this.#encodeInteger(value._raw);
+                } else if (value._type === DerType.BitString && typeof value._raw === "number") {
+                    return this.#encodeBitString(value._raw);
+                } else if (value._type === DerType.PrintableString && typeof value._raw === "string") {
+                    return this.#encodePrintableString(value._raw);
+                } else if (value._type === DerType.IA5String && typeof value._raw === "string") {
+                    return this.#encodeIA5String(value._raw);
                 } else {
-                    throw new DerError(`Unsupported override type ${value[DerKey.TypeOverride]}`);
+                    throw new DerError(`Unsupported override type ${value._type}`);
                 }
             } else if (
-                value[DerKey.Bytes] !== undefined &&
-                Bytes.isBytes(value[DerKey.Bytes]) &&
+                "_bytes" in value &&
+                value._bytes !== undefined &&
+                Bytes.isBytes(value._bytes) &&
                 Object.keys(value).length === 1
             ) {
                 // Raw Data
-                return Bytes.of(value[DerKey.Bytes]);
-            } else if (value[DerKey.TypeOverride] === undefined && value[DerKey.Bytes] === undefined) {
+                return Bytes.of(value._bytes);
+            } else if (value._type === undefined && value._bytes === undefined) {
                 return this.#encodeObject(value);
             } else {
                 throw new DerError(`Unsupported object type ${typeof value}`);
@@ -195,14 +271,14 @@ export class DerCodec {
             throw new DerError("Missing number in DER object");
         }
 
-        if (value[DerKey.TagId] !== DerType.Integer) {
-            throw new DerError(`Expected integer but DER tag is ${DerType[value[DerKey.TagId]]}`);
+        if (value._tag !== DerType.Integer) {
+            throw new DerError(`Expected integer but DER tag is ${DerType[value._tag]}`);
         }
 
-        if (!Bytes.isBytes(value[DerKey.Bytes])) {
+        if (!Bytes.isBytes(value._bytes)) {
             throw new DerError("Incorrect DER object type");
         }
-        const bytes = Bytes.of(value[DerKey.Bytes]);
+        const bytes = Bytes.of(value._bytes);
 
         // The common case
         if (bytes.length === byteLength) {
@@ -335,15 +411,15 @@ export class DerCodec {
         const { tag, bytes } = this.#decodeAsn1(reader);
         if (tag === DerType.BitString) {
             const data = Bytes.of(bytes);
-            return { [DerKey.TagId]: tag, [DerKey.Bytes]: data.slice(1), [DerKey.BitsPadding]: data[0] };
+            return { _tag: tag, _bytes: data.slice(1), _padding: data[0] };
         }
-        if ((tag & CONSTRUCTED) === 0) return { [DerKey.TagId]: tag, [DerKey.Bytes]: bytes };
+        if ((tag & CONSTRUCTED) === 0) return { _tag: tag, _bytes: bytes };
         const elementsReader = new DataReader(bytes);
         const elements: DerNode[] = [];
         while (elementsReader.remainingBytesCount > 0) {
             elements.push(this.#decodeRec(elementsReader));
         }
-        return { [DerKey.TagId]: tag, [DerKey.Bytes]: bytes, [DerKey.Elements]: elements };
+        return { _tag: tag, _bytes: bytes, _elements: elements };
     }
 
     static #decodeAsn1(reader: DataReader): { tag: number; bytes: Bytes } {

--- a/packages/general/src/crypto/CryptoError.ts
+++ b/packages/general/src/crypto/CryptoError.ts
@@ -35,3 +35,8 @@ export class KeyInputError extends CryptoInputError {}
  * Thrown when verification fails because of an invalid signature format.
  */
 export class SignatureEncodingError extends CryptoVerifyError {}
+
+/**
+ * Thrown when we encounter corrupted certificate data.
+ */
+export class CertificateError extends CryptoError {}

--- a/packages/node/src/behaviors/operational-credentials/OperationalCredentialsServer.ts
+++ b/packages/node/src/behaviors/operational-credentials/OperationalCredentialsServer.ts
@@ -10,12 +10,19 @@ import { ProductDescriptionServer } from "#behavior/system/product-description/P
 import { AccessControlServer } from "#behaviors/access-control";
 import { OperationalCredentials } from "#clusters/operational-credentials";
 import { Endpoint } from "#endpoint/Endpoint.js";
-import { Crypto, CryptoVerifyError, Logger, MatterFlowError, MaybePromise, UnexpectedDataError } from "#general";
+import {
+    CertificateError,
+    Crypto,
+    CryptoVerifyError,
+    Logger,
+    MatterFlowError,
+    MaybePromise,
+    UnexpectedDataError,
+} from "#general";
 import { AccessLevel } from "#model";
 import type { Node } from "#node/Node.js";
 import {
     assertRemoteActor,
-    CertificateError,
     DeviceCertification,
     DeviceCommissioner,
     Fabric,

--- a/packages/protocol/src/certificate/index.ts
+++ b/packages/protocol/src/certificate/index.ts
@@ -11,7 +11,6 @@ export * from "./DeviceCertification.js";
 export * from "./kinds/AttestationCertificates.js";
 export * from "./kinds/Certificate.js";
 export * from "./kinds/CertificationDeclaration.js";
-export { CertificateError } from "./kinds/common.js";
 export * from "./kinds/Icac.js";
 export * from "./kinds/Noc.js";
 export * from "./kinds/Rcac.js";

--- a/packages/protocol/src/certificate/kinds/AttestationCertificates.ts
+++ b/packages/protocol/src/certificate/kinds/AttestationCertificates.ts
@@ -8,12 +8,12 @@ import { Bytes, Crypto, DerBitString, DerCodec, X962 } from "#general";
 import { Certificate } from "./Certificate.js";
 import { assertCertificateDerSize } from "./common.js";
 import { AttestationCertificate } from "./definitions/attestation.js";
-import { X509Certificate } from "./definitions/base.js";
+import { MatterCertificate } from "./definitions/base.js";
 
 /**
  * Base class for Attestation Certificates (PAA, PAI, DAC).
  */
-export abstract class AttestationBaseCertificate<CT extends X509Certificate> extends Certificate<CT> {
+export abstract class AttestationBaseCertificate<CT extends MatterCertificate> extends Certificate<CT> {
     /**
      * Sign the certificate using the provided crypto and key.
      * If the certificate is already signed, it throws a CertificateError.

--- a/packages/protocol/src/certificate/kinds/Icac.ts
+++ b/packages/protocol/src/certificate/kinds/Icac.ts
@@ -4,10 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Bytes, Crypto, Diagnostic, PublicKey } from "#general";
+import { Bytes, CertificateError, Crypto, Diagnostic, PublicKey } from "#general";
 import { FabricId } from "#types";
 import { Certificate } from "./Certificate.js";
-import { CertificateError } from "./common.js";
 import { ExtensionKeyUsageSchema } from "./definitions/base.js";
 import { OperationalCertificate } from "./definitions/operational.js";
 import { OperationalBase } from "./OperationalBase.js";

--- a/packages/protocol/src/certificate/kinds/Noc.ts
+++ b/packages/protocol/src/certificate/kinds/Noc.ts
@@ -4,10 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Bytes, Crypto, Diagnostic, PublicKey } from "#general";
+import { Bytes, CertificateError, Crypto, Diagnostic, PublicKey } from "#general";
 import { CaseAuthenticatedTag, FabricId, NodeId } from "#types";
 import { Certificate } from "./Certificate.js";
-import { CertificateError } from "./common.js";
 import { OperationalCertificate } from "./definitions/operational.js";
 import { Icac } from "./Icac.js";
 import { OperationalBase } from "./OperationalBase.js";

--- a/packages/protocol/src/certificate/kinds/OperationalBase.ts
+++ b/packages/protocol/src/certificate/kinds/OperationalBase.ts
@@ -4,17 +4,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Bytes, DerBitString, DerCodec, Logger, Time, X962 } from "#general";
+import { Bytes, CertificateError, DerBitString, DerCodec, Logger, Time, X962 } from "#general";
 import { Certificate } from "./Certificate.js";
-import { assertCertificateDerSize, CertificateError, Unsigned } from "./common.js";
-import { X509Certificate } from "./definitions/base.js";
+import { assertCertificateDerSize, Unsigned } from "./common.js";
+import { MatterCertificate } from "./definitions/base.js";
 
 const logger = Logger.get("OperationalBaseCertificate");
 
 /**
  * Base class for all operational certificates (RCAC, ICAC, NOC)
  */
-export abstract class OperationalBase<CT extends X509Certificate> extends Certificate<CT> {
+export abstract class OperationalBase<CT extends MatterCertificate> extends Certificate<CT> {
     constructor(cert: CT | Unsigned<CT>) {
         super(cert);
         this.validateFields();

--- a/packages/protocol/src/certificate/kinds/Rcac.ts
+++ b/packages/protocol/src/certificate/kinds/Rcac.ts
@@ -4,10 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Bytes, Crypto, Diagnostic, PublicKey } from "#general";
+import { Bytes, CertificateError, Crypto, Diagnostic, PublicKey } from "#general";
 import { FabricId } from "#types";
 import { Certificate } from "./Certificate.js";
-import { CertificateError } from "./common.js";
 import { ExtensionKeyUsageSchema } from "./definitions/base.js";
 import { OperationalCertificate } from "./definitions/operational.js";
 import { OperationalBase } from "./OperationalBase.js";

--- a/packages/protocol/src/certificate/kinds/Vvsc.ts
+++ b/packages/protocol/src/certificate/kinds/Vvsc.ts
@@ -4,8 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Bytes, Crypto, Diagnostic } from "#general";
-import { CertificateError } from "./common.js";
+import { Bytes, CertificateError, Crypto, Diagnostic } from "#general";
 import { OperationalCertificate } from "./definitions/operational.js";
 import { OperationalBase } from "./OperationalBase.js";
 

--- a/packages/protocol/src/certificate/kinds/common.ts
+++ b/packages/protocol/src/certificate/kinds/common.ts
@@ -3,15 +3,13 @@
  * Copyright 2022-2026 Matter.js Authors
  * SPDX-License-Identifier: Apache-2.0
  */
-import { Bytes, ImplementationError, MatterError } from "#general";
+import { Bytes, ImplementationError } from "#general";
 
 /**
  * Matter specific Certificate Sizes
  * @see {@link MatterSpecification.v13.Core} 6.1.3.
  */
 export const MAX_DER_CERTIFICATE_SIZE = 600;
-
-export class CertificateError extends MatterError {}
 
 export type Unsigned<Type> = { [Property in keyof Type as Exclude<Property, "signature">]: Type[Property] };
 

--- a/packages/protocol/src/certificate/kinds/definitions/attestation.ts
+++ b/packages/protocol/src/certificate/kinds/definitions/attestation.ts
@@ -5,11 +5,11 @@
  */
 
 import { VendorId } from "#types";
-import { X509Certificate } from "./base.js";
+import { MatterCertificate } from "./base.js";
 
 /** Definitions for Matter Attestation certificates (PAA, PAI, DAC) */
 export namespace AttestationCertificate {
-    export interface Dac extends X509Certificate {
+    export interface Dac extends MatterCertificate {
         issuer: {
             commonName: string;
             productId?: number;
@@ -22,7 +22,7 @@ export namespace AttestationCertificate {
         };
     }
 
-    export interface Pai extends X509Certificate {
+    export interface Pai extends MatterCertificate {
         issuer: {
             commonName: string;
             vendorId?: VendorId;
@@ -34,7 +34,7 @@ export namespace AttestationCertificate {
         };
     }
 
-    export interface Paa extends X509Certificate {
+    export interface Paa extends MatterCertificate {
         issuer: {
             commonName: string;
             vendorId?: VendorId;

--- a/packages/protocol/src/certificate/kinds/definitions/base.ts
+++ b/packages/protocol/src/certificate/kinds/definitions/base.ts
@@ -19,7 +19,7 @@ export const ExtensionKeyUsageBitmap = {
 };
 export const ExtensionKeyUsageSchema = BitmapSchema(ExtensionKeyUsageBitmap);
 
-export interface X509Certificate {
+export interface MatterCertificate {
     serialNumber: Bytes;
     signatureAlgorithm: number;
     issuer: {};

--- a/packages/protocol/src/codec/index.ts
+++ b/packages/protocol/src/codec/index.ts
@@ -4,6 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export { Base64, DerCodec, DerKey, DnsCodec, type DerNode } from "#general";
+export { Base64, DerCodec, DnsCodec, type DerNode } from "#general";
 export * from "./BtpCodec.js";
 export * from "./MessageCodec.js";

--- a/packages/protocol/test/certificate/CertificatesTest.ts
+++ b/packages/protocol/test/certificate/CertificatesTest.ts
@@ -11,14 +11,13 @@ import {
 } from "#certificate/ChipPAAuthorities.js";
 import { Paa } from "#certificate/kinds/AttestationCertificates.js";
 import { Certificate } from "#certificate/kinds/Certificate.js";
-import { CertificateError } from "#certificate/kinds/common.js";
 import { Icac } from "#certificate/kinds/Icac.js";
 import { Noc } from "#certificate/kinds/Noc.js";
 import { Rcac } from "#certificate/kinds/Rcac.js";
 import {
     Bytes,
+    CertificateError,
     DerCodec,
-    DerKey,
     DerNode,
     EcdsaSignature,
     PrivateKey,
@@ -476,15 +475,15 @@ describe("Certificates", () => {
             );
 
             const derNode = DerCodec.decode(result);
-            expect(derNode[DerKey.Elements]?.length).equal(3);
-            const [requestNode, signatureAlgorithmNode, signatureNode] = derNode[DerKey.Elements] as DerNode[];
+            expect(derNode._elements?.length).equal(3);
+            const [requestNode, signatureAlgorithmNode, signatureNode] = derNode._elements as DerNode[];
             expect(DerCodec.encode(signatureAlgorithmNode)).deep.equal(DerCodec.encode(X962.EcdsaWithSHA256));
             const requestBytes = DerCodec.encode(requestNode);
             expect(requestBytes).deep.equal(TEST_CSR_REQUEST_ASN1);
             await crypto.verifyEcdsa(
                 PublicKey(TEST_PUBLIC_KEY),
                 DerCodec.encode(requestNode),
-                new EcdsaSignature(signatureNode[DerKey.Bytes], "der"),
+                new EcdsaSignature(signatureNode._bytes, "der"),
             );
         });
     });


### PR DESCRIPTION
* Removes a bunch of anys

* Moves CertificateError to @matter/general

* Renames X509Certificate to MatterCertificate because it reflects TLV encoding