### PR TITLE
Fix shell storage not closing on CTRL-C and CTRL-D

### DIFF
--- a/packages/nodejs-shell/src/MatterNode.ts
+++ b/packages/nodejs-shell/src/MatterNode.ts
@@ -138,9 +138,12 @@ export class MatterNode {
     }
 
     async close() {
-        await this.commissioningController?.close();
-        this.#observers?.close();
-        await this.#storageManager?.close();
+        try {
+            await this.commissioningController?.close();
+        } finally {
+            this.#observers?.close();
+            await this.#storageManager?.close();
+        }
     }
 
     async start() {

--- a/packages/nodejs-shell/src/shell/Shell.ts
+++ b/packages/nodejs-shell/src/shell/Shell.ts
@@ -107,6 +107,20 @@ export class Shell {
                         process.exit(1);
                     });
             })
+            .on("SIGINT", () => {
+                // Readline in terminal mode intercepts CTRL-C as a keypress and does not
+                // propagate it as a process signal, so we need to handle it explicitly.
+                console.log("\nGoodbye.");
+                try {
+                    this.writeStream?.end();
+                } catch (e) {
+                    process.stderr.write(`Error happened during history file write: ${e}\n`);
+                }
+                exit().catch(e => {
+                    process.stderr.write(`Exit error: ${e}\n`);
+                    process.exit(1);
+                });
+            })
             .on("close", () => {
                 try {
                     this.writeStream?.end();
@@ -115,12 +129,10 @@ export class Shell {
                 }
                 // only exit if we are running in a terminal
                 if (this.input === process.stdin && this.output === process.stdout) {
-                    exit()
-                        .then(() => process.exit(0))
-                        .catch(e => {
-                            process.stderr.write(`Close error: ${e}\n`);
-                            process.exit(1);
-                        });
+                    exit().catch(e => {
+                        process.stderr.write(`Close error: ${e}\n`);
+                        process.exit(1);
+                    });
                 }
             });
 


### PR DESCRIPTION
## Summary
- **CTRL-C fix**: Readline in terminal mode intercepts CTRL-C as a keypress (raw mode) and never propagates it as a process signal. Added explicit `SIGINT` listener on the readline interface to trigger clean shutdown.
- **CTRL-D fix**: Removed premature `process.exit(0)` from the `close` handler that was killing the process before async cleanup (`MatterNode.close()` / `storageManager.close()`) could complete. The `runtime.inactive` handler in `app.ts` already exits the process after all workers finish.
- **Resilient close**: Wrapped `commissioningController.close()` in try/finally in `MatterNode.close()` so storage is always closed even if the controller close throws.

## Test plan
- [ ] Start the shell, press CTRL-C — verify "Goodbye." is printed and shutdown log messages appear
- [ ] Start the shell, press CTRL-D — verify clean shutdown with storage properly closed
- [ ] Start the shell, type `exit` — verify clean shutdown
- [ ] Verify no storage lock files remain after exit

🤖 Generated with [Claude Code](https://claude.com/claude-code)