### PR TITLE
fix: add missing generated cluster forward declarations

### DIFF
--- a/packages/main/src/forwards/clusters/access-control.d.ts
+++ b/packages/main/src/forwards/clusters/access-control.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/access-control.d";

--- a/packages/main/src/forwards/clusters/account-login.d.ts
+++ b/packages/main/src/forwards/clusters/account-login.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/account-login.d";

--- a/packages/main/src/forwards/clusters/actions.d.ts
+++ b/packages/main/src/forwards/clusters/actions.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/actions.d";

--- a/packages/main/src/forwards/clusters/activated-carbon-filter-monitoring.d.ts
+++ b/packages/main/src/forwards/clusters/activated-carbon-filter-monitoring.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/activated-carbon-filter-monitoring.d";

--- a/packages/main/src/forwards/clusters/administrator-commissioning.d.ts
+++ b/packages/main/src/forwards/clusters/administrator-commissioning.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/administrator-commissioning.d";

--- a/packages/main/src/forwards/clusters/air-quality.d.ts
+++ b/packages/main/src/forwards/clusters/air-quality.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/air-quality.d";

--- a/packages/main/src/forwards/clusters/alarm-base.d.ts
+++ b/packages/main/src/forwards/clusters/alarm-base.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/alarm-base.d";

--- a/packages/main/src/forwards/clusters/application-basic.d.ts
+++ b/packages/main/src/forwards/clusters/application-basic.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/application-basic.d";

--- a/packages/main/src/forwards/clusters/application-launcher.d.ts
+++ b/packages/main/src/forwards/clusters/application-launcher.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/application-launcher.d";

--- a/packages/main/src/forwards/clusters/audio-output.d.ts
+++ b/packages/main/src/forwards/clusters/audio-output.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/audio-output.d";

--- a/packages/main/src/forwards/clusters/basic-information.d.ts
+++ b/packages/main/src/forwards/clusters/basic-information.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/basic-information.d";

--- a/packages/main/src/forwards/clusters/binding.d.ts
+++ b/packages/main/src/forwards/clusters/binding.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/binding.d";

--- a/packages/main/src/forwards/clusters/boolean-state-configuration.d.ts
+++ b/packages/main/src/forwards/clusters/boolean-state-configuration.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/boolean-state-configuration.d";

--- a/packages/main/src/forwards/clusters/boolean-state.d.ts
+++ b/packages/main/src/forwards/clusters/boolean-state.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/boolean-state.d";

--- a/packages/main/src/forwards/clusters/bridged-device-basic-information.d.ts
+++ b/packages/main/src/forwards/clusters/bridged-device-basic-information.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/bridged-device-basic-information.d";

--- a/packages/main/src/forwards/clusters/carbon-dioxide-concentration-measurement.d.ts
+++ b/packages/main/src/forwards/clusters/carbon-dioxide-concentration-measurement.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/carbon-dioxide-concentration-measurement.d";

--- a/packages/main/src/forwards/clusters/carbon-monoxide-concentration-measurement.d.ts
+++ b/packages/main/src/forwards/clusters/carbon-monoxide-concentration-measurement.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/carbon-monoxide-concentration-measurement.d";

--- a/packages/main/src/forwards/clusters/channel.d.ts
+++ b/packages/main/src/forwards/clusters/channel.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/channel.d";

--- a/packages/main/src/forwards/clusters/color-control.d.ts
+++ b/packages/main/src/forwards/clusters/color-control.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/color-control.d";

--- a/packages/main/src/forwards/clusters/commissioner-control.d.ts
+++ b/packages/main/src/forwards/clusters/commissioner-control.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/commissioner-control.d";

--- a/packages/main/src/forwards/clusters/concentration-measurement.d.ts
+++ b/packages/main/src/forwards/clusters/concentration-measurement.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/concentration-measurement.d";

--- a/packages/main/src/forwards/clusters/content-app-observer.d.ts
+++ b/packages/main/src/forwards/clusters/content-app-observer.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/content-app-observer.d";

--- a/packages/main/src/forwards/clusters/content-control.d.ts
+++ b/packages/main/src/forwards/clusters/content-control.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/content-control.d";

--- a/packages/main/src/forwards/clusters/content-launcher.d.ts
+++ b/packages/main/src/forwards/clusters/content-launcher.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/content-launcher.d";

--- a/packages/main/src/forwards/clusters/descriptor.d.ts
+++ b/packages/main/src/forwards/clusters/descriptor.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/descriptor.d";

