### PR TITLE
SSL support for remote protocols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,11 +52,12 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: Fixes Duration string parsing
 
 - @matter/model
-    - Enhancement: Re-Parsed the Matter 1.4.2 specification to improve captured details. No functional changes
+    - Enhancement: Re-parsed the Matter 1.4.2 specification to improve captured details. No functional changes
     - Enhancement: Adds "writable" as decorator to mark attributes writable
 
 - @matter/node
     - Feature: We now allocate node IDs as sequential numbers; the old behavior of randomized node behavior is available if you set `ControllerBehavior` state property `nodeIdAssignment` to `"random"`
+    - Feature: HttpServer and WebSocketServer now optionally support SSL; matter.js will generate a self-signed certificate if you do not provide one
     - Enhancement: Also export Matter events via ChangeNotificationService
     - Enhancement: Added updateFailed event to the OTA behavior
     - Enhancement: Allows to access the update queue 

--- a/packages/general/src/crypto/Pem.ts
+++ b/packages/general/src/crypto/Pem.ts
@@ -59,7 +59,7 @@ export namespace Pem {
         }
 
         const base64 = lines
-            .slice(startPos + 1, endPos - startPos - 1)
+            .slice(startPos + 1, endPos)
             .join("")
             .replace(/\s/g, "");
 

--- a/packages/general/src/net/http/HttpEndpoint.ts
+++ b/packages/general/src/net/http/HttpEndpoint.ts
@@ -55,6 +55,14 @@ export namespace HttpEndpoint {
      * Configuration options.
      */
     export interface Options {
+        certificate?: string;
+        key?: string;
+    }
+
+    /**
+     * Full configuration.
+     */
+    export interface Configuration extends Options {
         address: AppAddress.Definition;
     }
 }

--- a/packages/general/src/net/http/HttpEndpointFactory.ts
+++ b/packages/general/src/net/http/HttpEndpointFactory.ts
@@ -23,5 +23,5 @@ export abstract class HttpEndpointFactory {
      */
     supportsWs = true;
 
-    abstract create(options: HttpEndpoint.Options): Promise<HttpEndpoint>;
+    abstract create(options: HttpEndpoint.Configuration): Promise<HttpEndpoint>;
 }

--- a/packages/general/src/net/http/HttpService.ts
+++ b/packages/general/src/net/http/HttpService.ts
@@ -24,16 +24,18 @@ export class HttpService {
         this.#factory = factory;
     }
 
