### PR TITLE
docs: add Home Assistant Matter Hub to matter.js-based projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ The following projects are available on any platform with access to Node.js 20+:
 - [node-red-matter](https://github.com/FezVrasta/node-red-matter): a Node-Red node for devices and controllers (outdated)
 - [zigbee-matter-bridge](https://github.com/antonio-gabriele/zigbee-matter-bridge): a Zigbee to Matter Bridge
 - [Gladys Assistant](https://github.com/GladysAssistant/Gladys): An open-source smart home assistant integrating `matter.js` as a Matter controller to connect and manage Matter devices
+- [Home Assistant Matter Hub](https://github.com/RiDDiX/home-assistant-matter-hub): Expose Home Assistant entities as Matter devices to any Matter controller (Apple Home, Google Home, Alexa, SmartThings)
 - [matterbridge](https://github.com/Luligu/matterbridge): a matter.js plugin manager with 7 example plugins
   - [matterbridge-zigbee2mqtt](https://github.com/Luligu/matterbridge-zigbee2mqtt): matterbridge production-level plugin that expose all zigbee2mqtt devices and groups to Matter
   - [matterbridge-somfy-tahoma](https://github.com/Luligu/matterbridge-somfy-tahoma): matterbridge production-level plugin that expose all somfy tahoma screens to Matter


### PR DESCRIPTION
Adds Home Assistant Matter Hub to the list of matter.js-based projects.

Home Assistant Matter Hub exposes Home Assistant entities as Matter bridge devices, making them accessible to any Matter-compatible controller including Apple Home, Google Home, Amazon Alexa, and SmartThings.

The project is actively maintained and has been using matter.js since its inception.

Repository: https://github.com/RiDDiX/home-assistant-matter-hub