--- a/packages/main/src/forwards/clusters/device-energy-management-mode.d.ts
+++ b/packages/main/src/forwards/clusters/device-energy-management-mode.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/device-energy-management-mode.d";

--- a/packages/main/src/forwards/clusters/device-energy-management.d.ts
+++ b/packages/main/src/forwards/clusters/device-energy-management.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/device-energy-management.d";

--- a/packages/main/src/forwards/clusters/diagnostic-logs.d.ts
+++ b/packages/main/src/forwards/clusters/diagnostic-logs.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/diagnostic-logs.d";

--- a/packages/main/src/forwards/clusters/dishwasher-alarm.d.ts
+++ b/packages/main/src/forwards/clusters/dishwasher-alarm.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/dishwasher-alarm.d";

--- a/packages/main/src/forwards/clusters/dishwasher-mode.d.ts
+++ b/packages/main/src/forwards/clusters/dishwasher-mode.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/dishwasher-mode.d";

--- a/packages/main/src/forwards/clusters/door-lock.d.ts
+++ b/packages/main/src/forwards/clusters/door-lock.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/door-lock.d";

--- a/packages/main/src/forwards/clusters/ecosystem-information.d.ts
+++ b/packages/main/src/forwards/clusters/ecosystem-information.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/ecosystem-information.d";

--- a/packages/main/src/forwards/clusters/electrical-energy-measurement.d.ts
+++ b/packages/main/src/forwards/clusters/electrical-energy-measurement.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/electrical-energy-measurement.d";

--- a/packages/main/src/forwards/clusters/electrical-power-measurement.d.ts
+++ b/packages/main/src/forwards/clusters/electrical-power-measurement.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/electrical-power-measurement.d";

--- a/packages/main/src/forwards/clusters/energy-evse-mode.d.ts
+++ b/packages/main/src/forwards/clusters/energy-evse-mode.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/energy-evse-mode.d";

--- a/packages/main/src/forwards/clusters/energy-evse.d.ts
+++ b/packages/main/src/forwards/clusters/energy-evse.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/energy-evse.d";

--- a/packages/main/src/forwards/clusters/energy-preference.d.ts
+++ b/packages/main/src/forwards/clusters/energy-preference.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/energy-preference.d";

--- a/packages/main/src/forwards/clusters/ethernet-network-diagnostics.d.ts
+++ b/packages/main/src/forwards/clusters/ethernet-network-diagnostics.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/ethernet-network-diagnostics.d";

--- a/packages/main/src/forwards/clusters/fan-control.d.ts
+++ b/packages/main/src/forwards/clusters/fan-control.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/fan-control.d";

--- a/packages/main/src/forwards/clusters/fixed-label.d.ts
+++ b/packages/main/src/forwards/clusters/fixed-label.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/fixed-label.d";

--- a/packages/main/src/forwards/clusters/flow-measurement.d.ts
+++ b/packages/main/src/forwards/clusters/flow-measurement.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/flow-measurement.d";

--- a/packages/main/src/forwards/clusters/formaldehyde-concentration-measurement.d.ts
+++ b/packages/main/src/forwards/clusters/formaldehyde-concentration-measurement.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/formaldehyde-concentration-measurement.d";

--- a/packages/main/src/forwards/clusters/general-commissioning.d.ts
+++ b/packages/main/src/forwards/clusters/general-commissioning.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/general-commissioning.d";

--- a/packages/main/src/forwards/clusters/general-diagnostics.d.ts
+++ b/packages/main/src/forwards/clusters/general-diagnostics.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/general-diagnostics.d";

--- a/packages/main/src/forwards/clusters/group-key-management.d.ts
+++ b/packages/main/src/forwards/clusters/group-key-management.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/group-key-management.d";

--- a/packages/main/src/forwards/clusters/groups.d.ts
+++ b/packages/main/src/forwards/clusters/groups.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/groups.d";

--- a/packages/main/src/forwards/clusters/hepa-filter-monitoring.d.ts
+++ b/packages/main/src/forwards/clusters/hepa-filter-monitoring.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/hepa-filter-monitoring.d";

--- a/packages/main/src/forwards/clusters/icd-management.d.ts
+++ b/packages/main/src/forwards/clusters/icd-management.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/icd-management.d";

--- a/packages/main/src/forwards/clusters/identify.d.ts
+++ b/packages/main/src/forwards/clusters/identify.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/identify.d";

--- a/packages/main/src/forwards/clusters/illuminance-measurement.d.ts
+++ b/packages/main/src/forwards/clusters/illuminance-measurement.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/illuminance-measurement.d";

