### PR TITLE
Fix maximumPeerResponseTime calculation

### DIFF
--- a/packages/protocol/src/action/client/ClientInteraction.ts
+++ b/packages/protocol/src/action/client/ClientInteraction.ts
@@ -858,8 +858,8 @@ export class ClientInteraction<
     }
 
     /** Calculates the current maximum response time for a message use in additional logic like timers. */
-    maximumPeerResponseTime(expectedProcessingTime?: Duration) {
-        return this.#exchanges.maximumPeerResponseTime(expectedProcessingTime);
+    maximumPeerResponseTime(expectedProcessingTime?: Duration, includeMaximumSendingTime = false) {
+        return this.#exchanges.maximumPeerResponseTime(expectedProcessingTime, includeMaximumSendingTime);
     }
 
     get address() {

--- a/packages/protocol/src/interaction/InteractionMessenger.ts
+++ b/packages/protocol/src/interaction/InteractionMessenger.ts
@@ -197,7 +197,7 @@ class InteractionMessenger {
         const { status } = TlvStatusResponse.decode(payload);
         if (status !== Status.Success)
             throw new ReceivedStatusResponseError(
-                `Received error status: ${status}${logHint ? ` (${logHint})` : ""}`,
+                `Received error status: ${Status[status]}(${status})${logHint ? ` (${logHint})` : ""}`,
                 status,
             );
     }

--- a/packages/protocol/src/peer/ControllerCommissioningFlow.ts
+++ b/packages/protocol/src/peer/ControllerCommissioningFlow.ts
@@ -766,7 +766,7 @@ export class ControllerCommissioningFlow {
     }
 
     async #ensureFailsafeTimerFor(maxProcessingTime: Duration) {
-        const minFailsafeTime = this.interaction.maximumPeerResponseTime(maxProcessingTime);
+        const minFailsafeTime = this.interaction.maximumPeerResponseTime(maxProcessingTime, true);
 
         if (this.interaction.channelType === ChannelType.BLE) {
             this.#armFailsafeInterval?.stop();

--- a/packages/protocol/src/protocol/ExchangeManager.ts
+++ b/packages/protocol/src/protocol/ExchangeManager.ts
@@ -420,11 +420,13 @@ export class ExchangeManager {
     calculateMaximumPeerResponseTimeMsFor(
         session: Session,
         expectedProcessingTime = MRP.DEFAULT_EXPECTED_PROCESSING_TIME,
+        includeMaximumSendingTime = false,
     ) {
         return session.channel.calculateMaximumPeerResponseTime(
             session.parameters,
             this.#sessions.sessionParameters,
             expectedProcessingTime,
+            includeMaximumSendingTime,
         );
     }
 

--- a/packages/protocol/src/protocol/ExchangeProvider.ts
+++ b/packages/protocol/src/protocol/ExchangeProvider.ts
@@ -35,7 +35,7 @@ export abstract class ExchangeProvider {
         this.exchangeManager.addProtocolHandler(handler);
     }
 
-    abstract maximumPeerResponseTime(expectedProcessingTime?: Duration): Duration;
+    abstract maximumPeerResponseTime(expectedProcessingTime?: Duration, includeMaximumSendingTime?: boolean): Duration;
     abstract initiateExchange(protocol?: number): Promise<MessageExchange>;
     abstract reconnectChannel(options: { asOf?: Timestamp; resetInitialState?: boolean }): Promise<boolean>;
     abstract session: Session;
@@ -69,8 +69,15 @@ export class DedicatedChannelExchangeProvider extends ExchangeProvider {
         return this.#session;
     }
 
-    maximumPeerResponseTime(expectedProcessingTime = MRP.DEFAULT_EXPECTED_PROCESSING_TIME) {
-        return this.exchangeManager.calculateMaximumPeerResponseTimeMsFor(this.#session, expectedProcessingTime);
+    maximumPeerResponseTime(
+        expectedProcessingTime = MRP.DEFAULT_EXPECTED_PROCESSING_TIME,
+        includeMaximumSendingTime?: boolean,
+    ) {
+        return this.exchangeManager.calculateMaximumPeerResponseTimeMsFor(
+            this.#session,
+            expectedProcessingTime,
+            includeMaximumSendingTime,
+        );
     }
 }
 
@@ -130,10 +137,14 @@ export class ReconnectableExchangeProvider extends ExchangeProvider {
         return this.sessions.sessionFor(this.#address);
     }
 
-    maximumPeerResponseTime(expectedProcessingTimeMs = MRP.DEFAULT_EXPECTED_PROCESSING_TIME) {
+    maximumPeerResponseTime(
+        expectedProcessingTime = MRP.DEFAULT_EXPECTED_PROCESSING_TIME,
+        includeMaximumSendingTime?: boolean,
+    ) {
         return this.exchangeManager.calculateMaximumPeerResponseTimeMsFor(
             this.sessions.sessionFor(this.#address),
-            expectedProcessingTimeMs,
+            expectedProcessingTime,
+            includeMaximumSendingTime,
         );
     }
 }

--- a/packages/protocol/src/protocol/MRP.ts
+++ b/packages/protocol/src/protocol/MRP.ts
@@ -49,7 +49,10 @@ export namespace MRP {
     const PEER_RESPONSE_TIME_BUFFER = Seconds(5);
 
     export interface ResponseTimeInputs {
-        peerSessionParameters: SessionParameters;
+        /**
+         * When local session parameters are missing we only calculate the expected maximum time from the device back to us
+         */
+        peerSessionParameters?: SessionParameters;
         localSessionParameters: SessionParameters;
         channelType: ChannelType;
         isPeerActive: boolean;
@@ -75,10 +78,10 @@ export namespace MRP {
                 if (!usesMrp) {
                     throw new MatterFlowError("No response expected for this message exchange because UDP and no MRP");
                 }
-                // Calculate the maximum time till the peer got our last retry and worst case for the way back
+                // Calculate the maximum time till the peer got our last retry and worst-case for the way back
                 return Millis(
-                    maxResponseTimeOf(peerSessionParameters, isPeerActive) +
-                        maxResponseTimeOf(localSessionParameters, isPeerActive) +
+                    (peerSessionParameters !== undefined ? maxResponseTimeOf(peerSessionParameters, isPeerActive) : 0) +
+                        maxResponseTimeOf(localSessionParameters, true) + // We consider us as always active initially
                         expectedProcessingTime +
                         PEER_RESPONSE_TIME_BUFFER,
                 );

--- a/packages/protocol/src/protocol/MessageChannel.ts
+++ b/packages/protocol/src/protocol/MessageChannel.ts
@@ -153,9 +153,10 @@ export class MessageChannel implements Channel<Message> {
         peerSessionParameters: SessionParameters,
         localSessionParameters: SessionParameters,
         expectedProcessingTime?: Duration,
+        includeMaximumSendingTime?: boolean,
     ): Duration {
         return MRP.maxPeerResponseTimeOf({
-            peerSessionParameters,
+            peerSessionParameters: includeMaximumSendingTime ? peerSessionParameters : undefined,
             localSessionParameters,
             channelType: this.#channel.type,
             isPeerActive: this.session.isPeerActive,


### PR DESCRIPTION
When waiting for responses we only need to calculate with our intervals, else both