### PR TITLE
Improve stale lock detection in Docker

### DIFF
--- a/packages/nodejs/src/fs/lock-utils.ts
+++ b/packages/nodejs/src/fs/lock-utils.ts
@@ -5,6 +5,7 @@
  */
 
 import { Logger, StorageLockError } from "@matter/general";
+import { randomBytes } from "node:crypto";
 import { open as fsOpen, readFile, stat, unlink, writeFile } from "node:fs/promises";
 import { resolve } from "node:path";
 
@@ -12,6 +13,17 @@ const logger = Logger.get("NodeJsDirectoryLock");
 
 const LOCK_FILE = "matter.lock";
 const PID_FILE = "matter.pid";
+
+/**
+ * A random token unique to this process instance.  Written alongside the PID so we can detect PID reuse (e.g. in
+ * Docker where the new container's entrypoint often gets the same PID as the old one).
+ */
+const PROCESS_TOKEN = randomBytes(8).toString("hex");
+
+interface LockInfo {
+    pid: number;
+    token?: string;
+}
 
 /**
  * Acquire an exclusive lock on a directory using O_EXCL and a PID file for stale-lock detection.
@@ -29,7 +41,7 @@ export async function acquireDirectoryLock(dirPath: string, dirName: string): Pr
     }
 
     await acquireLock(lockPath, pidPath);
-    await writeFile(pidPath, String(process.pid));
+    await writeFile(pidPath, `${process.pid} ${PROCESS_TOKEN}`);
 
     logger.debug("Acquired storage lock for", dirName, "pid", process.pid);
 
@@ -50,7 +62,9 @@ async function acquireLock(lockPath: string, pidPath: string) {
         }
 
         // Lock file exists — check if the owning process is still alive
-        if (await isStale(pidPath)) {
+        const info = await readLockInfo(pidPath);
+
+        if (isStale(info)) {
             logger.info("Cleaning stale storage lock");
             await safeUnlink(pidPath);
             await safeUnlink(lockPath);
@@ -65,22 +79,34 @@ async function acquireLock(lockPath: string, pidPath: string) {
                 }
                 throw retryError;
             }
+        } else if (info?.pid === process.pid) {
+            throw new StorageLockError("Storage is already locked by this process");
         } else {
-            const ownerPid = await readPid(pidPath);
-            throw new StorageLockError(`Storage is locked by another process (pid ${ownerPid})`);
+            throw new StorageLockError(`Storage is locked by another process (pid ${info?.pid})`);
         }
     }
 }
 
-async function isStale(pidPath: string): Promise<boolean> {
-    const pid = await readPid(pidPath);
-    if (pid === undefined) {
-        // No PID file or unreadable — treat as stale (crash between lock and PID write)
+/**
+ * A lock is stale if:
+ *
+ * - There is no PID file (crash between lock creation and PID write)
+ * - The owning process no longer exists
+ * - The PID matches ours but the token differs (PID reuse, e.g. Docker container restart)
+ */
+function isStale(info: LockInfo | undefined): boolean {
+    if (info === undefined) {
         return true;
     }
 
+    if (info.pid === process.pid) {
+        // Same PID — check whether it's actually us via the token.  If the token matches, the lock is held by another
+        // call site in this process.  If it differs (or is missing from an old-format file), the PID was reused.
+        return info.token !== PROCESS_TOKEN;
+    }
+
     try {
-        process.kill(pid, 0);
+        process.kill(info.pid, 0);
         // Process exists and we have permission to signal it — lock is not stale
         return false;
     } catch (error) {
@@ -93,11 +119,15 @@ async function isStale(pidPath: string): Promise<boolean> {
     }
 }
 
-async function readPid(pidPath: string): Promise<number | undefined> {
+async function readLockInfo(pidPath: string): Promise<LockInfo | undefined> {
     try {
         const content = await readFile(pidPath, "utf-8");
-        const pid = parseInt(content.trim(), 10);
-        return Number.isFinite(pid) && pid > 0 ? pid : undefined;
+        const parts = content.trim().split(/\s+/);
+        const pid = parseInt(parts[0], 10);
+        if (!Number.isFinite(pid) || pid <= 0) {
+            return undefined;
+        }
+        return { pid, token: parts[1] };
     } catch {
         return undefined;
     }

--- a/packages/nodejs/test/fs/DirectoryLockTest.ts
+++ b/packages/nodejs/test/fs/DirectoryLockTest.ts
@@ -1,0 +1,132 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { acquireDirectoryLock } from "#fs/lock-utils.js";
+import { StorageLockError } from "@matter/general";
+import { spawn } from "node:child_process";
+import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+describe("DirectoryLock", () => {
+    let rootDir: string;
+
+    beforeEach(async () => {
+        rootDir = await mkdtemp(join(tmpdir(), "matterjs-lock-test-"));
+    });
+
+    afterEach(async () => {
+        await rm(rootDir, { recursive: true, force: true });
+    });
+
+    it("acquires and releases lock files", async () => {
+        const release = await acquireDirectoryLock(rootDir, "test");
+
+        // Lock and PID files should exist
+        await expectFileExists(join(rootDir, "matter.lock"));
+        await expectFileExists(join(rootDir, "matter.pid"));
+
+        // PID file should contain our PID and a token
+        const content = await readFile(join(rootDir, "matter.pid"), "utf-8");
+        const parts = content.trim().split(/\s+/);
+        expect(parts).length(2);
+        expect(parseInt(parts[0], 10)).equal(process.pid);
+        expect(parts[1]).match(/^[0-9a-f]{16}$/);
+
+        await release();
+
+        // Both files should be gone
+        await expectFileNotExists(join(rootDir, "matter.lock"));
+        await expectFileNotExists(join(rootDir, "matter.pid"));
+    });
+
+    it("throws on in-process conflict", async () => {
+        const release = await acquireDirectoryLock(rootDir, "test");
+
+        try {
+            await expect(acquireDirectoryLock(rootDir, "test")).rejectedWith(
+                StorageLockError,
+                "Storage is already locked by this process",
+            );
+        } finally {
+            await release();
+        }
+    });
+
+    it("cleans up stale lock from dead process", async () => {
+        // Simulate a stale lock left by a process that no longer exists.  PID 2147483647 is the max PID on most
+        // systems and is extremely unlikely to be alive.
+        await writeFile(join(rootDir, "matter.lock"), "");
+        await writeFile(join(rootDir, "matter.pid"), "2147483647 deadbeefdeadbeef");
+
+        const release = await acquireDirectoryLock(rootDir, "test");
+
+        // Should have acquired the lock successfully
+        const content = await readFile(join(rootDir, "matter.pid"), "utf-8");
+        expect(parseInt(content.trim().split(/\s+/)[0], 10)).equal(process.pid);
+
+        await release();
+    });
+
+    it("cleans up stale lock from reused PID", async () => {
+        // Simulate the Docker PID-reuse scenario: the PID file has our own PID but a different token
+        await writeFile(join(rootDir, "matter.lock"), "");
+        await writeFile(join(rootDir, "matter.pid"), `${process.pid} aaaaaaaaaaaaaaaa`);
+
+        const release = await acquireDirectoryLock(rootDir, "test");
+
+        // Should have acquired the lock — the stale lock was cleaned up
+        const content = await readFile(join(rootDir, "matter.pid"), "utf-8");
+        const parts = content.trim().split(/\s+/);
+        expect(parseInt(parts[0], 10)).equal(process.pid);
+        expect(parts[1]).not.equal("aaaaaaaaaaaaaaaa");
+
+        await release();
+    });
+
+    it("throws on out-of-process conflict", async () => {
+        // Spawn a real process that sleeps briefly so we have a live PID to write into the lock file
+        const child = spawn(process.argv[0], ["-e", "setTimeout(() => {}, 30000)"], { stdio: "ignore" });
+
+        try {
+            await writeFile(join(rootDir, "matter.lock"), "");
+            await writeFile(join(rootDir, "matter.pid"), `${child.pid} cafecafecafecafe`);
+
+            await expect(acquireDirectoryLock(rootDir, "test")).rejectedWith(
+                StorageLockError,
+                `Storage is locked by another process (pid ${child.pid})`,
+            );
+        } finally {
+            child.kill();
+        }
+    });
+
+    it("cleans up stale lock with old PID-only format", async () => {
+        // Backward compat: old lock files without a token should be treated as stale when the process is dead
+        await writeFile(join(rootDir, "matter.lock"), "");
+        await writeFile(join(rootDir, "matter.pid"), "2147483647");
+
+        const release = await acquireDirectoryLock(rootDir, "test");
+        await release();
+    });
+});
+
+async function expectFileExists(path: string) {
+    try {
+        await stat(path);
+    } catch {
+        expect.fail(`Expected file to exist: ${path}`);
+    }
+}
+
+async function expectFileNotExists(path: string) {
+    try {
+        await stat(path);
+        expect.fail(`Expected file not to exist: ${path}`);
+    } catch (e) {
+        expect((e as NodeJS.ErrnoException).code).equal("ENOENT");
+    }
+}


### PR DESCRIPTION
In Docker containers the new process often gets the same PID as the old one, so the existing `process.kill(pid, 0)` check sees "alive" and refuses to clean up the stale lock.

* Write a random per-process token alongside the PID in `matter.pid`
* When PID matches ours but token differs, treat lock as stale
* Backward compatible with old PID-only format
* Add DirectoryLock tests covering acquire/release, stale cleanup, PID reuse, and cross-process conflict