--- a/packages/main/src/forwards/clusters/joint-fabric-administrator.d.ts
+++ b/packages/main/src/forwards/clusters/joint-fabric-administrator.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/joint-fabric-administrator.d";

--- a/packages/main/src/forwards/clusters/joint-fabric-datastore.d.ts
+++ b/packages/main/src/forwards/clusters/joint-fabric-datastore.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/joint-fabric-datastore.d";

--- a/packages/main/src/forwards/clusters/keypad-input.d.ts
+++ b/packages/main/src/forwards/clusters/keypad-input.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/keypad-input.d";

--- a/packages/main/src/forwards/clusters/label.d.ts
+++ b/packages/main/src/forwards/clusters/label.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/label.d";

--- a/packages/main/src/forwards/clusters/laundry-dryer-controls.d.ts
+++ b/packages/main/src/forwards/clusters/laundry-dryer-controls.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/laundry-dryer-controls.d";

--- a/packages/main/src/forwards/clusters/laundry-washer-controls.d.ts
+++ b/packages/main/src/forwards/clusters/laundry-washer-controls.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/laundry-washer-controls.d";

--- a/packages/main/src/forwards/clusters/laundry-washer-mode.d.ts
+++ b/packages/main/src/forwards/clusters/laundry-washer-mode.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/laundry-washer-mode.d";

--- a/packages/main/src/forwards/clusters/level-control.d.ts
+++ b/packages/main/src/forwards/clusters/level-control.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/level-control.d";

--- a/packages/main/src/forwards/clusters/localization-configuration.d.ts
+++ b/packages/main/src/forwards/clusters/localization-configuration.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/localization-configuration.d";

--- a/packages/main/src/forwards/clusters/low-power.d.ts
+++ b/packages/main/src/forwards/clusters/low-power.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/low-power.d";

--- a/packages/main/src/forwards/clusters/media-input.d.ts
+++ b/packages/main/src/forwards/clusters/media-input.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/media-input.d";

--- a/packages/main/src/forwards/clusters/media-playback.d.ts
+++ b/packages/main/src/forwards/clusters/media-playback.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/media-playback.d";

--- a/packages/main/src/forwards/clusters/messages.d.ts
+++ b/packages/main/src/forwards/clusters/messages.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/messages.d";

--- a/packages/main/src/forwards/clusters/microwave-oven-control.d.ts
+++ b/packages/main/src/forwards/clusters/microwave-oven-control.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/microwave-oven-control.d";

--- a/packages/main/src/forwards/clusters/microwave-oven-mode.d.ts
+++ b/packages/main/src/forwards/clusters/microwave-oven-mode.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/microwave-oven-mode.d";

--- a/packages/main/src/forwards/clusters/mode-base.d.ts
+++ b/packages/main/src/forwards/clusters/mode-base.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/mode-base.d";

--- a/packages/main/src/forwards/clusters/mode-select.d.ts
+++ b/packages/main/src/forwards/clusters/mode-select.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/mode-select.d";

--- a/packages/main/src/forwards/clusters/network-commissioning.d.ts
+++ b/packages/main/src/forwards/clusters/network-commissioning.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/network-commissioning.d";

--- a/packages/main/src/forwards/clusters/nitrogen-dioxide-concentration-measurement.d.ts
+++ b/packages/main/src/forwards/clusters/nitrogen-dioxide-concentration-measurement.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/nitrogen-dioxide-concentration-measurement.d";

--- a/packages/main/src/forwards/clusters/occupancy-sensing.d.ts
+++ b/packages/main/src/forwards/clusters/occupancy-sensing.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/occupancy-sensing.d";

--- a/packages/main/src/forwards/clusters/on-off.d.ts
+++ b/packages/main/src/forwards/clusters/on-off.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/on-off.d";

--- a/packages/main/src/forwards/clusters/operational-credentials.d.ts
+++ b/packages/main/src/forwards/clusters/operational-credentials.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/operational-credentials.d";

--- a/packages/main/src/forwards/clusters/operational-state.d.ts
+++ b/packages/main/src/forwards/clusters/operational-state.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/operational-state.d";

--- a/packages/main/src/forwards/clusters/ota-software-update-provider.d.ts
+++ b/packages/main/src/forwards/clusters/ota-software-update-provider.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/ota-software-update-provider.d";

--- a/packages/main/src/forwards/clusters/ota-software-update-requestor.d.ts
+++ b/packages/main/src/forwards/clusters/ota-software-update-requestor.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/ota-software-update-requestor.d";

