### PR TITLE
Graceful shutdown in storage paths

### DIFF
--- a/packages/general/src/storage/StorageService.ts
+++ b/packages/general/src/storage/StorageService.ts
@@ -171,16 +171,25 @@ export class StorageService {
         // Create the driver — pass root so it can acquire a ref-counted lock
         const storage = await impl.create(root, descriptor);
 
-        // Write driver.json if the directory exists after creation (before initialize, so we persist intent)
-        if (await dir.exists()) {
-            await this.#writeDescriptor(dir, descriptor);
+        try {
+            // Write driver.json if the directory exists after creation (before initialize, so we persist intent)
+            if (await dir.exists()) {
+                await this.#writeDescriptor(dir, descriptor);
+            }
+
+            this.#openDrivers.set(cacheKey, { driver: storage, refs: 1 });
+
+            const manager = new StorageManager(new StorageDriverHandle(storage, () => this.#release(cacheKey)));
+            await manager.initialize();
+            return manager;
+        } catch (e) {
+            try {
+                await storage.close();
+            } catch (closeError) {
+                logger.warn("Error closing storage after failed initialization:", closeError);
+            }
+            throw e;
         }
-
-        this.#openDrivers.set(cacheKey, { driver: storage, refs: 1 });
-
-        const manager = new StorageManager(new StorageDriverHandle(storage, () => this.#release(cacheKey)));
-        await manager.initialize();
-        return manager;
     }
 
     async #openSimple(cacheKey: string, dataNs: DataNamespace) {
@@ -194,11 +203,20 @@ export class StorageService {
 
         const storage = await impl.create(dataNs, descriptor);
 
-        this.#openDrivers.set(cacheKey, { driver: storage, refs: 1 });
+        try {
+            this.#openDrivers.set(cacheKey, { driver: storage, refs: 1 });
 
-        const manager = new StorageManager(new StorageDriverHandle(storage, () => this.#release(cacheKey)));
-        await manager.initialize();
-        return manager;
+            const manager = new StorageManager(new StorageDriverHandle(storage, () => this.#release(cacheKey)));
+            await manager.initialize();
+            return manager;
+        } catch (e) {
+            try {
+                await storage.close();
+            } catch (closeError) {
+                logger.warn("Error closing storage after failed initialization:", closeError);
+            }
+            throw e;
+        }
     }
 
     async #release(cacheKey: string) {

--- a/packages/matter.js/src/MatterController.ts
+++ b/packages/matter.js/src/MatterController.ts
@@ -159,48 +159,54 @@ export class MatterController {
 
         const baseStorage: StorageManager = await options.environment.get(StorageService).open(options.id);
 
-        // Storage data migration from legacy Controller to ServerNode based controller
-        const oldStorage = baseStorage.createContext("credentials");
-        const newStorage = baseStorage.createContext("certificates");
-        const newFabricStorage = baseStorage.createContext("fabrics");
+        try {
+            // Storage data migration from legacy Controller to ServerNode based controller
+            const oldStorage = baseStorage.createContext("credentials");
+            const newStorage = baseStorage.createContext("certificates");
+            const newFabricStorage = baseStorage.createContext("fabrics");
 
-        const keys = await oldStorage.keys();
+            const keys = await oldStorage.keys();
 
-        const newFabrics = await newFabricStorage.get<Fabric.Config[]>("fabrics", []);
-        if (keys.length !== 0) {
-            for (const key of await oldStorage.keys()) {
-                if (key === "fabric") {
-                    if (rootFabric !== undefined) {
-                        logger.debug("Skipping fabric migration because a rootFabric was provided.");
-                        continue;
-                    }
-                    const oldFabric = await oldStorage.get<Fabric.Config>("fabric");
-                    if (
-                        newFabrics.length &&
-                        newFabrics.some(
-                            fab =>
-                                fab.fabricIndex === oldFabric.fabricIndex &&
-                                Bytes.areEqual(fab.rootCert, oldFabric.rootCert),
-                        )
-                    ) {
-                        logger.debug("Skipping fabric migration because a new storage already has matching fabric");
-                        continue;
-                    }
-                    fabric = await Fabric.create(Environment.default.get(Crypto), oldFabric);
-                } else {
-                    // Migrates Certificate Authority data to a new location
-                    if (!(await newStorage.has(key))) {
-                        await newStorage.set(key, await oldStorage.get(key));
+            const newFabrics = await newFabricStorage.get<Fabric.Config[]>("fabrics", []);
+            if (keys.length !== 0) {
+                for (const key of await oldStorage.keys()) {
+                    if (key === "fabric") {
+                        if (rootFabric !== undefined) {
+                            logger.debug("Skipping fabric migration because a rootFabric was provided.");
+                            continue;
+                        }
+                        const oldFabric = await oldStorage.get<Fabric.Config>("fabric");
+                        if (
+                            newFabrics.length &&
+                            newFabrics.some(
+                                fab =>
+                                    fab.fabricIndex === oldFabric.fabricIndex &&
+                                    Bytes.areEqual(fab.rootCert, oldFabric.rootCert),
+                            )
+                        ) {
+                            logger.debug("Skipping fabric migration because a new storage already has matching fabric");
+                            continue;
+                        }
+                        fabric = await Fabric.create(Environment.default.get(Crypto), oldFabric);
+                    } else {
+                        // Migrates Certificate Authority data to a new location
+                        if (!(await newStorage.has(key))) {
+                            await newStorage.set(key, await oldStorage.get(key));
+                        }
                     }
                 }
             }
-        }
 
-        if (rootCertificateAuthority !== undefined) {
-            environment.set(CertificateAuthority, rootCertificateAuthority);
+            if (rootCertificateAuthority !== undefined) {
+                environment.set(CertificateAuthority, rootCertificateAuthority);
+            }
+        } finally {
+            try {
+                await baseStorage.close();
+            } catch (closeError) {
+                logger.warn("Error closing base storage:", closeError);
+            }
         }
-
-        await baseStorage.close();
 
         controller = new MatterController({
             ...options,

--- a/packages/nodejs-shell/src/app.ts
+++ b/packages/nodejs-shell/src/app.ts
@@ -182,16 +182,10 @@ process.on("message", function (message) {
 });
 
 export async function exit(code = 0) {
-    process.off("SIGINT", sigIntHandler);
-    process.emit("SIGINT");
-    process.exit(code);
+    process.exitCode = code;
+    Environment.default.runtime.cancel();
 }
 
-const sigIntHandler = () => {
-    // Pragmatic way to make sure the storage is correctly closed before the process ends.
-    exit().catch(error => logger.error(error));
-};
-
-process.on("SIGINT", sigIntHandler);
-
-Environment.default.runtime.add(main());
+const runtime = Environment.default.runtime;
+runtime.add(main());
+void runtime.inactive.then(() => process.exit(process.exitCode ?? 0));


### PR DESCRIPTION
Implement clean shutdown for shell and try to ensure StorageDriver close in error paths.  For shell shutdown we use runtime cancel but then also fall back on process.exit() in case anything lingers.

Primary goal is to avoid node warnings when an open wal log file handle is gc'ed, but also just good hygiene.