### PR TITLE
Add wildcard operational query at controller startup

### DIFF
--- a/packages/node/src/behavior/system/controller/ControllerBehavior.ts
+++ b/packages/node/src/behavior/system/controller/ControllerBehavior.ts
@@ -214,9 +214,6 @@ export class ControllerBehavior extends Behavior {
             }
         }
 
-        // Clear operational targets
-        this.internal.mdnsTargetCriteria.operationalTargets.length = 0;
-
         const netTransports = this.env.get(ConnectionlessTransportSet);
         if (this.state.ble) {
             netTransports.delete(this.env.get(Ble).centralInterface);
@@ -224,8 +221,6 @@ export class ControllerBehavior extends Behavior {
     }
 
     #enableScanningForFabric(fabric: Fabric) {
-        this.internal.mdnsTargetCriteria.operationalTargets.push({ fabricId: fabric.globalId });
-
         // Send a one-time wildcard query via DnssdNames so existing operational nodes on this fabric respond and
         // populate IpService for known peers
         if (this.internal.services) {
@@ -252,7 +247,6 @@ export namespace ControllerBehavior {
          */
         mdnsTargetCriteria: MdnsScannerTargetCriteria = {
             commissionable: true,
-            operationalTargets: [],
         };
 
         services?: SharedEnvironmentServices;

--- a/packages/node/src/behavior/system/controller/discovery/ActiveDiscoveries.ts
+++ b/packages/node/src/behavior/system/controller/discovery/ActiveDiscoveries.ts
@@ -49,7 +49,7 @@ export class ActiveDiscoveries extends Set<Discovery<any>> {
         }
 
         if (this.#mdnsTargetCriteria === undefined) {
-            this.#mdnsTargetCriteria = { commissionable: true, operationalTargets: [] };
+            this.#mdnsTargetCriteria = { commissionable: true };
         }
         scanner.targetCriteriaProviders.add(this.#mdnsTargetCriteria);
     }

--- a/packages/protocol/src/common/BleScanner.ts
+++ b/packages/protocol/src/common/BleScanner.ts
@@ -275,16 +275,6 @@ export class BleScanner implements Scanner {
         return foundRecords;
     }
 
-    async findOperationalDevice(): Promise<undefined> {
-        logger.info(`skip BLE scan because scanning for operational devices is not supported`);
-        return undefined;
-    }
-
-    getDiscoveredOperationalDevice(): undefined {
-        logger.info(`skip BLE scan because scanning for operational devices is not supported`);
-        return undefined;
-    }
-
     async findCommissionableDevices(
         identifier: CommissionableDeviceIdentifiers,
         timeout = Seconds(10),

--- a/packages/protocol/src/common/Scanner.ts
+++ b/packages/protocol/src/common/Scanner.ts
@@ -15,8 +15,7 @@ import {
     ServerAddress,
     ServerAddressUdp,
 } from "@matter/general";
-import { DiscoveryCapabilitiesBitmap, NodeId, TypeFromPartialBitSchema, VendorId } from "@matter/types";
-import { Fabric } from "../fabric/Fabric.js";
+import { DiscoveryCapabilitiesBitmap, TypeFromPartialBitSchema, VendorId } from "@matter/types";
 
 /**
  * All information exposed by a device via announcements.
@@ -158,23 +157,6 @@ export type CommissionableDeviceIdentifiers =
 
 export interface Scanner {
     type: ChannelType;
-
-    /**
-     * Send DNS-SD queries to discover the current addresses of an operational paired device by its operational ID
-     * and return them.
-     */
-    findOperationalDevice(
-        fabric: Fabric,
-        nodeId: NodeId,
-        timeout?: Duration,
-        ignoreExistingRecords?: boolean,
-    ): Promise<OperationalDevice | undefined>;
-
-    /**
-     * Return already discovered addresses of an operational paired device and return them. Does not send out new
-     * DNS-SD queries.
-     */
-    getDiscoveredOperationalDevice(fabric: Fabric, nodeId: NodeId): OperationalDevice | undefined;
 
     /**
      * Send DNS-SD queries to discover commissionable devices by a provided identifier (e.g. discriminator,

--- a/packages/protocol/src/mdns/MdnsClient.ts
+++ b/packages/protocol/src/mdns/MdnsClient.ts
@@ -4,10 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { PeerAddress } from "#peer/PeerAddress.js";
 import {
     AddressLifespan,
-    BasicMultiplex,
     BasicSet,
     ChannelType,
     Diagnostic,
@@ -20,7 +18,6 @@ import {
     Hours,
     ImplementationError,
     Instant,
-    InternalError,
     Lifetime,
     Logger,
     MdnsSocket,
@@ -37,24 +34,15 @@ import {
     createPromise,
     isIPv6,
 } from "@matter/general";
-import { GlobalFabricId, NodeId, VendorId } from "@matter/types";
-import {
-    CommissionableDevice,
-    CommissionableDeviceIdentifiers,
-    DiscoveryData,
-    OperationalDevice,
-    Scanner,
-} from "../common/Scanner.js";
-import { Fabric } from "../fabric/Fabric.js";
+import { VendorId } from "@matter/types";
+import { CommissionableDevice, CommissionableDeviceIdentifiers, DiscoveryData, Scanner } from "../common/Scanner.js";
 import {
     MATTER_COMMISSION_SERVICE_QNAME,
     MATTER_SERVICE_QNAME,
     getCommissionableDeviceQname,
     getCommissioningModeQname,
     getDeviceTypeQname,
-    getFabricQname,
     getLongDiscriminatorQname,
-    getOperationalDeviceQname,
     getShortDiscriminatorQname,
     getVendorQname,
 } from "./MdnsConsts.js";
@@ -88,12 +76,6 @@ type CommissionableDeviceRecordWithExpire = Omit<CommissionableDevice, "addresse
         P?: number; // Additional Field for Product ID
     };
 
-/** Type for operational Device records including Lifespan details. */
-type OperationalDeviceRecordWithExpire = Omit<OperationalDevice, "addresses"> &
-    AddressLifespan & {
-        addresses: Map<string, MatterServerRecordWithExpire>; // Override addresses type to include expiration
-    };
-
 /** Type for any DNS record with Lifespan (discoveredAt and ttl) details. */
 type AnyDnsRecordWithExpiry = DnsRecord<any> & AddressLifespan;
 
@@ -113,24 +95,14 @@ type StructuredDnsAnswers = {
 const START_ANNOUNCE_INTERVAL = Seconds(1.5);
 
 /**
- * Interface to add criteria for MDNS discovery a node is interested in
+ * Interface to add criteria for MDNS discovery a node is interested in.
  *
- * This interface is used to define criteria for mDNS scanner targets. It includes the information if commissionable
- * devices are relevant for the target and a list of operational targets. Operational targets can consist of operational
- * IDs and optional node IDs.
- *
- * When no commissionable devices are relevant and no operational targets are defined, it is not required to add a
- * criteria to the scanner.
+ * This interface is used to define criteria for mDNS scanner targets. It includes whether commissionable devices are
+ * relevant for the target.
  */
 export interface MdnsScannerTargetCriteria {
     /** Are commissionable MDNS records relevant? */
     commissionable: boolean;
-
-    /** List of operational targets. */
-    operationalTargets: {
-        fabricId: GlobalFabricId;
-        nodeId?: NodeId;
-    }[];
 }
 
 interface WaiterRecord {
@@ -151,7 +123,6 @@ interface WaiterRecord {
  */
 export class MdnsClient implements Scanner {
     readonly #lifetime: Lifetime;
-    #operationalInitialQueries?: BasicMultiplex;
 
     readonly type = ChannelType.UDP;
 
@@ -160,9 +131,6 @@ export class MdnsClient implements Scanner {
 
     /** Known IP addresses by network interface */
     readonly #discoveredIpRecords = new Map<string, StructuredDnsAddressAnswers>();
-
-    /** Known operational device records by Matter Qname */
-    readonly #operationalDeviceRecords = new Map<string, OperationalDeviceRecordWithExpire>();
 
     /** Known commissionable device records by queryId */
     readonly #commissionableDeviceRecords = new Map<string, CommissionableDeviceRecordWithExpire>();
@@ -180,7 +148,6 @@ export class MdnsClient implements Scanner {
     readonly #targetCriteriaProviders = new BasicSet<MdnsScannerTargetCriteria>();
     #scanForCommissionableDevices = false;
     #hasCommissionableWaiters = false;
-    readonly #operationalScanTargets = new Set<string>();
     readonly #observers = new ObserverGroup();
 
     /** True, if any node is interested in MDNS traffic, else we ignore all traffic */
@@ -210,68 +177,22 @@ export class MdnsClient implements Scanner {
             "MDNS Scan targets updated :",
             Diagnostic.dict({
                 commissionable: this.#scanForCommissionableDevices,
-                operational: this.#operationalScanTargets,
             }),
         );
     }
 
-    /** Update the MDNS scan criteria state and collect the desired operational targets */
     #updateScanTargets() {
         if (this.#closing) {
             return;
         }
 
-        const formerTargets = new Set(this.#operationalScanTargets);
-        const initialSendQueries = new Set<string>();
-        // Add all operational targets from the criteria providers
-        this.#operationalScanTargets.clear();
         let cacheCommissionableDevices = false;
         for (const criteria of this.#targetCriteriaProviders) {
-            const { operationalTargets, commissionable } = criteria;
-            cacheCommissionableDevices = cacheCommissionableDevices || commissionable;
-            for (const { fabricId, nodeId } of operationalTargets) {
-                let target: string;
-                let scanTarget: string;
-                if (nodeId === undefined) {
-                    target = GlobalFabricId.strOf(fabricId).toUpperCase();
-                    scanTarget = getFabricQname(fabricId);
-                } else {
-                    target = `${GlobalFabricId.strOf(fabricId)}-${NodeId.strOf(nodeId)}`.toUpperCase();
-                    scanTarget = getOperationalDeviceQname(fabricId, nodeId);
-                }
-
-                this.#operationalScanTargets.add(target);
-                if (!formerTargets.has(target)) {
-                    initialSendQueries.add(scanTarget);
-                }
-            }
+            cacheCommissionableDevices = cacheCommissionableDevices || criteria.commissionable;
         }
         this.#scanForCommissionableDevices = cacheCommissionableDevices;
 
-        // Register all operational targets for running queries
-        for (const queryId of this.#recordWaiters.keys()) {
-            this.#registerOperationalQuery(queryId);
-        }
         this.#updateListeningStatus();
-
-        if (initialSendQueries.size > 0) {
-            logger.debug(
-                `Sending initial operational mDNS queries for ${initialSendQueries.size} new operational targets`,
-            );
-            if (this.#operationalInitialQueries === undefined) {
-                this.#operationalInitialQueries = new BasicMultiplex();
-            }
-            this.#operationalInitialQueries.add(
-                this.#socket.send({
-                    messageType: DnsMessageType.Query,
-                    queries: Array.from(initialSendQueries.values()).map(target => ({
-                        name: target,
-                        recordClass: DnsRecordClass.IN,
-                        recordType: DnsRecordType.PTR,
-                    })),
-                }),
-            );
-        }
     }
 
     /** Update the status if we care about MDNS messages or not */
@@ -279,13 +200,9 @@ export class MdnsClient implements Scanner {
         const formerListenStatus = this.#listening;
         // Are we interested in MDNS traffic or not?
         this.#listening =
-            this.#scanForCommissionableDevices ||
-            this.#operationalScanTargets.size > 0 ||
-            this.#recordWaiters.size > 0 ||
-            this.#activeAnnounceQueries.size > 0;
+            this.#scanForCommissionableDevices || this.#recordWaiters.size > 0 || this.#activeAnnounceQueries.size > 0;
         if (!this.#listening) {
             this.#discoveredIpRecords.clear();
-            this.#operationalDeviceRecords.clear();
             this.#commissionableDeviceRecords.clear();
         }
         if (this.#listening !== formerListenStatus) {
@@ -390,28 +307,6 @@ export class MdnsClient implements Scanner {
     }
 
     /**
-     * Returns the list of all targets (IP/port) discovered for a queried operational device record.
-     */
-    #getOperationalDeviceRecords(deviceMatterQname: string): OperationalDevice | undefined {
-        const device = this.#operationalDeviceRecords.get(deviceMatterQname);
-        if (device === undefined) {
-            return undefined;
-        }
-        const { addresses } = device;
-        if (addresses.size === 0) {
-            return undefined;
-        }
-        return {
-            ...device,
-            addresses: this.#sortServerEntries(Array.from(addresses.values())).map(({ ip, port }) => ({
-                ip,
-                port,
-                type: "udp",
-            })) as ServerAddressUdp[],
-        };
-    }
-
-    /**
      * Sort the list of found IP/ports and make sure link-local IPv6 addresses come first, IPv6 next and IPv4 last.
      *
      * @param entries
@@ -438,15 +333,6 @@ export class MdnsClient implements Scanner {
             }
             return 0; // no preference
         });
-    }
-
-    #registerOperationalQuery(queryId: string) {
-        const separator = queryId.indexOf(".");
-        if (separator !== -1) {
-            this.#operationalScanTargets.add(queryId.substring(0, separator));
-        } else {
-            throw new InternalError(`Invalid queryId ${queryId} for operational device, no separator found`);
-        }
     }
 
     /**
@@ -483,9 +369,6 @@ export class MdnsClient implements Scanner {
         });
         this.#recordWaiters.set(queryId, waiters);
         this.#hasCommissionableWaiters = this.#hasCommissionableWaiters || commissionable;
-        if (!commissionable) {
-            this.#registerOperationalQuery(queryId);
-        }
         logger.info(
             `Registered waiter for query ${queryId} (${id}) with ${
                 timeout !== undefined ? `timeout ${timeout}` : "no timeout"
@@ -534,85 +417,20 @@ export class MdnsClient implements Scanner {
         if (!this.#closing) {
             // We removed a waiter, so update what we still have left
             this.#hasCommissionableWaiters = false;
-            let hasOperationalWaiters = false;
-            loop: for (const waiters of this.#recordWaiters.values()) {
+            for (const waiters of this.#recordWaiters.values()) {
                 for (const { commissionable } of waiters) {
                     if (commissionable) {
                         this.#hasCommissionableWaiters = true;
-                        if (hasOperationalWaiters) {
-                            break loop; // No need to check further
-                        }
-                    } else {
-                        hasOperationalWaiters = true;
-                        if (this.#hasCommissionableWaiters) {
-                            break loop; // No need to check further
-                        }
+                        break;
                     }
+                }
+                if (this.#hasCommissionableWaiters) {
+                    break;
                 }
             }
 
-            if (!commissionableRecordFinished) {
-                // We removed an operational device waiter, so we need to update the scan targets
-                this.#updateScanTargets();
-            } else {
-                this.#updateListeningStatus();
-            }
+            this.#updateListeningStatus();
         }
-    }
-
-    /** Returns weather a waiter promise is registered for a specific queryId. */
-    #hasWaiter(queryId: string) {
-        return this.#recordWaiters.has(queryId);
-    }
-
-    /**
-     * Method to find an operational device (already commissioned) and return a promise with the list of discovered
-     * IP/ports or an empty array if not found.
-     */
-    async findOperationalDevice(
-        fabric: Fabric,
-        nodeId: NodeId,
-        timeout?: Duration,
-        ignoreExistingRecords = false,
-    ): Promise<OperationalDevice | undefined> {
-        if (this.#closing) {
-            throw new ImplementationError("Cannot discover operational device because scanner is closing.");
-        }
-        const deviceMatterQname = getOperationalDeviceQname(fabric.globalId, nodeId);
-
-        let storedDevice = this.#getOperationalDeviceRecords(deviceMatterQname);
-        if (storedDevice === undefined || ignoreExistingRecords) {
-            using _finding = this.#lifetime.join(
-                "finding peer",
-                PeerAddress({ fabricIndex: fabric.fabricIndex, nodeId }),
-            );
-
-            if (storedDevice) {
-                // We know the device including IPs but want to query anew, so forget the addresses to ensure they get updated
-                const device = this.#operationalDeviceRecords.get(deviceMatterQname);
-                device?.addresses.clear();
-            }
-
-            const promise = this.#registerWaiterPromise(deviceMatterQname, false, timeout, () =>
-                this.#getOperationalDeviceRecords(deviceMatterQname),
-            );
-
-            this.#setQueryRecords(deviceMatterQname, [
-                {
-                    name: deviceMatterQname,
-                    recordClass: DnsRecordClass.IN,
-                    recordType: DnsRecordType.SRV,
-                },
-            ]);
-
-            storedDevice = await promise;
-        }
-        return storedDevice;
-    }
-
-    cancelOperationalDeviceDiscovery(fabric: Fabric, nodeId: NodeId, resolvePromise = true) {
-        const deviceMatterQname = getOperationalDeviceQname(fabric.globalId, nodeId);
-        this.#finishWaiter(deviceMatterQname, resolvePromise);
     }
 
     cancelCommissionableDeviceDiscovery(identifier: CommissionableDeviceIdentifiers, resolvePromise = true) {
@@ -623,10 +441,6 @@ export class MdnsClient implements Scanner {
             cancelResolver?.();
         }
         this.#finishWaiter(queryId, resolvePromise);
-    }
-
-    getDiscoveredOperationalDevice({ globalId }: Fabric, nodeId: NodeId) {
-        return this.#getOperationalDeviceRecords(getOperationalDeviceQname(globalId, nodeId));
     }
 
     /**
@@ -873,7 +687,7 @@ export class MdnsClient implements Scanner {
         );
 
         // We scan continuously, so make sure we are registered for commissionable devices
-        const criteria: MdnsScannerTargetCriteria = { commissionable: true, operationalTargets: [] };
+        const criteria: MdnsScannerTargetCriteria = { commissionable: true };
         this.targetCriteriaProviders.add(criteria);
 
         using finding = this.#lifetime.join("finding commissionable");
@@ -925,7 +739,6 @@ export class MdnsClient implements Scanner {
         this.#observers.close();
         this.#periodicTimer.stop();
         this.#queryTimer?.stop();
-        await this.#operationalInitialQueries?.close();
         // Resolve all pending promises where logic waits for the response (aka: has a timer)
         [...this.#recordWaiters.entries()].forEach(([queryId, waiters]) => {
             for (const { timer, id } of waiters) {
@@ -1137,10 +950,8 @@ export class MdnsClient implements Scanner {
         const answers = this.#structureAnswers([...message.answers, ...message.additionalRecords]);
 
         const formerAnswers = this.#getActiveQueryEarlierAnswers(message.sourceIntf);
-        // Check if we got operational discovery records and handle them
-        this.#handleOperationalRecords(answers, formerAnswers, message.sourceIntf);
 
-        // Else check if we got commissionable discovery records and handle them
+        // Check if we got commissionable discovery records and handle them
         this.#handleCommissionableRecords(answers, formerAnswers, message.sourceIntf);
 
         this.#updateIpRecords(answers, message.sourceIntf);
@@ -1258,191 +1069,6 @@ export class MdnsClient implements Scanner {
             }
         });
         return [...collectedIps.values()];
-    }
-
-    #handleOperationalRecords(
-        answers: StructuredDnsAnswers,
-        formerAnswers: StructuredDnsAnswers,
-        netInterface: string,
-    ) {
-        // Does the message contain data for an operational service?
-        if (!answers.operational) return;
-
-        const operationalTxtRecords = answers.operational[DnsRecordType.TXT] ?? [];
-        operationalTxtRecords.forEach(record => this.#handleOperationalTxtRecord(record, netInterface));
-
-        let operationalSrvRecords = answers.operational[DnsRecordType.SRV] ?? [];
-        if (!operationalSrvRecords.length && formerAnswers.operational) {
-            operationalSrvRecords = formerAnswers.operational[DnsRecordType.SRV] ?? [];
-        }
-
-        if (operationalSrvRecords.length) {
-            operationalSrvRecords.forEach(record =>
-                this.#handleOperationalSrvRecord(record, answers, formerAnswers, netInterface),
-            );
-        }
-    }
-
-    #matchesOperationalCriteria(matterName: string) {
-        const nameParts = matterName.match(/^([\dA-F]{16})-([\dA-F]{16})\._matter\._tcp\.local$/i);
-        if (!nameParts) {
-            return false;
-        }
-        const operationalId = nameParts[1];
-        const nodeId = nameParts[2];
-        return (
-            this.#operationalScanTargets.has(operationalId) ||
-            this.#operationalScanTargets.has(`${operationalId}-${nodeId}`)
-        );
-    }
-
-    /**
-     * Handle goodbye (TTL=0) for an operational device record with protection against out-of-order packets.
-     * Returns true if the goodbye was processed (record deleted or protected), false if no action needed.
-     */
-    #handleOperationalDeviceGoodbye(matterName: string, netInterface: string, now: number): boolean {
-        const existingRecord = this.#operationalDeviceRecords.get(matterName);
-        if (!existingRecord) {
-            return false;
-        }
-        const recordAge = now - existingRecord.discoveredAt;
-        if (recordAge < GOODBYE_PROTECTION_WINDOW) {
-            // Record was recently added - ignore goodbye (likely out-of-order packet)
-            return true;
-        }
-        logger.debug(
-            `Removing operational device ${matterName} from cache (interface ${netInterface}) because of ttl=0`,
-        );
-        this.#operationalDeviceRecords.delete(matterName);
-        return true;
-    }
-
-    #handleOperationalTxtRecord(record: DnsRecord<any>, netInterface: string) {
-        const { name: matterName, value, ttl } = record as DnsRecord<string[]>;
-        const now = Time.nowMs;
-
-        // we got expiry info, so we can remove the record if we know it already and are done
-        if (ttl === 0) {
-            this.#handleOperationalDeviceGoodbye(matterName, netInterface, now);
-            return;
-        }
-        const discoveredAt = now;
-        if (!Array.isArray(value)) return;
-
-        // Existing records are always updated if relevant, but no new are added if they are not matching the criteria
-        if (!this.#operationalDeviceRecords.has(matterName) && !this.#matchesOperationalCriteria(matterName)) {
-            //logger.debug(`Operational device ${matterName} is not in the list of operational scan targets, ignoring.`);
-            return;
-        }
-
-        const txtData = this.#parseTxtRecord(record);
-        if (txtData === undefined) return;
-
-        let device = this.#operationalDeviceRecords.get(matterName);
-        if (device !== undefined) {
-            device = {
-                ...device,
-                discoveredAt,
-                ttl,
-                ...txtData,
-            };
-        } else {
-            logNewService(matterName, "operational", txtData);
-            device = {
-                deviceIdentifier: matterName,
-                addresses: new Map<string, MatterServerRecordWithExpire>(),
-                discoveredAt,
-                ttl,
-                ...txtData,
-            };
-        }
-
-        this.#operationalDeviceRecords.set(matterName, device);
-    }
-
-    #handleOperationalSrvRecord(
-        record: DnsRecord<any>,
-        answers: StructuredDnsAnswers,
-        formerAnswers: StructuredDnsAnswers,
-        netInterface: string,
-    ) {
-        const {
-            name: matterName,
-            ttl,
-            value: { target, port },
-        } = record;
-
-        const now = Time.nowMs;
-
-        // We got device expiry info, so we can remove the record if we know it already and are done
-        if (ttl === 0) {
-            this.#handleOperationalDeviceGoodbye(matterName, netInterface, now);
-            return;
-        }
-
-        const ips = this.#handleIpRecords([formerAnswers, answers], target, netInterface);
-        const deviceExisted = this.#operationalDeviceRecords.has(matterName);
-
-        // Existing records are always updated if relevant, but no new are added if they are not matching the criteria
-        if (!deviceExisted && !this.#matchesOperationalCriteria(matterName)) {
-            //logger.debug(`Operational device ${matterName} is not in the list of operational scan targets, ignoring.`);
-            return;
-        }
-
-        const discoveredAt = now;
-        const device = this.#operationalDeviceRecords.get(matterName) ?? {
-            deviceIdentifier: matterName,
-            addresses: new Map<string, MatterServerRecordWithExpire>(),
-            discoveredAt,
-            ttl,
-        };
-        const ipsInitiallyEmpty = device.addresses.size === 0;
-        const { addresses } = device;
-        if (ips.length > 0) {
-            for (const { value: ip, ttl } of ips) {
-                if (ttl === 0) {
-                    const existingAddress = addresses.get(ip);
-                    if (existingAddress) {
-                        const addressAge = now - existingAddress.discoveredAt;
-                        if (addressAge < GOODBYE_PROTECTION_WINDOW) {
-                            // Address was recently added - ignore goodbye (likely out-of-order packet)
-                            continue;
-                        }
-                        logger.debug(
-                            `Removing IP ${ip} for operational device ${matterName} from cache (interface ${netInterface}) because of ttl=0`,
-                        );
-                        addresses.delete(ip);
-                    }
-                    continue;
-                }
-                const address = addresses.get(ip) ?? ({ ip, port, type: "udp" } as MatterServerRecordWithExpire);
-                address.discoveredAt = discoveredAt;
-                address.ttl = ttl;
-
-                addresses.set(address.ip, address);
-            }
-            device.addresses = addresses;
-            if (ipsInitiallyEmpty) {
-                logNewAddresses(matterName, "operational", netInterface, addresses);
-            }
-            this.#operationalDeviceRecords.set(matterName, device);
-        }
-
-        if (addresses.size === 0 && this.#hasWaiter(matterName)) {
-            // We have no or no more (because expired) IPs, and we are interested in this particular service name, request them
-            const queries = [{ name: target, recordClass: DnsRecordClass.IN, recordType: DnsRecordType.AAAA }];
-            if (this.#socket.supportsIpv4) {
-                queries.push({ name: target, recordClass: DnsRecordClass.IN, recordType: DnsRecordType.A });
-            }
-            if (this.#setQueryRecords(matterName, queries, answers)) {
-                // Only log when we are not already searching for them
-                logger.debug(
-                    `Requesting IP addresses for operational device ${matterName} (interface ${netInterface}).`,
-                );
-            }
-        } else if (addresses.size > 0) {
-            this.#finishWaiter(matterName, true, deviceExisted);
-        }
     }
 
     /**
@@ -1662,20 +1288,6 @@ export class MdnsClient implements Scanner {
 
     #expire() {
         const now = Time.nowMs;
-        [...this.#operationalDeviceRecords.entries()].forEach(([recordKey, { addresses, discoveredAt, ttl }]) => {
-            const expires = discoveredAt + this.#effectiveTTL(ttl);
-            if (now <= expires) {
-                // Only check expired IPs if not device itself has expired
-                [...addresses.entries()].forEach(([key, { discoveredAt, ttl }]) => {
-                    if (now < discoveredAt + this.#effectiveTTL(ttl)) return; // not expired yet
-                    addresses.delete(key);
-                });
-            }
-            if (now > expires && !addresses.size) {
-                // device expired and also has no addresses anymore
-                this.#operationalDeviceRecords.delete(recordKey);
-            }
-        });
         [...this.#commissionableDeviceRecords.entries()].forEach(([recordKey, { addresses, discoveredAt, ttl }]) => {
             const expires = discoveredAt + this.#effectiveTTL(ttl);
             if (now <= expires) {

--- a/packages/protocol/src/peer/ControllerDiscovery.ts
+++ b/packages/protocol/src/peer/ControllerDiscovery.ts
@@ -15,17 +15,13 @@ import {
     Seconds,
     ServerAddress,
 } from "@matter/general";
-import { NodeId } from "@matter/types";
 import {
     AddressTypeFromDevice,
     CommissionableDevice,
     CommissionableDeviceIdentifiers,
     DiscoverableDevice,
-    OperationalDevice,
     Scanner,
 } from "../common/Scanner.js";
-import { Fabric } from "../fabric/Fabric.js";
-import { MdnsClient } from "../mdns/MdnsClient.js";
 import { CommissioningError } from "./CommissioningError.js";
 
 const logger = Logger.get("ControllerDiscovery");
@@ -123,26 +119,6 @@ export class ControllerDiscovery {
         });
 
         return Array.from(finalDiscoveredDevices.values());
-    }
-
-    static async discoverOperationalDevice(
-        fabric: Fabric,
-        peerNodeId: NodeId,
-        scanner: MdnsClient,
-        timeout?: Duration,
-        ignoreExistingRecords?: boolean,
-    ): Promise<OperationalDevice> {
-        const foundDevice = await scanner.findOperationalDevice(fabric, peerNodeId, timeout, ignoreExistingRecords);
-        if (foundDevice === undefined) {
-            throw new DiscoveryError(
-                "The operational device cannot be found on the network. Please make sure it is online.",
-            );
-        }
-        return foundDevice;
-    }
-
-    static cancelOperationalDeviceDiscovery(fabric: Fabric, peerNodeId: NodeId, scanner: MdnsClient) {
-        scanner.cancelOperationalDeviceDiscovery(fabric, peerNodeId);
     }
 
     static cancelCommissionableDeviceDiscovery(scanner: Scanner, identifier: CommissionableDeviceIdentifiers = {}) {

--- a/packages/protocol/test/mdns/MdnsTest.ts
+++ b/packages/protocol/test/mdns/MdnsTest.ts
@@ -15,12 +15,10 @@ import {
     ServiceDescription,
 } from "#index.js";
 import {
-    Bytes,
     ConnectionlessTransport,
     DnsCodec,
     DnsMessage,
     DnsMessageType,
-    DnsMessageTypeFlag,
     DnsRecordType,
     Duration,
     Instant,
@@ -34,7 +32,6 @@ import {
     NetworkSimulator,
     Seconds,
     Time,
-    TxtRecord,
     UdpChannel,
 } from "@matter/general";
 import { GlobalFabricId, NodeId, VendorId } from "@matter/types";
@@ -206,11 +203,6 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
 
         function advertise(service: ServiceDescription, port = PORT) {
             const ad = getAdvertiser(port).advertise({ ...service, port }, "startup")!;
-            expect(ad).not.undefined;
-        }
-
-        async function serve(service: ServiceDescription, port = PORT) {
-            const ad = getAdvertiser(port).getAdvertisement({ ...service, port });
             expect(ad).not.undefined;
         }
 
@@ -947,17 +939,11 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
 
                 await collection;
 
-                // Same result when we just get the records
-                expect(client.getDiscoveredOperationalDevice(FABRIC, NODE_ID)?.addresses).deep.equal(undefined);
-
                 // No commissionable devices because never queried
                 expect(client.getDiscoveredCommissionableDevices({ longDiscriminator: 1234 })).deep.equal([]);
 
                 // And expire the announcement
                 await closeAll();
-
-                // And removed after expiry
-                expect(client.getDiscoveredOperationalDevice(FABRIC, NODE_ID)).deep.equal(undefined);
 
                 expect(client.getDiscoveredCommissionableDevices({ longDiscriminator: 1234 })).deep.equal([]);
             });
@@ -966,12 +952,11 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
         describe("Only commissionable discovery", () => {
             const criteria: MdnsScannerTargetCriteria = {
                 commissionable: true,
-                operationalTargets: [],
             };
             beforeEach(() => client.targetCriteriaProviders.add(criteria));
             afterEach(() => client.targetCriteriaProviders.delete(criteria));
 
-            it("the client do not know announced operational records if scanning is not enabled by criteria", async () => {
+            it("the client discovers commissionable records when scanning is enabled by criteria", async () => {
                 const collection = waitForMessages({ count: 2 });
 
                 advertise(COMMISSIONABLE_SERVICE);
@@ -979,10 +964,6 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
 
                 await collection;
 
-                // Same result when we just get the records
-                expect(client.getDiscoveredOperationalDevice(FABRIC, NODE_ID)?.addresses).deep.equal(undefined);
-
-                // No commissionable devices because never queried
                 expect(client.getDiscoveredCommissionableDevices({ longDiscriminator: 1234 })).deep.equal([
                     {
                         CM: 1,
@@ -1009,9 +990,6 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
 
                 // And expire the announcement
                 await closeAll();
-
-                // And removed after expiry
-                expect(client.getDiscoveredOperationalDevice(FABRIC, NODE_ID)).deep.equal(undefined);
 
                 expect(client.getDiscoveredCommissionableDevices({ longDiscriminator: 1234 })).deep.equal([]);
             });
@@ -1085,715 +1063,16 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
             });
         });
 
-        describe("Operational discovery", () => {
-            const criteria: MdnsScannerTargetCriteria = {
-                commissionable: false,
-                operationalTargets: [{ fabricId: GLOBAL_ID }],
-            };
-            beforeEach(() => client.targetCriteriaProviders.add(criteria));
-            afterEach(() => client.targetCriteriaProviders.delete(criteria));
-
-            it("the client directly returns server record if it has been announced before and records are removed on cancel", async () => {
-                const collection = waitForMessages(Seconds(10));
-                advertise(OPERATIONAL_SERVICE);
-
-                const messages = await collection;
-
-                const result = await client.findOperationalDevice(FABRIC, NODE_ID, Seconds.one);
-
-                // Ensure no additional queries sent (only the initial PTR query from criteria add should exist)
-                // findOperationalDevice should use cached data from the broadcast
-                expect(
-                    messages.filter(
-                        m => m?.messageType === DnsMessageType.Query && m.queries[0]?.recordType === DnsRecordType.SRV,
-                    ).length,
-                ).equals(0);
-
-                expect(result?.addresses).deep.equal(IPIntegrationResultsPort1);
-
-                // Same result when we just get the records
-                expect(client.getDiscoveredOperationalDevice(FABRIC, NODE_ID)?.addresses).deep.equal(
-                    IPIntegrationResultsPort1,
-                );
-
-                // And expire the announcement
-                await close();
-                await MockTime.yield3();
-
-                // And empty result after expiry
-                expect(client.getDiscoveredOperationalDevice(FABRIC, NODE_ID)).deep.equal(undefined);
-            });
-
-            it("the client queries the server record if it has not been announced before", async () => {
-                const sentData = new Array<Bytes>();
-                const listener = scanListener.onData((_netInterface, _peerAddress, _peerPort, data) =>
-                    sentData.push(data),
-                );
-
-                advertise(OPERATIONAL_SERVICE);
-
-                const findPromise = client.findOperationalDevice(FABRIC, NODE_ID);
-
-                await MockTime.resolve(findPromise);
-
-                // Find the SRV query (not the initial PTR query from criteria add)
-                const srvQueryData = sentData.find(data => {
-                    const msg = DnsCodec.decode(data);
-                    return msg?.queries[0]?.recordType === DnsRecordType.SRV;
-                });
-                expect(srvQueryData).not.undefined;
-                expectMessage(DnsCodec.decode(srvQueryData!), {
-                    additionalRecords: [],
-                    answers: [],
-                    authorities: [],
-                    messageType: 0,
-                    queries: [
-                        {
-                            name: "0000000000000018-0000000000000001._matter._tcp.local",
-                            recordClass: 1,
-                            recordType: 33,
-                            uniCastResponse: false,
-                        },
-                    ],
-                    transactionId: 0,
-                });
-
-                const result = await findPromise;
-
-                expect(result?.addresses).deep.equal(IPIntegrationResultsPort1);
-                await listener.close();
-
-                // Same result when we just get the records
-                expect(client.getDiscoveredOperationalDevice(FABRIC, NODE_ID)?.addresses).deep.equal(
-                    IPIntegrationResultsPort1,
-                );
-
-                // And expire the announcement
-                await close();
-
-                // And empty result after expiry
-                expect(client.getDiscoveredOperationalDevice(FABRIC, NODE_ID)).deep.equal(undefined);
-            });
-
-            it("the client queries the server record and get correct response also with multiple announced instances", async () => {
-                // Wait for 4 messages: 1 initial PTR query + 1 PTR response + 1 SRV query + 1 SRV response
-                const messages = waitForMessages({ count: 4 });
-
-                await serve(COMMISSIONABLE_SERVICE, PORT);
-                await serve(OPERATIONAL_SERVICE, PORT2);
-
-                const findPromise = client.findOperationalDevice(FABRIC, NODE_ID);
-
-                const allMessages = await MockTime.resolve(messages);
-
-                // Find the SRV query and SRV response (skip the initial PTR query/response)
-                const query = allMessages.find(
-                    m => m?.messageType === DnsMessageType.Query && m.queries[0]?.recordType === DnsRecordType.SRV,
-                );
-                // Find response that contains an SRV answer (not the PTR response from initial query)
-                const response = allMessages.find(
-                    m =>
-                        DnsMessageType.isResponse(m?.messageType ?? 0) &&
-                        m?.answers.some(a => a.recordType === DnsRecordType.SRV),
-                );
-
-                expectMessage(query, {
-                    additionalRecords: [],
-                    answers: [],
-                    authorities: [],
-                    messageType: 0,
-                    queries: [
-                        {
-                            name: "0000000000000018-0000000000000001._matter._tcp.local",
-                            recordClass: 1,
-                            recordType: 33,
-                            uniCastResponse: false,
-                        },
-                    ],
-                    transactionId: 0,
-                });
-                expectMessage(response, {
-                    additionalRecords: [
-                        {
-                            flushCache: false,
-                            name: "0000000000000018-0000000000000001._matter._tcp.local",
-                            recordClass: 1,
-                            recordType: 16,
-                            ttl: Seconds(120),
-                            value: ["SII=500", "SAI=300", "SAT=4000"],
-                        },
-                        ...IPDnsRecords,
-                    ],
-                    answers: [
-                        {
-                            flushCache: false,
-                            name: "0000000000000018-0000000000000001._matter._tcp.local",
-                            recordClass: 1,
-                            recordType: 33,
-                            ttl: Seconds(120),
-                            value: { port: PORT2, priority: 0, target: "00B0D063C2260000.local", weight: 0 },
-                        },
-                    ],
-                    authorities: [],
-                    messageType: 0x8400,
-                    queries: [],
-                    transactionId: 0,
-                });
-
-                const result = await findPromise;
-
-                expect(result?.addresses).deep.equal(IPIntegrationResultsPort2);
-
-                // Same result when we just get the records
-                expect(client.getDiscoveredOperationalDevice(FABRIC, NODE_ID)?.addresses).deep.equal(
-                    IPIntegrationResultsPort2,
-                );
-
-                // No commissionable devices because never queried
-                expect(client.getDiscoveredCommissionableDevices({ longDiscriminator: 1234 })).deep.equal([]);
-
-                // And expire the announcement
-                await closeAll();
-
-                // And empty result after expiry
-                expect(client.getDiscoveredOperationalDevice(FABRIC, NODE_ID)).deep.equal(undefined);
-            });
-
-            it("the client queries the server record and also accepts unauthoritative responses", async () => {
-                const sentData = new Array<Bytes>();
-                const listener = scanListener.onData((_netInterface, _peerAddress, _peerPort, data) =>
-                    sentData.push(data),
-                );
-                let packetManipulated = false;
-                scannerInterceptor = (packet, route) => {
-                    const message = DnsCodec.decode(packet.payload);
-                    if (message) {
-                        // If Authoritative response turn into unauthoritative answer
-                        if (message.messageType === DnsMessageType.Response) {
-                            message.messageType &= ~DnsMessageTypeFlag.AA;
-                            packet.payload = DnsCodec.encode(message);
-                            packetManipulated = true;
-                        }
-                    }
-                    route(packet);
-                };
-
-                advertise(OPERATIONAL_SERVICE);
-
-                const findPromise = client.findOperationalDevice(FABRIC, NODE_ID);
-
-                await MockTime.resolve(findPromise);
-
-                expect(packetManipulated).to.equal(true);
-
-                // Find the SRV query (not the initial PTR query from criteria add)
-                const srvQueryData = sentData.find(data => {
-                    const msg = DnsCodec.decode(data);
-                    return msg?.queries[0]?.recordType === DnsRecordType.SRV;
-                });
-                expect(srvQueryData).not.undefined;
-                expectMessage(DnsCodec.decode(srvQueryData!), {
-                    additionalRecords: [],
-                    answers: [],
-                    authorities: [],
-                    messageType: 0,
-                    queries: [
-                        {
-                            name: "0000000000000018-0000000000000001._matter._tcp.local",
-                            recordClass: 1,
-                            recordType: 33,
-                            uniCastResponse: false,
-                        },
-                    ],
-                    transactionId: 0,
-                });
-
-                const result = await findPromise;
-
-                expect(result?.addresses).deep.equal(IPIntegrationResultsPort1);
-                await listener.close();
-
-                // Same result when we just get the records
-                expect(client.getDiscoveredOperationalDevice(FABRIC, NODE_ID)?.addresses).deep.equal(
-                    IPIntegrationResultsPort1,
-                );
-
-                // And expire the announcement
-                await close();
-
-                // And empty result after expiry
-                expect(client.getDiscoveredOperationalDevice(FABRIC, NODE_ID)).deep.equal(undefined);
-            });
-
-            describe("Multiple concurrent waiters for the same query", () => {
-                it("two timed discoveries with different timeouts resolve in the correct order", async () => {
-                    // Start two findOperationalDevice calls with different timeouts
-                    // Neither will find a device (not advertised), so they should timeout and return undefined
-                    const shortTimeout = Millis(500);
-                    const longTimeout = Millis(1000);
-
-                    const shortPromise = client.findOperationalDevice(FABRIC, NODE_ID, shortTimeout);
-                    const longPromise = client.findOperationalDevice(FABRIC, NODE_ID, longTimeout);
-
-                    const results: Array<{
-                        which: string;
-                        result: typeof shortPromise extends Promise<infer T> ? T : never;
-                    }> = [];
-
-                    // Track which promise resolves first
-
-                    shortPromise.then(result => results.push({ which: "short", result })).catch(() => {});
-                    longPromise.then(result => results.push({ which: "long", result })).catch(() => {});
-
-                    // Advance past the short timeout
-                    await MockTime.advance(600);
-                    await MockTime.yield3();
-
-                    // Short timeout should have resolved first with undefined
-                    expect(results.length).equals(1);
-                    expect(results[0].which).equals("short");
-                    expect(results[0].result).equals(undefined);
-
-                    // Advance past the long timeout
-                    await MockTime.advance(500);
-                    await MockTime.yield3();
-
-                    // Long timeout should now also have resolved with undefined
-                    expect(results.length).equals(2);
-                    expect(results[1].which).equals("long");
-                    expect(results[1].result).equals(undefined);
-                });
-
-                it("two concurrent queries both resolve when a matching record is found", async () => {
-                    // Start two findOperationalDevice calls for the same device
-                    const timeout = Seconds(10);
-
-                    const promise1 = client.findOperationalDevice(FABRIC, NODE_ID, timeout);
-                    const promise2 = client.findOperationalDevice(FABRIC, NODE_ID, timeout);
-
-                    // Now advertise the device - both waiters should be notified
-                    advertise(OPERATIONAL_SERVICE);
-
-                    // Wait for the broadcast to be processed
-                    const [result1, result2] = await MockTime.resolve(Promise.all([promise1, promise2]));
-
-                    // Both should have found the device
-                    expect(result1?.addresses).deep.equal(IPIntegrationResultsPort1);
-                    expect(result2?.addresses).deep.equal(IPIntegrationResultsPort1);
-
-                    // Cleanup
-                    await close();
-                });
-            });
-        });
-
-        it("the client queries the server record with a truncated query", async () => {
-            const sentData = new Array<Bytes>();
-            const listener = scanListener.onData((_netInterface, _peerAddress, _peerPort, data) => {
-                if (DnsMessageType.isResponse(DnsCodec.decode(data)?.messageType ?? DnsMessageType.Response)) return;
-                if (sentData.some(d => Bytes.areEqual(d, data))) return; // Sort out duplicates
-                sentData.push(data);
-            });
-
-            // Intercept the message to be sent and make it bigger to generate a truncated query
-            const DUMMY_TRX_ID = 0x1234;
-            MockTime.interceptOnce(
-                MdnsSocket.prototype,
-                "send",
-                async res => res,
-                args => {
-                    const message = args[0];
-                    if (message.messageType === DnsMessageType.Query) {
-                        message.transactionId = DUMMY_TRX_ID;
-                        message.answers = [];
-                        for (let i = 0; i < 50; i++) {
-                            message.answers.push(TxtRecord("a.b.c.d", [`A=${i}`]));
-                        }
-                    }
-                    return args;
-                },
-            );
-
-            advertise(OPERATIONAL_SERVICE);
-
-            const findPromise = client.findOperationalDevice(FABRIC, NODE_ID);
-
-            await MockTime.resolve(findPromise);
-
-            const initialQuery = DnsCodec.decode(sentData[0]);
-            expect(initialQuery?.transactionId).equal(DUMMY_TRX_ID);
-            expect(initialQuery?.queries).deep.equal([
-                {
-                    name: "0000000000000018-0000000000000001._matter._tcp.local",
-                    recordClass: 1,
-                    recordType: 33,
-                    uniCastResponse: false,
-                },
-            ]);
-            expect(initialQuery?.answers.length).equal(48);
-            expect(initialQuery?.messageType).equal(DnsMessageType.Query | DnsMessageTypeFlag.TC);
-
-            const secondQuery = DnsCodec.decode(sentData[1]);
-            expect(secondQuery?.messageType).equal(DnsMessageType.Query);
-            expect(secondQuery?.transactionId).equal(DUMMY_TRX_ID);
-            expect(secondQuery?.queries).deep.equal([]);
-            expect(secondQuery?.answers.length).equal(2);
-
-            const result = await findPromise;
-
-            expect(result?.addresses).deep.equal(IPIntegrationResultsPort1);
-            await listener.close();
-            await close();
-        });
-
-        describe("Initial query on new operational targets", () => {
-            function waitForQuery(): Promise<DnsMessage> {
-                return new Promise((resolve, reject) => {
-                    const listener = scanListener.onData((_netInterface, _peerAddress, _peerPort, data) => {
-                        const message = DnsCodec.decode(data);
-                        if (message && DnsMessageType.isQuery(message.messageType)) {
-                            listener.close().then(
-                                () => resolve(message),
-                                err => reject(err as Error),
-                            );
-                        }
-                    });
-                });
-            }
-
-            it("sends initial PTR query when a new operational target is added", async () => {
-                const queryPromise = waitForQuery();
-
-                // Add criteria with operational target - should trigger initial query
-                const criteria: MdnsScannerTargetCriteria = {
-                    commissionable: false,
-                    operationalTargets: [{ fabricId: GLOBAL_ID, nodeId: NODE_ID }],
-                };
-
-                client.targetCriteriaProviders.add(criteria);
-
-                const query = await queryPromise;
-
-                expect(query.messageType).equals(DnsMessageType.Query);
-                expect(query.queries).deep.includes({
-                    name: "0000000000000018-0000000000000001._matter._tcp.local",
-                    recordClass: 1,
-                    recordType: DnsRecordType.PTR,
-                    uniCastResponse: false,
-                });
-
-                client.targetCriteriaProviders.delete(criteria);
-            });
-
-            it("sends initial PTR query for fabric-only target", async () => {
-                const queryPromise = waitForQuery();
-
-                // Add criteria with fabric-only operational target (no nodeId)
-                const criteria: MdnsScannerTargetCriteria = {
-                    commissionable: false,
-                    operationalTargets: [{ fabricId: GLOBAL_ID }],
-                };
-
-                client.targetCriteriaProviders.add(criteria);
-
-                const query = await queryPromise;
-
-                expect(query.messageType).equals(DnsMessageType.Query);
-                expect(query.queries).deep.includes({
-                    name: "_I0000000000000018._sub._matter._tcp.local",
-                    recordClass: 1,
-                    recordType: DnsRecordType.PTR,
-                    uniCastResponse: false,
-                });
-
-                client.targetCriteriaProviders.delete(criteria);
-            });
-
-            it("does not send initial query for already known targets", async () => {
-                // First add a criteria to establish a known target
-                const queryPromise1 = waitForQuery();
-
-                const criteria1: MdnsScannerTargetCriteria = {
-                    commissionable: false,
-                    operationalTargets: [{ fabricId: GLOBAL_ID, nodeId: NODE_ID }],
-                };
-
-                client.targetCriteriaProviders.add(criteria1);
-                await queryPromise1; // Wait for initial query
-
-                // Now add same target again via different criteria - should NOT trigger new query
-                let queryReceived = false;
-                const listener = scanListener.onData((_netInterface, _peerAddress, _peerPort, data) => {
-                    const message = DnsCodec.decode(data);
-                    if (message && DnsMessageType.isQuery(message.messageType)) {
-                        queryReceived = true;
-                    }
-                });
-
-                const criteria2: MdnsScannerTargetCriteria = {
-                    commissionable: false,
-                    operationalTargets: [{ fabricId: GLOBAL_ID, nodeId: NODE_ID }],
-                };
-
-                client.targetCriteriaProviders.add(criteria2);
-
-                // Wait a bit for any potential query
-                await MockTime.resolve(Time.sleep("wait", Millis(10)));
-
-                // No new queries should be sent for already known target
-                expect(queryReceived).equals(false);
-
-                await listener.close();
-                client.targetCriteriaProviders.delete(criteria1);
-                client.targetCriteriaProviders.delete(criteria2);
-            });
-
-            it("sends initial queries for multiple new targets in one message", async () => {
-                const queryPromise = waitForQuery();
-
-                const GLOBAL_ID_2 = GlobalFabricId(0x19);
-                const NODE_ID_2 = NodeId(2);
-
-                // Add criteria with multiple operational targets
-                const criteria: MdnsScannerTargetCriteria = {
-                    commissionable: false,
-                    operationalTargets: [
-                        { fabricId: GLOBAL_ID, nodeId: NODE_ID },
-                        { fabricId: GLOBAL_ID_2, nodeId: NODE_ID_2 },
-                    ],
-                };
-
-                client.targetCriteriaProviders.add(criteria);
-
-                const query = await queryPromise;
-
-                expect(query.messageType).equals(DnsMessageType.Query);
-                expect(query.queries.length).equals(2);
-                expect(query.queries).deep.includes({
-                    name: "0000000000000018-0000000000000001._matter._tcp.local",
-                    recordClass: 1,
-                    recordType: DnsRecordType.PTR,
-                    uniCastResponse: false,
-                });
-                expect(query.queries).deep.includes({
-                    name: "0000000000000019-0000000000000002._matter._tcp.local",
-                    recordClass: 1,
-                    recordType: DnsRecordType.PTR,
-                    uniCastResponse: false,
-                });
-
-                client.targetCriteriaProviders.delete(criteria);
-            });
-        });
-
-        describe("Operational and commissionable discovery", () => {
-            const criteria: MdnsScannerTargetCriteria = {
-                commissionable: true,
-                operationalTargets: [{ fabricId: GLOBAL_ID }],
-            };
-            beforeEach(() => client.targetCriteriaProviders.add(criteria));
-            afterEach(() => client.targetCriteriaProviders.delete(criteria));
-
-            it("the client knows announced records if scanning is enabled by criteria", async () => {
-                // Wait for 3 messages: 1 initial PTR query (from criteria add) + 2 broadcast responses
-                const messages = waitForMessages({ count: 3 });
-                advertise(COMMISSIONABLE_SERVICE);
-                advertise(OPERATIONAL_SERVICE, PORT2);
-
-                await messages;
-
-                // Same result when we just get the records
-                expect(client.getDiscoveredOperationalDevice(FABRIC, NODE_ID)?.addresses).deep.equal(
-                    IPIntegrationResultsPort2,
-                );
-
-                // No commissionable devices because never queried
-                expect(client.getDiscoveredCommissionableDevices({ longDiscriminator: 1234 })).deep.equal([
-                    {
-                        CM: 1,
-                        D: 1234,
-                        DN: "Test Device",
-                        DT: 1,
-                        P: 32768,
-                        PH: 33,
-                        SAI: Millis(300),
-                        SD: 4,
-                        SII: Millis(500),
-                        SAT: Seconds(4),
-                        T: 0,
-                        ICD: 0,
-                        V: 1,
-                        VP: "1+32768",
-                        addresses: IPIntegrationResultsPort1,
-                        deviceIdentifier: "8080808080808080",
-                        discoveredAt: undefined,
-                        ttl: undefined,
-                        instanceId: "8080808080808080",
-                    },
-                ]);
-
-                // And expire the announcement
-                await closeAll();
-
-                // And removed after expiry
-                expect(client.getDiscoveredOperationalDevice(FABRIC, NODE_ID)).deep.equal(undefined);
-
-                expect(client.getDiscoveredCommissionableDevices({ longDiscriminator: 1234 })).deep.equal([]);
-            });
-
-            it("the client queries the server record and get correct response when announced before", async () => {
-                const collection = waitForMessages(Seconds(10));
-
-                advertise(COMMISSIONABLE_SERVICE);
-                advertise(OPERATIONAL_SERVICE, PORT2);
-
-                const messages = await collection;
-
-                const result = await client.findOperationalDevice(FABRIC, NODE_ID, Seconds(10));
-
-                // Ensure no additional SRV queries sent (only the initial PTR query from criteria add should exist)
-                // findOperationalDevice should use cached data from the broadcast
-                expect(
-                    messages.filter(
-                        m => m?.messageType === DnsMessageType.Query && m.queries[0]?.recordType === DnsRecordType.SRV,
-                    ).length,
-                ).equals(0);
-
-                expect(result?.addresses).deep.equal(IPIntegrationResultsPort2);
-
-                // Same result when we just get the records
-                expect(client.getDiscoveredOperationalDevice(FABRIC, NODE_ID)?.addresses).deep.equal(
-                    IPIntegrationResultsPort2,
-                );
-
-                // Also commissionable devices known now
-                expect(client.getDiscoveredCommissionableDevices({ longDiscriminator: 1234 })).deep.equal([
-                    {
-                        CM: 1,
-                        D: 1234,
-                        DN: "Test Device",
-                        DT: 1,
-                        P: 32768,
-                        PH: 33,
-                        SAI: Millis(300),
-                        SD: 4,
-                        SII: Millis(500),
-                        SAT: Seconds(4),
-                        T: 0,
-                        ICD: 0,
-                        V: 1,
-                        VP: "1+32768",
-                        addresses: IPIntegrationResultsPort1,
-                        deviceIdentifier: "8080808080808080",
-                        discoveredAt: undefined,
-                        ttl: undefined,
-                        instanceId: "8080808080808080",
-                    },
-                ]);
-
-                // And expire the announcement
-                await closeAll();
-
-                // And removed after expiry
-                expect(client.getDiscoveredOperationalDevice(FABRIC, NODE_ID)).deep.equal(undefined);
-
-                expect(client.getDiscoveredCommissionableDevices({ longDiscriminator: 1234 })).deep.equal([]);
-            });
-        });
-
         describe("Goodbye protection against out-of-order packets", () => {
             const criteria: MdnsScannerTargetCriteria = {
                 commissionable: true,
-                operationalTargets: [{ fabricId: GLOBAL_ID }],
             };
             beforeEach(() => client.targetCriteriaProviders.add(criteria));
             afterEach(() => client.targetCriteriaProviders.delete(criteria));
 
-            it("ignores goodbye (TTL=0) for operational device discovered within 1 second", async () => {
-                // Wait for the initial announcement to be received
-                const messages = waitForMessages({ count: 2 });
-                advertise(OPERATIONAL_SERVICE);
-                await messages;
-
-                // Verify the device is discovered
-                expect(client.getDiscoveredOperationalDevice(FABRIC, NODE_ID)?.addresses).deep.equal(
-                    IPIntegrationResultsPort1,
-                );
-
-                // Send a goodbye message (TTL=0) immediately - simulating out-of-order packet
-                await serverSocket.send(
-                    {
-                        messageType: DnsMessageType.Response,
-                        answers: [
-                            {
-                                name: "0000000000000018-0000000000000001._matter._tcp.local",
-                                recordType: DnsRecordType.TXT,
-                                recordClass: 1,
-                                ttl: Instant, // TTL=0
-                                value: [],
-                                flushCache: false,
-                            },
-                        ],
-                    },
-                    "fake0",
-                );
-
-                // Wait for the message to be processed
-                await MockTime.resolve(Time.sleep("process", Millis(50)));
-
-                // Device should still be there - goodbye was ignored due to protection window
-                expect(client.getDiscoveredOperationalDevice(FABRIC, NODE_ID)?.addresses).deep.equal(
-                    IPIntegrationResultsPort1,
-                );
-
-                await closeAll();
-            });
-
-            it("accepts goodbye (TTL=0) for operational device discovered more than 1 second ago", async () => {
-                // Wait for an initial announcement to be received
-                const messages = waitForMessages({ count: 2 });
-                advertise(OPERATIONAL_SERVICE);
-                await messages;
-
-                // Verify device is discovered
-                expect(client.getDiscoveredOperationalDevice(FABRIC, NODE_ID)?.addresses).deep.equal(
-                    IPIntegrationResultsPort1,
-                );
-
-                // Wait more than 1 second (protection window)
-                await MockTime.resolve(Time.sleep("wait", Millis(1100)));
-
-                // Send a goodbye message (TTL=0) - now outside protection window
-                await serverSocket.send(
-                    {
-                        messageType: DnsMessageType.Response,
-                        answers: [
-                            {
-                                name: "0000000000000018-0000000000000001._matter._tcp.local",
-                                recordType: DnsRecordType.TXT,
-                                recordClass: 1,
-                                ttl: Instant, // TTL=0
-                                value: [],
-                                flushCache: false,
-                            },
-                        ],
-                    },
-                    "fake0",
-                );
-
-                // Wait for the message to be processed
-                await MockTime.resolve(Time.sleep("process", Millis(50)));
-                await MockTime.yield3();
-
-                // Device should be removed - goodbye was accepted
-                expect(client.getDiscoveredOperationalDevice(FABRIC, NODE_ID)).deep.equal(undefined);
-
-                await closeAll();
-            });
-
             it("ignores goodbye (TTL=0) for commissionable device discovered within 1 second", async () => {
                 // Wait for initial announcement to be received
-                const messages = waitForMessages({ count: 2 });
+                const messages = waitForMessages({ count: 1 });
                 advertise(COMMISSIONABLE_SERVICE);
                 await messages;
 
@@ -1832,7 +1111,7 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
 
             it("accepts goodbye (TTL=0) for commissionable device discovered more than 1 second ago", async () => {
                 // Wait for initial announcement to be received
-                const messages = waitForMessages({ count: 2 });
+                const messages = waitForMessages({ count: 1 });
                 advertise(COMMISSIONABLE_SERVICE);
                 await messages;
 
@@ -1867,45 +1146,6 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                 // Device should be removed - goodbye was accepted
                 const devicesAfter = client.getDiscoveredCommissionableDevices({ longDiscriminator: 1234 });
                 expect(devicesAfter.length).equals(0);
-
-                await closeAll();
-            });
-
-            it("ignores goodbye (TTL=0) for IP address discovered within 1 second", async () => {
-                // Wait for initial announcement to be received
-                const messages = waitForMessages({ count: 2 });
-                advertise(OPERATIONAL_SERVICE);
-                await messages;
-
-                // Verify device is discovered with addresses
-                const device = client.getDiscoveredOperationalDevice(FABRIC, NODE_ID);
-                expect(device?.addresses.length).greaterThan(0);
-                const initialAddressCount = device?.addresses.length ?? 0;
-
-                // Send a goodbye for a specific IP address immediately
-                await serverSocket.send(
-                    {
-                        messageType: DnsMessageType.Response,
-                        answers: [
-                            {
-                                name: "00B0D063C2260000.local",
-                                recordType: DnsRecordType.AAAA,
-                                recordClass: 1,
-                                ttl: Instant, // TTL=0
-                                value: SERVER_IPv6,
-                                flushCache: false,
-                            },
-                        ],
-                    },
-                    "fake0",
-                );
-
-                // Wait for message to be processed
-                await MockTime.resolve(Time.sleep("process", Millis(50)));
-
-                // IP address should still be there - goodbye was ignored due to protection window
-                const deviceAfter = client.getDiscoveredOperationalDevice(FABRIC, NODE_ID);
-                expect(deviceAfter?.addresses.length).equals(initialAddressCount);
 
                 await closeAll();
             });


### PR DESCRIPTION
* During controller startup, send a one-time wildcard PTR query for each fabric via the new `DnssdNames` solicitor so existing operational nodes respond and populate `IpService` for known peers
* Uses `solicit()` which coalesces calls in the same macrotask, so all fabrics from the `#nodeOnline()` loop produce a single multicast query
* Remove ~1200 lines of dead operational discovery code from `MdnsClient`, `Scanner` interface, `BleScanner`, `ControllerDiscovery`, and associated tests — this pipeline is fully replaced by `DnssdNames`/`IpService`

🤖 Generated with [Claude Code](https://claude.com/claude-code)