### PR TITLE
Restore Cluster.with() as typing-only compat shim

### DIFF
--- a/packages/types/src/cluster/ClusterType.ts
+++ b/packages/types/src/cluster/ClusterType.ts
@@ -163,6 +163,21 @@ function installLazyProperties(ns: object, model: ClusterModel) {
             }
             return Object.freeze(result);
         });
+
+        // Compat shim for pre-PR #3466 call sites: `PowerSource.Cluster.with(Feature.X, Feature.Y)`.
+        // Returns a shallow prototype-based clone of the namespace with `supportedFeatures` set.  Feature
+        // selection has no other runtime effect (attribute maps are not culled by conformance).
+        // @deprecated Removal tracked for 0.18.
+        lazy("with", () => (...features: string[]) => {
+            const clone = Object.create(ns) as Record<string, unknown>;
+            const supportedFeatures: Record<string, true> = {};
+            for (const feature of features) {
+                // Feature enum values are PascalCase; SupportedFeatures keys are camelCase.
+                supportedFeatures[feature.charAt(0).toLowerCase() + feature.slice(1)] = true;
+            }
+            clone.supportedFeatures = Object.freeze(supportedFeatures);
+            return clone;
+        });
     }
 
     // Enum values, error classes, struct/bitmap classes from all datatypes in the cluster
