### PR TITLE
Fix: keep cluster absent from descriptor server list when peer sends data for it

### DIFF
--- a/packages/node/src/node/client/ClientStructure.ts
+++ b/packages/node/src/node/client/ClientStructure.ts
@@ -534,7 +534,7 @@ export class ClientStructure {
                 let anyPendingDelete = false;
                 for (const id of currentlySupported) {
                     const clusterStructure = this.#clusterFor(structure, id);
-                    // Only delete when peer did not sent attribute data for this cluster in the same interaction
+                    // Only delete it when peer did not sent attribute data for this cluster in the same interaction
                     // despite it not being in the server list; a device is buggy but we tolerate it by skipping the
                     // deletion, aka "Schrödinger's cluster"
                     if (!clusterStructure.pendingBehavior) {


### PR DESCRIPTION
## Problem

During a subscription (or re-subscription), a device with a buggy descriptor can trigger an unintended cluster removal. The device has a custom cluster (e.g. `NeoCluster`, id `0x125dfc11`) that it actively reports attribute data for, but omits from its descriptor's `ServerList`.

Two things happen in the same ReportData interaction for that endpoint:

1. **Descriptor `ServerList` processed** — the cluster is currently supported but not in the list → `pendingDelete = true` is set, a `rebuild` is scheduled.
2. **Cluster attribute data received** — `#synchronizeCluster` sets `pendingBehavior` on the cluster.

Regardless of which chunk arrives first, `#rebuild()` saw `pendingDelete` and called `drop()` then `continue`, silently ignoring `pendingBehavior`. Result: the cluster is removed on every re-subscription even though the peer is actively sending data for it.

An existing `TODO` comment in the code already acknowledged this gap:
```
// TODO Should we somehow validate that against descriptor serverList
// because we might load data not in there
```

Observable symptom in logs:
```
INFO  Behaviors  Removing server-X.@Y:Z.epN.<clusterName> from active endpoint
```
...immediately followed by fresh attribute updates for that same cluster.

## Fix

Guard both write sites in the data-processing flow so they cancel each other — **`pendingDelete` and `pendingBehavior` being set simultaneously means the device is reporting data for a cluster it didn't declare; we keep the cluster.**

1. **When `pendingBehavior` is set** (`#synchronizeCluster`, cluster data received): if `pendingDelete` is already on the cluster, clear it.

2. **When `pendingDelete` would be set** (ServerList processing, cluster absent from list): if `pendingBehavior` is already on the cluster, skip setting `pendingDelete`.

Both arrival orderings are covered by these two guards working together.

### Genuine removals are unaffected

Clusters truly removed from the device are absent from `ServerList` **and** send no attribute data. In that case `pendingBehavior` is `undefined`, the `else` branch runs, `pendingDelete = true` is set, and `#rebuild()` drops the cluster as before.

A `warn` log is emitted when the device inconsistency is detected so it remains visible.

## Test scenario

Device `@1:9b` endpoint 1 — `NeoCluster` (`0x125dfc11`) exists and reports data but is not in the descriptor `ServerList` (`[2, 3, 6, 29]`). Before this fix the cluster was removed on every re-subscription. After this fix it is retained and a warning is logged.