### PR TITLE
Fix commissioning failure when A/AAAA records arrive after SRV/TXT

### DIFF
--- a/packages/protocol/src/mdns/CommissionableMdnsScanner.ts
+++ b/packages/protocol/src/mdns/CommissionableMdnsScanner.ts
@@ -36,6 +36,7 @@ interface CachedDevice {
     ipService: IpService;
     name: DnssdName;
     observer: (changes: DnssdName.Changes) => void;
+    onAddresses?: () => void;
 }
 
 interface Waiter {
@@ -104,10 +105,10 @@ export class CommissionableMdnsScanner implements Scanner {
         const seen = new Set<string>();
         const result: CommissionableDevice[] = [];
 
-        // Deliver cached matches immediately
+        // Deliver cached matches that have resolved addresses
         for (const cached of this.#cache.values()) {
             const device = refreshAddresses(cached);
-            if (matchesIdentifier(device, identifier)) {
+            if (matchesIdentifier(device, identifier) && device.addresses.length > 0) {
                 seen.add(device.deviceIdentifier);
                 result.push(device);
                 callback(device);
@@ -156,7 +157,7 @@ export class CommissionableMdnsScanner implements Scanner {
     getDiscoveredCommissionableDevices(identifier: CommissionableDeviceIdentifiers): CommissionableDevice[] {
         return [...this.#cache.values()]
             .map(cached => refreshAddresses(cached))
-            .filter(device => matchesIdentifier(device, identifier));
+            .filter(device => matchesIdentifier(device, identifier) && device.addresses.length > 0);
     }
 
     cancelCommissionableDeviceDiscovery(identifier: CommissionableDeviceIdentifiers) {
@@ -209,6 +210,10 @@ export class CommissionableMdnsScanner implements Scanner {
                 if (cached) {
                     this.#cache.delete(lower);
                     this.#observers.off(name, cached.observer);
+                    if (cached.onAddresses) {
+                        this.#observers.off(ipService.changed, cached.onAddresses);
+                        cached.onAddresses = undefined;
+                    }
                     void cached.ipService.close();
                 }
             }
@@ -218,9 +223,30 @@ export class CommissionableMdnsScanner implements Scanner {
         this.#cache.set(lower, cached);
         this.#observers.on(name, observer);
 
-        for (const waiter of this.#waiters) {
-            waiter.notify(refreshAddresses(cached));
+        // Only notify waiters once the device has resolved IP addresses.
+        // A/AAAA records may arrive after the initial SRV/TXT discovery;
+        // defer notification until addresses become available.
+        if (!this.#deliverDeviceIfResolved(cached)) {
+            const onAddresses = () => {
+                if (this.#deliverDeviceIfResolved(cached)) {
+                    this.#observers.off(ipService.changed, onAddresses);
+                    cached.onAddresses = undefined;
+                }
+            };
+            cached.onAddresses = onAddresses;
+            this.#observers.on(ipService.changed, onAddresses);
         }
+    }
+
+    #deliverDeviceIfResolved(cached: CachedDevice): boolean {
+        const device = refreshAddresses(cached);
+        if (device.addresses.length === 0) {
+            return false;
+        }
+        for (const waiter of this.#waiters) {
+            waiter.notify(device);
+        }
+        return true;
     }
 
     async #startDiscovery(identifier: CommissionableDeviceIdentifiers, abort: Abort) {

--- a/packages/protocol/test/mdns/CommissionableMdnsScannerTest.ts
+++ b/packages/protocol/test/mdns/CommissionableMdnsScannerTest.ts
@@ -207,6 +207,13 @@ describe("CommissionableMdnsScanner", () => {
                         ttl: Seconds(120),
                         value: { priority: 0, weight: 0, port: PORT, target: HOSTNAME },
                     },
+                    {
+                        name: HOSTNAME,
+                        recordType: DnsRecordType.A,
+                        recordClass: DnsRecordClass.IN,
+                        ttl: Seconds(120),
+                        value: SERVER_IPv4,
+                    },
                 ],
                 additionalRecords: [],
             });
@@ -268,6 +275,13 @@ describe("CommissionableMdnsScanner", () => {
                         recordClass: DnsRecordClass.IN,
                         ttl: Seconds(120),
                         value: { priority: 0, weight: 0, port: PORT, target: HOSTNAME },
+                    },
+                    {
+                        name: HOSTNAME,
+                        recordType: DnsRecordType.A,
+                        recordClass: DnsRecordClass.IN,
+                        ttl: Seconds(120),
+                        value: SERVER_IPv4,
                     },
                 ],
                 additionalRecords: [],
@@ -344,6 +358,13 @@ describe("CommissionableMdnsScanner", () => {
                         recordClass: DnsRecordClass.IN as const,
                         ttl: Seconds(2),
                         value: { priority: 0, weight: 0, port: PORT, target: HOSTNAME },
+                    },
+                    {
+                        name: HOSTNAME,
+                        recordType: DnsRecordType.A as const,
+                        recordClass: DnsRecordClass.IN as const,
+                        ttl: Seconds(2),
+                        value: SERVER_IPv4,
                     },
                 ],
                 additionalRecords: [] as DnsRecord[],
@@ -517,6 +538,96 @@ describe("CommissionableMdnsScanner", () => {
 
             const noResults = scanner.getDiscoveredCommissionableDevices({ longDiscriminator: 1234 });
             expect(noResults.length).equals(0);
+        } finally {
+            await scanner.close();
+            await clientNames.close();
+            await serverSocket.close();
+            await clientSocket.close();
+        }
+    });
+
+    it("defers delivery until A/AAAA records arrive", async () => {
+        const simulator = new NetworkSimulator();
+        const serverNetwork = new MockNetwork(simulator, SERVER_MAC, [SERVER_IPv4, SERVER_IPv6]);
+        const clientNetwork = new MockNetwork(simulator, CLIENT_MAC, [CLIENT_IPv4, CLIENT_IPv6]);
+
+        const serverSocket = await MdnsSocket.create(serverNetwork);
+        const clientSocket = await MdnsSocket.create(clientNetwork);
+        const clientNames = new DnssdNames({ socket: clientSocket, entropy: MockCrypto(0x08) });
+        const scanner = new CommissionableMdnsScanner(clientNames);
+
+        try {
+            const found: CommissionableDevice[] = [];
+            const identifier = { longDiscriminator: 3840 };
+            const discoveryPromise = scanner.findCommissionableDevicesContinuously(
+                identifier,
+                device => found.push(device),
+                Seconds(10),
+            );
+
+            // Send SRV+TXT without A/AAAA records
+            const instanceQname = `${INSTANCE_ID}._matterc._udp.local`;
+            await serverSocket.send({
+                messageType: DnsMessageType.Response,
+                answers: [
+                    {
+                        name: instanceQname,
+                        recordType: DnsRecordType.TXT,
+                        recordClass: DnsRecordClass.IN,
+                        ttl: Seconds(120),
+                        value: [`D=3840`, `CM=1`, `VP=4996+22`],
+                    },
+                    {
+                        name: instanceQname,
+                        recordType: DnsRecordType.SRV,
+                        recordClass: DnsRecordClass.IN,
+                        ttl: Seconds(120),
+                        value: { priority: 0, weight: 0, port: PORT, target: HOSTNAME },
+                    },
+                ],
+                additionalRecords: [],
+            });
+            await MockTime.advance(10);
+
+            // Device should not be delivered yet — no addresses
+            expect(found.length).equals(0);
+            expect(scanner.getDiscoveredCommissionableDevices(identifier).length).equals(0);
+
+            // Send A record in a follow-up response alongside a filtered record so DnssdNames
+            // processes it (the iterative second pass requires at least one filtered record to trigger).
+            await serverSocket.send({
+                messageType: DnsMessageType.Response,
+                answers: [
+                    {
+                        name: `_matterc._udp.local`,
+                        recordType: DnsRecordType.PTR,
+                        recordClass: DnsRecordClass.IN,
+                        ttl: Seconds(120),
+                        value: `${INSTANCE_ID}._matterc._udp.local`,
+                    },
+                ],
+                additionalRecords: [
+                    {
+                        name: HOSTNAME,
+                        recordType: DnsRecordType.A,
+                        recordClass: DnsRecordClass.IN,
+                        ttl: Seconds(120),
+                        value: SERVER_IPv4,
+                    },
+                ],
+            });
+            await MockTime.advance(10);
+
+            // Now the device should be delivered
+            expect(found.length).equals(1);
+            expect(found[0].deviceIdentifier).equals(INSTANCE_ID);
+            expect(found[0].addresses.length).greaterThan(0);
+
+            // getDiscoveredCommissionableDevices should also return it now
+            expect(scanner.getDiscoveredCommissionableDevices(identifier).length).equals(1);
+
+            scanner.cancelCommissionableDeviceDiscovery(identifier);
+            await MockTime.resolve(discoveryPromise);
         } finally {
             await scanner.close();
             await clientNames.close();


### PR DESCRIPTION
## Summary

- **CommissionableMdnsScanner** was delivering discovered devices to the commissioning flow before their IP addresses (A/AAAA records) had been resolved by `IpService`, causing immediate "node has not been located" errors
- The scanner now defers delivery until `IpService` reports at least one resolved address, subscribing to `ipService.changed` to notify waiters when addresses become available
- Observer cleanup is handled on device eviction (TTL expiry / goodbye) and scanner close

## Root cause

When mDNS discovers a commissionable device, `buildCommissionableDevice()` creates it with `addresses: []`. `refreshAddresses()` then copies from `ipService.addresses`, but the `IpService` may not have resolved A/AAAA records yet at the time `#cacheDevice` notifies waiters. The parallel commissioning flow receives a device with empty addresses and fails immediately at `CommissioningClient.commission()` line 190.

Observed in production logs (matter-server 0.5.13): all three commissioning attempts failed within 5ms of endpoint ready, each with "Cannot commission server-1-fff1.peerN because the node has not been located".

## Changes

- `#cacheDevice`: Defers waiter notification when `ipService.addresses` is empty; subscribes to `ipService.changed` to deliver when addresses resolve
- `findCommissionableDevicesContinuously` cached loop: Skips devices without resolved addresses
- `getDiscoveredCommissionableDevices`: Same address filter
- `CachedDevice.onAddresses`: Tracks pending observer for cleanup on eviction
- Tests: Existing tests updated to include A records; new test validates deferred-address delivery

addresses https://github.com/matter-js/matterjs-server/issues/512

🤖 Generated with [Claude Code](https://claude.com/claude-code)