### PR TITLE
Fix WalWriter reentrancy bugs causing file handle leaks

### DIFF
--- a/packages/general/src/storage/wal/WalStorageDriver.ts
+++ b/packages/general/src/storage/wal/WalStorageDriver.ts
@@ -62,6 +62,7 @@ export class WalStorageDriver extends FilesystemStorageDriver implements Cloneab
     readonly #storageDir: Directory;
     readonly #options: WalStorageDriver.Options;
     #cache?: StoreData;
+    #cacheLoading?: Promise<StoreData>;
     #abort = new Abort();
     #workers = new BasicMultiplex();
     #initialized = false;
@@ -261,6 +262,7 @@ export class WalStorageDriver extends FilesystemStorageDriver implements Cloneab
             this.#lastCommitId = id;
             this.#lastCommitTs = ts;
             this.#cache = undefined;
+            this.#cacheLoading = undefined;
         });
     }
 
@@ -357,6 +359,20 @@ export class WalStorageDriver extends FilesystemStorageDriver implements Cloneab
             return this.#cache;
         }
 
+        if (this.#cacheLoading) {
+            return this.#cacheLoading;
+        }
+
+        this.#cacheLoading = this.#doLoadCache();
+
+        try {
+            return await this.#cacheLoading;
+        } finally {
+            this.#cacheLoading = undefined;
+        }
+    }
+
+    async #doLoadCache(): Promise<StoreData> {
         const store: StoreData = {};
         let afterCommitId: WalCommitId | undefined;
 

