### PR TITLE
Enable SQLite WAL mode for better performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,11 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Enhancement: `CommissioningController.commissionNode()` now uses the parallel PASE commissioning path for pre-discovered devices; WiFi/Thread/regulatory credentials and abort signal are fully propagated
     - Adjustment: The "Waiting for device discovery" node state is now bound to the availability of IP announcements from MDNS
 
+## 0.16.11 (2026-04-10)
+
+- @project-chip/matter.js
+    - Fix: (Pierre-Gilles) Added fallback discoveredAt to node migration in case discoveryData doesn't have one
+
 ## 0.16.10 (2026-02-22)
 
 - @matter/create

--- a/packages/nodejs/src/storage/sqlite/platform/BunSqlite.ts
+++ b/packages/nodejs/src/storage/sqlite/platform/BunSqlite.ts
@@ -24,11 +24,7 @@ export function createBunDatabase(path: string): DatabaseLike {
     });
 
     if (path === ":memory:") {
-        return {
-            prepare: db.prepare.bind(db),
-            exec: db.exec.bind(db),
-            close: db.close.bind(db),
-        };
+        return db;
     }
 
     db.exec("PRAGMA journal_mode = WAL");

--- a/packages/nodejs/src/storage/sqlite/platform/BunSqlite.ts
+++ b/packages/nodejs/src/storage/sqlite/platform/BunSqlite.ts
@@ -4,10 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { Logger } from "@matter/general";
 // @ts-expect-error - bun:sqlite is only available in Bun runtime
-import { Database } from "bun:sqlite";
+import { constants, Database } from "bun:sqlite";
 
 import type { DatabaseLike } from "../SqliteTypes.js";
+
+const logger = Logger.get("BunSqlite");
 
 /**
  * Create a Bun SQLite database.
@@ -15,8 +18,39 @@ import type { DatabaseLike } from "../SqliteTypes.js";
  * DO NOT IMPORT DIRECTLY — use {@link SqliteStorageDriver.create} instead.
  */
 export function createBunDatabase(path: string): DatabaseLike {
-    return new Database(path, {
+    const db = new Database(path, {
         strict: true,
         create: true,
     });
+
+    if (path === ":memory:") {
+        return {
+            prepare: db.prepare.bind(db),
+            exec: db.exec.bind(db),
+            close: db.close.bind(db),
+        };
+    }
+
+    db.exec("PRAGMA journal_mode = WAL");
+    db.exec("PRAGMA synchronous = NORMAL");
+
+    return {
+        prepare: db.prepare.bind(db),
+        exec: db.exec.bind(db),
+        close: () => {
+            try {
+                // Bun persists the WAL file by default; clear the flag so it is removed after checkpoint
+                db.fileControl(constants.SQLITE_FCNTL_PERSIST_WAL, 0);
+            } catch (error) {
+                logger.warn("Failed to clear WAL persistence flag:", error);
+            }
+            try {
+                db.exec("PRAGMA wal_checkpoint(TRUNCATE)");
+            } catch (error) {
+                logger.warn("WAL checkpoint failed, WAL will be replayed on next open:", error);
+            } finally {
+                db.close();
+            }
+        },
+    };
 }

--- a/packages/nodejs/src/storage/sqlite/platform/NodeJsSqlite.ts
+++ b/packages/nodejs/src/storage/sqlite/platform/NodeJsSqlite.ts
@@ -19,21 +19,15 @@ export function createNodeJsDatabase(path: string): DatabaseLike {
     const db = new DatabaseSync(path);
 
     // Cast needed: node:sqlite's StatementSync doesn't satisfy DatabaseLike's generic prepare signature
-    const prepare = db.prepare.bind(db) as DatabaseLike["prepare"];
-
     if (path === ":memory:") {
-        return {
-            prepare,
-            exec: db.exec.bind(db),
-            close: db.close.bind(db),
-        };
+        return db as unknown as DatabaseLike;
     }
 
     db.exec("PRAGMA journal_mode = WAL");
     db.exec("PRAGMA synchronous = NORMAL");
 
     return {
-        prepare,
+        prepare: db.prepare.bind(db) as DatabaseLike["prepare"],
         exec: db.exec.bind(db),
         close: () => {
             try {

--- a/packages/nodejs/src/storage/sqlite/platform/NodeJsSqlite.ts
+++ b/packages/nodejs/src/storage/sqlite/platform/NodeJsSqlite.ts
@@ -3,9 +3,12 @@
  * Copyright 2022-2026 Matter.js Authors
  * SPDX-License-Identifier: Apache-2.0
  */
+import { Logger } from "@matter/general";
 import { DatabaseSync } from "node:sqlite";
 
 import type { DatabaseLike } from "../SqliteTypes.js";
+
+const logger = Logger.get("NodeJsSqlite");
 
 /**
  * Create a Node.js SQLite database.
@@ -13,5 +16,33 @@ import type { DatabaseLike } from "../SqliteTypes.js";
  * DO NOT IMPORT DIRECTLY — use {@link SqliteStorageDriver.create} instead.
  */
 export function createNodeJsDatabase(path: string): DatabaseLike {
-    return new DatabaseSync(path) as DatabaseLike;
+    const db = new DatabaseSync(path);
+
+    // Cast needed: node:sqlite's StatementSync doesn't satisfy DatabaseLike's generic prepare signature
+    const prepare = db.prepare.bind(db) as DatabaseLike["prepare"];
+
+    if (path === ":memory:") {
+        return {
+            prepare,
+            exec: db.exec.bind(db),
+            close: db.close.bind(db),
+        };
+    }
+
+    db.exec("PRAGMA journal_mode = WAL");
+    db.exec("PRAGMA synchronous = NORMAL");
+
+    return {
+        prepare,
+        exec: db.exec.bind(db),
+        close: () => {
+            try {
+                db.exec("PRAGMA wal_checkpoint(TRUNCATE)");
+            } catch (error) {
+                logger.warn("WAL checkpoint failed, WAL will be replayed on next open:", error);
+            } finally {
+                db.close();
+            }
+        },
+    };
 }


### PR DESCRIPTION
## Summary

- Enables WAL journal mode and `synchronous = NORMAL` pragma on database open for on-disk SQLite databases (both Node.js and Bun platforms)
- On close, runs `PRAGMA wal_checkpoint(TRUNCATE)` to merge the WAL back and leave a clean state for next open
- Bun-specific: clears the `PERSIST_WAL` flag via `fileControl` before checkpoint so the WAL file is removed from disk
- Returns `DatabaseLike` wrapper objects instead of casting/monkey-patching the raw database instances
- Skips all WAL logic for `:memory:` databases
- Checkpoint failures are logged via `Logger.warn` and never prevent `close()` from completing

🤖 Generated with [Claude Code](https://claude.com/claude-code)