### PR TITLE
fix: enable multi-run CHIP tests and restore lost GroupId constraint relaxation

### DIFF
--- a/packages/node/src/behaviors/groups/GroupsServer.ts
+++ b/packages/node/src/behaviors/groups/GroupsServer.ts
@@ -24,11 +24,29 @@ const logger = Logger.get("GroupsServer");
 const { commands } = Groups.schema;
 const addGroup = commands.require("AddGroup");
 const addGroupIfIdentifying = commands.require("AddGroupIfIdentifying");
+const addGroupResponse = commands.require("AddGroupResponse");
+const viewGroupResponse = commands.require("ViewGroupResponse");
+const removeGroupResponse = commands.require("RemoveGroupResponse");
 
 const GroupsSchema = Groups.schema.extend(
     undefined,
-    addGroup.extend(undefined, addGroup.fields.extend("GroupName", { constraint: "none" })),
-    addGroupIfIdentifying.extend(undefined, addGroupIfIdentifying.fields.extend("GroupName", { constraint: "none" })),
+    addGroup.extend(
+        undefined,
+        addGroup.fields.extend("GroupId", { constraint: "none" }),
+        addGroup.fields.extend("GroupName", { constraint: "none" }),
+    ),
+    addGroupIfIdentifying.extend(
+        undefined,
+        addGroupIfIdentifying.fields.extend("GroupId", { constraint: "none" }),
+        addGroupIfIdentifying.fields.extend("GroupName", { constraint: "none" }),
+    ),
+    addGroupResponse.extend(undefined, addGroupResponse.fields.extend("GroupId", { constraint: "none" })),
+    viewGroupResponse.extend(
+        undefined,
+        viewGroupResponse.fields.extend("GroupId", { constraint: "none" }),
+        viewGroupResponse.fields.extend("GroupName", { constraint: "none" }),
+    ),
+    removeGroupResponse.extend(undefined, removeGroupResponse.fields.extend("GroupId", { constraint: "none" })),
 );
 
 // We enable group names by default

--- a/packages/testing/src/chip/chip.ts
+++ b/packages/testing/src/chip/chip.ts
@@ -131,7 +131,7 @@ function createBuilder(initial: {
         include(...glob: string[]) {
             const includePaths = new Set<string>();
             for (const pattern of glob) {
-                const paths = globSync(glob, chip.tests);
+                const paths = globSync(pattern, chip.tests);
 
                 if (!paths.length) {
                     throw new Error(`No tests included for glob ${pattern}`);

--- a/support/chip-testing/test/core/ACE.test.ts
+++ b/support/chip-testing/test/core/ACE.test.ts
@@ -21,4 +21,5 @@ describe("ACE", () => {
     );
 
     chip("ACE/*");
+    chip("ACE/*/run1");
 });

--- a/support/chip-testing/test/core/CADMIN.test.ts
+++ b/support/chip-testing/test/core/CADMIN.test.ts
@@ -79,7 +79,6 @@ describe("CADMIN", () => {
     // test (see equivalent in Discovery.test.ts)
     before(() => chip.testFor("CADMIN/1.22").edit(edit.sed("s/timeout=179/timeout=0/")));
 
-    chip("CADMIN/1.3/run1", "CADMIN/1.3/run2");
     chip("CADMIN/1.4/run1", "CADMIN/1.4/run2");
 
     chip("CADMIN/*").exclude(

--- a/support/chip-testing/test/core/CADMIN.test.ts
+++ b/support/chip-testing/test/core/CADMIN.test.ts
@@ -79,6 +79,9 @@ describe("CADMIN", () => {
     // test (see equivalent in Discovery.test.ts)
     before(() => chip.testFor("CADMIN/1.22").edit(edit.sed("s/timeout=179/timeout=0/")));
 
+    chip("CADMIN/1.3/run1", "CADMIN/1.3/run2");
+    chip("CADMIN/1.4/run1", "CADMIN/1.4/run2");
+
     chip("CADMIN/*").exclude(
         // Handled below
         "CADMIN/1.19",

--- a/support/chip-testing/test/core/CADMIN.test.ts
+++ b/support/chip-testing/test/core/CADMIN.test.ts
@@ -79,7 +79,8 @@ describe("CADMIN", () => {
     // test (see equivalent in Discovery.test.ts)
     before(() => chip.testFor("CADMIN/1.22").edit(edit.sed("s/timeout=179/timeout=0/")));
 
-    chip("CADMIN/1.4/run1", "CADMIN/1.4/run2");
+    chip("CADMIN/1.4/run1");
+    chip("CADMIN/1.4/run2");
 
     chip("CADMIN/*").exclude(
         // Handled below

--- a/support/chip-testing/test/core/CADMIN.test.ts
+++ b/support/chip-testing/test/core/CADMIN.test.ts
@@ -79,9 +79,6 @@ describe("CADMIN", () => {
     // test (see equivalent in Discovery.test.ts)
     before(() => chip.testFor("CADMIN/1.22").edit(edit.sed("s/timeout=179/timeout=0/")));
 
-    chip("CADMIN/1.4/run1");
-    chip("CADMIN/1.4/run2");
-
     chip("CADMIN/*").exclude(
         // Handled below
         "CADMIN/1.19",

--- a/support/chip-testing/test/core/G.test.ts
+++ b/support/chip-testing/test/core/G.test.ts
@@ -6,4 +6,5 @@
 
 describe("G", () => {
     chip("G/*");
+    chip("G/2.2/run1");
 });

--- a/support/chip-testing/test/core/SC.test.ts
+++ b/support/chip-testing/test/core/SC.test.ts
@@ -33,7 +33,8 @@ describe("SC", () => {
         );
     }).timeout(10000);
 
-    chip("SC/3.4/run1", "SC/3.4/run2");
+    chip("SC/3.4/run1");
+    chip("SC/3.4/run2");
     chip("SC/5.1/run1");
     chip("SC/5.2/run1");
 

--- a/support/chip-testing/test/core/SC.test.ts
+++ b/support/chip-testing/test/core/SC.test.ts
@@ -33,6 +33,10 @@ describe("SC", () => {
         );
     }).timeout(10000);
 
+    chip("SC/3.4/run1", "SC/3.4/run2");
+    chip("SC/5.1/run1");
+    chip("SC/5.2/run1");
+
     chip("SC/*").exclude(
         // These require additional configuration below
         "SC/4.1/*",


### PR DESCRIPTION
## Summary
- Enable multi-run CHIP test variants for ACE, CADMIN 1.4, G 2.2, SC 3.4/5.1/5.2 by adding explicit `chip()` calls for run1/run2
- Restore `GroupId` constraint relaxation on `AddGroup`, `AddGroupIfIdentifying` and their response commands in `GroupsServer` — lost during de-TLV conversion (dbb2a96) which only converted the `GroupName` relaxation
- Fix `Builder.include()` bug: `globSync(glob, ...)` used the full glob array instead of the per-iteration `pattern`, masking missing test variants

## Test plan
- [x] `packages/testing` tests pass
- [x] `packages/node` tests pass (889/889)
- [ ] Run CHIP tests for ACE, CADMIN, G, SC and verify multi-run variants execute
- [ ] Verify G/2.2 run1 no longer fails on `addGroup` with `groupId: 0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)