@@ -305,6 +320,24 @@ export namespace ClusterType {
      */
     export type WithSupportedFeatures<N extends ClusterTyping, S> = Omit<N, "SupportedFeatures"> & {
         SupportedFeatures: S;
+    };
+
+    /**
+     * Compat layer for pre-PR #3466 call sites that pin features via `Cluster.with(...)`.  Returns the namespace
+     * shape with a `with()` method that shifts `Typing.SupportedFeatures`.  Feature selection has no further runtime
+     * effect; the shim exists only to keep existing call sites typing correctly during the 0.17 → 0.18 migration.
+     *
+     * @deprecated Scheduled for removal in 0.18.  New code should type the cluster via
+     * {@link WithSupportedFeatures} directly.
+     */
+    export type WithCompat<NS, T extends ClusterTyping> = NS & {
+        /**
+         * @deprecated Feature selection is a typing-only compat shim for pre-PR #3466 call sites.
+         * Scheduled for removal in 0.18.  Prefer typing the cluster via {@link WithSupportedFeatures} directly.
+         */
+        with<const F extends readonly (T extends { Features: infer All extends string } ? All : never)[]>(
+            ...features: F
+        ): Omit<NS, "Typing"> & { Typing: WithSupportedFeatures<T, FeaturesAsFlags<T, F>> };
     };
 
     /**

--- a/packages/types/src/cluster/ClusterType.ts
+++ b/packages/types/src/cluster/ClusterType.ts
@@ -176,6 +176,11 @@ function installLazyProperties(ns: object, model: ClusterModel) {
                 supportedFeatures[feature.charAt(0).toLowerCase() + feature.slice(1)] = true;
             }
             clone.supportedFeatures = Object.freeze(supportedFeatures);
+            // Preserve the `Cluster`/`Complete` self-reference invariant on the clone; prototype-chain lookup would
+            // otherwise resolve these to the source namespace and drop the `supportedFeatures` marker.  Must use
+            // defineProperty because the inherited props are non-writable (installed via lazy() with no `writable`).
+            Object.defineProperty(clone, "Cluster", { value: clone, enumerable: true, configurable: true });
+            Object.defineProperty(clone, "Complete", { value: clone, enumerable: true, configurable: true });
             return clone;
         });
     }

--- a/packages/types/src/clusters/access-control.d.ts
+++ b/packages/types/src/clusters/access-control.d.ts
@@ -1302,7 +1302,7 @@ export declare namespace AccessControl {
     /**
      * @deprecated Use {@link AccessControl}.
      */
-    export const Cluster: typeof AccessControl;
+    export const Cluster: ClusterType.WithCompat<typeof AccessControl, AccessControl>;
 
     /**
      * @deprecated Use {@link AccessControl}.

--- a/packages/types/src/clusters/activated-carbon-filter-monitoring.d.ts
+++ b/packages/types/src/clusters/activated-carbon-filter-monitoring.d.ts
@@ -228,7 +228,7 @@ export declare namespace ActivatedCarbonFilterMonitoring {
     /**
      * @deprecated Use {@link ActivatedCarbonFilterMonitoring}.
      */
-    export const Cluster: typeof ActivatedCarbonFilterMonitoring;
+    export const Cluster: ClusterType.WithCompat<typeof ActivatedCarbonFilterMonitoring, ActivatedCarbonFilterMonitoring>;
 
     /**
      * @deprecated Use {@link ActivatedCarbonFilterMonitoring}.

--- a/packages/types/src/clusters/administrator-commissioning.d.ts
+++ b/packages/types/src/clusters/administrator-commissioning.d.ts
@@ -508,7 +508,7 @@ export declare namespace AdministratorCommissioning {
     /**
      * @deprecated Use {@link AdministratorCommissioning}.
      */
-    export const Cluster: typeof AdministratorCommissioning;
+    export const Cluster: ClusterType.WithCompat<typeof AdministratorCommissioning, AdministratorCommissioning>;
 
     /**
      * @deprecated Use {@link AdministratorCommissioning}.

--- a/packages/types/src/clusters/air-quality.d.ts
+++ b/packages/types/src/clusters/air-quality.d.ts
@@ -161,7 +161,7 @@ export declare namespace AirQuality {
     /**
      * @deprecated Use {@link AirQuality}.
      */
-    export const Cluster: typeof AirQuality;
+    export const Cluster: ClusterType.WithCompat<typeof AirQuality, AirQuality>;
 
     /**
      * @deprecated Use {@link AirQuality}.

--- a/packages/types/src/clusters/application-launcher.d.ts
+++ b/packages/types/src/clusters/application-launcher.d.ts
@@ -460,7 +460,7 @@ export declare namespace ApplicationLauncher {
     /**
      * @deprecated Use {@link ApplicationLauncher}.
      */
-    export const Cluster: typeof ApplicationLauncher;
+    export const Cluster: ClusterType.WithCompat<typeof ApplicationLauncher, ApplicationLauncher>;
 
     /**
      * @deprecated Use {@link ApplicationLauncher}.

--- a/packages/types/src/clusters/audio-output.d.ts
+++ b/packages/types/src/clusters/audio-output.d.ts
@@ -249,7 +249,7 @@ export declare namespace AudioOutput {
     /**
      * @deprecated Use {@link AudioOutput}.
      */
-    export const Cluster: typeof AudioOutput;
+    export const Cluster: ClusterType.WithCompat<typeof AudioOutput, AudioOutput>;
 
     /**
      * @deprecated Use {@link AudioOutput}.

--- a/packages/types/src/clusters/boolean-state-configuration.d.ts
+++ b/packages/types/src/clusters/boolean-state-configuration.d.ts
@@ -555,7 +555,7 @@ export declare namespace BooleanStateConfiguration {
     /**
      * @deprecated Use {@link BooleanStateConfiguration}.
      */
-    export const Cluster: typeof BooleanStateConfiguration;
+    export const Cluster: ClusterType.WithCompat<typeof BooleanStateConfiguration, BooleanStateConfiguration>;
 
     /**
      * @deprecated Use {@link BooleanStateConfiguration}.

--- a/packages/types/src/clusters/bridged-device-basic-information.d.ts
+++ b/packages/types/src/clusters/bridged-device-basic-information.d.ts
@@ -614,7 +614,7 @@ export declare namespace BridgedDeviceBasicInformation {
     /**
      * @deprecated Use {@link BridgedDeviceBasicInformation}.
      */
-    export const Cluster: typeof BridgedDeviceBasicInformation;
+    export const Cluster: ClusterType.WithCompat<typeof BridgedDeviceBasicInformation, BridgedDeviceBasicInformation>;
 
     /**
      * @deprecated Use {@link BridgedDeviceBasicInformation}.

--- a/packages/types/src/clusters/carbon-dioxide-concentration-measurement.d.ts
+++ b/packages/types/src/clusters/carbon-dioxide-concentration-measurement.d.ts
@@ -318,7 +318,7 @@ export declare namespace CarbonDioxideConcentrationMeasurement {
     /**
      * @deprecated Use {@link CarbonDioxideConcentrationMeasurement}.
      */
-    export const Cluster: typeof CarbonDioxideConcentrationMeasurement;
+    export const Cluster: ClusterType.WithCompat<typeof CarbonDioxideConcentrationMeasurement, CarbonDioxideConcentrationMeasurement>;
 
     /**
      * @deprecated Use {@link CarbonDioxideConcentrationMeasurement}.

--- a/packages/types/src/clusters/carbon-monoxide-concentration-measurement.d.ts
+++ b/packages/types/src/clusters/carbon-monoxide-concentration-measurement.d.ts
@@ -318,7 +318,7 @@ export declare namespace CarbonMonoxideConcentrationMeasurement {
     /**
      * @deprecated Use {@link CarbonMonoxideConcentrationMeasurement}.
      */
-    export const Cluster: typeof CarbonMonoxideConcentrationMeasurement;
+    export const Cluster: ClusterType.WithCompat<typeof CarbonMonoxideConcentrationMeasurement, CarbonMonoxideConcentrationMeasurement>;
 
     /**
      * @deprecated Use {@link CarbonMonoxideConcentrationMeasurement}.

--- a/packages/types/src/clusters/channel.d.ts
+++ b/packages/types/src/clusters/channel.d.ts
@@ -1044,7 +1044,7 @@ export declare namespace Channel {
     /**
      * @deprecated Use {@link Channel}.
      */
-    export const Cluster: typeof Channel;
+    export const Cluster: ClusterType.WithCompat<typeof Channel, Channel>;
 
     /**
      * @deprecated Use {@link Channel}.

--- a/packages/types/src/clusters/color-control.d.ts
+++ b/packages/types/src/clusters/color-control.d.ts
@@ -2210,7 +2210,7 @@ export declare namespace ColorControl {
     /**
      * @deprecated Use {@link ColorControl}.
      */
-    export const Cluster: typeof ColorControl;
+    export const Cluster: ClusterType.WithCompat<typeof ColorControl, ColorControl>;
 
     /**
      * @deprecated Use {@link ColorControl}.

--- a/packages/types/src/clusters/content-control.d.ts
+++ b/packages/types/src/clusters/content-control.d.ts
@@ -1470,7 +1470,7 @@ export declare namespace ContentControl {
     /**
      * @deprecated Use {@link ContentControl}.
      */
-    export const Cluster: typeof ContentControl;
+    export const Cluster: ClusterType.WithCompat<typeof ContentControl, ContentControl>;
 
     /**
      * @deprecated Use {@link ContentControl}.

--- a/packages/types/src/clusters/content-launcher.d.ts
+++ b/packages/types/src/clusters/content-launcher.d.ts
@@ -842,7 +842,7 @@ export declare namespace ContentLauncher {
     /**
      * @deprecated Use {@link ContentLauncher}.
      */
-    export const Cluster: typeof ContentLauncher;
+    export const Cluster: ClusterType.WithCompat<typeof ContentLauncher, ContentLauncher>;
 
     /**
      * @deprecated Use {@link ContentLauncher}.

--- a/packages/types/src/clusters/descriptor.d.ts
+++ b/packages/types/src/clusters/descriptor.d.ts
@@ -293,7 +293,7 @@ export declare namespace Descriptor {
     /**
      * @deprecated Use {@link Descriptor}.
      */
-    export const Cluster: typeof Descriptor;
+    export const Cluster: ClusterType.WithCompat<typeof Descriptor, Descriptor>;
 
     /**
      * @deprecated Use {@link Descriptor}.

--- a/packages/types/src/clusters/device-energy-management-mode.d.ts
+++ b/packages/types/src/clusters/device-energy-management-mode.d.ts
@@ -334,7 +334,7 @@ export declare namespace DeviceEnergyManagementMode {
     /**
      * @deprecated Use {@link DeviceEnergyManagementMode}.
      */
-    export const Cluster: typeof DeviceEnergyManagementMode;
+    export const Cluster: ClusterType.WithCompat<typeof DeviceEnergyManagementMode, DeviceEnergyManagementMode>;
 
     /**
      * @deprecated Use {@link DeviceEnergyManagementMode}.

--- a/packages/types/src/clusters/device-energy-management.d.ts
+++ b/packages/types/src/clusters/device-energy-management.d.ts
@@ -1910,7 +1910,7 @@ export declare namespace DeviceEnergyManagement {
     /**
      * @deprecated Use {@link DeviceEnergyManagement}.
      */
-    export const Cluster: typeof DeviceEnergyManagement;
+    export const Cluster: ClusterType.WithCompat<typeof DeviceEnergyManagement, DeviceEnergyManagement>;
 
     /**
      * @deprecated Use {@link DeviceEnergyManagement}.

--- a/packages/types/src/clusters/dishwasher-alarm.d.ts
+++ b/packages/types/src/clusters/dishwasher-alarm.d.ts
@@ -360,7 +360,7 @@ export declare namespace DishwasherAlarm {
     /**
      * @deprecated Use {@link DishwasherAlarm}.
      */
-    export const Cluster: typeof DishwasherAlarm;
+    export const Cluster: ClusterType.WithCompat<typeof DishwasherAlarm, DishwasherAlarm>;
 
     /**
      * @deprecated Use {@link DishwasherAlarm}.

--- a/packages/types/src/clusters/dishwasher-mode.d.ts
+++ b/packages/types/src/clusters/dishwasher-mode.d.ts
@@ -308,7 +308,7 @@ export declare namespace DishwasherMode {
     /**
      * @deprecated Use {@link DishwasherMode}.
      */
-    export const Cluster: typeof DishwasherMode;
+    export const Cluster: ClusterType.WithCompat<typeof DishwasherMode, DishwasherMode>;
 
     /**
      * @deprecated Use {@link DishwasherMode}.

--- a/packages/types/src/clusters/door-lock.d.ts
+++ b/packages/types/src/clusters/door-lock.d.ts
@@ -4918,7 +4918,7 @@ export declare namespace DoorLock {
     /**
      * @deprecated Use {@link DoorLock}.
      */
-    export const Cluster: typeof DoorLock;
+    export const Cluster: ClusterType.WithCompat<typeof DoorLock, DoorLock>;
 
     /**
      * @deprecated Use {@link DoorLock}.

--- a/packages/types/src/clusters/electrical-energy-measurement.d.ts
+++ b/packages/types/src/clusters/electrical-energy-measurement.d.ts
@@ -720,7 +720,7 @@ export declare namespace ElectricalEnergyMeasurement {
     /**
      * @deprecated Use {@link ElectricalEnergyMeasurement}.
      */
-    export const Cluster: typeof ElectricalEnergyMeasurement;
+    export const Cluster: ClusterType.WithCompat<typeof ElectricalEnergyMeasurement, ElectricalEnergyMeasurement>;
 
     /**
      * @deprecated Use {@link ElectricalEnergyMeasurement}.

--- a/packages/types/src/clusters/electrical-power-measurement.d.ts
+++ b/packages/types/src/clusters/electrical-power-measurement.d.ts
@@ -1135,7 +1135,7 @@ export declare namespace ElectricalPowerMeasurement {
     /**
      * @deprecated Use {@link ElectricalPowerMeasurement}.
      */
-    export const Cluster: typeof ElectricalPowerMeasurement;
+    export const Cluster: ClusterType.WithCompat<typeof ElectricalPowerMeasurement, ElectricalPowerMeasurement>;
 
     /**
      * @deprecated Use {@link ElectricalPowerMeasurement}.

--- a/packages/types/src/clusters/energy-evse-mode.d.ts
+++ b/packages/types/src/clusters/energy-evse-mode.d.ts
@@ -342,7 +342,7 @@ export declare namespace EnergyEvseMode {
     /**
      * @deprecated Use {@link EnergyEvseMode}.
      */
-    export const Cluster: typeof EnergyEvseMode;
+    export const Cluster: ClusterType.WithCompat<typeof EnergyEvseMode, EnergyEvseMode>;
 
     /**
      * @deprecated Use {@link EnergyEvseMode}.

--- a/packages/types/src/clusters/energy-evse.d.ts
+++ b/packages/types/src/clusters/energy-evse.d.ts
@@ -1689,7 +1689,7 @@ export declare namespace EnergyEvse {
     /**
      * @deprecated Use {@link EnergyEvse}.
      */
-    export const Cluster: typeof EnergyEvse;
+    export const Cluster: ClusterType.WithCompat<typeof EnergyEvse, EnergyEvse>;
 
     /**
      * @deprecated Use {@link EnergyEvse}.

--- a/packages/types/src/clusters/energy-preference.d.ts
+++ b/packages/types/src/clusters/energy-preference.d.ts
@@ -339,7 +339,7 @@ export declare namespace EnergyPreference {
     /**
      * @deprecated Use {@link EnergyPreference}.
      */
-    export const Cluster: typeof EnergyPreference;
+    export const Cluster: ClusterType.WithCompat<typeof EnergyPreference, EnergyPreference>;
 
     /**
      * @deprecated Use {@link EnergyPreference}.

--- a/packages/types/src/clusters/ethernet-network-diagnostics.d.ts
+++ b/packages/types/src/clusters/ethernet-network-diagnostics.d.ts
@@ -344,7 +344,7 @@ export declare namespace EthernetNetworkDiagnostics {
     /**
      * @deprecated Use {@link EthernetNetworkDiagnostics}.
      */
-    export const Cluster: typeof EthernetNetworkDiagnostics;
+    export const Cluster: ClusterType.WithCompat<typeof EthernetNetworkDiagnostics, EthernetNetworkDiagnostics>;
 
     /**
      * @deprecated Use {@link EthernetNetworkDiagnostics}.

--- a/packages/types/src/clusters/fan-control.d.ts
+++ b/packages/types/src/clusters/fan-control.d.ts
@@ -735,7 +735,7 @@ export declare namespace FanControl {
     /**
      * @deprecated Use {@link FanControl}.
      */
-    export const Cluster: typeof FanControl;
+    export const Cluster: ClusterType.WithCompat<typeof FanControl, FanControl>;
 
     /**
      * @deprecated Use {@link FanControl}.

--- a/packages/types/src/clusters/formaldehyde-concentration-measurement.d.ts
+++ b/packages/types/src/clusters/formaldehyde-concentration-measurement.d.ts
@@ -316,7 +316,7 @@ export declare namespace FormaldehydeConcentrationMeasurement {
     /**
      * @deprecated Use {@link FormaldehydeConcentrationMeasurement}.
      */
-    export const Cluster: typeof FormaldehydeConcentrationMeasurement;
+    export const Cluster: ClusterType.WithCompat<typeof FormaldehydeConcentrationMeasurement, FormaldehydeConcentrationMeasurement>;
 
     /**
      * @deprecated Use {@link FormaldehydeConcentrationMeasurement}.

--- a/packages/types/src/clusters/general-commissioning.d.ts
+++ b/packages/types/src/clusters/general-commissioning.d.ts
@@ -1021,7 +1021,7 @@ export declare namespace GeneralCommissioning {
     /**
      * @deprecated Use {@link GeneralCommissioning}.
      */
-    export const Cluster: typeof GeneralCommissioning;
+    export const Cluster: ClusterType.WithCompat<typeof GeneralCommissioning, GeneralCommissioning>;
 
     /**
      * @deprecated Use {@link GeneralCommissioning}.

--- a/packages/types/src/clusters/general-diagnostics.d.ts
+++ b/packages/types/src/clusters/general-diagnostics.d.ts
@@ -956,7 +956,7 @@ export declare namespace GeneralDiagnostics {
     /**
      * @deprecated Use {@link GeneralDiagnostics}.
      */
-    export const Cluster: typeof GeneralDiagnostics;
+    export const Cluster: ClusterType.WithCompat<typeof GeneralDiagnostics, GeneralDiagnostics>;
 
     /**
      * @deprecated Use {@link GeneralDiagnostics}.

--- a/packages/types/src/clusters/group-key-management.d.ts
+++ b/packages/types/src/clusters/group-key-management.d.ts
@@ -644,7 +644,7 @@ export declare namespace GroupKeyManagement {
     /**
      * @deprecated Use {@link GroupKeyManagement}.
      */
-    export const Cluster: typeof GroupKeyManagement;
+    export const Cluster: ClusterType.WithCompat<typeof GroupKeyManagement, GroupKeyManagement>;
 
     /**
      * @deprecated Use {@link GroupKeyManagement}.

--- a/packages/types/src/clusters/groups.d.ts
+++ b/packages/types/src/clusters/groups.d.ts
@@ -422,7 +422,7 @@ export declare namespace Groups {
     /**
      * @deprecated Use {@link Groups}.
      */
-    export const Cluster: typeof Groups;
+    export const Cluster: ClusterType.WithCompat<typeof Groups, Groups>;
 
     /**
      * @deprecated Use {@link Groups}.

--- a/packages/types/src/clusters/hepa-filter-monitoring.d.ts
+++ b/packages/types/src/clusters/hepa-filter-monitoring.d.ts
@@ -228,7 +228,7 @@ export declare namespace HepaFilterMonitoring {
     /**
      * @deprecated Use {@link HepaFilterMonitoring}.
      */
-    export const Cluster: typeof HepaFilterMonitoring;
+    export const Cluster: ClusterType.WithCompat<typeof HepaFilterMonitoring, HepaFilterMonitoring>;
 
     /**
      * @deprecated Use {@link HepaFilterMonitoring}.

--- a/packages/types/src/clusters/icd-management.d.ts
+++ b/packages/types/src/clusters/icd-management.d.ts
@@ -941,7 +941,7 @@ export declare namespace IcdManagement {
     /**
      * @deprecated Use {@link IcdManagement}.
      */
-    export const Cluster: typeof IcdManagement;
+    export const Cluster: ClusterType.WithCompat<typeof IcdManagement, IcdManagement>;
 
     /**
      * @deprecated Use {@link IcdManagement}.

--- a/packages/types/src/clusters/keypad-input.d.ts
+++ b/packages/types/src/clusters/keypad-input.d.ts
@@ -295,7 +295,7 @@ export declare namespace KeypadInput {
     /**
      * @deprecated Use {@link KeypadInput}.
      */
-    export const Cluster: typeof KeypadInput;
+    export const Cluster: ClusterType.WithCompat<typeof KeypadInput, KeypadInput>;
 
     /**
      * @deprecated Use {@link KeypadInput}.

--- a/packages/types/src/clusters/laundry-washer-controls.d.ts
+++ b/packages/types/src/clusters/laundry-washer-controls.d.ts
@@ -217,7 +217,7 @@ export declare namespace LaundryWasherControls {
     /**
      * @deprecated Use {@link LaundryWasherControls}.
      */
-    export const Cluster: typeof LaundryWasherControls;
+    export const Cluster: ClusterType.WithCompat<typeof LaundryWasherControls, LaundryWasherControls>;
 
     /**
      * @deprecated Use {@link LaundryWasherControls}.

--- a/packages/types/src/clusters/laundry-washer-mode.d.ts
+++ b/packages/types/src/clusters/laundry-washer-mode.d.ts
@@ -315,7 +315,7 @@ export declare namespace LaundryWasherMode {
     /**
      * @deprecated Use {@link LaundryWasherMode}.
      */
-    export const Cluster: typeof LaundryWasherMode;
+    export const Cluster: ClusterType.WithCompat<typeof LaundryWasherMode, LaundryWasherMode>;
 
     /**
      * @deprecated Use {@link LaundryWasherMode}.

--- a/packages/types/src/clusters/level-control.d.ts
+++ b/packages/types/src/clusters/level-control.d.ts
@@ -693,7 +693,7 @@ export declare namespace LevelControl {
     /**
      * @deprecated Use {@link LevelControl}.
      */
-    export const Cluster: typeof LevelControl;
+    export const Cluster: ClusterType.WithCompat<typeof LevelControl, LevelControl>;
 
     /**
      * @deprecated Use {@link LevelControl}.

--- a/packages/types/src/clusters/media-input.d.ts
+++ b/packages/types/src/clusters/media-input.d.ts
@@ -269,7 +269,7 @@ export declare namespace MediaInput {
     /**
      * @deprecated Use {@link MediaInput}.
      */
-    export const Cluster: typeof MediaInput;
+    export const Cluster: ClusterType.WithCompat<typeof MediaInput, MediaInput>;
 
     /**
      * @deprecated Use {@link MediaInput}.

--- a/packages/types/src/clusters/media-playback.d.ts
+++ b/packages/types/src/clusters/media-playback.d.ts
@@ -1267,7 +1267,7 @@ export declare namespace MediaPlayback {
     /**
      * @deprecated Use {@link MediaPlayback}.
      */
-    export const Cluster: typeof MediaPlayback;
+    export const Cluster: ClusterType.WithCompat<typeof MediaPlayback, MediaPlayback>;
 
     /**
      * @deprecated Use {@link MediaPlayback}.

--- a/packages/types/src/clusters/messages.d.ts
+++ b/packages/types/src/clusters/messages.d.ts
@@ -656,7 +656,7 @@ export declare namespace Messages {
     /**
      * @deprecated Use {@link Messages}.
      */
-    export const Cluster: typeof Messages;
+    export const Cluster: ClusterType.WithCompat<typeof Messages, Messages>;
 
     /**
      * @deprecated Use {@link Messages}.

--- a/packages/types/src/clusters/microwave-oven-control.d.ts
+++ b/packages/types/src/clusters/microwave-oven-control.d.ts
@@ -422,7 +422,7 @@ export declare namespace MicrowaveOvenControl {
     /**
      * @deprecated Use {@link MicrowaveOvenControl}.
      */
-    export const Cluster: typeof MicrowaveOvenControl;
+    export const Cluster: ClusterType.WithCompat<typeof MicrowaveOvenControl, MicrowaveOvenControl>;
 
     /**
      * @deprecated Use {@link MicrowaveOvenControl}.

--- a/packages/types/src/clusters/microwave-oven-mode.d.ts
+++ b/packages/types/src/clusters/microwave-oven-mode.d.ts
@@ -279,7 +279,7 @@ export declare namespace MicrowaveOvenMode {
     /**
      * @deprecated Use {@link MicrowaveOvenMode}.
      */
-    export const Cluster: typeof MicrowaveOvenMode;
+    export const Cluster: ClusterType.WithCompat<typeof MicrowaveOvenMode, MicrowaveOvenMode>;
 
     /**
      * @deprecated Use {@link MicrowaveOvenMode}.

--- a/packages/types/src/clusters/mode-select.d.ts
+++ b/packages/types/src/clusters/mode-select.d.ts
@@ -360,7 +360,7 @@ export declare namespace ModeSelect {
     /**
      * @deprecated Use {@link ModeSelect}.
      */
-    export const Cluster: typeof ModeSelect;
+    export const Cluster: ClusterType.WithCompat<typeof ModeSelect, ModeSelect>;
 
     /**
      * @deprecated Use {@link ModeSelect}.

--- a/packages/types/src/clusters/network-commissioning.d.ts
+++ b/packages/types/src/clusters/network-commissioning.d.ts
@@ -1547,7 +1547,7 @@ export declare namespace NetworkCommissioning {
     /**
      * @deprecated Use {@link NetworkCommissioning}.
      */
-    export const Cluster: typeof NetworkCommissioning;
+    export const Cluster: ClusterType.WithCompat<typeof NetworkCommissioning, NetworkCommissioning>;
 
     /**
      * @deprecated Use {@link NetworkCommissioning}.

--- a/packages/types/src/clusters/nitrogen-dioxide-concentration-measurement.d.ts
+++ b/packages/types/src/clusters/nitrogen-dioxide-concentration-measurement.d.ts
@@ -318,7 +318,7 @@ export declare namespace NitrogenDioxideConcentrationMeasurement {
     /**
      * @deprecated Use {@link NitrogenDioxideConcentrationMeasurement}.
      */
-    export const Cluster: typeof NitrogenDioxideConcentrationMeasurement;
+    export const Cluster: ClusterType.WithCompat<typeof NitrogenDioxideConcentrationMeasurement, NitrogenDioxideConcentrationMeasurement>;
 
     /**
      * @deprecated Use {@link NitrogenDioxideConcentrationMeasurement}.

--- a/packages/types/src/clusters/occupancy-sensing.d.ts
+++ b/packages/types/src/clusters/occupancy-sensing.d.ts
@@ -556,7 +556,7 @@ export declare namespace OccupancySensing {
     /**
      * @deprecated Use {@link OccupancySensing}.
      */
-    export const Cluster: typeof OccupancySensing;
+    export const Cluster: ClusterType.WithCompat<typeof OccupancySensing, OccupancySensing>;
 
     /**
      * @deprecated Use {@link OccupancySensing}.

--- a/packages/types/src/clusters/on-off.d.ts
+++ b/packages/types/src/clusters/on-off.d.ts
@@ -481,7 +481,7 @@ export declare namespace OnOff {
     /**
      * @deprecated Use {@link OnOff}.
      */
-    export const Cluster: typeof OnOff;
+    export const Cluster: ClusterType.WithCompat<typeof OnOff, OnOff>;
 
     /**
      * @deprecated Use {@link OnOff}.

--- a/packages/types/src/clusters/oven-mode.d.ts
+++ b/packages/types/src/clusters/oven-mode.d.ts
@@ -353,7 +353,7 @@ export declare namespace OvenMode {
     /**
      * @deprecated Use {@link OvenMode}.
      */
-    export const Cluster: typeof OvenMode;
+    export const Cluster: ClusterType.WithCompat<typeof OvenMode, OvenMode>;
 
     /**
      * @deprecated Use {@link OvenMode}.

--- a/packages/types/src/clusters/ozone-concentration-measurement.d.ts
+++ b/packages/types/src/clusters/ozone-concentration-measurement.d.ts
@@ -316,7 +316,7 @@ export declare namespace OzoneConcentrationMeasurement {
     /**
      * @deprecated Use {@link OzoneConcentrationMeasurement}.
      */
-    export const Cluster: typeof OzoneConcentrationMeasurement;
+    export const Cluster: ClusterType.WithCompat<typeof OzoneConcentrationMeasurement, OzoneConcentrationMeasurement>;
 
     /**
      * @deprecated Use {@link OzoneConcentrationMeasurement}.

--- a/packages/types/src/clusters/pm1-concentration-measurement.d.ts
+++ b/packages/types/src/clusters/pm1-concentration-measurement.d.ts
@@ -316,7 +316,7 @@ export declare namespace Pm1ConcentrationMeasurement {
     /**
      * @deprecated Use {@link Pm1ConcentrationMeasurement}.
      */
-    export const Cluster: typeof Pm1ConcentrationMeasurement;
+    export const Cluster: ClusterType.WithCompat<typeof Pm1ConcentrationMeasurement, Pm1ConcentrationMeasurement>;
 
     /**
      * @deprecated Use {@link Pm1ConcentrationMeasurement}.

--- a/packages/types/src/clusters/pm10-concentration-measurement.d.ts
+++ b/packages/types/src/clusters/pm10-concentration-measurement.d.ts
@@ -316,7 +316,7 @@ export declare namespace Pm10ConcentrationMeasurement {
     /**
      * @deprecated Use {@link Pm10ConcentrationMeasurement}.
      */
-    export const Cluster: typeof Pm10ConcentrationMeasurement;
+    export const Cluster: ClusterType.WithCompat<typeof Pm10ConcentrationMeasurement, Pm10ConcentrationMeasurement>;
 
     /**
      * @deprecated Use {@link Pm10ConcentrationMeasurement}.

--- a/packages/types/src/clusters/pm25-concentration-measurement.d.ts
+++ b/packages/types/src/clusters/pm25-concentration-measurement.d.ts
@@ -316,7 +316,7 @@ export declare namespace Pm25ConcentrationMeasurement {
     /**
      * @deprecated Use {@link Pm25ConcentrationMeasurement}.
      */
-    export const Cluster: typeof Pm25ConcentrationMeasurement;
+    export const Cluster: ClusterType.WithCompat<typeof Pm25ConcentrationMeasurement, Pm25ConcentrationMeasurement>;
 
     /**
      * @deprecated Use {@link Pm25ConcentrationMeasurement}.

--- a/packages/types/src/clusters/power-source.d.ts
+++ b/packages/types/src/clusters/power-source.d.ts
@@ -1729,7 +1729,7 @@ export declare namespace PowerSource {
     /**
      * @deprecated Use {@link PowerSource}.
      */
-    export const Cluster: typeof PowerSource;
+    export const Cluster: ClusterType.WithCompat<typeof PowerSource, PowerSource>;
 
     /**
      * @deprecated Use {@link PowerSource}.

--- a/packages/types/src/clusters/power-topology.d.ts
+++ b/packages/types/src/clusters/power-topology.d.ts
@@ -145,7 +145,7 @@ export declare namespace PowerTopology {
     /**
      * @deprecated Use {@link PowerTopology}.
      */
-    export const Cluster: typeof PowerTopology;
+    export const Cluster: ClusterType.WithCompat<typeof PowerTopology, PowerTopology>;
 
     /**
      * @deprecated Use {@link PowerTopology}.

--- a/packages/types/src/clusters/pressure-measurement.d.ts
+++ b/packages/types/src/clusters/pressure-measurement.d.ts
@@ -256,7 +256,7 @@ export declare namespace PressureMeasurement {
     /**
      * @deprecated Use {@link PressureMeasurement}.
      */
-    export const Cluster: typeof PressureMeasurement;
+    export const Cluster: ClusterType.WithCompat<typeof PressureMeasurement, PressureMeasurement>;
 
     /**
      * @deprecated Use {@link PressureMeasurement}.

--- a/packages/types/src/clusters/pump-configuration-and-control.d.ts
+++ b/packages/types/src/clusters/pump-configuration-and-control.d.ts
@@ -1237,7 +1237,7 @@ export declare namespace PumpConfigurationAndControl {
     /**
      * @deprecated Use {@link PumpConfigurationAndControl}.
      */
-    export const Cluster: typeof PumpConfigurationAndControl;
+    export const Cluster: ClusterType.WithCompat<typeof PumpConfigurationAndControl, PumpConfigurationAndControl>;
 
     /**
      * @deprecated Use {@link PumpConfigurationAndControl}.

--- a/packages/types/src/clusters/radon-concentration-measurement.d.ts
+++ b/packages/types/src/clusters/radon-concentration-measurement.d.ts
@@ -316,7 +316,7 @@ export declare namespace RadonConcentrationMeasurement {
     /**
      * @deprecated Use {@link RadonConcentrationMeasurement}.
      */
-    export const Cluster: typeof RadonConcentrationMeasurement;
+    export const Cluster: ClusterType.WithCompat<typeof RadonConcentrationMeasurement, RadonConcentrationMeasurement>;
 
     /**
      * @deprecated Use {@link RadonConcentrationMeasurement}.

--- a/packages/types/src/clusters/refrigerator-alarm.d.ts
+++ b/packages/types/src/clusters/refrigerator-alarm.d.ts
@@ -286,7 +286,7 @@ export declare namespace RefrigeratorAlarm {
     /**
      * @deprecated Use {@link RefrigeratorAlarm}.
      */
-    export const Cluster: typeof RefrigeratorAlarm;
+    export const Cluster: ClusterType.WithCompat<typeof RefrigeratorAlarm, RefrigeratorAlarm>;
 
     /**
      * @deprecated Use {@link RefrigeratorAlarm}.

--- a/packages/types/src/clusters/refrigerator-and-temperature-controlled-cabinet-mode.d.ts
+++ b/packages/types/src/clusters/refrigerator-and-temperature-controlled-cabinet-mode.d.ts
@@ -301,7 +301,7 @@ export declare namespace RefrigeratorAndTemperatureControlledCabinetMode {
     /**
      * @deprecated Use {@link RefrigeratorAndTemperatureControlledCabinetMode}.
      */
-    export const Cluster: typeof RefrigeratorAndTemperatureControlledCabinetMode;
+    export const Cluster: ClusterType.WithCompat<typeof RefrigeratorAndTemperatureControlledCabinetMode, RefrigeratorAndTemperatureControlledCabinetMode>;
 
     /**
      * @deprecated Use {@link RefrigeratorAndTemperatureControlledCabinetMode}.

--- a/packages/types/src/clusters/rvc-clean-mode.d.ts
+++ b/packages/types/src/clusters/rvc-clean-mode.d.ts
@@ -334,7 +334,7 @@ export declare namespace RvcCleanMode {
     /**
      * @deprecated Use {@link RvcCleanMode}.
      */
-    export const Cluster: typeof RvcCleanMode;
+    export const Cluster: ClusterType.WithCompat<typeof RvcCleanMode, RvcCleanMode>;
 
     /**
      * @deprecated Use {@link RvcCleanMode}.

--- a/packages/types/src/clusters/rvc-run-mode.d.ts
+++ b/packages/types/src/clusters/rvc-run-mode.d.ts
@@ -389,7 +389,7 @@ export declare namespace RvcRunMode {
     /**
      * @deprecated Use {@link RvcRunMode}.
      */
-    export const Cluster: typeof RvcRunMode;
+    export const Cluster: ClusterType.WithCompat<typeof RvcRunMode, RvcRunMode>;
 
     /**
      * @deprecated Use {@link RvcRunMode}.

--- a/packages/types/src/clusters/scenes-management.d.ts
+++ b/packages/types/src/clusters/scenes-management.d.ts
@@ -839,7 +839,7 @@ export declare namespace ScenesManagement {
     /**
      * @deprecated Use {@link ScenesManagement}.
      */
-    export const Cluster: typeof ScenesManagement;
+    export const Cluster: ClusterType.WithCompat<typeof ScenesManagement, ScenesManagement>;
 
     /**
      * @deprecated Use {@link ScenesManagement}.

--- a/packages/types/src/clusters/service-area.d.ts
+++ b/packages/types/src/clusters/service-area.d.ts
@@ -1016,7 +1016,7 @@ export declare namespace ServiceArea {
     /**
      * @deprecated Use {@link ServiceArea}.
      */
-    export const Cluster: typeof ServiceArea;
+    export const Cluster: ClusterType.WithCompat<typeof ServiceArea, ServiceArea>;
 
     /**
      * @deprecated Use {@link ServiceArea}.

--- a/packages/types/src/clusters/smoke-co-alarm.d.ts
+++ b/packages/types/src/clusters/smoke-co-alarm.d.ts
@@ -881,7 +881,7 @@ export declare namespace SmokeCoAlarm {
     /**
      * @deprecated Use {@link SmokeCoAlarm}.
      */
-    export const Cluster: typeof SmokeCoAlarm;
+    export const Cluster: ClusterType.WithCompat<typeof SmokeCoAlarm, SmokeCoAlarm>;
 
     /**
      * @deprecated Use {@link SmokeCoAlarm}.

--- a/packages/types/src/clusters/software-diagnostics.d.ts
+++ b/packages/types/src/clusters/software-diagnostics.d.ts
@@ -308,7 +308,7 @@ export declare namespace SoftwareDiagnostics {
     /**
      * @deprecated Use {@link SoftwareDiagnostics}.
      */
-    export const Cluster: typeof SoftwareDiagnostics;
+    export const Cluster: ClusterType.WithCompat<typeof SoftwareDiagnostics, SoftwareDiagnostics>;
 
     /**
      * @deprecated Use {@link SoftwareDiagnostics}.

--- a/packages/types/src/clusters/switch.d.ts
+++ b/packages/types/src/clusters/switch.d.ts
@@ -743,7 +743,7 @@ export declare namespace Switch {
     /**
      * @deprecated Use {@link Switch}.
      */
-    export const Cluster: typeof Switch;
+    export const Cluster: ClusterType.WithCompat<typeof Switch, Switch>;
 
     /**
      * @deprecated Use {@link Switch}.

--- a/packages/types/src/clusters/temperature-control.d.ts
+++ b/packages/types/src/clusters/temperature-control.d.ts
@@ -302,7 +302,7 @@ export declare namespace TemperatureControl {
     /**
      * @deprecated Use {@link TemperatureControl}.
      */
-    export const Cluster: typeof TemperatureControl;
+    export const Cluster: ClusterType.WithCompat<typeof TemperatureControl, TemperatureControl>;
 
     /**
      * @deprecated Use {@link TemperatureControl}.

--- a/packages/types/src/clusters/thermostat.d.ts
+++ b/packages/types/src/clusters/thermostat.d.ts
@@ -3308,7 +3308,7 @@ export declare namespace Thermostat {
     /**
      * @deprecated Use {@link Thermostat}.
      */
-    export const Cluster: typeof Thermostat;
+    export const Cluster: ClusterType.WithCompat<typeof Thermostat, Thermostat>;
 
     /**
      * @deprecated Use {@link Thermostat}.

--- a/packages/types/src/clusters/thread-border-router-management.d.ts
+++ b/packages/types/src/clusters/thread-border-router-management.d.ts
@@ -361,7 +361,7 @@ export declare namespace ThreadBorderRouterManagement {
     /**
      * @deprecated Use {@link ThreadBorderRouterManagement}.
      */
-    export const Cluster: typeof ThreadBorderRouterManagement;
+    export const Cluster: ClusterType.WithCompat<typeof ThreadBorderRouterManagement, ThreadBorderRouterManagement>;
 
     /**
      * @deprecated Use {@link ThreadBorderRouterManagement}.

--- a/packages/types/src/clusters/thread-network-diagnostics.d.ts
+++ b/packages/types/src/clusters/thread-network-diagnostics.d.ts
@@ -1722,7 +1722,7 @@ export declare namespace ThreadNetworkDiagnostics {
     /**
      * @deprecated Use {@link ThreadNetworkDiagnostics}.
      */
-    export const Cluster: typeof ThreadNetworkDiagnostics;
+    export const Cluster: ClusterType.WithCompat<typeof ThreadNetworkDiagnostics, ThreadNetworkDiagnostics>;
 
     /**
      * @deprecated Use {@link ThreadNetworkDiagnostics}.

--- a/packages/types/src/clusters/time-format-localization.d.ts
+++ b/packages/types/src/clusters/time-format-localization.d.ts
@@ -248,7 +248,7 @@ export declare namespace TimeFormatLocalization {
     /**
      * @deprecated Use {@link TimeFormatLocalization}.
      */
-    export const Cluster: typeof TimeFormatLocalization;
+    export const Cluster: ClusterType.WithCompat<typeof TimeFormatLocalization, TimeFormatLocalization>;
 
     /**
      * @deprecated Use {@link TimeFormatLocalization}.

--- a/packages/types/src/clusters/time-synchronization.d.ts
+++ b/packages/types/src/clusters/time-synchronization.d.ts
@@ -1253,7 +1253,7 @@ export declare namespace TimeSynchronization {
     /**
      * @deprecated Use {@link TimeSynchronization}.
      */
-    export const Cluster: typeof TimeSynchronization;
+    export const Cluster: ClusterType.WithCompat<typeof TimeSynchronization, TimeSynchronization>;
 
     /**
      * @deprecated Use {@link TimeSynchronization}.

--- a/packages/types/src/clusters/total-volatile-organic-compounds-concentration-measurement.d.ts
+++ b/packages/types/src/clusters/total-volatile-organic-compounds-concentration-measurement.d.ts
@@ -320,7 +320,7 @@ export declare namespace TotalVolatileOrganicCompoundsConcentrationMeasurement {
     /**
      * @deprecated Use {@link TotalVolatileOrganicCompoundsConcentrationMeasurement}.
      */
-    export const Cluster: typeof TotalVolatileOrganicCompoundsConcentrationMeasurement;
+    export const Cluster: ClusterType.WithCompat<typeof TotalVolatileOrganicCompoundsConcentrationMeasurement, TotalVolatileOrganicCompoundsConcentrationMeasurement>;
 
     /**
      * @deprecated Use {@link TotalVolatileOrganicCompoundsConcentrationMeasurement}.

--- a/packages/types/src/clusters/unit-localization.d.ts
+++ b/packages/types/src/clusters/unit-localization.d.ts
@@ -149,7 +149,7 @@ export declare namespace UnitLocalization {
     /**
      * @deprecated Use {@link UnitLocalization}.
      */
-    export const Cluster: typeof UnitLocalization;
+    export const Cluster: ClusterType.WithCompat<typeof UnitLocalization, UnitLocalization>;
 
     /**
      * @deprecated Use {@link UnitLocalization}.

--- a/packages/types/src/clusters/valve-configuration-and-control.d.ts
+++ b/packages/types/src/clusters/valve-configuration-and-control.d.ts
@@ -649,7 +649,7 @@ export declare namespace ValveConfigurationAndControl {
     /**
      * @deprecated Use {@link ValveConfigurationAndControl}.
      */
-    export const Cluster: typeof ValveConfigurationAndControl;
+    export const Cluster: ClusterType.WithCompat<typeof ValveConfigurationAndControl, ValveConfigurationAndControl>;
 
     /**
      * @deprecated Use {@link ValveConfigurationAndControl}.

--- a/packages/types/src/clusters/water-heater-management.d.ts
+++ b/packages/types/src/clusters/water-heater-management.d.ts
@@ -519,7 +519,7 @@ export declare namespace WaterHeaterManagement {
     /**
      * @deprecated Use {@link WaterHeaterManagement}.
      */
-    export const Cluster: typeof WaterHeaterManagement;
+    export const Cluster: ClusterType.WithCompat<typeof WaterHeaterManagement, WaterHeaterManagement>;
 
     /**
      * @deprecated Use {@link WaterHeaterManagement}.

--- a/packages/types/src/clusters/water-heater-mode.d.ts
+++ b/packages/types/src/clusters/water-heater-mode.d.ts
@@ -320,7 +320,7 @@ export declare namespace WaterHeaterMode {
     /**
      * @deprecated Use {@link WaterHeaterMode}.
      */
-    export const Cluster: typeof WaterHeaterMode;
+    export const Cluster: ClusterType.WithCompat<typeof WaterHeaterMode, WaterHeaterMode>;
 
     /**
      * @deprecated Use {@link WaterHeaterMode}.

--- a/packages/types/src/clusters/water-tank-level-monitoring.d.ts
+++ b/packages/types/src/clusters/water-tank-level-monitoring.d.ts
@@ -228,7 +228,7 @@ export declare namespace WaterTankLevelMonitoring {
     /**
      * @deprecated Use {@link WaterTankLevelMonitoring}.
      */
-    export const Cluster: typeof WaterTankLevelMonitoring;
+    export const Cluster: ClusterType.WithCompat<typeof WaterTankLevelMonitoring, WaterTankLevelMonitoring>;
 
     /**
      * @deprecated Use {@link WaterTankLevelMonitoring}.

--- a/packages/types/src/clusters/wi-fi-network-diagnostics.d.ts
+++ b/packages/types/src/clusters/wi-fi-network-diagnostics.d.ts
@@ -571,7 +571,7 @@ export declare namespace WiFiNetworkDiagnostics {
     /**
      * @deprecated Use {@link WiFiNetworkDiagnostics}.
      */
-    export const Cluster: typeof WiFiNetworkDiagnostics;
+    export const Cluster: ClusterType.WithCompat<typeof WiFiNetworkDiagnostics, WiFiNetworkDiagnostics>;
 
     /**
      * @deprecated Use {@link WiFiNetworkDiagnostics}.

--- a/packages/types/src/clusters/window-covering.d.ts
+++ b/packages/types/src/clusters/window-covering.d.ts
@@ -1441,7 +1441,7 @@ export declare namespace WindowCovering {
     /**
      * @deprecated Use {@link WindowCovering}.
      */
-    export const Cluster: typeof WindowCovering;
+    export const Cluster: ClusterType.WithCompat<typeof WindowCovering, WindowCovering>;
 
     /**
      * @deprecated Use {@link WindowCovering}.

--- a/packages/types/test/cluster/ClusterTypeWithCompatTest.ts
+++ b/packages/types/test/cluster/ClusterTypeWithCompatTest.ts
@@ -1,0 +1,70 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { PowerSource } from "#clusters/power-source.js";
+
+describe("ClusterType.Cluster.with() compat shim", () => {
+    it("returns a namespace with identity metadata preserved", () => {
+        const selected = PowerSource.Cluster.with(PowerSource.Feature.Rechargeable, PowerSource.Feature.Battery);
+
+        expect(selected.name).equal("PowerSource");
+        expect(selected.id).equal(PowerSource.id);
+        expect(selected.schema).equal(PowerSource.schema);
+        expect(selected.revision).equal(PowerSource.revision);
+    });
+
+    it("exposes attribute metadata identical to the source namespace", () => {
+        const selected = PowerSource.Cluster.with(PowerSource.Feature.Battery);
+
+        expect(selected.attributes.status).equal(PowerSource.attributes.status);
+        expect(selected.attributes.order).equal(PowerSource.attributes.order);
+    });
+
+    it("records selected features in supportedFeatures with camelCase keys", () => {
+        // The shim's return type is intentionally minimal (typing-only SupportedFeatures shift); `supportedFeatures`
+        // is a runtime-only marker consumed by ClusterBehaviorType.syncFeatures, so this cast is required.
+        const selected = PowerSource.Cluster.with(
+            PowerSource.Feature.Rechargeable,
+            PowerSource.Feature.Battery,
+        ) as unknown as {
+            supportedFeatures: Record<string, true>;
+        };
+
+        expect(selected.supportedFeatures).deep.equal({
+            rechargeable: true,
+            battery: true,
+        });
+    });
+
+    it("returns an empty supportedFeatures record when called without features", () => {
+        const selected = PowerSource.Cluster.with() as unknown as { supportedFeatures: Record<string, true> };
+
+        expect(selected.supportedFeatures).deep.equal({});
+    });
+
+    it("does not mutate the source namespace", () => {
+        PowerSource.Cluster.with(PowerSource.Feature.Rechargeable);
+
+        expect(Object.prototype.hasOwnProperty.call(PowerSource.Cluster, "supportedFeatures")).equal(false);
+        expect(Object.prototype.hasOwnProperty.call(PowerSource, "supportedFeatures")).equal(false);
+    });
+
+    it("falls through to the source namespace via the prototype chain", () => {
+        const selected = PowerSource.Cluster.with(PowerSource.Feature.Battery);
+
+        // Not an own property — resolved via prototype delegation.
+        expect(Object.prototype.hasOwnProperty.call(selected, "features")).equal(false);
+        expect(selected.features).equal(PowerSource.features);
+        expect(selected.events).equal(PowerSource.events);
+    });
+
+    it("produces a fresh clone per call", () => {
+        const a = PowerSource.Cluster.with(PowerSource.Feature.Battery);
+        const b = PowerSource.Cluster.with(PowerSource.Feature.Battery);
+
+        expect(a).not.equal(b);
+    });
+});

--- a/packages/types/test/cluster/ClusterTypeWithCompatTest.ts
+++ b/packages/types/test/cluster/ClusterTypeWithCompatTest.ts
@@ -61,6 +61,20 @@ describe("ClusterType.Cluster.with() compat shim", () => {
         expect(selected.events).equal(PowerSource.events);
     });
 
+    it("preserves the Cluster/Complete self-reference invariant on the clone", () => {
+        const selected = PowerSource.Cluster.with(PowerSource.Feature.Battery) as unknown as {
+            Cluster: { supportedFeatures: Record<string, true> };
+            Complete: unknown;
+            supportedFeatures: Record<string, true>;
+        };
+
+        // `selected.Cluster` must point to the clone itself, not to the source namespace — otherwise the
+        // `supportedFeatures` marker is silently dropped for any caller that re-fetches `.Cluster`.
+        expect(selected.Cluster).equal(selected);
+        expect(selected.Complete).equal(selected);
+        expect(selected.Cluster.supportedFeatures).equal(selected.supportedFeatures);
+    });
+
     it("produces a fresh clone per call", () => {
         const a = PowerSource.Cluster.with(PowerSource.Feature.Battery);
         const b = PowerSource.Cluster.with(PowerSource.Feature.Battery);

--- a/support/codegen/src/clusters/generate-cluster.ts
+++ b/support/codegen/src/clusters/generate-cluster.ts
@@ -108,7 +108,10 @@ function generateComponents(file: ClusterFile) {
     // --- Deprecated ---
 
     if (cluster.id !== undefined) {
-        file.ns.atom(`export const Cluster: typeof ${name}`).document(`@deprecated Use {@link ${name}}.`);
+        // Clusters with features get a pre-PR #3466 compat shim (`.with(Feature.X, ...)`) via
+        // ClusterType.WithCompat.  See ClusterType.WithCompat JSDoc; scheduled for removal in 0.18.
+        const clusterType = hasFeatures ? `ClusterType.WithCompat<typeof ${name}, ${name}>` : `typeof ${name}`;
+        file.ns.atom(`export const Cluster: ${clusterType}`).document(`@deprecated Use {@link ${name}}.`);
     }
     file.ns.atom(`export const Complete: typeof ${name}`).document(`@deprecated Use {@link ${name}}.`);
 


### PR DESCRIPTION
## Summary

- Restores the pre-PR #3466 `PowerSource.Cluster.with(Feature.X, Feature.Y)` call site that external users still rely on.
- New reusable helper type `ClusterType.WithCompat<NS, T>` layers a `.with()` method onto the deprecated `Cluster` const. Codegen emits a single-line declaration per feature-bearing cluster.
- Runtime install in `ClusterType.ts` returns an `Object.create(ns)` clone with a `supportedFeatures` marker. Feature selection has no further runtime effect — attribute maps are not culled by conformance.
- Deprecated from day one. Tracked for removal in 0.18.

## Design notes

- **Why "born @deprecated".** Compat shim, not a new API. The `@deprecated` JSDoc is intentional — restores a removed call site while signalling the path forward. TS surfaces `[6387]` deprecation warnings on every call.
- **Why `.with()` despite the name collision with `ClusterBehavior.with()`.** The two operations have different semantics: the behavior-layer `.with()` performs real schema-level feature derivation via `applyFeatureSelection`; this namespace shim is typing-only. Keeping the pre-#3466 name is the whole point — renaming would defeat the shim.
- **Runtime compatibility with `ClusterBehaviorType.syncFeatures`.** `syncFeatures` reads `namespace.supportedFeatures` and feeds it to `new FeatureSet(...)`. `FeatureSet.normalize` matches feature names case-insensitively, so the shim's camelCase keys resolve correctly against schema feature short/long names.
- **Scope intentionally limited.** Only `.with()` is restored. `.alter() / .enable() / .set()` from the old `MutableCluster` are not re-added — no demand surfaced. `.with()` is attached only to the `Cluster` const (already `@deprecated`), not to the top-level namespace.

## Test plan

- [x] `npm run build` full repo — clean
- [x] `npm test -w @matter/types` — 297/297 pass, including new `ClusterTypeWithCompatTest` suite covering identity metadata, attribute pass-through, `supportedFeatures` population, empty selection, no source mutation, prototype-chain fallthrough, and fresh clone per call
- [x] `npm run format-verify` — clean
- [x] `npm test` full suite — no failures
- [x] TS `[6387]` deprecation diagnostic fires on `PowerSource.Cluster.with(...)` call sites — confirms IDE surfacing via the helper type
- [ ] Verified by the external user who reported the regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)