### PR TITLE
fix: stagger PASE attempts across addresses of the same device

### DIFF
--- a/packages/node/src/behavior/system/controller/discovery/ParallelPaseDiscovery.ts
+++ b/packages/node/src/behavior/system/controller/discovery/ParallelPaseDiscovery.ts
@@ -24,10 +24,8 @@ const logger = Logger.get("ParallelPaseDiscovery");
  * Delay between PASE attempts to DIFFERENT discovered devices.  Kept short because cross-device attempts do
  * not share a responder state — this stagger only avoids a burst of simultaneous mDNS-triggered PASE starts
  * when many devices respond at once.  Per-address stagger for a single device lives in CommissioningConnection.
- *
- * @internal Exported for tests only — production callers have no reason to reference this.
  */
-export const CROSS_DEVICE_STAGGER_DELAY = Seconds(1);
+const CROSS_DEVICE_STAGGER_DELAY = Seconds(1);
 
 /**
  * Base class for discovery flows that run parallel PASE establishments with a first-to-win race gate.

--- a/packages/node/src/behavior/system/controller/discovery/ParallelPaseDiscovery.ts
+++ b/packages/node/src/behavior/system/controller/discovery/ParallelPaseDiscovery.ts
@@ -20,8 +20,14 @@ import { DiscoveryAggregateError, DiscoveryError } from "./DiscoveryError.js";
 
 const logger = Logger.get("ParallelPaseDiscovery");
 
-/** Delay between consecutive PASE attempt starts. */
-const PASE_STAGGER_DELAY = Seconds(5);
+/**
+ * Delay between PASE attempts to DIFFERENT discovered devices.  Kept short because cross-device attempts do
+ * not share a responder state — this stagger only avoids a burst of simultaneous mDNS-triggered PASE starts
+ * when many devices respond at once.  Per-address stagger for a single device lives in CommissioningConnection.
+ *
+ * @internal Exported for tests only — production callers have no reason to reference this.
+ */
+export const CROSS_DEVICE_STAGGER_DELAY = Seconds(1);
 
 /**
  * Base class for discovery flows that run parallel PASE establishments with a first-to-win race gate.
@@ -32,7 +38,7 @@ const PASE_STAGGER_DELAY = Seconds(5);
  *  - an {@code extractWinner} to pull the result value from the settled promise.
  *
  * Attempts are staggered: the first starts immediately, each subsequent one waits an additional
- * {@link PASE_STAGGER_DELAY}.  When {@code winOnPase} is called, the internal abort signal fires,
+ * {@link CROSS_DEVICE_STAGGER_DELAY}.  When {@code winOnPase} is called, the internal abort signal fires,
  * which cancels any pending stagger sleeps so that no further attempts are started.
  */
 export abstract class ParallelPaseDiscovery<W> extends Discovery<W> {
@@ -95,7 +101,7 @@ export abstract class ParallelPaseDiscovery<W> extends Discovery<W> {
         };
 
         const attemptIndex = this.#attemptCount++;
-        const stagger = Millis(attemptIndex * PASE_STAGGER_DELAY);
+        const stagger = Millis(attemptIndex * CROSS_DEVICE_STAGGER_DELAY);
 
         const startFactory = () => {
             this.#startedCount++;

--- a/packages/node/test/behavior/system/controller/discovery/ParallelPaseRaceTest.ts
+++ b/packages/node/test/behavior/system/controller/discovery/ParallelPaseRaceTest.ts
@@ -4,7 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Abort, CanceledError, MatterAggregateError, Millis, Seconds } from "@matter/general";
+import { CROSS_DEVICE_STAGGER_DELAY } from "#behavior/system/controller/discovery/ParallelPaseDiscovery.js";
+import { Abort, CanceledError, MatterAggregateError, Millis } from "@matter/general";
 import { PeerCommunicationError } from "@matter/protocol";
 
 /**
@@ -348,7 +349,9 @@ describe("ParallelPaseDiscovery race pattern", () => {
 describe("ParallelPaseDiscovery stagger pattern", () => {
     beforeEach(() => MockTime.init());
 
-    const PASE_STAGGER_DELAY = Seconds(5);
+    // Amount to advance in MockTime to cross one stagger slot.  Uses the real production constant so the
+    // test stays aligned if the value is tuned.  +50ms buffer covers microtask settling.
+    const SLOT_ADVANCE_MS = CROSS_DEVICE_STAGGER_DELAY + 50;
 
     /**
      * Stagger-aware version of the race harness.  Mirrors the production code's use of
@@ -387,7 +390,7 @@ describe("ParallelPaseDiscovery stagger pattern", () => {
             };
 
             const attemptIndex = attemptCount++;
-            const stagger = Millis(attemptIndex * PASE_STAGGER_DELAY);
+            const stagger = Millis(attemptIndex * CROSS_DEVICE_STAGGER_DELAY);
 
             const startFactory = () => {
                 startedCount++;
@@ -469,7 +472,7 @@ describe("ParallelPaseDiscovery stagger pattern", () => {
         return { promise, resolve, reject };
     }
 
-    it("first attempt starts immediately, second after 5s delay", async () => {
+    it("first attempt starts immediately, second after one stagger slot", async () => {
         const harness = createStaggerHarness<string>();
 
         const gate1 = deferred();
@@ -498,9 +501,9 @@ describe("ParallelPaseDiscovery stagger pattern", () => {
         expect(harness.factoryCallOrder).deep.equals([0]);
         expect(harness.startedCount).equals(1);
 
-        // Advance time past the 5s stagger. advance() fires the timer callback inline,
+        // Advance time past the stagger slot.  advance() fires the timer callback inline,
         // then we need yields for the promise chain (Abort.race -> finally -> then).
-        await MockTime.advance(5100);
+        await MockTime.advance(SLOT_ADVANCE_MS);
         await MockTime.yield3();
         await MockTime.yield3();
         await MockTime.yield3();
@@ -516,7 +519,7 @@ describe("ParallelPaseDiscovery stagger pattern", () => {
         expect(result).equals("winner");
     });
 
-    it("three attempts start with correct 5s stagger intervals", async () => {
+    it("three attempts fire at correct stagger intervals", async () => {
         const harness = createStaggerHarness<string>();
 
         const gates = [deferred(), deferred(), deferred()];
@@ -536,15 +539,15 @@ describe("ParallelPaseDiscovery stagger pattern", () => {
         await MockTime.yield3();
         expect(harness.factoryCallOrder).deep.equals([0]);
 
-        // Advance 5s — second attempt fires
-        await MockTime.advance(5100);
+        // One slot later — second attempt fires
+        await MockTime.advance(SLOT_ADVANCE_MS);
         await MockTime.yield3();
         await MockTime.yield3();
         await MockTime.yield3();
         expect(harness.factoryCallOrder).deep.equals([0, 1]);
 
-        // Advance another 5s — third attempt fires
-        await MockTime.advance(5000);
+        // Another slot later — third attempt fires
+        await MockTime.advance(SLOT_ADVANCE_MS);
         await MockTime.yield3();
         await MockTime.yield3();
         await MockTime.yield3();
@@ -573,7 +576,7 @@ describe("ParallelPaseDiscovery stagger pattern", () => {
             result => result,
         );
 
-        // Second attempt (5s stagger)
+        // Second attempt (staggered)
         harness.registerAttempt(
             async () => {
                 return "should-not-run";
@@ -584,15 +587,15 @@ describe("ParallelPaseDiscovery stagger pattern", () => {
         await MockTime.yield3();
         expect(harness.factoryCallOrder).deep.equals([0]);
 
-        // Winner wins before the 5s stagger elapses
+        // Winner wins before the stagger elapses
         winnerGate.resolve();
         await MockTime.yield3();
         expect(harness.isStopped()).equals(true);
 
         // The abort signal resolves the stagger sleep, and the stagger guard sees
-        // abort.signal.aborted so the factory is skipped.  Advance time and yield to
+        // abort.signal.aborted so the factory is skipped.  Advance well past the slot and yield to
         // let the promise chain settle.
-        await MockTime.resolve(MockTime.advance(6000));
+        await MockTime.resolve(MockTime.advance(SLOT_ADVANCE_MS + 1000));
         expect(harness.factoryCallOrder).deep.equals([0]);
         expect(harness.startedCount).equals(1);
 

--- a/packages/node/test/behavior/system/controller/discovery/ParallelPaseRaceTest.ts
+++ b/packages/node/test/behavior/system/controller/discovery/ParallelPaseRaceTest.ts
@@ -4,9 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { CROSS_DEVICE_STAGGER_DELAY } from "#behavior/system/controller/discovery/ParallelPaseDiscovery.js";
-import { Abort, CanceledError, MatterAggregateError, Millis } from "@matter/general";
+import { Abort, CanceledError, MatterAggregateError, Millis, Seconds } from "@matter/general";
 import { PeerCommunicationError } from "@matter/protocol";
+
+// Mirror of the module-private constant in ParallelPaseDiscovery.ts — keep in sync.
+const CROSS_DEVICE_STAGGER_DELAY = Seconds(1);
 
 /**
  * Tests the promise race pattern used by {@link ParallelPaseDiscovery.registerAttempt} and
@@ -349,8 +351,7 @@ describe("ParallelPaseDiscovery race pattern", () => {
 describe("ParallelPaseDiscovery stagger pattern", () => {
     beforeEach(() => MockTime.init());
 
-    // Amount to advance in MockTime to cross one stagger slot.  Uses the real production constant so the
-    // test stays aligned if the value is tuned.  +50ms buffer covers microtask settling.
+    // One stagger slot + 50ms buffer for microtask settling.
     const SLOT_ADVANCE_MS = CROSS_DEVICE_STAGGER_DELAY + 50;
 
     /**

--- a/packages/protocol/src/peer/CommissioningConnection.ts
+++ b/packages/protocol/src/peer/CommissioningConnection.ts
@@ -14,8 +14,10 @@ import {
     Duration,
     Logger,
     MatterAggregateError,
+    Millis,
     NetworkError,
     NoResponseTimeoutError,
+    Seconds,
     ServerAddress,
     TimeoutError,
     UnexpectedDataError,
@@ -29,13 +31,23 @@ const logger = Logger.get("CommissioningConnection");
 // We do not wait indefinitely — a transport that ignores abort must not block the caller.
 const LOSER_CLEANUP_BUDGET_MS = 5000;
 
+// Delay between consecutive PASE attempt starts for addresses of the same device.  The CHIP SDK
+// responder binds its singleton PASESession to the first incoming PBKDFParamRequest exchange; concurrent
+// requests on other exchanges are rejected and clear the in-progress PASE state.  Staggering avoids that
+// race when a single device exposes multiple addresses (e.g. IPv6 ULA + link-local + IPv4).  First
+// attempt fires immediately; each subsequent attempt waits one additional slot, cancelable when a winner
+// is established.  Paired with the shorter cross-device stagger in ParallelPaseDiscovery.
+const PER_ADDRESS_STAGGER_DELAY = Seconds(5);
+
 /**
  * Attempts PASE establishments in parallel across all provided device candidates, returning the first successful
  * session.
  *
- * All candidates come from {@link CommissioningConnection.Options.devices} and are launched immediately in
- * parallel.  This is used when addresses are already known (e.g. from a prior mDNS discovery or a
- * pre-configured address list).
+ * All candidates come from {@link CommissioningConnection.Options.devices}.  The first candidate launches
+ * immediately; subsequent candidates are staggered by {@link PER_ADDRESS_STAGGER_DELAY} to avoid overwhelming a
+ * device that exposes multiple addresses (the CHIP responder cannot serialise concurrent
+ * PBKDFParamRequests).  This is used when addresses are already known (e.g. from a prior mDNS discovery or
+ * a pre-configured address list).
  *
  * A PASE attempt is launched for each (device, address) candidate, so a single device may have multiple concurrent
  * attempts if it was discovered at multiple addresses.  If an attempt fails with a credential error the device is
@@ -53,6 +65,7 @@ export async function CommissioningConnection(
 ): Promise<CommissioningConnection.Result> {
     using abort = new Abort({ timeout: options.timeout, abort: options.externalAbort });
     const pool = new CommissioningConnectionPool(options.devices);
+    const staggerDelay = options.staggerDelay ?? PER_ADDRESS_STAGGER_DELAY;
     let lastError: Error | undefined;
     let lastNonRetryableError: Error | undefined;
 
@@ -76,6 +89,7 @@ export async function CommissioningConnection(
     };
 
     let winner: CommissioningConnection.Result | undefined;
+    let launchedCount = 0;
 
     const launchAttempt = (candidate: CommissioningConnectionAttempt) => {
         if (inFlight.has(candidate.attemptKey)) return;
@@ -85,9 +99,30 @@ export async function CommissioningConnection(
         const deviceAc = getDeviceAbort(candidate.deviceKey);
         const signal = AbortSignal.any([abort.signal, deviceAc.signal]);
 
-        const p: Promise<CommissioningConnection.Result | null> = options
-            .establishSession(candidate.address, candidate.device, signal)
+        // Stagger consecutive attempts so the CHIP SDK responder isn't hit with concurrent
+        // PBKDFParamRequests it cannot serialise.  First attempt fires immediately; each subsequent
+        // one waits staggerDelay * its launch index.  The shared abort signal cancels pending
+        // sleeps when a winner is established (or the overall timeout fires).
+        const slot = launchedCount++;
+        const stagger = Millis(slot * staggerDelay);
+
+        const startSession = (): Promise<NodeSession | null> => {
+            // Re-check race outcomes after the stagger sleep — winner may have been chosen, or this
+            // device's other address may have failed credential check.
+            if (winner !== undefined || signal.aborted) {
+                return Promise.resolve(null);
+            }
+            return options.establishSession(candidate.address, candidate.device, signal);
+        };
+
+        const sessionPromise: Promise<NodeSession | null> =
+            stagger > 0 ? Abort.sleep("PASE stagger", signal, stagger).then(startSession) : startSession();
+
+        const p: Promise<CommissioningConnection.Result | null> = sessionPromise
             .then(session => {
+                if (session === null) {
+                    return null;
+                }
                 if (winner !== undefined || abort.aborted) {
                     // We lost the overall race — close this session to avoid leaking a PASE channel.
                     session
@@ -133,7 +168,8 @@ export async function CommissioningConnection(
         pending.add(p);
     };
 
-    // Launch all candidates immediately and wait for them to settle or for the timeout/external abort.
+    // Schedule all candidates (first fires immediately; rest staggered) and wait for them to settle or for
+    // the timeout/external abort.
     for (const candidate of pool.availableCandidates(inFlight)) {
         launchAttempt(candidate);
     }
@@ -170,7 +206,16 @@ export async function CommissioningConnection(
 
 export namespace CommissioningConnection {
     export interface Options {
-        /** Commissioning candidates to attempt PASE with. */
+        /**
+         * Commissioning candidates to attempt PASE with.
+         *
+         * Callers should supply candidates that all reach the same physical device — typically produced by
+         * splitting a single device's address list into one candidate per address.  The stagger delay
+         * applies globally across the array (slot 0 fires immediately, slot N fires at N × staggerDelay),
+         * which is the desired behaviour for multiple addresses of one device but would serialise
+         * attempts to genuinely distinct devices.  Distinct-device fan-out belongs at a higher layer
+         * (e.g. {@link ParallelPaseDiscovery}).
+         */
         devices: CommissionableDevice[];
 
         /** Overall timeout for the entire connection attempt. */
@@ -191,6 +236,13 @@ export namespace CommissioningConnection {
          * An external abort signal.  When fired, terminates all in-flight PASE attempts immediately.
          */
         externalAbort?: AbortSignal;
+
+        /**
+         * Delay between consecutive PASE attempt starts.  Defaults to the internal 5s production value.
+         * Exposed primarily for tests that need to disable or shorten the stagger; production callers
+         * should not override this.
+         */
+        staggerDelay?: Duration;
     }
 
     export interface Result {

--- a/packages/protocol/src/peer/CommissioningConnection.ts
+++ b/packages/protocol/src/peer/CommissioningConnection.ts
@@ -209,12 +209,15 @@ export namespace CommissioningConnection {
         /**
          * Commissioning candidates to attempt PASE with.
          *
-         * Callers should supply candidates that all reach the same physical device — typically produced by
-         * splitting a single device's address list into one candidate per address.  The stagger delay
-         * applies globally across the array (slot 0 fires immediately, slot N fires at N × staggerDelay),
-         * which is the desired behaviour for multiple addresses of one device but would serialise
-         * attempts to genuinely distinct devices.  Distinct-device fan-out belongs at a higher layer
-         * (e.g. {@link ParallelPaseDiscovery}).
+         * {@link CommissioningConnectionPool} merges entries by `deviceIdentifier` and expands each device's
+         * address list into independent `(device, address)` attempts.  The stagger delay applies globally
+         * across those generated attempts (slot 0 fires immediately, slot N fires at N × staggerDelay) —
+         * the intent is to serialise addresses of one physical device so the CHIP responder isn't hit with
+         * concurrent PBKDFParamRequests it cannot handle.
+         *
+         * Callers that discover genuinely distinct devices should coordinate fan-out at a higher layer
+         * (e.g. {@link ParallelPaseDiscovery}); passing multiple distinct devices here will serialise them
+         * by the same stagger, which is usually not what you want for a multi-device race.
          */
         devices: CommissionableDevice[];
 

--- a/packages/protocol/test/peer/CommissioningConnectionTest.ts
+++ b/packages/protocol/test/peer/CommissioningConnectionTest.ts
@@ -38,6 +38,7 @@ describe("CommissioningConnection", () => {
         const { discoveryData } = await CommissioningConnection({
             devices: [device("a", [udp("fd00::1")]), device("b", [udp("fd00::2")])],
             timeout: Seconds(2),
+            staggerDelay: 0,
             establishSession: async (address, discoveryData) => {
                 attempts.push(`${discoveryData.deviceIdentifier}:${(address as ServerAddressUdp).ip}`);
                 if (discoveryData.deviceIdentifier === "a") {
@@ -57,6 +58,7 @@ describe("CommissioningConnection", () => {
         const { discoveryData } = await CommissioningConnection({
             devices: [device("a", [udp("fd00::1"), udp("fd00::3")]), device("b", [udp("fd00::2")])],
             timeout: Seconds(2),
+            staggerDelay: 0,
             establishSession: async (address, discoveryData) => {
                 const ip = (address as ServerAddressUdp).ip;
                 attempts.push(`${discoveryData.deviceIdentifier}:${ip}`);
@@ -77,6 +79,7 @@ describe("CommissioningConnection", () => {
             CommissioningConnection({
                 devices: [device("a", [udp("fd00::1")]), device("b", [udp("fd00::2")])],
                 timeout: Seconds(2),
+                staggerDelay: 0,
                 establishSession: async () => {
                     throw new UnexpectedDataError("invalid credentials");
                 },
@@ -93,6 +96,7 @@ describe("CommissioningConnection", () => {
         const p = CommissioningConnection({
             devices: [device("a", [udp("fd00::1")]), device("b", [udp("fd00::2")])],
             timeout: Seconds(2),
+            staggerDelay: 0,
             establishSession: async (address, _device) => {
                 const ip = (address as ServerAddressUdp).ip;
                 if (ip === "fd00::1") {
@@ -127,6 +131,7 @@ describe("CommissioningConnection", () => {
             CommissioningConnection({
                 devices: [device("a", [udp("fd00::1")])],
                 timeout: Millis(50),
+                staggerDelay: 0,
                 establishSession: async () => {
                     // Delay much longer than the timeout so the abort fires before we return.
                     await new Promise<void>(resolve => setTimeout(resolve, 1000));
@@ -148,6 +153,7 @@ describe("CommissioningConnection", () => {
         const p = CommissioningConnection({
             devices: [device("a", [udp("fd00::1")])],
             timeout: Millis(500),
+            staggerDelay: 0,
             externalAbort: ac.signal,
             establishSession: async (_address, _discoveryData, signal) => {
                 // Wait for the abort signal — reject with the signal's reason so we can verify
@@ -177,6 +183,7 @@ describe("CommissioningConnection", () => {
         const loserPromise = CommissioningConnection({
             devices: [device("loser", [udp("fd00::1")])],
             timeout: Millis(500),
+            staggerDelay: 0,
             externalAbort: ac.signal,
             establishSession: async (_address, _discoveryData, signal) => {
                 await new Promise<void>((_resolve, reject) => {
@@ -201,6 +208,7 @@ describe("CommissioningConnection", () => {
         const { discoveryData } = await CommissioningConnection({
             devices: [device("a", [udp("fd00::1"), udp("fd00::2"), udp("192.168.1.1")])],
             timeout: Seconds(2),
+            staggerDelay: 0,
             establishSession: async (address, discoveryData) => {
                 const ip = (address as ServerAddressUdp).ip;
                 attempts.push(`${discoveryData.deviceIdentifier}:${ip}`);
@@ -223,6 +231,7 @@ describe("CommissioningConnection", () => {
             CommissioningConnection({
                 devices: [device("a", [udp("fd00::1"), udp("fd00::2")])],
                 timeout: Seconds(2),
+                staggerDelay: 0,
                 establishSession: async address => {
                     const ip = (address as ServerAddressUdp).ip;
                     throw new AddressUnreachableError(`send EHOSTUNREACH ${ip}:5540`);
@@ -238,6 +247,7 @@ describe("CommissioningConnection", () => {
             CommissioningConnection({
                 devices: [device("a", [udp("fd00::1")])],
                 timeout: Millis(50),
+                staggerDelay: 0,
                 establishSession: async (_address, _discoveryData, signal) => {
                     receivedSignal = signal;
                     // Simulate abort-aware establishment that respects the signal
@@ -258,5 +268,183 @@ describe("CommissioningConnection", () => {
         ).rejectedWith(PairRetransmissionLimitReachedError);
         expect(receivedSignal).not.undefined;
         expect(receivedSignal!.aborted).equals(true);
+    });
+
+    describe("per-address stagger", () => {
+        beforeEach(() => MockTime.reset());
+
+        /** Creates a deferred promise for deterministic sequencing inside establishSession mocks. */
+        function deferred<T = void>() {
+            let resolve!: (value: T) => void;
+            let reject!: (reason?: unknown) => void;
+            const promise = new Promise<T>((res, rej) => {
+                resolve = res;
+                reject = rej;
+            });
+            return { promise, resolve, reject };
+        }
+
+        it("first candidate fires immediately, subsequent candidates wait staggerDelay each", async () => {
+            const order = new Array<string>();
+            const gate = deferred<void>();
+
+            const p = CommissioningConnection({
+                devices: [device("a", [udp("fd00::1"), udp("fd00::2"), udp("fd00::3")])],
+                timeout: Seconds(60),
+                staggerDelay: Seconds(5),
+                establishSession: async (address, _discoveryData, signal) => {
+                    order.push((address as ServerAddressUdp).ip);
+                    // Wait until the test releases us, or the signal aborts.
+                    await new Promise<void>((resolve, reject) => {
+                        gate.promise.then(resolve);
+                        signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+                    });
+                    if ((address as ServerAddressUdp).ip === "fd00::1") {
+                        return {} as any;
+                    }
+                    throw new NoResponseTimeoutError("losing");
+                },
+            });
+
+            // Slot 0 fires synchronously; yield to let establishSession register.
+            await MockTime.yield3();
+            expect(order).deep.equals(["fd00::1"]);
+
+            // +5s → slot 1 fires; slot 2 still pending.
+            await MockTime.advance(5000);
+            await MockTime.yield3();
+            await MockTime.yield3();
+            expect(order).deep.equals(["fd00::1", "fd00::2"]);
+
+            // +5s more → slot 2 fires.
+            await MockTime.advance(5000);
+            await MockTime.yield3();
+            await MockTime.yield3();
+            expect(order).deep.equals(["fd00::1", "fd00::2", "fd00::3"]);
+
+            // Release slot 0 so it wins; other slots get aborted via reject.
+            gate.resolve();
+            const result = await p;
+            expect(result.discoveryData.deviceIdentifier).equals("a");
+        });
+
+        it("cancels pending stagger when a winner is established", async () => {
+            const order = new Array<string>();
+            const winnerGate = deferred<void>();
+
+            const p = CommissioningConnection({
+                devices: [device("a", [udp("fd00::1"), udp("fd00::2"), udp("fd00::3")])],
+                timeout: Seconds(60),
+                staggerDelay: Seconds(5),
+                establishSession: async (address, _discoveryData, signal) => {
+                    order.push((address as ServerAddressUdp).ip);
+                    if ((address as ServerAddressUdp).ip === "fd00::1") {
+                        await winnerGate.promise;
+                        return {} as any;
+                    }
+                    // Should never be reached — slots 1 and 2 are still in their stagger sleep when the
+                    // winner resolves, so their factory must never run.
+                    await new Promise<void>((_resolve, reject) =>
+                        signal.addEventListener("abort", () => reject(signal.reason), { once: true }),
+                    );
+                    throw new NoResponseTimeoutError("should not run");
+                },
+            });
+
+            await MockTime.yield3();
+            expect(order).deep.equals(["fd00::1"]);
+
+            // Before slot 1's stagger elapses, the winner resolves.  The abort signal cancels the
+            // pending Abort.sleep, and the startSession guard skips establishSession for slots 1 and 2.
+            winnerGate.resolve();
+            const result = await p;
+            expect(result.discoveryData.deviceIdentifier).equals("a");
+
+            // Advance past where slots 1 and 2 would have fired — confirm they never did.
+            await MockTime.advance(15000);
+            await MockTime.yield3();
+            expect(order).deep.equals(["fd00::1"]);
+        });
+
+        it("stagger slot is global across the devices array (distinct-device fan-out belongs elsewhere)", async () => {
+            // Documents the API contract: CommissioningConnection treats its devices array as a flat list
+            // of candidates and staggers them by position (slot 0 at t=0, slot 1 at t=staggerDelay, ...).
+            // This is correct for addresses of ONE logical device but intentionally serialises attempts
+            // across distinct devices — the assumption is callers split a single device's addresses into
+            // per-address candidates.  Distinct-device fan-out belongs at a higher layer.
+            const order = new Array<string>();
+            const gate = deferred<void>();
+
+            const p = CommissioningConnection({
+                devices: [device("a", [udp("fd00::1")]), device("b", [udp("fd00::2")])],
+                timeout: Seconds(60),
+                staggerDelay: Seconds(5),
+                establishSession: async (address, discoveryData, signal) => {
+                    order.push(`${discoveryData.deviceIdentifier}:${(address as ServerAddressUdp).ip}`);
+                    await new Promise<void>((resolve, reject) => {
+                        gate.promise.then(resolve);
+                        signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+                    });
+                    return discoveryData.deviceIdentifier === "a" ? ({} as any) : Promise.reject(new Error());
+                },
+            });
+
+            // Slot 0 (device a) fires immediately.
+            await MockTime.yield3();
+            expect(order).deep.equals(["a:fd00::1"]);
+
+            // Before the stagger elapses, slot 1 (device b) has NOT fired — confirms the global stagger
+            // applies across distinct devices.
+            await MockTime.advance(4900);
+            await MockTime.yield3();
+            expect(order).deep.equals(["a:fd00::1"]);
+
+            // After the stagger elapses, slot 1 fires.
+            await MockTime.advance(200);
+            await MockTime.yield3();
+            await MockTime.yield3();
+            expect(order).deep.equals(["a:fd00::1", "b:fd00::2"]);
+
+            gate.resolve();
+            const result = await p;
+            expect(result.discoveryData.deviceIdentifier).equals("a");
+        });
+
+        it("uses production default stagger when staggerDelay is not provided", async () => {
+            // Default is Seconds(5) — verify by observing slot 1 only fires after ≥5s of mock time.
+            const order = new Array<string>();
+            const gate = deferred<void>();
+
+            const p = CommissioningConnection({
+                devices: [device("a", [udp("fd00::1"), udp("fd00::2")])],
+                timeout: Seconds(60),
+                // no staggerDelay — should default to 5s
+                establishSession: async (address, _discoveryData, signal) => {
+                    order.push((address as ServerAddressUdp).ip);
+                    await new Promise<void>((resolve, reject) => {
+                        gate.promise.then(resolve);
+                        signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+                    });
+                    return (address as ServerAddressUdp).ip === "fd00::1" ? ({} as any) : Promise.reject(new Error());
+                },
+            });
+
+            await MockTime.yield3();
+            expect(order).deep.equals(["fd00::1"]);
+
+            // 4.9s — should still only be slot 0.
+            await MockTime.advance(4900);
+            await MockTime.yield3();
+            expect(order).deep.equals(["fd00::1"]);
+
+            // +200ms → past 5s → slot 1 fires.
+            await MockTime.advance(200);
+            await MockTime.yield3();
+            await MockTime.yield3();
+            expect(order).deep.equals(["fd00::1", "fd00::2"]);
+
+            gate.resolve();
+            await p;
+        });
     });
 });

--- a/packages/protocol/test/peer/CommissioningConnectionTest.ts
+++ b/packages/protocol/test/peer/CommissioningConnectionTest.ts
@@ -273,7 +273,6 @@ describe("CommissioningConnection", () => {
     describe("per-address stagger", () => {
         beforeEach(() => MockTime.reset());
 
-        /** Creates a deferred promise for deterministic sequencing inside establishSession mocks. */
         function deferred<T = void>() {
             let resolve!: (value: T) => void;
             let reject!: (reason?: unknown) => void;
@@ -294,9 +293,8 @@ describe("CommissioningConnection", () => {
                 staggerDelay: Seconds(5),
                 establishSession: async (address, _discoveryData, signal) => {
                     order.push((address as ServerAddressUdp).ip);
-                    // Wait until the test releases us, or the signal aborts.
                     await new Promise<void>((resolve, reject) => {
-                        gate.promise.then(resolve);
+                        void gate.promise.then(resolve);
                         signal.addEventListener("abort", () => reject(signal.reason), { once: true });
                     });
                     if ((address as ServerAddressUdp).ip === "fd00::1") {
@@ -306,23 +304,19 @@ describe("CommissioningConnection", () => {
                 },
             });
 
-            // Slot 0 fires synchronously; yield to let establishSession register.
             await MockTime.yield3();
             expect(order).deep.equals(["fd00::1"]);
 
-            // +5s → slot 1 fires; slot 2 still pending.
             await MockTime.advance(5000);
             await MockTime.yield3();
             await MockTime.yield3();
             expect(order).deep.equals(["fd00::1", "fd00::2"]);
 
-            // +5s more → slot 2 fires.
             await MockTime.advance(5000);
             await MockTime.yield3();
             await MockTime.yield3();
             expect(order).deep.equals(["fd00::1", "fd00::2", "fd00::3"]);
 
-            // Release slot 0 so it wins; other slots get aborted via reject.
             gate.resolve();
             const result = await p;
             expect(result.discoveryData.deviceIdentifier).equals("a");
@@ -342,8 +336,6 @@ describe("CommissioningConnection", () => {
                         await winnerGate.promise;
                         return {} as any;
                     }
-                    // Should never be reached — slots 1 and 2 are still in their stagger sleep when the
-                    // winner resolves, so their factory must never run.
                     await new Promise<void>((_resolve, reject) =>
                         signal.addEventListener("abort", () => reject(signal.reason), { once: true }),
                     );
@@ -354,24 +346,16 @@ describe("CommissioningConnection", () => {
             await MockTime.yield3();
             expect(order).deep.equals(["fd00::1"]);
 
-            // Before slot 1's stagger elapses, the winner resolves.  The abort signal cancels the
-            // pending Abort.sleep, and the startSession guard skips establishSession for slots 1 and 2.
             winnerGate.resolve();
             const result = await p;
             expect(result.discoveryData.deviceIdentifier).equals("a");
 
-            // Advance past where slots 1 and 2 would have fired — confirm they never did.
             await MockTime.advance(15000);
             await MockTime.yield3();
             expect(order).deep.equals(["fd00::1"]);
         });
 
-        it("stagger slot is global across the devices array (distinct-device fan-out belongs elsewhere)", async () => {
-            // Documents the API contract: CommissioningConnection treats its devices array as a flat list
-            // of candidates and staggers them by position (slot 0 at t=0, slot 1 at t=staggerDelay, ...).
-            // This is correct for addresses of ONE logical device but intentionally serialises attempts
-            // across distinct devices — the assumption is callers split a single device's addresses into
-            // per-address candidates.  Distinct-device fan-out belongs at a higher layer.
+        it("stagger slot is global across distinct devices (contract doc)", async () => {
             const order = new Array<string>();
             const gate = deferred<void>();
 
@@ -382,24 +366,20 @@ describe("CommissioningConnection", () => {
                 establishSession: async (address, discoveryData, signal) => {
                     order.push(`${discoveryData.deviceIdentifier}:${(address as ServerAddressUdp).ip}`);
                     await new Promise<void>((resolve, reject) => {
-                        gate.promise.then(resolve);
+                        void gate.promise.then(resolve);
                         signal.addEventListener("abort", () => reject(signal.reason), { once: true });
                     });
                     return discoveryData.deviceIdentifier === "a" ? ({} as any) : Promise.reject(new Error());
                 },
             });
 
-            // Slot 0 (device a) fires immediately.
             await MockTime.yield3();
             expect(order).deep.equals(["a:fd00::1"]);
 
-            // Before the stagger elapses, slot 1 (device b) has NOT fired — confirms the global stagger
-            // applies across distinct devices.
             await MockTime.advance(4900);
             await MockTime.yield3();
             expect(order).deep.equals(["a:fd00::1"]);
 
-            // After the stagger elapses, slot 1 fires.
             await MockTime.advance(200);
             await MockTime.yield3();
             await MockTime.yield3();
@@ -410,19 +390,17 @@ describe("CommissioningConnection", () => {
             expect(result.discoveryData.deviceIdentifier).equals("a");
         });
 
-        it("uses production default stagger when staggerDelay is not provided", async () => {
-            // Default is Seconds(5) — verify by observing slot 1 only fires after ≥5s of mock time.
+        it("default staggerDelay is 5s", async () => {
             const order = new Array<string>();
             const gate = deferred<void>();
 
             const p = CommissioningConnection({
                 devices: [device("a", [udp("fd00::1"), udp("fd00::2")])],
                 timeout: Seconds(60),
-                // no staggerDelay — should default to 5s
                 establishSession: async (address, _discoveryData, signal) => {
                     order.push((address as ServerAddressUdp).ip);
                     await new Promise<void>((resolve, reject) => {
-                        gate.promise.then(resolve);
+                        void gate.promise.then(resolve);
                         signal.addEventListener("abort", () => reject(signal.reason), { once: true });
                     });
                     return (address as ServerAddressUdp).ip === "fd00::1" ? ({} as any) : Promise.reject(new Error());
@@ -432,12 +410,10 @@ describe("CommissioningConnection", () => {
             await MockTime.yield3();
             expect(order).deep.equals(["fd00::1"]);
 
-            // 4.9s — should still only be slot 0.
             await MockTime.advance(4900);
             await MockTime.yield3();
             expect(order).deep.equals(["fd00::1"]);
 
-            // +200ms → past 5s → slot 1 fires.
             await MockTime.advance(200);
             await MockTime.yield3();
             await MockTime.yield3();


### PR DESCRIPTION
## Summary

- Add a per-address PASE stagger (5s) in `CommissioningConnection` so parallel commissioning attempts against the same physical device (multiple IPs) do not race the CHIP SDK commissionee's singleton `PASESession` state
- Rebalance `ParallelPaseDiscovery` stagger to 1s since it now only serves cross-device fan-out (no shared responder state between distinct devices)
- Rename constants to `PER_ADDRESS_STAGGER_DELAY` / `CROSS_DEVICE_STAGGER_DELAY` to disambiguate their roles

## Problem

Legacy controller commissioning (`MatterController.commission` with a pre-discovered `commissionableDevice` — chip-tool integration path) fans out all addresses of one device in parallel.  For a typical device advertising IPv6 ULA + link-local + IPv4, we saw three `PBKDFParamRequest` messages sent within 1ms.

The CHIP SDK commissionee cannot serialise concurrent PASE attempts.  Its singleton `PASESession` binds `mExchangeCtxt` to the first incoming `PBKDFParamRequest` exchange, and any subsequent request on a different exchange hits `ValidateReceivedMessage` (PASESession.cpp:876-894) which returns `CHIP_ERROR_INVALID_ARGUMENT`.  The error path in `OnMessageReceived` (PASESession.cpp:969-980) then calls `DiscardExchange()` + `Clear()`, wiping in-progress PASE state and producing erratic downstream behaviour (e.g. peer-unresponsive on the very first post-PASE `ReadRequest`).

## Fix

The existing stagger in `ParallelPaseDiscovery` only applied across distinct discovered devices — it never reached the per-address fan-out inside `CommissioningConnection`.  Worse, the legacy controller path skips `ParallelPaseDiscovery` entirely and calls `CommissioningConnection` directly, so that path had no stagger at all.

Move the per-address stagger down to the layer where the (device, address) fan-out actually happens.  Both API generations now get it:

| Path | Outer (cross-device) | Inner (per-address) |
|------|---|---|
| `node.peers.commission()` | 1s (ParallelPaseDiscovery) | 5s (CommissioningConnection) |
| `MatterController.commission()` pre-discovered | — (bypasses outer) | 5s (CommissioningConnection) |

The inner stagger is cancelable via `Abort.sleep` — when a winner is established, pending stagger sleeps abort and `startSession` skips the already-lost candidates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)