### PR TITLE
fix(matter.js): Spread discoveryData instead of deviceData in node migration

### DIFF
--- a/packages/matter.js/src/MatterController.ts
+++ b/packages/matter.js/src/MatterController.ts
@@ -779,7 +779,7 @@ export class MatterController {
         const migratedPeers = new Set<string>();
 
         const newClientStores = serverStore.clientStores;
-        for (const { address: peerAddress, discoveryData, deviceData, operationalAddress } of peers) {
+        for (const { address: peerAddress, discoveryData, operationalAddress } of peers) {
             logger.debug(`Migrating data for commissioned node ${peerAddress.toString()}`);
             const clientNode = server.peers.get(peerAddress);
             if (clientNode !== undefined) {

--- a/packages/matter.js/src/MatterController.ts
+++ b/packages/matter.js/src/MatterController.ts
@@ -832,7 +832,7 @@ export class MatterController {
             const commissioning = RemoteDescriptor.toLongForm({
                 // Fallback discoveredAt in case discoveryData doesn't have one
                 discoveredAt: Time.nowMs,
-                ...(discoveryData ? deviceData : {}),
+                ...discoveryData,
                 addresses: operationalAddress ? [operationalAddress] : [],
             });
             logger.debug(


### PR DESCRIPTION
### Problem

When migrating node data from pre-0.16.0 storage format, the migration code incorrectly spreads `deviceData` instead of `discoveryData`:

```typescript
const commissioning = RemoteDescriptor.toLongForm({
    discoveredAt: Time.nowMs,
    ...(discoveryData ? deviceData : {}),  // Bug: checks discoveryData but spreads deviceData
    addresses: operationalAddress ? [operationalAddress] : [],
});
```

This causes all discovery metadata to be lost during migration because:

- **`discoveryData`** contains: `VP` (vendor/product), `DT` (device type), `DN` (device name), `SII`/`SAI`/`SAT` (session parameters), `T` (TCP support), `ICD` (long idle time mode)
- **`deviceData`** contains: `basicInformation`, `deviceMeta` — fields that [RemoteDescriptor.toLongForm()](cci:1://file:///Users/pierre-gilles/code/matter.js/packages/node/src/behavior/system/commissioning/RemoteDescriptor.ts:153:4-211:5) doesn't use

### Impact

Users upgrading from 0.13.x (or any pre-0.16.0 version) to 0.16.x lose their device discovery metadata.

### Fix

Simply spread `discoveryData` directly:

```typescript
const commissioning = RemoteDescriptor.toLongForm({
    discoveredAt: Time.nowMs,
    ...discoveryData,
    addresses: operationalAddress ? [operationalAddress] : [],
});
```

### Related

- Introduced in #2827 (commit 71c21f90)