### PR TITLE
fix(protocol): retry quickly on NoSharedTrustRoots without resumption record

### DIFF
--- a/packages/protocol/src/peer/PeerConnection.ts
+++ b/packages/protocol/src/peer/PeerConnection.ts
@@ -494,14 +494,23 @@ export async function PeerConnection(
                     address,
                     `Peer requested to delay and retry no earlier than ${Duration.format(csre.busyDelay)} from now (retry in ${Duration.format(delay)})`,
                 );
-            } else if (
-                csre.protocolStatusCode === SecureChannelStatusCode.NoSharedTrustRoots &&
-                (await context.sessions.deleteResumptionRecord(peer.address))
-            ) {
-                warn(
-                    address,
-                    "Authorization rejected by peer on session resumption; clearing resumption data and retrying",
-                );
+            } else if (csre.protocolStatusCode === SecureChannelStatusCode.NoSharedTrustRoots) {
+                if (await context.sessions.deleteResumptionRecord(peer.address)) {
+                    warn(
+                        address,
+                        "Authorization rejected by peer on session resumption; clearing resumption data and retrying",
+                    );
+                } else {
+                    // Device doesn't recognise our fabric yet. During commissioning this
+                    // is transient: the device is still initialising after a network
+                    // transition (BLE to Wi-Fi). Retry quickly instead of the 2-minute
+                    // delayAfterPeerError which burns the 4-minute connection timeout.
+                    delay = timing.delayAfterNetworkError;
+                    warn(
+                        address,
+                        `Peer reports no shared trust roots (device may still be initialising), retrying in ${Duration.format(delay)}`,
+                    );
+                }
             } else {
                 delay = timing.delayAfterPeerError;
                 error(address, `Peer error (retry in ${Duration.format(delay)}):`, Diagnostic.errorMessage(e));


### PR DESCRIPTION
## Summary

During BLE commissioning, after a device transitions from BLE to Wi-Fi, CASE session establishment can fail with `NoSharedTrustRoots` because the device hasn't finished initialising its fabric. The current handling in `PeerConnection.ts` (line ~497) combines two distinct cases into a single `&&` condition:

```ts
} else if (
    csre.protocolStatusCode === SecureChannelStatusCode.NoSharedTrustRoots &&
    (await context.sessions.deleteResumptionRecord(peer.address))
) {
```

When `deleteResumptionRecord` returns `false` (no record exists, which is always the case during fresh commissioning), the entire condition fails and execution falls through to the generic `delayAfterPeerError` handler (2 minutes). With a 4-minute connection timeout, this leaves time for at most one retry — often insufficient for devices that need several seconds to complete their network transition.

## Fix

Split the `&&` into nested `if`/`else`:

- **Resumption record exists**: Delete it and retry (existing behaviour, unchanged).
- **No resumption record**: Use `delayAfterNetworkError` (15 seconds during commissioning) instead, giving multiple retries within the timeout window.

## How to reproduce

1. Commission a Matter device over BLE (e.g. Nanoleaf NL75).
2. Device transitions from BLE to Wi-Fi.
3. CASE establishment fails with `NoSharedTrustRoots` while the device initialises.
4. Before this fix: 2-minute delay, usually times out. After: 15-second delay, succeeds within a few retries.

## Testing

Tested with Nanoleaf NL75 commissioning via `@matter/nodejs-ble`. Before the fix, commissioning timed out roughly 70% of the time on the CASE retry. After the fix, commissioning succeeds reliably.