### PR TITLE
Fix inverted autoConnect logic in CommissioningController

### DIFF
--- a/packages/matter.js/src/CommissioningController.ts
+++ b/packages/matter.js/src/CommissioningController.ts
@@ -404,7 +404,7 @@ export class CommissioningController {
                 continue;
             }
             const networkState = peer.stateOf(NetworkClient);
-            const desiredDisabled = !!this.#options.autoConnect;
+            const desiredDisabled = this.#options.autoConnect === false;
             if (desiredDisabled !== networkState.isDisabled) {
                 await peer.set({ network: { isDisabled: desiredDisabled } });
             }


### PR DESCRIPTION
## Summary

- **Bug:** `CommissioningController.#initializeController()` computes the peer network `isDisabled` flag as `!!this.#options.autoConnect`, which inverts the intended behavior — `autoConnect: true` disables the network, and `autoConnect: false` enables it.
- **Fix:** Change to `this.#options.autoConnect === false` so only an explicit `false` disables auto-connection, matching the JSDoc contract where `true` and `undefined` both mean "connect all nodes on startup".

## Details

At line 407 of `CommissioningController.ts`, the peer network disabled state was set as:

```typescript
const desiredDisabled = !!this.#options.autoConnect;
```

| `autoConnect` value | Before (buggy) `isDisabled` | After (fixed) `isDisabled` |
|---|---|---|
| `true` | `true` (network off) | `false` (network on) |
| `undefined` | `false` (network on) | `false` (network on) |
| `false` | `false` (network on) | `true` (network off) |

Users upgrading from older versions with `autoConnect: true` found their nodes no longer connecting on startup. The workaround was to set `autoConnect: false` (which paradoxically enabled connections) and manually call `get()` on each cluster to trigger lazy initialization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)