### PR TITLE
Allow shared access to storage drivers

### DIFF
--- a/packages/general/src/storage/DatafileRoot.ts
+++ b/packages/general/src/storage/DatafileRoot.ts
@@ -20,7 +20,7 @@ import { DataNamespace } from "./DataNamespace.js";
 export class DatafileRoot extends DataNamespace {
     #directory: Directory;
     #release?: () => MaybePromise<void>;
-    #refCount = 0;
+    #refs = 0;
     #lockPromise?: Promise<DatafileRoot.Lock>;
 
     constructor(directory: Directory) {
@@ -37,7 +37,7 @@ export class DatafileRoot extends DataNamespace {
     }
 
     get isLocked(): boolean {
-        return this.#refCount > 0;
+        return this.#refs > 0;
     }
 
     /**
@@ -62,17 +62,17 @@ export class DatafileRoot extends DataNamespace {
     }
 
     async #acquireRef(): Promise<DatafileRoot.Lock> {
-        if (this.#refCount === 0) {
+        if (this.#refs === 0) {
             this.#release = await this.#directory.lock();
         }
-        this.#refCount++;
+        this.#refs++;
 
         return new DatafileRoot.Lock(this.#directory, () => this.#releaseRef());
     }
 
     async #releaseRef(): Promise<void> {
-        this.#refCount--;
-        if (this.#refCount === 0) {
+        this.#refs--;
+        if (this.#refs === 0) {
             const release = this.#release;
             this.#release = undefined;
             await release?.();

--- a/packages/general/src/storage/StorageDriverHandle.ts
+++ b/packages/general/src/storage/StorageDriverHandle.ts
@@ -1,0 +1,103 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Bytes } from "#util/Bytes.js";
+import { MaybePromise } from "../util/Promises.js";
+import { CloneableStorage, StorageDriver } from "./StorageDriver.js";
+import { SupportedStorageTypes } from "./StringifyTools.js";
+
+/**
+ * A lightweight handle that delegates all operations to an underlying {@link StorageDriver}.
+ *
+ * {@link StorageService} returns these instead of raw drivers so that multiple callers can share the same underlying
+ * driver instance.  {@link close} calls a release callback (to decrement a reference count) rather than closing the
+ * real driver.
+ */
+export class StorageDriverHandle extends StorageDriver {
+    #driver: StorageDriver;
+    #release: () => MaybePromise<void>;
+    clone?: () => MaybePromise<StorageDriver>;
+
+    constructor(driver: StorageDriver, release: () => MaybePromise<void>) {
+        super();
+        this.#driver = driver;
+        this.#release = release;
+
+        // If the underlying driver supports cloning, expose clone() so CloneableStorage.is() detects this handle
+        if (CloneableStorage.is(driver)) {
+            this.clone = () => driver.clone();
+        }
+    }
+
+    override get id() {
+        return this.#driver.id;
+    }
+
+    override get initialized() {
+        return this.#driver.initialized;
+    }
+
+    override initialize(): MaybePromise<void> {
+        // No-op — the underlying driver is already initialized
+    }
+
+    override close(): MaybePromise<void> {
+        return this.#release();
+    }
+
+    override get(contexts: string[], key: string): MaybePromise<SupportedStorageTypes | undefined> {
+        return this.#driver.get(contexts, key);
+    }
+
+    override set(contexts: string[], values: Record<string, SupportedStorageTypes>): MaybePromise<void>;
+    override set(contexts: string[], key: string, value: SupportedStorageTypes): MaybePromise<void>;
+    override set(
+        contexts: string[],
+        keyOrValues: string | Record<string, SupportedStorageTypes>,
+        value?: SupportedStorageTypes,
+    ): MaybePromise<void> {
+        if (typeof keyOrValues === "string") {
+            return this.#driver.set(contexts, keyOrValues, value!);
+        }
+        return this.#driver.set(contexts, keyOrValues);
+    }
+
+    override delete(contexts: string[], key: string): MaybePromise<void> {
+        return this.#driver.delete(contexts, key);
+    }
+
+    override keys(contexts: string[]): MaybePromise<string[]> {
+        return this.#driver.keys(contexts);
+    }
+
+    override values(contexts: string[]): MaybePromise<Record<string, SupportedStorageTypes>> {
+        return this.#driver.values(contexts);
+    }
+
+    override contexts(contexts: string[]): MaybePromise<string[]> {
+        return this.#driver.contexts(contexts);
+    }
+
+    override clearAll(contexts: string[]): MaybePromise<void> {
+        return this.#driver.clearAll(contexts);
+    }
+
+    override has(contexts: string[], key: string): MaybePromise<boolean> {
+        return this.#driver.has(contexts, key);
+    }
+
+    override openBlob(contexts: string[], key: string): MaybePromise<Blob> {
+        return this.#driver.openBlob(contexts, key);
+    }
+
+    override writeBlobFromStream(contexts: string[], key: string, stream: ReadableStream<Bytes>): MaybePromise<void> {
+        return this.#driver.writeBlobFromStream(contexts, key, stream);
+    }
+
+    override begin(): MaybePromise<StorageDriver.Transaction> {
+        return this.#driver.begin();
+    }
+}

--- a/packages/general/src/storage/StorageService.ts
+++ b/packages/general/src/storage/StorageService.ts
@@ -13,6 +13,7 @@ import { Logger } from "../log/Logger.js";
 import { DataNamespace } from "./DataNamespace.js";
 import { DatafileRoot } from "./DatafileRoot.js";
 import { StorageDriver } from "./StorageDriver.js";
+import { StorageDriverHandle } from "./StorageDriverHandle.js";
 import { StorageManager } from "./StorageManager.js";
 import { StorageMigration } from "./StorageMigration.js";
 
@@ -26,6 +27,7 @@ export class StorageService {
     #defaultDriver = "wal";
     #configuredDriver?: string;
     #environment: Environment;
+    #openDrivers = new Map<string, { driver: StorageDriver; refs: number }>();
 
     constructor(environment: Environment) {
         environment.set(StorageService, this);
@@ -105,16 +107,23 @@ export class StorageService {
             dataNs = namespace;
         }
 
+        const cacheKey = dataNs.namespace;
+        const cached = this.#openDrivers.get(cacheKey);
+        if (cached) {
+            cached.refs++;
+            return new StorageManager(new StorageDriverHandle(cached.driver, () => this.#release(cacheKey)));
+        }
+
         // Filesystem path — full detection, migration, driver.json
         if (dataNs instanceof DatafileRoot) {
-            return this.#openFilesystem(dataNs);
+            return this.#openFilesystem(cacheKey, dataNs);
         }
 
         // Non-filesystem path — simple create, no detection/migration
-        return this.#openSimple(dataNs);
+        return this.#openSimple(cacheKey, dataNs);
     }
 
-    async #openFilesystem(root: DatafileRoot) {
+    async #openFilesystem(cacheKey: string, root: DatafileRoot) {
         const fs = this.#environment.get(Filesystem);
         const dir = root.directory;
         const namespace = root.namespace;
@@ -167,12 +176,14 @@ export class StorageService {
             await this.#writeDescriptor(dir, descriptor);
         }
 
-        const manager = new StorageManager(storage);
+        this.#openDrivers.set(cacheKey, { driver: storage, refs: 1 });
+
+        const manager = new StorageManager(new StorageDriverHandle(storage, () => this.#release(cacheKey)));
         await manager.initialize();
         return manager;
     }
 
-    async #openSimple(dataNs: DataNamespace) {
+    async #openSimple(cacheKey: string, dataNs: DataNamespace) {
         const targetKind = this.#configuredDriver ?? this.#defaultDriver;
         const descriptor: StorageDriver.Descriptor = { kind: targetKind };
 
@@ -183,9 +194,23 @@ export class StorageService {
 
         const storage = await impl.create(dataNs, descriptor);
 
-        const manager = new StorageManager(storage);
+        this.#openDrivers.set(cacheKey, { driver: storage, refs: 1 });
+
+        const manager = new StorageManager(new StorageDriverHandle(storage, () => this.#release(cacheKey)));
         await manager.initialize();
         return manager;
+    }
+
+    async #release(cacheKey: string) {
+        const cached = this.#openDrivers.get(cacheKey);
+        if (!cached) {
+            return;
+        }
+        cached.refs--;
+        if (cached.refs <= 0) {
+            this.#openDrivers.delete(cacheKey);
+            await cached.driver.close();
+        }
     }
 
     /**

--- a/packages/general/src/storage/index.ts
+++ b/packages/general/src/storage/index.ts
@@ -11,6 +11,7 @@ export * from "./MemoryStorageDriver.js";
 export * from "./MockStorageService.js";
 export * from "./StorageContext.js";
 export * from "./StorageDriver.js";
+export * from "./StorageDriverHandle.js";
 export * from "./StorageManager.js";
 export * from "./StorageMigration.js";
 export * from "./StorageService.js";


### PR DESCRIPTION
@matter/shell and various examples open redundant copies of storage drivers.  This causes issues with drivers that assume exclusive access.  Modify `StorageService` to use reference counting to provide multiple callers with the same `StorageDriver` instance and thus properly support this pattern.