--- a/packages/main/src/forwards/clusters/oven-cavity-operational-state.d.ts
+++ b/packages/main/src/forwards/clusters/oven-cavity-operational-state.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/oven-cavity-operational-state.d";

--- a/packages/main/src/forwards/clusters/oven-mode.d.ts
+++ b/packages/main/src/forwards/clusters/oven-mode.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/oven-mode.d";

--- a/packages/main/src/forwards/clusters/ozone-concentration-measurement.d.ts
+++ b/packages/main/src/forwards/clusters/ozone-concentration-measurement.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/ozone-concentration-measurement.d";

--- a/packages/main/src/forwards/clusters/pm1-concentration-measurement.d.ts
+++ b/packages/main/src/forwards/clusters/pm1-concentration-measurement.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/pm1-concentration-measurement.d";

--- a/packages/main/src/forwards/clusters/pm10-concentration-measurement.d.ts
+++ b/packages/main/src/forwards/clusters/pm10-concentration-measurement.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/pm10-concentration-measurement.d";

--- a/packages/main/src/forwards/clusters/pm25-concentration-measurement.d.ts
+++ b/packages/main/src/forwards/clusters/pm25-concentration-measurement.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/pm25-concentration-measurement.d";

--- a/packages/main/src/forwards/clusters/power-source-configuration.d.ts
+++ b/packages/main/src/forwards/clusters/power-source-configuration.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/power-source-configuration.d";

--- a/packages/main/src/forwards/clusters/power-source.d.ts
+++ b/packages/main/src/forwards/clusters/power-source.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/power-source.d";

--- a/packages/main/src/forwards/clusters/power-topology.d.ts
+++ b/packages/main/src/forwards/clusters/power-topology.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/power-topology.d";

--- a/packages/main/src/forwards/clusters/pressure-measurement.d.ts
+++ b/packages/main/src/forwards/clusters/pressure-measurement.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/pressure-measurement.d";

--- a/packages/main/src/forwards/clusters/pump-configuration-and-control.d.ts
+++ b/packages/main/src/forwards/clusters/pump-configuration-and-control.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/pump-configuration-and-control.d";

--- a/packages/main/src/forwards/clusters/radon-concentration-measurement.d.ts
+++ b/packages/main/src/forwards/clusters/radon-concentration-measurement.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/radon-concentration-measurement.d";

--- a/packages/main/src/forwards/clusters/refrigerator-alarm.d.ts
+++ b/packages/main/src/forwards/clusters/refrigerator-alarm.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/refrigerator-alarm.d";

--- a/packages/main/src/forwards/clusters/refrigerator-and-temperature-controlled-cabinet-mode.d.ts
+++ b/packages/main/src/forwards/clusters/refrigerator-and-temperature-controlled-cabinet-mode.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/refrigerator-and-temperature-controlled-cabinet-mode.d";

--- a/packages/main/src/forwards/clusters/relative-humidity-measurement.d.ts
+++ b/packages/main/src/forwards/clusters/relative-humidity-measurement.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/relative-humidity-measurement.d";

--- a/packages/main/src/forwards/clusters/resource-monitoring.d.ts
+++ b/packages/main/src/forwards/clusters/resource-monitoring.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/resource-monitoring.d";

--- a/packages/main/src/forwards/clusters/rvc-clean-mode.d.ts
+++ b/packages/main/src/forwards/clusters/rvc-clean-mode.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/rvc-clean-mode.d";

--- a/packages/main/src/forwards/clusters/rvc-operational-state.d.ts
+++ b/packages/main/src/forwards/clusters/rvc-operational-state.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/rvc-operational-state.d";

--- a/packages/main/src/forwards/clusters/rvc-run-mode.d.ts
+++ b/packages/main/src/forwards/clusters/rvc-run-mode.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/rvc-run-mode.d";

--- a/packages/main/src/forwards/clusters/scenes-management.d.ts
+++ b/packages/main/src/forwards/clusters/scenes-management.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/scenes-management.d";

--- a/packages/main/src/forwards/clusters/service-area.d.ts
+++ b/packages/main/src/forwards/clusters/service-area.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/service-area.d";

--- a/packages/main/src/forwards/clusters/smoke-co-alarm.d.ts
+++ b/packages/main/src/forwards/clusters/smoke-co-alarm.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/smoke-co-alarm.d";

--- a/packages/main/src/forwards/clusters/software-diagnostics.d.ts
+++ b/packages/main/src/forwards/clusters/software-diagnostics.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/software-diagnostics.d";