--- a/packages/general/src/storage/wal/WalWriter.ts
+++ b/packages/general/src/storage/wal/WalWriter.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { Mutex } from "#util/Mutex.js";
 import type { Directory } from "../../fs/Directory.js";
 import type { File } from "../../fs/File.js";
 import {
@@ -25,6 +26,7 @@ export class WalWriter {
     readonly #maxSegmentSize: number;
     readonly #fsync: boolean;
     readonly #onRotate?: (closedSegment: number) => void;
+    readonly #mutex = new Mutex(this);
 
     #handle?: File.Handle;
     #currentSegment = 0;
@@ -50,37 +52,40 @@ export class WalWriter {
      * Write a commit to the WAL, returning its commit ID and timestamp.
      */
     async write(ops: WalOp[]): Promise<{ id: WalCommitId; ts: number }> {
-        if (!this.#handle) {
-            await this.#openSegment();
-        }
+        return this.#mutex.produce(async () => {
+            if (!this.#handle) {
+                await this.#openSegment();
+            }
 
-        // Check if rotation is needed (size threshold or line overflow)
-        if (
-            this.#currentSize > 0 &&
-            (this.#currentSize >= this.#maxSegmentSize || this.#currentOffset >= MAX_SEGMENT_LINES)
-        ) {
-            await this.#rotate();
-        }
+            // Check if rotation is needed (size threshold or line overflow)
+            if (
+                this.#currentSize > 0 &&
+                (this.#currentSize >= this.#maxSegmentSize || this.#currentOffset >= MAX_SEGMENT_LINES)
+            ) {
+                await this.#rotate();
+            }
 
-        const ts = Date.now();
-        const line = serializeCommit({ ts, ops }) + "\n";
-        const id: WalCommitId = { segment: this.#currentSegment, offset: this.#currentOffset };
+            const ts = Date.now();
+            const line = serializeCommit({ ts, ops }) + "\n";
+            const id: WalCommitId = { segment: this.#currentSegment, offset: this.#currentOffset };
 
-        await this.#handle!.writeHandle(line);
-        if (this.#fsync) {
-            await this.#handle!.fsync();
-        }
+            await this.#handle!.writeHandle(line);
+            if (this.#fsync) {
+                await this.#handle!.fsync();
+            }
 
-        this.#currentOffset++;
-        this.#currentSize += new TextEncoder().encode(line).length;
+            this.#currentOffset++;
+            this.#currentSize += new TextEncoder().encode(line).length;
 
-        return { id, ts };
+            return { id, ts };
+        });
     }
 
     /**
      * Close the current file handle.
      */
     async close(): Promise<void> {
+        await this.#mutex.close();
         if (this.#handle) {
             await this.#handle.close();
             this.#handle = undefined;

--- a/packages/general/test/storage/wal/WalStorageDriverTest.ts
+++ b/packages/general/test/storage/wal/WalStorageDriverTest.ts
@@ -125,6 +125,36 @@ describe("WalStorageDriver", () => {
         await storage.close();
     });
 
+    it("handles concurrent writes without data loss", async () => {
+        const storageDir = fs.directory("storage");
+        const storage = new WalStorageDriver(undefined, {
+            storageDir,
+            fsync: false,
+            snapshotInterval: Seconds(600),
+            cleanInterval: Seconds(1200),
+        });
+        await storage.initialize();
+
+        // Fire 20 concurrent set() calls to different keys
+        const count = 20;
+        await Promise.all(Array.from({ length: count }, (_, i) => storage.set(["ctx"], `key${i}`, `value${i}`)));
+        await storage.close();
+
+        // Reopen and verify every write landed
+        const storage2 = new WalStorageDriver(undefined, {
+            storageDir,
+            fsync: false,
+            snapshotInterval: Seconds(600),
+            cleanInterval: Seconds(1200),
+        });
+        await storage2.initialize();
+
+        for (let i = 0; i < count; i++) {
+            expect(await storage2.get(["ctx"], `key${i}`)).equal(`value${i}`);
+        }
+        await storage2.close();
+    });
+
     describe("transactions", () => {
         it("buffers writes until commit", async () => {
             const storage = await createStorage();

--- a/packages/general/test/storage/wal/WalWriterTest.ts
+++ b/packages/general/test/storage/wal/WalWriterTest.ts
@@ -96,6 +96,36 @@ describe("WalWriter", () => {
         expect(lines.length).equal(2);
     });
 
+    it("serializes concurrent writes", async () => {
+        const walDir = fs.directory("wal");
+        const writer = new WalWriter(walDir, { fsync: false });
+
+        // Fire 20 concurrent writes
+        const count = 20;
+        const promises = Array.from({ length: count }, (_, i) =>
+            writer.write([{ op: "upd", key: `ctx`, values: { [`key${i}`]: i } }]),
+        );
+        const results = await Promise.all(promises);
+        await writer.close();
+
+        // Every commit should have a unique segment+offset
+        const ids = results.map(r => `${r.id.segment}:${r.id.offset}`);
+        const uniqueIds = new Set(ids);
+        expect(uniqueIds.size).equal(count);
+
+        // Read back the segment and verify all commits landed
+        const file = walDir.file(segmentFilename(1));
+        const text = await file.readAllText();
+        const lines = text.split("\n").filter(l => l.length > 0);
+        expect(lines.length).equal(count);
+
+        // Verify each line is valid JSON (no interleaving corruption)
+        for (const line of lines) {
+            const commit = deserializeCommit(line);
+            expect(commit.ops.length).equal(1);
+        }
+    });
+
     it("creates wal directory if it does not exist", async () => {
         const walDir = fs.directory("wal");
         const writer = new WalWriter(walDir, { fsync: false });

--- a/packages/node/src/behavior/cluster/ClusterBehavior.ts
+++ b/packages/node/src/behavior/cluster/ClusterBehavior.ts
@@ -505,6 +505,9 @@ export namespace ClusterBehavior {
      *
      *     override foo: () => {}
      *
+     * This is also required for protected properties because TypeScript doesn't include them in the mapped types our
+     * typing system uses to define modified behaviors.
+     *
      * See {@link ClusterInterface} for more details.
      */
     export declare const ExtensionInterface: {};


### PR DESCRIPTION
Apparently claude and I both forgot about concurrency when implementing WAL storage.  Fixed now.