### PR TITLE
Add local matter.js controller for docker-based CHIP testing

### DIFF
--- a/packages/testing/src/chip/config.ts
+++ b/packages/testing/src/chip/config.ts
@@ -21,6 +21,7 @@ export namespace ContainerPaths {
     export const chipPics = "/src/app/tests/suites/certification/ci-pics-values";
     export const accessoryClient =
         "/usr/local/lib/python3.12/dist-packages/matter/yamltests/pseudo_clusters/clusters/accessory_server_bridge.py";
+    export const dummyWsServer = "/bin/mjs-ws-dummy";
 }
 
 export type ContainerPathsType = typeof ContainerPaths;
@@ -53,6 +54,9 @@ export namespace Constants {
      */
     export const imageName = env.MATTER_CHIP_IMAGE || "ghcr.io/matter-js/chip:latest";
     export const mdnsVolumeName = env.MATTER_MDNS_VOLUME || "matter.js-mdns";
+
+    export const useLocalController = !!env.MATTER_LOCAL_CONTROLLER;
+    export const controllerPort = env.MATTER_CONTROLLER_PORT ? parseInt(env.MATTER_CONTROLLER_PORT, 10) : 9002;
 
     export const initTimeout = 60_000;
     export const defaultTimeoutMs = 60_000;

--- a/packages/testing/src/chip/state.ts
+++ b/packages/testing/src/chip/state.ts
@@ -47,6 +47,7 @@ const Values = {
     testMap: new Map<TestDescriptor, Test>(),
     pullBeforeTesting: true,
     commandPipe: undefined as ContainerCommandPipe | undefined,
+    localControllerPort: undefined as number | undefined,
 };
 
 /**
@@ -114,6 +115,10 @@ export const State = {
         }
 
         return Values.test;
+    },
+
+    get localControllerPort() {
+        return Values.localControllerPort;
     },
 
     get isInitialized() {
@@ -381,6 +386,10 @@ async function initialize() {
     await configureTests();
     await configureNetwork();
 
+    if (Constants.useLocalController) {
+        await configureLocalController();
+    }
+
     Values.isInitialized = true;
 }
 
@@ -519,6 +528,23 @@ async function configureNetwork() {
 }
 
 /**
+ * Install a dummy WebSocket server script in the container and configure the local controller port.
+ *
+ * The dummy script satisfies chiptool.py's `--server_path` validation (click.Path(exists=True)) and its
+ * WebSocketRunner startup protocol (expects "== WebSocket Server Ready" on stdout).  The actual WebSocket server runs
+ * on the host in the matter.js controller process.
+ */
+async function configureLocalController() {
+    const dummyScript = '#!/bin/bash\necho "== WebSocket Server Ready"\nexec sleep infinity\n';
+    await State.container.exec([
+        "bash",
+        "-c",
+        `echo '${dummyScript}' > /bin/mjs-ws-dummy && chmod +x /bin/mjs-ws-dummy`,
+    ]);
+    Values.localControllerPort = Constants.controllerPort;
+}
+
+/**
  * Obtain a subject.  Subjects are qualified by factory and test domain.
  */
 function loadSubject(factory: Subject.Factory, kind: TestDescriptor["kind"]) {
@@ -568,7 +594,7 @@ function createTest(descriptor: TestDescriptor) {
 
     switch (descriptor.kind) {
         case "yaml":
-            return new YamlTest(descriptor as TestFileDescriptor, State.container);
+            return new YamlTest(descriptor as TestFileDescriptor, State.container, Values.localControllerPort);
 
         case "py":
             return new PythonTest(descriptor as TestFileDescriptor, State.container);

--- a/packages/testing/src/chip/yaml-test.ts
+++ b/packages/testing/src/chip/yaml-test.ts
@@ -7,14 +7,31 @@
 import { basename } from "node:path";
 import { Subject } from "../device/subject.js";
 import { BaseTest } from "../device/test.js";
+import { Container } from "../docker/container.js";
 import { Terminal } from "../docker/terminal.js";
+import { TestFileDescriptor } from "../test-descriptor.js";
 import { deansify } from "../util/text.js";
 import { parseStep } from "./chip-test-common.js";
 import { Constants, ContainerPaths } from "./config.js";
 import { PicsSource } from "./pics/source.js";
 
 export class YamlTest extends BaseTest {
+    #localControllerPort?: number;
+
+    constructor(descriptor: TestFileDescriptor, container: Container, localControllerPort?: number) {
+        super(descriptor, container);
+        this.#localControllerPort = localControllerPort;
+    }
+
     async initializeSubject(subject: Subject) {
+        if (this.#localControllerPort !== undefined) {
+            await this.#initializeSubjectViaWebSocket(subject);
+        } else {
+            await this.#initializeSubjectViaChipTool(subject);
+        }
+    }
+
+    async #initializeSubjectViaChipTool(subject: Subject) {
         const command = ["chip-tool", "pairing"];
 
         const { kind, passcode, discriminator, network } = subject.commissioning;
@@ -55,20 +72,50 @@ export class YamlTest extends BaseTest {
         }
     }
 
-    async invoke(subject: Subject, step: (title: string) => void, args: string[]) {
-        if (!args.includes("--PICS")) {
-            args.push("--PICS", await PicsSource.install(subject.pics));
-        }
+    /**
+     * Commission via the local matter.js WebSocket controller.  The YAML runner's WebSocketRunner connects to the
+     * host-side controller, which handles the `pairing code <nodeId> <qrCode>` text command.
+     */
+    async #initializeSubjectViaWebSocket(subject: Subject) {
+        const { qrPairingCode } = subject.commissioning;
 
         const terminal = await this.container.exec(
             [
                 "python3",
                 ContainerPaths.yamlRunner,
-                "tests",
-                basename(this.descriptor.path),
-                ...Constants.YamlRunnerArgs,
-                ...args,
+                "pairing",
+                "code",
+                "0x12344321",
+                qrPairingCode,
+                "--server_path",
+                ContainerPaths.dummyWsServer,
             ],
+            Terminal.Line,
+        );
+
+        try {
+            for await (const line of terminal) {
+                MockLogger.injectExternalMessage("PAIR", line);
+            }
+        } catch (e) {
+            throw new Error("Error pairing test app via WebSocket controller", { cause: e });
+        }
+    }
+
+    async invoke(subject: Subject, step: (title: string) => void, args: string[]) {
+        if (!args.includes("--PICS")) {
+            args.push("--PICS", await PicsSource.install(subject.pics));
+        }
+
+        const runnerArgs =
+            this.#localControllerPort !== undefined
+                ? Constants.YamlRunnerArgs.map((arg, i, arr) =>
+                      arr[i - 1] === "--server_path" ? ContainerPaths.dummyWsServer : arg,
+                  )
+                : Constants.YamlRunnerArgs;
+
+        const terminal = await this.container.exec(
+            ["python3", ContainerPaths.yamlRunner, "tests", basename(this.descriptor.path), ...runnerArgs, ...args],
             Terminal.Line,
         );
 

--- a/support/chip-testing/src/local-controller.ts
+++ b/support/chip-testing/src/local-controller.ts
@@ -1,0 +1,43 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Logger } from "@matter/general";
+import { ControllerTestInstance, ControllerTestInstanceConfig } from "./ControllerTestInstance.js";
+import { StorageBackendAsyncJsonFile } from "./storage/StorageBackendAsyncJsonFile.js";
+
+const logger = Logger.get("LocalController");
+
+/**
+ * Start a local matter.js controller for WebSocket-based YAML testing.
+ *
+ * Creates a {@link ControllerTestInstance} with three identities (alpha, beta, gamma) and a WebSocket server on the
+ * specified port.  The controller runs in-process alongside the DUT, isolated via separate {@link Environment}
+ * instances.
+ *
+ * @returns a close function to shut down the controller
+ */
+export async function startLocalController(options?: { port?: number; storagePath?: string }) {
+    const port = options?.port ?? 9002;
+    const storagePath = options?.storagePath ?? "/tmp/local-controller-kvs";
+
+    const storage = new StorageBackendAsyncJsonFile(storagePath);
+
+    const config: ControllerTestInstanceConfig = {
+        storage,
+        websocketPort: port,
+    };
+
+    const testInstance = new ControllerTestInstance(config);
+    await testInstance.initialize();
+    await testInstance.start();
+
+    logger.info(`Local controller started on port ${port}`);
+
+    return async () => {
+        logger.info("Closing local controller");
+        await testInstance.close();
+    };
+}

--- a/support/chip-testing/test/test.config.ts
+++ b/support/chip-testing/test/test.config.ts
@@ -6,6 +6,7 @@
 
 import { chip, Chip } from "@matter/testing";
 import { log } from "../src/GenericTestApp.js";
+import { startLocalController } from "../src/local-controller.js";
 
 // Disable stdout output required when run within CHIP test harnesses
 log.directive = () => {};
@@ -18,5 +19,11 @@ declare global {
 Object.assign(globalThis, { chip });
 
 await chip.initialize();
+
+if (process.env.MATTER_LOCAL_CONTROLLER) {
+    const port = process.env.MATTER_CONTROLLER_PORT ? parseInt(process.env.MATTER_CONTROLLER_PORT, 10) : 9002;
+    const close = await startLocalController({ port });
+    chip.onClose(close);
+}
 
 await import("./support.js");


### PR DESCRIPTION
When MATTER_LOCAL_CONTROLLER is set, runs an in-process matter.js WebSocket controller alongside the DUT instead of using chip-tool inside the container. This enables local development with the same YAML test runner used in CI.