--- a/packages/main/src/forwards/clusters/switch.d.ts
+++ b/packages/main/src/forwards/clusters/switch.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/switch.d";

--- a/packages/main/src/forwards/clusters/target-navigator.d.ts
+++ b/packages/main/src/forwards/clusters/target-navigator.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/target-navigator.d";

--- a/packages/main/src/forwards/clusters/temperature-control.d.ts
+++ b/packages/main/src/forwards/clusters/temperature-control.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/temperature-control.d";

--- a/packages/main/src/forwards/clusters/temperature-measurement.d.ts
+++ b/packages/main/src/forwards/clusters/temperature-measurement.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/temperature-measurement.d";

--- a/packages/main/src/forwards/clusters/thermostat-user-interface-configuration.d.ts
+++ b/packages/main/src/forwards/clusters/thermostat-user-interface-configuration.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/thermostat-user-interface-configuration.d";

--- a/packages/main/src/forwards/clusters/thermostat.d.ts
+++ b/packages/main/src/forwards/clusters/thermostat.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/thermostat.d";

--- a/packages/main/src/forwards/clusters/thread-border-router-management.d.ts
+++ b/packages/main/src/forwards/clusters/thread-border-router-management.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/thread-border-router-management.d";

--- a/packages/main/src/forwards/clusters/thread-network-diagnostics.d.ts
+++ b/packages/main/src/forwards/clusters/thread-network-diagnostics.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/thread-network-diagnostics.d";

--- a/packages/main/src/forwards/clusters/thread-network-directory.d.ts
+++ b/packages/main/src/forwards/clusters/thread-network-directory.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/thread-network-directory.d";

--- a/packages/main/src/forwards/clusters/time-format-localization.d.ts
+++ b/packages/main/src/forwards/clusters/time-format-localization.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/time-format-localization.d";

--- a/packages/main/src/forwards/clusters/time-synchronization.d.ts
+++ b/packages/main/src/forwards/clusters/time-synchronization.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/time-synchronization.d";

--- a/packages/main/src/forwards/clusters/total-volatile-organic-compounds-concentration-measurement.d.ts
+++ b/packages/main/src/forwards/clusters/total-volatile-organic-compounds-concentration-measurement.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/total-volatile-organic-compounds-concentration-measurement.d";

--- a/packages/main/src/forwards/clusters/unit-localization.d.ts
+++ b/packages/main/src/forwards/clusters/unit-localization.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/unit-localization.d";

--- a/packages/main/src/forwards/clusters/user-label.d.ts
+++ b/packages/main/src/forwards/clusters/user-label.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/user-label.d";

--- a/packages/main/src/forwards/clusters/valve-configuration-and-control.d.ts
+++ b/packages/main/src/forwards/clusters/valve-configuration-and-control.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/valve-configuration-and-control.d";

--- a/packages/main/src/forwards/clusters/wake-on-lan.d.ts
+++ b/packages/main/src/forwards/clusters/wake-on-lan.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/wake-on-lan.d";

--- a/packages/main/src/forwards/clusters/water-heater-management.d.ts
+++ b/packages/main/src/forwards/clusters/water-heater-management.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/water-heater-management.d";

--- a/packages/main/src/forwards/clusters/water-heater-mode.d.ts
+++ b/packages/main/src/forwards/clusters/water-heater-mode.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/water-heater-mode.d";

--- a/packages/main/src/forwards/clusters/water-tank-level-monitoring.d.ts
+++ b/packages/main/src/forwards/clusters/water-tank-level-monitoring.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/water-tank-level-monitoring.d";

--- a/packages/main/src/forwards/clusters/wi-fi-network-diagnostics.d.ts
+++ b/packages/main/src/forwards/clusters/wi-fi-network-diagnostics.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/wi-fi-network-diagnostics.d";

--- a/packages/main/src/forwards/clusters/wi-fi-network-management.d.ts
+++ b/packages/main/src/forwards/clusters/wi-fi-network-management.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/wi-fi-network-management.d";

--- a/packages/main/src/forwards/clusters/window-covering.d.ts
+++ b/packages/main/src/forwards/clusters/window-covering.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import "@matter/main/platform";
+
+export * from "@matter/types/clusters/window-covering.d";


### PR DESCRIPTION
## Summary
- Regeneration surfaced 120 cluster forward `.d.ts` files missing from `packages/main/src/forwards/clusters/`
- All files are auto-generated re-exports (`THIS FILE IS GENERATED, DO NOT EDIT`) forwarding `@matter/types/clusters/<name>.d`
- Brings forward declaration set in line with the current cluster set (121 → 241 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)