### PR TITLE
fix: handle noble Windows BLE errors during commissioning

### DIFF
--- a/packages/nodejs-ble/src/NobleBleChannel.ts
+++ b/packages/nodejs-ble/src/NobleBleChannel.ts
@@ -35,6 +35,24 @@ import { BleScanner } from "./BleScanner.js";
 const logger = Logger.get("BleChannel");
 
 /**
+ * Detect noble errors that indicate the BLE connection is no longer usable.
+ * On macOS/Linux noble throws errors starting with "Disconnected".
+ * On Windows the native WinRT binding throws "status: <N>" where N is the
+ * AsyncStatus enum (0=Started, 1=Completed, 2=Canceled, 3=Error).
+ * Values >= 2 indicate the async operation did not complete successfully.
+ */
+function isNobleDisconnectError(error: unknown): error is Error {
+    if (!(error instanceof Error)) {
+        return false;
+    }
+    if (error.message.startsWith("Disconnected")) {
+        return true;
+    }
+    const match = error.message.match(/^status:\s*(\d+)/);
+    return match !== null && Number(match[1]) >= 2;
+}
+
+/**
  * Convert a UUID in noble's format to a proper UUID.
  *
  * @param {string} uuid - UUID to convert
@@ -515,6 +533,9 @@ export class NobleBleChannel extends BleChannel<Bytes> {
         } catch (error) {
             btpHandshakeTimeout.stop();
             characteristicC2ForSubscribe.removeListener("data", handshakeHandler);
+            if (isNobleDisconnectError(error)) {
+                throw new BleDisconnectedError(error.message, { cause: error });
+            }
             throw error;
         }
 
@@ -523,13 +544,13 @@ export class NobleBleChannel extends BleChannel<Bytes> {
 
         const btpSession = await BtpSessionHandler.createAsCentral(
             new Uint8Array(handshakeResponse),
-            // callback to write data to characteristic C1; translates noble's generic disconnect
-            // error into BleDisconnectedError so BtpSessionHandler can handle it specifically
+            // callback to write data to characteristic C1; translates noble's disconnect/transport
+            // errors into BleDisconnectedError so BtpSessionHandler can handle them specifically
             async (data: Bytes) => {
                 try {
                     return await characteristicC1ForWrite.writeAsync(Buffer.from(Bytes.of(data)), false);
                 } catch (error) {
-                    if (error instanceof Error && error.message.startsWith("Disconnected")) {
+                    if (isNobleDisconnectError(error)) {
                         throw new BleDisconnectedError(error.message, { cause: error });
                     }
                     throw error;

--- a/packages/protocol/src/peer/ControllerCommissioningFlow.ts
+++ b/packages/protocol/src/peer/ControllerCommissioningFlow.ts
@@ -21,6 +21,7 @@ import {
     ImplementationError,
     Instant,
     Logger,
+    Millis,
     Minutes,
     repackErrorAs,
     Seconds,
@@ -201,6 +202,9 @@ const DEFAULT_FAILSAFE_TIME = Minutes.one;
 
 /** When we execute longer actions like network connections or reconnection, we need to keep the BTP session alive */
 const BTP_IDLE_ALIVE_INTERVAL = Seconds(25);
+
+/** Expected maximum time for CASE session establishment over the operational network. */
+const CASE_RECONNECT_TIMEOUT = Minutes(5);
 
 /** Devices may report very low scan/connect timeouts that are not enough in practice */
 const MIN_NETWORK_SCAN_TIMEOUT_SECONDS = 60;
@@ -817,6 +821,20 @@ export class ControllerCommissioningFlow {
         }
     }
 
+    /**
+     * For non-concurrent devices the BLE connection drops when connectNetwork is sent, so the
+     * failsafe must cover both the connect time and the subsequent CASE reconnection.
+     */
+    #connectNetworkFailsafeTime(connectMaxTimeSeconds: number): Duration {
+        if (this.collectedCommissioningData.supportsConcurrentConnection === false) {
+            return Duration.max(
+                Millis(Seconds(connectMaxTimeSeconds) + CASE_RECONNECT_TIMEOUT),
+                this.#defaultFailSafeTime,
+            );
+        }
+        return Seconds(connectMaxTimeSeconds);
+    }
+
     async #resetFailsafeTimer() {
         if (this.#currentFailSafeEndTime === undefined) return;
         try {
@@ -1361,7 +1379,7 @@ export class ControllerCommissioningFlow {
             };
         }
 
-        await this.#ensureFailsafeTimerFor(Seconds(connectMaxTimeSeconds));
+        await this.#ensureFailsafeTimerFor(this.#connectNetworkFailsafeTime(connectMaxTimeSeconds));
 
         const connectResult = await this.#invokeCommand(
             {
@@ -1559,7 +1577,7 @@ export class ControllerCommissioningFlow {
             };
         }
 
-        await this.#ensureFailsafeTimerFor(Seconds(connectMaxTimeSeconds));
+        await this.#ensureFailsafeTimerFor(this.#connectNetworkFailsafeTime(connectMaxTimeSeconds));
 
         const { networkingStatus, debugText } = await this.#invokeCommand(
             {
@@ -1608,9 +1626,18 @@ export class ControllerCommissioningFlow {
 
         // Reconnection with discovery could take longer than the default failsafe time, so we need to
         // re-arm the failsafe when we are in a concurrent commissioning flow also in parallel to
-        // the operative reconnection
-        await this.#ensureFailsafeTimerFor(Minutes(5));
-        if (!isConcurrentFlow) {
+        // the operative reconnection.
+        // For non-concurrent flow the BLE connection already dropped when connectNetwork was sent
+        // (step 16/17), so we cannot re-arm here — the failsafe was armed for long enough before
+        // that step.  For concurrent flow the BLE session is still alive, so try to extend it.
+        if (isConcurrentFlow) {
+            try {
+                await this.#ensureFailsafeTimerFor(CASE_RECONNECT_TIMEOUT);
+            } catch (error) {
+                // Ignore errors on PASE actions, either way CASE success/failure decides the outcome, not this re-arm.
+                logger.info("Failed to re-arm failsafe before operational reconnect, proceeding anyway", error);
+            }
+        } else {
             this.#armFailsafeInterval?.stop();
         }
 


### PR DESCRIPTION
## Summary

- Recognize noble's Windows WinRT BLE errors (`"status: <N>"`) as disconnect errors via `isNobleDisconnectError()` helper, so BtpSessionHandler handles them gracefully instead of crashing the commissioning flow
- Extend failsafe duration before `connectNetwork` for non-concurrent devices to cover both connect time and CASE reconnection (~5 min buffer)
- Skip futile failsafe re-arm in `#reconnectWithDevice()` for non-concurrent flow (BLE already dead); wrap concurrent flow re-arm in try/catch since BLE may be transitioning

addresses #3600 

🤖 Generated with [Claude Code](https://claude.com/claude-code)