-    async create(...addresses: AppAddress.Definition[]) {
+    async create({ address, certificate, key }: HttpService.Configuration) {
+        const addresses = Array.isArray(address) ? address : [address];
+
         if (addresses.length === 1) {
-            return this.#forAddress(addresses[0]);
+            return this.#forConfig({ address: addresses[0], certificate, key });
         }
 
         const endpoints = Array<HttpEndpoint>();
 
         try {
             for (const address of addresses) {
-                endpoints.push(await this.#forAddress(address));
+                endpoints.push(await this.#forConfig({ address, certificate, key }));
             }
         } catch (e) {
             await Promise.allSettled(endpoints.map(endpoint => endpoint.close()));
@@ -43,9 +45,9 @@ export class HttpService {
         return new HttpEndpointGroup(endpoints);
     }
 
-    async #forAddress(address: AppAddress.Definition) {
-        const addr = AppAddress.for(address);
-        if (addr.appProtocol !== "http" && addr.appProtocol !== "ws") {
+    async #forConfig(config: HttpEndpoint.Configuration) {
+        const addr = AppAddress.for(config.address);
+        if (!["http", "https", "ws", "wss"].includes(addr.appProtocol)) {
             throw new ImplementationError(`Unsupported address ${addr} for HTTP endpoint`);
         }
 
@@ -60,7 +62,7 @@ export class HttpService {
                 );
             }
         } else {
-            endpoint = new HttpSharedEndpoint(addr.isTls, () => this.#factory.create({ address }));
+            endpoint = new HttpSharedEndpoint(addr.isTls, () => this.#factory.create(config));
             this.#endpoints[key] = endpoint;
         }
 
@@ -71,5 +73,11 @@ export class HttpService {
         const instance = new HttpService(env.get(HttpEndpointFactory));
         env.set(HttpService, instance);
         return instance;
+    }
+}
+
+export namespace HttpService {
+    export interface Configuration extends HttpEndpoint.Options {
+        address: AppAddress.Definition | AppAddress.Definition[];
     }
 }

--- a/packages/general/src/net/mqtt/MqttEndpoint.ts
+++ b/packages/general/src/net/mqtt/MqttEndpoint.ts
@@ -37,6 +37,8 @@ export namespace MqttEndpoint {
 
     export interface ConnectionOptions {
         address: AppAddress.Definition;
+        certificate?: string;
+        key?: string;
         environment?: Environment;
         will?: Message;
         onUp?: (endpoint: MqttEndpoint) => MaybePromise<void>;

--- a/packages/general/test/crypto/KeyTest.ts
+++ b/packages/general/test/crypto/KeyTest.ts
@@ -5,7 +5,7 @@
  */
 
 import { CurveType, Key, KeyType } from "#crypto/Key.js";
-import { Bytes } from "#util/Bytes.js";
+import { b$ } from "#util/Bytes.js";
 
 describe("Key", () => {
     describe("sec1", () => {
@@ -36,7 +36,23 @@ describe("Key", () => {
                 y: "lnJe-V4UJoa6mPM5sP9lvDOL7Huei-C987J3SYJHYiA",
             });
         });
+
+        it("round-trips", () => {
+            const key = Key({ pkcs8: Fixture.pkcs8 });
+            const exported = key.pkcs8;
+            expect(exported).not.undefined;
+            const reimported = Key({ pkcs8: exported });
+            expect(reimported).deep.equal({
+                kty: KeyType.EC,
+                crv: CurveType.p256,
+                d: key.d,
+                x: key.x,
+                y: key.y,
+            });
+        });
     });
+
+    describe("pem", () => {});
 
     describe("spki", () => {
         it("decodes", () => {
@@ -68,18 +84,8 @@ describe("Key", () => {
 });
 
 namespace Fixture {
-    const b = (s: string) => Bytes.of(Bytes.fromHex(s));
-
-    export const sec1 = b(
-        "30770201010420aef3484116e9481ec57be0472df41bf499064e5024ad869eca5e889802d48075a00a06082a8648ce3d030107a144034200043c398922452b55caf389c25bd1bca4656952ccb90e8869249ad8474653014cbf95d687965e036b521c51037e6b8cedefca1eb44046694fa08882eed6519decba",
-    );
-    export const pkcs8 = b(
-        "308141020100301306072a8648ce3d020106082a8648ce3d030107042730250201010420727F1005CBA47ED7822A9D930943621617CFD3B79D9AF528B801ECF9F1992204",
-    );
-    export const spki = b(
-        "3059301306072a8648ce3d020106082a8648ce3d0301070342000462e2b6e1baff8d74a6fd8216c4cb67a3363a31e691492792e61aee610261481396725ef95e142686ba98f339b0ff65bc338bec7b9e8be0bdf3b2774982476220",
-    );
-    export const publicKey = b(
-        "0410ef02a81a87b68121fba8d31978f807a317e50aa8a828446828914b933de8edd4a5c39c9ff71a4ce3647fd7f62653b7d2495fcba4c0f47f876880039e07204a",
-    );
+    export const sec1 = b$`30770201010420aef3484116e9481ec57be0472df41bf499064e5024ad869eca5e889802d48075a00a06082a8648ce3d030107a144034200043c398922452b55caf389c25bd1bca4656952ccb90e8869249ad8474653014cbf95d687965e036b521c51037e6b8cedefca1eb44046694fa08882eed6519decba`;
+    export const pkcs8 = b$`308141020100301306072a8648ce3d020106082a8648ce3d030107042730250201010420727F1005CBA47ED7822A9D930943621617CFD3B79D9AF528B801ECF9F1992204`;
+    export const spki = b$`3059301306072a8648ce3d020106082a8648ce3d0301070342000462e2b6e1baff8d74a6fd8216c4cb67a3363a31e691492792e61aee610261481396725ef95e142686ba98f339b0ff65bc338bec7b9e8be0bdf3b2774982476220`;
+    export const publicKey = b$`0410ef02a81a87b68121fba8d31978f807a317e50aa8a828446828914b933de8edd4a5c39c9ff71a4ce3647fd7f62653b7d2495fcba4c0f47f876880039e07204a`;
 }

--- a/packages/mqtt/src/MqttJsEndpointFactory.ts
+++ b/packages/mqtt/src/MqttJsEndpointFactory.ts
@@ -68,6 +68,9 @@ export class MqttJsEndpointFactory extends MqttEndpointFactory {
             opts.will = MqttJsMessage.encode(options.will);
         }
 
+        opts.cert = options.certificate;
+        opts.key = options.key;
+
         const client = await connectAsync(opts);
 
         return new MqttJsEndpoint(client, options);

--- a/packages/node/src/behavior/system/http/HttpInterface.ts
+++ b/packages/node/src/behavior/system/http/HttpInterface.ts
@@ -35,7 +35,7 @@ export class HttpInterface extends RemoteInterface {
     #http?: HttpEndpoint;
 
     protected override async start() {
-        this.#http = await this.env.get(HttpService).create(this.address);
+        this.#http = await this.env.get(HttpService).create(this);
         this.#http.http = this.#handleRequest.bind(this);
     }
 

--- a/packages/node/src/behavior/system/mqtt/MqttInterface.ts
+++ b/packages/node/src/behavior/system/mqtt/MqttInterface.ts
@@ -49,6 +49,8 @@ export class MqttInterface extends RemoteInterface {
         this.#endpoint = await this.env.get(MqttService).connect({
             address: this.address,
             environment: this.node.env,
+            certificate: this.certificate,
+            key: this.key,
 
             will: {
                 topic: this.root.at("status").toString(),

--- a/packages/node/src/behavior/system/websocket/WebSocketInterface.ts
+++ b/packages/node/src/behavior/system/websocket/WebSocketInterface.ts
@@ -25,7 +25,7 @@ export class WebSocketInterface extends RemoteInterface {
     #mutex = new Mutex(this);
 
     protected override async start() {
-        this.#http = await this.env.get(HttpService).create(this.address);
+        this.#http = await this.env.get(HttpService).create(this);
         this.#http.ws = this.#handleConnection.bind(this);
     }
 

--- a/packages/nodejs-ws/test/WebSocketTest.ts
+++ b/packages/nodejs-ws/test/WebSocketTest.ts
@@ -25,8 +25,8 @@ let tempFileNum = 0;
 
 let environment: Environment;
 
-// TODO The timeouts of 5s are needed when the test runs locally with more network interfaces because it uses the
-//  real network. We should change that to use a mock network layer instead.
+// TODO The timeouts of 5s are needed when the test runs locally with more network interfaces because it uses the real
+//  network. We should change that to use a mock network layer instead.
 
 describe("WebSocket", () => {
     beforeEach(async () => {
@@ -249,7 +249,7 @@ describe("WebSocket", () => {
     });
 });
 
-async function setup() {
+async function setup(proto = "ws+unix") {
     const socketPath = join(tmpdir(), `${process.pid}-${tempFileNum++}.sock`);
 
     const node = new ServerNode(ServerNode.RootEndpoint.with(WebSocketServer), {
@@ -257,7 +257,7 @@ async function setup() {
         environment: environment,
 
         websocket: {
-            address: `ws+unix://${encodeURIComponent(socketPath)}/`,
+            address: `${proto}://${encodeURIComponent(socketPath)}/`,
         },
 
         parts: [new Endpoint(OnOffLightDevice.with(OnOffServer.with("Lighting")), { id: "light" })],
@@ -267,7 +267,7 @@ async function setup() {
         await node.lifecycle.partsReady;
     }
 
-    const ws = new WebSocket(`ws+unix://${socketPath}:/`);
+    const ws = new WebSocket(`${proto}://${socketPath}:/`);
 
     await new Promise<void>((resolve, reject) => {
         ws.addEventListener("open", onOpen);

--- a/packages/protocol/src/certificate/kinds/Certificate.ts
+++ b/packages/protocol/src/certificate/kinds/Certificate.ts
@@ -326,7 +326,7 @@ export namespace Certificate {
             const valueNode = DerCodec.decode(valueOctetString);
 
             switch (oidValue) {
-                case X509.Extension.BASIC_CONSTRAINTS:
+                case X509.Extensions.BASIC_CONSTRAINTS:
                     {
                         const { _elements: bcElements } = valueNode;
                         // Always initialize basicConstraints when extension is present
@@ -345,7 +345,7 @@ export namespace Certificate {
                     }
                     break;
 
-                case X509.Extension.KEY_USAGE:
+                case X509.Extensions.KEY_USAGE:
                     {
                         // Note: DerKey.Bytes for BIT STRING returns data without the padding byte
                         const bitString = Bytes.of(valueNode._bytes);
@@ -369,7 +369,7 @@ export namespace Certificate {
                     }
                     break;
 
-                case X509.Extension.EXTENDED_KEY_USAGE:
+                case X509.Extensions.EXTENDED_KEY_USAGE:
                     {
                         const { _elements: ekuElements } = valueNode;
                         if (ekuElements) {
@@ -404,11 +404,11 @@ export namespace Certificate {
                     }
                     break;
 
-                case X509.Extension.SUBJECT_KEY_IDENTIFIER:
+                case X509.Extensions.SUBJECT_KEY_IDENTIFIER:
                     result.subjectKeyIdentifier = valueNode._bytes;
                     break;
 
-                case X509.Extension.AUTHORITY_KEY_IDENTIFIER:
+                case X509.Extensions.AUTHORITY_KEY_IDENTIFIER:
                     {
                         const { _elements: akiElements } = valueNode;
                         if (akiElements && akiElements.length > 0) {


### PR DESCRIPTION
* Adds PEM support to `Key`

* Adds PKCS8 export to `Key`

* Modifies `X509` to support field combinations appropriate for SSL certs

* Fixes bug in PEM decoding

* Adds `https` and `wss` protocols and key/cert parameters to `HttpService`

* Adds key/cert state values to `RemoteServer`

* Adds self-signed cert generation to `RemoteServer` when the user doesn't provide