### PR TITLE
fix: handle ENOENT in NamedPipeCommandHandler.close()

### DIFF
--- a/support/chip-testing/src/NamedPipeCommandHandler.ts
+++ b/support/chip-testing/src/NamedPipeCommandHandler.ts
@@ -63,6 +63,12 @@ export class NamedPipeCommandHandler extends CommandPipe {
         }
         this.#namedPipe = undefined;
         this.#namedPipeSocket = undefined;
-        await unlink(this.filename);
+        try {
+            await unlink(this.filename);
+        } catch (error: any) {
+            if (error.code !== "ENOENT") {
+                throw error;
+            }
+        }
     }
 }


### PR DESCRIPTION
The unlink call was outside the try/catch, causing unhandled errors during shutdown when the pipe file was already removed.