### PR TITLE
Add filesystem locking to blob storage drivers

### DIFF
--- a/packages/general/src/storage/BlobStorageDriver.ts
+++ b/packages/general/src/storage/BlobStorageDriver.ts
@@ -6,8 +6,10 @@
 
 import { Bytes } from "#util/Bytes.js";
 import type { Directory } from "../fs/Directory.js";
+import { ImplementationError } from "../MatterError.js";
 import { MaybePromise } from "../util/Promises.js";
 import { BaseStorageDriver, type StorageType } from "./BaseStorageDriver.js";
+import { DatafileRoot } from "./DatafileRoot.js";
 import type { DataNamespace } from "./DataNamespace.js";
 
 /**
@@ -19,6 +21,42 @@ export abstract class BlobStorageDriver extends BaseStorageDriver {
 
     abstract openBlob(contexts: string[], key: string): MaybePromise<Blob>;
     abstract writeBlobFromStream(contexts: string[], key: string, stream: ReadableStream<Bytes>): MaybePromise<void>;
+}
+
+/**
+ * {@link BlobStorageDriver} subclass for drivers backed by the filesystem.
+ *
+ * Manages a {@link DatafileRoot.Lock} that is acquired during {@link initialize} and released during {@link close}.
+ * Filesystem-specific blob drivers should extend this instead of {@link BlobStorageDriver} directly.
+ */
+export abstract class FilesystemBlobStorageDriver extends BlobStorageDriver {
+    readonly #root?: DatafileRoot;
+    #lock?: DatafileRoot.Lock;
+
+    constructor(namespace?: DataNamespace) {
+        super();
+        if (namespace !== undefined) {
+            if (!(namespace instanceof DatafileRoot)) {
+                throw new ImplementationError("Filesystem blob storage driver requires a DatafileRoot namespace");
+            }
+            this.#root = namespace;
+        }
+    }
+
+    get root(): DatafileRoot | undefined {
+        return this.#root;
+    }
+
+    async initialize() {
+        if (this.#root) {
+            this.#lock = await this.#root.lock();
+        }
+    }
+
+    async close() {
+        await this.#lock?.close();
+        this.#lock = undefined;
+    }
 }
 
 export namespace BlobStorageDriver {

--- a/packages/general/src/storage/BlobStorageDriver.ts
+++ b/packages/general/src/storage/BlobStorageDriver.ts
@@ -48,6 +48,9 @@ export abstract class FilesystemBlobStorageDriver extends BlobStorageDriver {
     }
 
     async initialize() {
+        if (this.#lock) {
+            throw new ImplementationError("Filesystem blob storage driver is already initialized");
+        }
         if (this.#root) {
             this.#lock = await this.#root.lock();
         }

--- a/packages/general/src/storage/StorageDriver.ts
+++ b/packages/general/src/storage/StorageDriver.ts
@@ -217,9 +217,9 @@ export namespace StorageDriver {
 /**
  * {@link StorageDriver} subclass for drivers backed by the filesystem.
  *
- * Uses the {@link FilesystemLocking} mixin to acquire a {@link DatafileRoot.Lock} during
- * {@link initialize} and release it during {@link close}.  Filesystem-specific KV drivers
- * should extend this.  Blob drivers should use `FilesystemLocking(BlobStorageDriver)` directly.
+ * Manages a {@link DatafileRoot.Lock} that is acquired during {@link initialize} and released during
+ * {@link close}.  Filesystem-specific KV drivers should extend this instead of {@link StorageDriver}
+ * directly.  Blob drivers should extend {@link FilesystemBlobStorageDriver} instead.
  */
 export abstract class FilesystemStorageDriver extends StorageDriver {
     readonly #root?: DatafileRoot;
@@ -240,6 +240,9 @@ export abstract class FilesystemStorageDriver extends StorageDriver {
     }
 
     async initialize() {
+        if (this.#lock) {
+            throw new ImplementationError("Filesystem storage driver is already initialized");
+        }
         if (this.#root) {
             this.#lock = await this.#root.lock();
         }

--- a/packages/general/src/storage/StorageDriver.ts
+++ b/packages/general/src/storage/StorageDriver.ts
@@ -217,8 +217,9 @@ export namespace StorageDriver {
 /**
  * {@link StorageDriver} subclass for drivers backed by the filesystem.
  *
- * Manages a {@link DatafileRoot.Lock} that is acquired during {@link initialize} and released during {@link close}.
- * Filesystem-specific drivers should extend this instead of {@link StorageDriver} directly.
+ * Uses the {@link FilesystemLocking} mixin to acquire a {@link DatafileRoot.Lock} during
+ * {@link initialize} and release it during {@link close}.  Filesystem-specific KV drivers
+ * should extend this.  Blob drivers should use `FilesystemLocking(BlobStorageDriver)` directly.
  */
 export abstract class FilesystemStorageDriver extends StorageDriver {
     readonly #root?: DatafileRoot;

--- a/packages/nodejs/src/storage/fs/DirectoryBlobStorageDriver.ts
+++ b/packages/nodejs/src/storage/fs/DirectoryBlobStorageDriver.ts
@@ -8,10 +8,9 @@ import {
     BaseStorageDriver,
     BlobStorageDriver,
     Bytes,
-    DatafileRoot,
     type DataNamespace,
     type Directory,
-    ImplementationError,
+    FilesystemBlobStorageDriver,
     StorageError,
 } from "@matter/general";
 
@@ -21,7 +20,7 @@ import {
  * Contexts map to nested directories; keys map to files within those directories.
  * Context segments are percent-encoded to avoid path separator conflicts.
  */
-export class DirectoryBlobStorageDriver extends BlobStorageDriver {
+export class DirectoryBlobStorageDriver extends FilesystemBlobStorageDriver {
     static readonly id: string = "dir";
 
     static create(namespace: DataNamespace, _descriptor: BlobStorageDriver.Descriptor): DirectoryBlobStorageDriver {
@@ -32,24 +31,23 @@ export class DirectoryBlobStorageDriver extends BlobStorageDriver {
     #initialized = false;
 
     constructor(namespace: DataNamespace) {
-        super();
-        if (!(namespace instanceof DatafileRoot)) {
-            throw new ImplementationError("DirectoryBlobStorageDriver requires a DatafileRoot namespace");
-        }
-        this.#rootDir = namespace.directory;
+        super(namespace);
+        this.#rootDir = this.root!.directory;
     }
 
     get initialized() {
         return this.#initialized;
     }
 
-    async initialize() {
+    override async initialize() {
+        await super.initialize();
         await this.#rootDir.mkdir();
         this.#initialized = true;
     }
 
-    async close() {
+    override async close() {
         this.#initialized = false;
+        await super.close();
     }
 
     async openBlob(contexts: string[], key: string): Promise<Blob> {

--- a/packages/nodejs/src/storage/fs/FlatFileBlobStorageDriver.ts
+++ b/packages/nodejs/src/storage/fs/FlatFileBlobStorageDriver.ts
@@ -8,9 +8,8 @@ import {
     BaseStorageDriver,
     BlobStorageDriver,
     Bytes,
-    DatafileRoot,
     type DataNamespace,
-    ImplementationError,
+    FilesystemBlobStorageDriver,
     StorageError,
 } from "@matter/general";
 import { createWriteStream, existsSync, openAsBlob } from "node:fs";
@@ -24,7 +23,7 @@ import { join } from "node:path";
  * segments and key joined by `.`.  Example: contexts `["bin", "fff1", "8000"]` with key `"prod"`
  * becomes the file `bin.fff1.8000.prod` (percent-encoded).
  */
-export class FlatFileBlobStorageDriver extends BlobStorageDriver {
+export class FlatFileBlobStorageDriver extends FilesystemBlobStorageDriver {
     static readonly id = "file";
 
     static create(namespace: DataNamespace, _descriptor: BlobStorageDriver.Descriptor): FlatFileBlobStorageDriver {
@@ -35,24 +34,23 @@ export class FlatFileBlobStorageDriver extends BlobStorageDriver {
     #initialized = false;
 
     constructor(namespace: DataNamespace) {
-        super();
-        if (!(namespace instanceof DatafileRoot)) {
-            throw new ImplementationError("FlatFileBlobStorageDriver requires a DatafileRoot namespace");
-        }
-        this.#path = namespace.directory.path;
+        super(namespace);
+        this.#path = this.root!.directory.path;
     }
 
     get initialized() {
         return this.#initialized;
     }
 
-    async initialize() {
+    override async initialize() {
+        await super.initialize();
         await mkdir(this.#path, { recursive: true });
         this.#initialized = true;
     }
 
-    async close() {
+    override async close() {
         this.#initialized = false;
+        await super.close();
     }
 
     async openBlob(contexts: string[], key: string): Promise<Blob> {

--- a/packages/nodejs/src/storage/sqlite/SqliteBlobStorageDriver.ts
+++ b/packages/nodejs/src/storage/sqlite/SqliteBlobStorageDriver.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { BlobStorageDriver, type Bytes, type DataNamespace, DatafileRoot } from "@matter/general";
+import { type Bytes, type DataNamespace, DatafileRoot, FilesystemBlobStorageDriver } from "@matter/general";
 import { resolve } from "node:path";
 
 import { platformDatabaseCreator } from "./SqlitePlatform.js";
@@ -27,7 +27,7 @@ type BlobStoreType = {
  * Uses a dedicated `blobstore` table (separate from the KV `kvstore` table)
  * but can share the same `.db` file.
  */
-export class SqliteBlobStorageDriver extends BlobStorageDriver {
+export class SqliteBlobStorageDriver extends FilesystemBlobStorageDriver {
     static readonly id = "sqlite";
     public static readonly memoryPath = ":memory:";
     public static readonly defaultTableName = "blobstore";
@@ -71,9 +71,9 @@ export class SqliteBlobStorageDriver extends BlobStorageDriver {
         namespaceOrPath?: DataNamespace | string | null;
         tableName?: string;
     }) {
-        super();
-
         const namespaceOrPath = args?.namespaceOrPath;
+        // Pass DataNamespace for filesystem locking; string/null → no locking (e.g. :memory:)
+        super(typeof namespaceOrPath === "string" || namespaceOrPath == null ? undefined : namespaceOrPath);
 
         this.#dbPath =
             typeof namespaceOrPath === "string"
@@ -162,15 +162,17 @@ export class SqliteBlobStorageDriver extends BlobStorageDriver {
         if (this.#isInitialized) {
             throw new SqliteStorageDriverError("initialize", this.#tableName, "Storage already initialized!");
         }
+        await super.initialize();
         if (!this.#databaseCreator) {
             this.#openDatabase(await platformDatabaseCreator());
         }
         this.#isInitialized = true;
     }
 
-    override close() {
+    override async close() {
         this.#isInitialized = false;
         this.#database.close();
+        await super.close();
     }
 
     override openBlob(contexts: string[], key: string): Blob {

--- a/packages/nodejs/src/storage/sqlite/SqliteBlobStorageDriver.ts
+++ b/packages/nodejs/src/storage/sqlite/SqliteBlobStorageDriver.ts
@@ -43,7 +43,7 @@ export class SqliteBlobStorageDriver extends FilesystemBlobStorageDriver {
 
     #isInitialized = false;
 
-    #database!: DatabaseLike;
+    #database?: DatabaseLike;
     #databaseCreator?: DatabaseCreator;
     readonly #dbPath: string;
     readonly #tableName: string;
@@ -72,8 +72,8 @@ export class SqliteBlobStorageDriver extends FilesystemBlobStorageDriver {
         tableName?: string;
     }) {
         const namespaceOrPath = args?.namespaceOrPath;
-        // Pass DataNamespace for filesystem locking; string/null → no locking (e.g. :memory:)
-        super(typeof namespaceOrPath === "string" || namespaceOrPath == null ? undefined : namespaceOrPath);
+        // Only DatafileRoot namespaces get filesystem locking; string/null → no locking (e.g. :memory:)
+        super(namespaceOrPath instanceof DatafileRoot ? namespaceOrPath : undefined);
 
         this.#dbPath =
             typeof namespaceOrPath === "string"
@@ -171,7 +171,7 @@ export class SqliteBlobStorageDriver extends FilesystemBlobStorageDriver {
 
     override async close() {
         this.#isInitialized = false;
-        this.#database.close();
+        this.#database?.close();
         await super.close();
     }
 

--- a/packages/nodejs/test/storage/SqliteBlobStorageDriverTest.ts
+++ b/packages/nodejs/test/storage/SqliteBlobStorageDriverTest.ts
@@ -18,9 +18,9 @@ if (supportsSqlite()) {
             await storage.initialize();
         });
 
-        afterEach(() => {
+        afterEach(async () => {
             if (storage.initialized) {
-                storage.close();
+                await storage.close();
             }
         });
 


### PR DESCRIPTION
## Summary

- Add `FilesystemBlobStorageDriver` — mirrors `FilesystemStorageDriver` for blob drivers, acquires/releases `DatafileRoot.Lock` during initialize/close
- `DirectoryBlobStorageDriver`, `FlatFileBlobStorageDriver`, and `SqliteBlobStorageDriver` now extend it and get proper filesystem locking
- Fixes missing storage lock for blob namespaces (no "Acquired storage lock" was logged for blob storage)

Follow-up to #3561.

🤖 Generated with [Claude Code](https://claude.com/claude-code)