### PR TITLE
Prevent duplicate Failsafe on reconnect

### DIFF
--- a/packages/protocol/src/peer/ControllerCommissioningFlow.ts
+++ b/packages/protocol/src/peer/ControllerCommissioningFlow.ts
@@ -519,7 +519,6 @@ export class ControllerCommissioningFlow {
             stepNumber: 18, // includes step 19 (CASE connection)
             subStepNumber: 1,
             name: "Reconnect",
-            reArmFailsafe: true,
             stepLogic: () => this.#reconnectWithDevice(),
         });
 


### PR DESCRIPTION
... we already set the failsafe in the method with a higehr value so no need to do directly before