### PR TITLE
fix: improve BLE commissioning reliability

### DIFF
--- a/packages/general/src/storage/StorageService.ts
+++ b/packages/general/src/storage/StorageService.ts
@@ -568,7 +568,9 @@ export class StorageService {
     }) {
         const { label, storageType, fs, namespace, sourceDir, fromKind, toKind } = args;
 
-        logger.notice(`Migrating ${label} "${namespace}" from "${fromKind}" to "${toKind}"`);
+        logger.notice(
+            `Migrating ${label} "${namespace}" from "${fromKind}" to "${toKind}". Be patient, this may take a while...`,
+        );
 
         const migrationsDir = fs.directory(".migrations");
         await migrationsDir.mkdir();

--- a/packages/nodejs-ble/src/NobleBleChannel.ts
+++ b/packages/nodejs-ble/src/NobleBleChannel.ts
@@ -206,7 +206,7 @@ export class NobleBleCentralInterface implements ConnectionlessTransport {
                 peripheral.removeListener("disconnect", reTryHandler);
 
                 if (error) {
-                    logger.error(
+                    logger.info(
                         `Peripheral ${peripheralAddress} disconnected while trying to connect, try again`,
                         error,
                     );
@@ -228,12 +228,14 @@ export class NobleBleCentralInterface implements ConnectionlessTransport {
                 }
                 if (error) {
                     clearConnectionGuard();
+                    this.#connectionsInProgress.delete(peripheralAddress);
                     peripheral.removeListener("disconnect", reTryHandler);
                     rejectOnce(new BleError(`Error while connecting to peripheral ${peripheralAddress}`, error));
                     return;
                 }
                 if (this.#onMatterMessageListener === undefined) {
                     clearConnectionGuard();
+                    this.#connectionsInProgress.delete(peripheralAddress);
                     peripheral.removeListener("disconnect", reTryHandler);
                     rejectOnce(new InternalError(`Network Interface was not added to the system yet or was cleared.`));
                     return;

--- a/packages/nodejs-ble/src/NobleBleChannel.ts
+++ b/packages/nodejs-ble/src/NobleBleChannel.ts
@@ -230,7 +230,9 @@ export class NobleBleCentralInterface implements ConnectionlessTransport {
                     clearConnectionGuard();
                     this.#connectionsInProgress.delete(peripheralAddress);
                     peripheral.removeListener("disconnect", reTryHandler);
-                    rejectOnce(new BleError(`Error while connecting to peripheral ${peripheralAddress}`, error));
+                    rejectOnce(
+                        new BleError(`Error while connecting to peripheral ${peripheralAddress}`, { cause: error }),
+                    );
                     return;
                 }
                 if (this.#onMatterMessageListener === undefined) {

--- a/packages/protocol/src/ble/Ble.ts
+++ b/packages/protocol/src/ble/Ble.ts
@@ -4,11 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Bytes, Channel, ChannelType, ConnectionlessTransport, Duration, MatterError } from "@matter/general";
+import { Bytes, Channel, ChannelType, ConnectionlessTransport, Duration } from "@matter/general";
 import { Scanner } from "../common/Scanner.js";
+import { PeerCommunicationError } from "../peer/PeerCommunicationError.js";
 import { MatterBle } from "./BleConsts.js";
 
-export class BleError extends MatterError {}
+export class BleError extends PeerCommunicationError {}
 
 /** Thrown when a BLE write or subscribe operation fails because the peripheral disconnected. */
 export class BleDisconnectedError extends BleError {}

--- a/packages/protocol/src/common/BleScanner.ts
+++ b/packages/protocol/src/common/BleScanner.ts
@@ -45,6 +45,14 @@ export type DiscoveredBleDevice = {
     hasAdditionalAdvertisementData: boolean;
 };
 
+type StoredDiscoveredBleDevice = DiscoveredBleDevice & {
+    serviceDataHex: string;
+    lastSeen: number;
+};
+
+/** Entries older than this are treated as dead addresses when matching service data arrives from a new address. */
+const STALE_ENTRY_AGE = Seconds(60);
+
 export class BleScanner implements Scanner {
     readonly type = ChannelType.BLE;
 
@@ -58,7 +66,7 @@ export class BleScanner implements Scanner {
             cancelResolver?: (value: void) => void;
         }
     >();
-    readonly #discoveredMatterDevices = new Map<string, DiscoveredBleDevice>();
+    readonly #discoveredMatterDevices = new Map<string, StoredDiscoveredBleDevice>();
 
     constructor(client: BleScannerClient) {
         this.#client = client;
@@ -144,6 +152,19 @@ export class BleScanner implements Scanner {
                 addresses: [{ type: "ble", peripheralAddress: address }],
             };
             const deviceExisting = this.#discoveredMatterDevices.has(address);
+            const serviceDataHex = Bytes.toHex(manufacturerServiceData);
+            const now = Time.nowMs;
+
+            // Drop stale entries with matching service data — same device likely re-advertising under a rotated address
+            for (const [otherAddress, otherEntry] of this.#discoveredMatterDevices) {
+                if (otherAddress === address) continue;
+                if (otherEntry.serviceDataHex !== serviceDataHex) continue;
+                if (now - otherEntry.lastSeen <= STALE_ENTRY_AGE) continue;
+                logger.debug(
+                    `Dropping stale BLE entry ${otherAddress} — matching service data arrived from ${address} and prior entry is ${Duration.format(Millis(now - otherEntry.lastSeen))} old`,
+                );
+                this.#discoveredMatterDevices.delete(otherAddress);
+            }
 
             logger.debug(
                 `${deviceExisting ? "Re-" : ""}Discovered device ${address} data: ${Diagnostic.json(deviceData)}`,
@@ -153,6 +174,8 @@ export class BleScanner implements Scanner {
                 deviceData,
                 peripheral,
                 hasAdditionalAdvertisementData,
+                serviceDataHex,
+                lastSeen: now,
             });
 
             const queryKey = this.#findCommissionableQueryIdentifier(deviceData);
@@ -239,7 +262,10 @@ export class BleScanner implements Scanner {
     }
 
     #getCommissionableDevices(identifier: CommissionableDeviceIdentifiers) {
-        const storedRecords = Array.from(this.#discoveredMatterDevices.values());
+        // Newest first so ordered consumers (e.g. parallel PASE discovery) prefer the freshest advertisement
+        const storedRecords = Array.from(this.#discoveredMatterDevices.values()).sort(
+            (a, b) => b.lastSeen - a.lastSeen,
+        );
 
         const foundRecords = new Array<DiscoveredBleDevice>();
         if ("instanceId" in identifier || "deviceType" in identifier) {

--- a/packages/protocol/src/protocol/MRP.ts
+++ b/packages/protocol/src/protocol/MRP.ts
@@ -70,8 +70,8 @@ export namespace MRP {
     }: ResponseTimeInputs): Duration {
         switch (channelType) {
             case "tcp":
-                // TCP uses 30s timeout according to chip sdk implementation, so do the same
-                return Millis(Seconds(30) + PEER_RESPONSE_TIME_BUFFER);
+                // 30s base from chip sdk, but honor larger expectedProcessingTime for long-running commands
+                return Millis(Math.max(Seconds(30), expectedProcessingTime) + PEER_RESPONSE_TIME_BUFFER);
 
             case "udp":
                 // UDP normally uses MRP, if not we have Group communication, which normally have no responses
@@ -87,8 +87,8 @@ export namespace MRP {
                 );
 
             case "ble":
-                // chip sdk uses BTP_ACK_TIMEOUT_MS which is wrong in my eyes, so we use static 30s as like TCP here
-                return Millis(Seconds(30) + PEER_RESPONSE_TIME_BUFFER);
+                // 30s base like TCP, but honor larger expectedProcessingTime (e.g. connectNetwork during commissioning)
+                return Millis(Math.max(Seconds(30), expectedProcessingTime) + PEER_RESPONSE_TIME_BUFFER);
 
             default:
                 throw new MatterFlowError(

--- a/packages/protocol/test/common/BleScannerTest.ts
+++ b/packages/protocol/test/common/BleScannerTest.ts
@@ -1,0 +1,99 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { BlePeripheral, BleScanner, BleScannerClient } from "#common/BleScanner.js";
+import { Bytes, Seconds } from "@matter/general";
+
+const SERVICE_DATA_A = Bytes.fromHex("00c9067c11018000"); // D=1737, VP=4476+32769
+const SERVICE_DATA_B = Bytes.fromHex("00e8037c11018000"); // D=1000, VP=4476+32769
+
+class MockBleScannerClient implements BleScannerClient {
+    callback?: (peripheral: BlePeripheral, data: Bytes) => void;
+    setDiscoveryCallback(callback: (peripheral: BlePeripheral, data: Bytes) => void) {
+        this.callback = callback;
+    }
+    async startScanning() {}
+    async stopScanning() {}
+
+    discover(address: string, data: Bytes) {
+        this.callback!({ address }, data);
+    }
+}
+
+describe("BleScanner", () => {
+    before(() => MockTime.enable());
+
+    describe("service-data-based deduplication and aging", () => {
+        it("merges repeat advertisements from the same peripheral into a single entry", () => {
+            const client = new MockBleScannerClient();
+            const scanner = new BleScanner(client);
+
+            client.discover("aa:aa:aa:aa:aa:aa", SERVICE_DATA_A);
+            client.discover("aa:aa:aa:aa:aa:aa", SERVICE_DATA_A);
+
+            const devices = scanner.getDiscoveredCommissionableDevices({ longDiscriminator: 1737 });
+            expect(devices).to.have.lengthOf(1);
+            expect(devices[0].deviceIdentifier).to.equal("aa:aa:aa:aa:aa:aa");
+        });
+
+        it("keeps both entries when matching service data arrives from a second address within the stale window", async () => {
+            const client = new MockBleScannerClient();
+            const scanner = new BleScanner(client);
+
+            client.discover("aa:aa:aa:aa:aa:aa", SERVICE_DATA_A);
+
+            await MockTime.advance(Seconds(10));
+            client.discover("bb:bb:bb:bb:bb:bb", SERVICE_DATA_A);
+
+            const devices = scanner.getDiscoveredCommissionableDevices({ longDiscriminator: 1737 });
+            expect(devices).to.have.lengthOf(2);
+            expect(devices[0].deviceIdentifier).to.equal("bb:bb:bb:bb:bb:bb");
+            expect(devices[1].deviceIdentifier).to.equal("aa:aa:aa:aa:aa:aa");
+        });
+
+        it("replaces the existing entry when matching service data arrives after the stale window (address rotation)", async () => {
+            const client = new MockBleScannerClient();
+            const scanner = new BleScanner(client);
+
+            client.discover("aa:aa:aa:aa:aa:aa", SERVICE_DATA_A);
+
+            await MockTime.advance(Seconds(61));
+            client.discover("bb:bb:bb:bb:bb:bb", SERVICE_DATA_A);
+
+            const devices = scanner.getDiscoveredCommissionableDevices({ longDiscriminator: 1737 });
+            expect(devices).to.have.lengthOf(1);
+            expect(devices[0].deviceIdentifier).to.equal("bb:bb:bb:bb:bb:bb");
+        });
+
+        it("keeps stale entry alive when it is refreshed before the rotation window elapses", async () => {
+            const client = new MockBleScannerClient();
+            const scanner = new BleScanner(client);
+
+            client.discover("aa:aa:aa:aa:aa:aa", SERVICE_DATA_A);
+            await MockTime.advance(Seconds(55));
+            client.discover("aa:aa:aa:aa:aa:aa", SERVICE_DATA_A);
+
+            await MockTime.advance(Seconds(55));
+            client.discover("bb:bb:bb:bb:bb:bb", SERVICE_DATA_A);
+
+            const devices = scanner.getDiscoveredCommissionableDevices({ longDiscriminator: 1737 });
+            expect(devices).to.have.lengthOf(2);
+        });
+
+        it("does not drop entries whose service data differs from the new advertisement", async () => {
+            const client = new MockBleScannerClient();
+            const scanner = new BleScanner(client);
+
+            client.discover("aa:aa:aa:aa:aa:aa", SERVICE_DATA_A);
+            await MockTime.advance(Seconds(120));
+
+            client.discover("bb:bb:bb:bb:bb:bb", SERVICE_DATA_B);
+
+            expect(scanner.getDiscoveredCommissionableDevices({ longDiscriminator: 1737 })).to.have.lengthOf(1);
+            expect(scanner.getDiscoveredCommissionableDevices({ longDiscriminator: 1000 })).to.have.lengthOf(1);
+        });
+    });
+});

--- a/packages/protocol/test/protocol/MRPTest.ts
+++ b/packages/protocol/test/protocol/MRPTest.ts
@@ -68,6 +68,16 @@ describe("MRP", () => {
 
                 expect(timeout).to.equal(Seconds(65));
             });
+
+            it("falls back to the default expectedProcessingTime when omitted", () => {
+                const timeout = MRP.maxPeerResponseTimeOf({
+                    localSessionParameters,
+                    channelType: ChannelType.TCP,
+                    isPeerActive: true,
+                });
+
+                expect(timeout).to.equal(Seconds(35));
+            });
         });
     });
 });

--- a/packages/protocol/test/protocol/MRPTest.ts
+++ b/packages/protocol/test/protocol/MRPTest.ts
@@ -1,0 +1,73 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { MRP } from "#protocol/MRP.js";
+import { SessionParameters } from "#session/SessionParameters.js";
+import { ChannelType, Seconds } from "@matter/general";
+
+describe("MRP", () => {
+    describe("maxPeerResponseTimeOf", () => {
+        const localSessionParameters = SessionParameters();
+
+        describe("BLE channel", () => {
+            it("uses the 30s base when expectedProcessingTime is small", () => {
+                const timeout = MRP.maxPeerResponseTimeOf({
+                    localSessionParameters,
+                    channelType: ChannelType.BLE,
+                    isPeerActive: true,
+                    expectedProcessingTime: Seconds(2),
+                });
+
+                expect(timeout).to.equal(Seconds(35));
+            });
+
+            it("honors expectedProcessingTime when larger than the 30s base", () => {
+                const timeout = MRP.maxPeerResponseTimeOf({
+                    localSessionParameters,
+                    channelType: ChannelType.BLE,
+                    isPeerActive: true,
+                    expectedProcessingTime: Seconds(60),
+                });
+
+                expect(timeout).to.equal(Seconds(65));
+            });
+
+            it("falls back to the default expectedProcessingTime when omitted", () => {
+                const timeout = MRP.maxPeerResponseTimeOf({
+                    localSessionParameters,
+                    channelType: ChannelType.BLE,
+                    isPeerActive: true,
+                });
+
+                expect(timeout).to.equal(Seconds(35));
+            });
+        });
+
+        describe("TCP channel", () => {
+            it("uses the 30s base when expectedProcessingTime is small", () => {
+                const timeout = MRP.maxPeerResponseTimeOf({
+                    localSessionParameters,
+                    channelType: ChannelType.TCP,
+                    isPeerActive: true,
+                    expectedProcessingTime: Seconds(2),
+                });
+
+                expect(timeout).to.equal(Seconds(35));
+            });
+
+            it("honors expectedProcessingTime when larger than the 30s base", () => {
+                const timeout = MRP.maxPeerResponseTimeOf({
+                    localSessionParameters,
+                    channelType: ChannelType.TCP,
+                    isPeerActive: true,
+                    expectedProcessingTime: Seconds(60),
+                });
+
+                expect(timeout).to.equal(Seconds(65));
+            });
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Observed in a production log where a Thread device failed to commission over BLE: `connectNetwork` was killed at 35s despite the caller requesting a 60s budget, and subsequent retries were rejected due to leaked connection-in-progress state and targeted a rotated BLE address that was no longer live.

- **`MRP.maxPeerResponseTimeOf`**: honor `expectedProcessingTime` on BLE and TCP channels so long-running commands (notably `NetworkCommissioning.connectNetwork` during BLE commissioning, where Thread join routinely takes longer than 35s) get the time budget the caller requests. Computes `max(30s, expectedProcessingTime) + 5s buffer`, preserving the existing default-path behavior and only expanding the timeout when the caller asks for more.
- **`NobleBleChannel`**: release `connectionsInProgress` tracking on the two `connectHandler` error paths so subsequent commissioning attempts are not rejected with *"already in progress"* after a failed connect. Also lower retriable connect-disconnect log from `error` to `info` — the retry follows automatically and the cause stays visible.
- **`BleError`** now extends `PeerCommunicationError` so `ParallelPaseDiscovery`'s `causedBy` check classifies BLE transport failures as expected recoverable errors instead of logging them as *"Unexpected error from parallel commissioning attempt"*. Narrower `TransientPeerCommunicationError` checks in retry logic are unaffected (verified).
- **`BleScanner`**: dedup advertisements by full service data. When a new advertisement arrives with the same service data as an existing entry but a different peripheral address, replace the entry if the previous one is older than 60s (BLE address rotation), otherwise keep both (parallel advertisement). Results are returned newest-first so ordered consumers prefer the freshest candidate.
- **`StorageService`**: extend migration log to warn that it may take a while.

🤖 Generated with [Claude Code](https://claude.com/claude-code)