### PR TITLE
Make filesystem root path dynamic

### DIFF
--- a/packages/nodejs/src/environment/NodeJsEnvironment.ts
+++ b/packages/nodejs/src/environment/NodeJsEnvironment.ts
@@ -247,7 +247,7 @@ function configureStorage(env: Environment) {
 function configureFilesystem(env: Environment) {
     Boot.init(() => {
         if (env.vars.boolean("nodejs.filesystem")) {
-            env.set(Filesystem, new NodeJsFilesystem(env.vars.get("storage.path", rootDirOf(env))));
+            env.set(Filesystem, new NodeJsFilesystem(() => env.vars.get("storage.path", rootDirOf(env))));
             return;
         }
         // Extends default Filesystem

--- a/packages/nodejs/src/fs/NodeJsFilesystem.ts
+++ b/packages/nodejs/src/fs/NodeJsFilesystem.ts
@@ -35,10 +35,10 @@ import { finished } from "node:stream/promises";
  * Filesystem backed by the local OS filesystem via Node.js APIs.
  */
 export class NodeJsFilesystem extends Filesystem {
-    readonly #rootPath: string;
+    readonly #rootPath: string | (() => string);
     #tempCounter = 0;
 
-    constructor(workingDirectory: string) {
+    constructor(workingDirectory: string | (() => string)) {
         super();
         this.#rootPath = workingDirectory;
     }
@@ -48,15 +48,15 @@ export class NodeJsFilesystem extends Filesystem {
     }
 
     override get path() {
-        return this.#rootPath;
+        return typeof this.#rootPath === "function" ? this.#rootPath() : this.#rootPath;
     }
 
     async exists(): Promise<boolean> {
-        return nodeExists(this.#rootPath);
+        return nodeExists(this.path);
     }
 
     stat(): Promise<FilesystemNode.Stat> {
-        return nodeStat(this.#rootPath);
+        return nodeStat(this.path);
     }
 
     rename(): Promise<void> {
@@ -64,27 +64,27 @@ export class NodeJsFilesystem extends Filesystem {
     }
 
     async delete(): Promise<void> {
-        await rm(this.#rootPath, { recursive: true, force: true });
+        await rm(this.path, { recursive: true, force: true });
     }
 
     async *entries(): AsyncIterable<Directory.Entry> {
-        yield* nodeEntries(this, this.#rootPath);
+        yield* nodeEntries(this, this.path);
     }
 
     file(name: string): File {
-        return new NodeJsFile(this, resolve(this.#rootPath, name), name);
+        return new NodeJsFile(this, resolve(this.path, name), name);
     }
 
     directory(name: string): Directory {
-        return new NodeJsDirectory(this, resolve(this.#rootPath, name), name);
+        return new NodeJsDirectory(this, resolve(this.path, name), name);
     }
 
     async mkdir(): Promise<void> {
-        await mkdir(this.#rootPath, { recursive: true });
+        await mkdir(this.path, { recursive: true });
     }
 
     async copy(source: string | FilesystemNode, target: string | FilesystemNode): Promise<void> {
-        await nodeCopy(this.#rootPath, source, target);
+        await nodeCopy(this.path, source, target);
     }
 
     tempFilename(): string {

--- a/packages/nodejs/test/fs/NodeJsFilesystemTest.ts
+++ b/packages/nodejs/test/fs/NodeJsFilesystemTest.ts
@@ -342,4 +342,36 @@ describe("NodeJsFilesystem", () => {
             expect(fs.kind).equal("directory");
         });
     });
+
+    describe("Dynamic root path", () => {
+        it("resolves path from getter function", async () => {
+            const dir1 = await mkdtemp(join(tmpdir(), "matterjs-fs-dyn1-"));
+            const dir2 = await mkdtemp(join(tmpdir(), "matterjs-fs-dyn2-"));
+
+            try {
+                let currentPath = dir1;
+                const dynFs = new NodeJsFilesystem(() => currentPath);
+
+                // Write a file using the initial path
+                await dynFs.file("test.txt").write("hello");
+                expect(await dynFs.file("test.txt").readAllText()).equal("hello");
+                expect(dynFs.path).equal(dir1);
+
+                // Switch the root path
+                currentPath = dir2;
+                expect(dynFs.path).equal(dir2);
+
+                // File operations now target the new root
+                await dynFs.file("test.txt").write("world");
+                expect(await dynFs.file("test.txt").readAllText()).equal("world");
+
+                // Original file is still in the old directory
+                const oldFs = new NodeJsFilesystem(dir1);
+                expect(await oldFs.file("test.txt").readAllText()).equal("hello");
+            } finally {
+                await rm(dir1, { recursive: true, force: true });
+                await rm(dir2, { recursive: true, force: true });
+            }
+        });
+    });
 });


### PR DESCRIPTION
`Filesystem.path` now behaves identically to `StorageService.location` with fs-based storage